### PR TITLE
Fix version resolution in reusable CI

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -444,29 +444,42 @@ jobs:
             "tomlkit"
           )
 
+          resolve_spec() {
+            local package=$1
+            local version=${2:-}
+            local default_version=${3:-}
+            if [ -n "$version" ]; then
+              echo "${package}==${version}"
+            elif [ -n "$default_version" ]; then
+              echo "${package}==${default_version}"
+            else
+              echo "$package"
+            fi
+          }
+
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
-            black_spec="black==${BLACK_VERSION}"
-            docformatter_spec="docformatter==${DOCFORMATTER_VERSION}"
-            isort_spec="isort==${ISORT_VERSION}"
-            ruff_spec="ruff==${RUFF_VERSION}"
-            mypy_spec="mypy==${MYPY_VERSION}"
-            pytest_spec="pytest==${PYTEST_VERSION}"
-            pytest_cov_spec="pytest-cov==${PYTEST_COV_VERSION}"
-            coverage_spec="coverage==${COVERAGE_VERSION:-7.2.7}"
-            pytest_xdist_spec="pytest-xdist==${PYTEST_XDIST_VERSION:-3.6.1}"
+            black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
+            docformatter_spec=$(resolve_spec "docformatter" "${DOCFORMATTER_VERSION:-}" "")
+            isort_spec=$(resolve_spec "isort" "${ISORT_VERSION:-}" "")
+            ruff_spec=$(resolve_spec "ruff" "${RUFF_VERSION:-}" "")
+            mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
+            pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
+            pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.2.7")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
             base_test_specs=(
-              "hypothesis==${HYPOTHESIS_VERSION:-6.0.0}"
-              "pandas==${PANDAS_VERSION:-2.3.0}"
-              "numpy==${NUMPY_VERSION:-2.1.0}"
-              "pydantic==${PYDANTIC_VERSION:-2.10.3}"
-              "pydantic-core==${PYDANTIC_CORE_VERSION:-2.23.4}"
-              "requests==${REQUESTS_VERSION:-2.31.0}"
-              "jsonschema==${JSONSCHEMA_VERSION:-4.0.0}"
-              "PyYAML==${PYYAML_VERSION:-6.0.2}"
-              "tomlkit==${TOMLKIT_VERSION:-0.13.0}"
+              "$(resolve_spec "hypothesis" "${HYPOTHESIS_VERSION:-}" "6.0.0")"
+              "$(resolve_spec "pandas" "${PANDAS_VERSION:-}" "2.3.0")"
+              "$(resolve_spec "numpy" "${NUMPY_VERSION:-}" "2.1.0")"
+              "$(resolve_spec "pydantic" "${PYDANTIC_VERSION:-}" "2.10.3")"
+              "$(resolve_spec "pydantic-core" "${PYDANTIC_CORE_VERSION:-}" "2.23.4")"
+              "$(resolve_spec "requests" "${REQUESTS_VERSION:-}" "2.31.0")"
+              "$(resolve_spec "jsonschema" "${JSONSCHEMA_VERSION:-}" "4.0.0")"
+              "$(resolve_spec "PyYAML" "${PYYAML_VERSION:-}" "6.0.2")"
+              "$(resolve_spec "tomlkit" "${TOMLKIT_VERSION:-}" "0.13.0")"
             )
           else
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
@@ -709,29 +722,42 @@ jobs:
             "tomlkit"
           )
 
+          resolve_spec() {
+            local package=$1
+            local version=${2:-}
+            local default_version=${3:-}
+            if [ -n "$version" ]; then
+              echo "${package}==${version}"
+            elif [ -n "$default_version" ]; then
+              echo "${package}==${default_version}"
+            else
+              echo "$package"
+            fi
+          }
+
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
-            black_spec="black==${BLACK_VERSION}"
-            docformatter_spec="docformatter==${DOCFORMATTER_VERSION}"
-            isort_spec="isort==${ISORT_VERSION}"
-            ruff_spec="ruff==${RUFF_VERSION}"
-            mypy_spec="mypy==${MYPY_VERSION}"
-            pytest_spec="pytest==${PYTEST_VERSION}"
-            pytest_cov_spec="pytest-cov==${PYTEST_COV_VERSION}"
-            coverage_spec="coverage==${COVERAGE_VERSION:-7.2.7}"
-            pytest_xdist_spec="pytest-xdist==${PYTEST_XDIST_VERSION:-3.6.1}"
+            black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
+            docformatter_spec=$(resolve_spec "docformatter" "${DOCFORMATTER_VERSION:-}" "")
+            isort_spec=$(resolve_spec "isort" "${ISORT_VERSION:-}" "")
+            ruff_spec=$(resolve_spec "ruff" "${RUFF_VERSION:-}" "")
+            mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
+            pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
+            pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.2.7")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
             base_test_specs=(
-              "hypothesis==${HYPOTHESIS_VERSION:-6.0.0}"
-              "pandas==${PANDAS_VERSION:-2.3.0}"
-              "numpy==${NUMPY_VERSION:-2.1.0}"
-              "pydantic==${PYDANTIC_VERSION:-2.10.3}"
-              "pydantic-core==${PYDANTIC_CORE_VERSION:-2.23.4}"
-              "requests==${REQUESTS_VERSION:-2.31.0}"
-              "jsonschema==${JSONSCHEMA_VERSION:-4.0.0}"
-              "PyYAML==${PYYAML_VERSION:-6.0.2}"
-              "tomlkit==${TOMLKIT_VERSION:-0.13.0}"
+              "$(resolve_spec "hypothesis" "${HYPOTHESIS_VERSION:-}" "6.0.0")"
+              "$(resolve_spec "pandas" "${PANDAS_VERSION:-}" "2.3.0")"
+              "$(resolve_spec "numpy" "${NUMPY_VERSION:-}" "2.1.0")"
+              "$(resolve_spec "pydantic" "${PYDANTIC_VERSION:-}" "2.10.3")"
+              "$(resolve_spec "pydantic-core" "${PYDANTIC_CORE_VERSION:-}" "2.23.4")"
+              "$(resolve_spec "requests" "${REQUESTS_VERSION:-}" "2.31.0")"
+              "$(resolve_spec "jsonschema" "${JSONSCHEMA_VERSION:-}" "4.0.0")"
+              "$(resolve_spec "PyYAML" "${PYYAML_VERSION:-}" "6.0.2")"
+              "$(resolve_spec "tomlkit" "${TOMLKIT_VERSION:-}" "0.13.0")"
             )
           else
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
@@ -982,29 +1008,42 @@ jobs:
             "tomlkit"
           )
 
+          resolve_spec() {
+            local package=$1
+            local version=${2:-}
+            local default_version=${3:-}
+            if [ -n "$version" ]; then
+              echo "${package}==${version}"
+            elif [ -n "$default_version" ]; then
+              echo "${package}==${default_version}"
+            else
+              echo "$package"
+            fi
+          }
+
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
-            black_spec="black==${BLACK_VERSION}"
-            docformatter_spec="docformatter==${DOCFORMATTER_VERSION}"
-            isort_spec="isort==${ISORT_VERSION}"
-            ruff_spec="ruff==${RUFF_VERSION}"
-            mypy_spec="mypy==${MYPY_VERSION}"
-            pytest_spec="pytest==${PYTEST_VERSION}"
-            pytest_cov_spec="pytest-cov==${PYTEST_COV_VERSION}"
-            coverage_spec="coverage==${COVERAGE_VERSION:-7.2.7}"
-            pytest_xdist_spec="pytest-xdist==${PYTEST_XDIST_VERSION:-3.6.1}"
+            black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
+            docformatter_spec=$(resolve_spec "docformatter" "${DOCFORMATTER_VERSION:-}" "")
+            isort_spec=$(resolve_spec "isort" "${ISORT_VERSION:-}" "")
+            ruff_spec=$(resolve_spec "ruff" "${RUFF_VERSION:-}" "")
+            mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
+            pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
+            pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.2.7")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
             base_test_specs=(
-              "hypothesis==${HYPOTHESIS_VERSION:-6.0.0}"
-              "pandas==${PANDAS_VERSION:-2.3.0}"
-              "numpy==${NUMPY_VERSION:-2.1.0}"
-              "pydantic==${PYDANTIC_VERSION:-2.10.3}"
-              "pydantic-core==${PYDANTIC_CORE_VERSION:-2.23.4}"
-              "requests==${REQUESTS_VERSION:-2.31.0}"
-              "jsonschema==${JSONSCHEMA_VERSION:-4.0.0}"
-              "PyYAML==${PYYAML_VERSION:-6.0.2}"
-              "tomlkit==${TOMLKIT_VERSION:-0.13.0}"
+              "$(resolve_spec "hypothesis" "${HYPOTHESIS_VERSION:-}" "6.0.0")"
+              "$(resolve_spec "pandas" "${PANDAS_VERSION:-}" "2.3.0")"
+              "$(resolve_spec "numpy" "${NUMPY_VERSION:-}" "2.1.0")"
+              "$(resolve_spec "pydantic" "${PYDANTIC_VERSION:-}" "2.10.3")"
+              "$(resolve_spec "pydantic-core" "${PYDANTIC_CORE_VERSION:-}" "2.23.4")"
+              "$(resolve_spec "requests" "${REQUESTS_VERSION:-}" "2.31.0")"
+              "$(resolve_spec "jsonschema" "${JSONSCHEMA_VERSION:-}" "4.0.0")"
+              "$(resolve_spec "PyYAML" "${PYYAML_VERSION:-}" "6.0.2")"
+              "$(resolve_spec "tomlkit" "${TOMLKIT_VERSION:-}" "0.13.0")"
             )
           else
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
@@ -1298,29 +1337,42 @@ jobs:
             "tomlkit"
           )
 
+          resolve_spec() {
+            local package=$1
+            local version=${2:-}
+            local default_version=${3:-}
+            if [ -n "$version" ]; then
+              echo "${package}==${version}"
+            elif [ -n "$default_version" ]; then
+              echo "${package}==${default_version}"
+            else
+              echo "$package"
+            fi
+          }
+
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
-            black_spec="black==${BLACK_VERSION}"
-            docformatter_spec="docformatter==${DOCFORMATTER_VERSION}"
-            isort_spec="isort==${ISORT_VERSION}"
-            ruff_spec="ruff==${RUFF_VERSION}"
-            mypy_spec="mypy==${MYPY_VERSION}"
-            pytest_spec="pytest==${PYTEST_VERSION}"
-            pytest_cov_spec="pytest-cov==${PYTEST_COV_VERSION}"
-            coverage_spec="coverage==${COVERAGE_VERSION:-7.2.7}"
-            pytest_xdist_spec="pytest-xdist==${PYTEST_XDIST_VERSION:-3.6.1}"
+            black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
+            docformatter_spec=$(resolve_spec "docformatter" "${DOCFORMATTER_VERSION:-}" "")
+            isort_spec=$(resolve_spec "isort" "${ISORT_VERSION:-}" "")
+            ruff_spec=$(resolve_spec "ruff" "${RUFF_VERSION:-}" "")
+            mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
+            pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
+            pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.2.7")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
             base_test_specs=(
-              "hypothesis==${HYPOTHESIS_VERSION:-6.0.0}"
-              "pandas==${PANDAS_VERSION:-2.3.0}"
-              "numpy==${NUMPY_VERSION:-2.1.0}"
-              "pydantic==${PYDANTIC_VERSION:-2.10.3}"
-              "pydantic-core==${PYDANTIC_CORE_VERSION:-2.23.4}"
-              "requests==${REQUESTS_VERSION:-2.31.0}"
-              "jsonschema==${JSONSCHEMA_VERSION:-4.0.0}"
-              "PyYAML==${PYYAML_VERSION:-6.0.2}"
-              "tomlkit==${TOMLKIT_VERSION:-0.13.0}"
+              "$(resolve_spec "hypothesis" "${HYPOTHESIS_VERSION:-}" "6.0.0")"
+              "$(resolve_spec "pandas" "${PANDAS_VERSION:-}" "2.3.0")"
+              "$(resolve_spec "numpy" "${NUMPY_VERSION:-}" "2.1.0")"
+              "$(resolve_spec "pydantic" "${PYDANTIC_VERSION:-}" "2.10.3")"
+              "$(resolve_spec "pydantic-core" "${PYDANTIC_CORE_VERSION:-}" "2.23.4")"
+              "$(resolve_spec "requests" "${REQUESTS_VERSION:-}" "2.31.0")"
+              "$(resolve_spec "jsonschema" "${JSONSCHEMA_VERSION:-}" "4.0.0")"
+              "$(resolve_spec "PyYAML" "${PYYAML_VERSION:-}" "6.0.2")"
+              "$(resolve_spec "tomlkit" "${TOMLKIT_VERSION:-}" "0.13.0")"
             )
           else
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2

--- a/scripts/dev_check.sh
+++ b/scripts/dev_check.sh
@@ -259,7 +259,7 @@ fi
 
 echo -e "${BLUE}2. Workflow validation...${NC}"
 if command -v actionlint >/dev/null 2>&1; then
-    quick_check "Workflow YAML validation" "actionlint .github/workflows/" ""
+    quick_check "Workflow YAML validation" "actionlint $(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) -print | tr '\n' ' ')" ""
 else
     echo -e "${YELLOW}⚠ actionlint not installed; skipping workflow validation${NC}"
 fi


### PR DESCRIPTION
- Guard reusable python CI against unset tool version env vars to avoid set -u failures in consumer repos.
- Make dev_check actionlint invocation robust to missing globs and directory execution issues.

Validated with ./scripts/dev_check.sh --verbose.