### PR TITLE
Add autofix loop metrics emission

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -30,6 +30,11 @@ jobs:
       stop_reason: ${{ steps.evaluate.outputs.stop_reason }}
       attempts: ${{ steps.evaluate.outputs.attempts }}
       max_attempts: ${{ steps.evaluate.outputs.max_attempts }}
+      trigger_reason: ${{ steps.evaluate.outputs.trigger_reason }}
+      trigger_job: ${{ steps.evaluate.outputs.trigger_job }}
+      trigger_step: ${{ steps.evaluate.outputs.trigger_step }}
+      gate_conclusion: ${{ steps.evaluate.outputs.gate_conclusion }}
+      gate_run_id: ${{ steps.evaluate.outputs.gate_run_id }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
     steps:
@@ -110,6 +115,11 @@ jobs:
               stop_reason: '',
               attempts: '0',
               max_attempts: '3',
+              trigger_reason: 'unknown',
+              trigger_job: '',
+              trigger_step: '',
+              gate_conclusion: String(run?.conclusion || run?.status || ''),
+              gate_run_id: String(run?.id || ''),
             };
 
             const stop = (reason, stopReason = '') => {
@@ -202,6 +212,8 @@ jobs:
             outputs.max_attempts = String(maxAttempts);
 
             const failingJobs = [];
+            let triggerJob = null;
+            let triggerStep = null;
             for (const job of jobs) {
               const conclusion = (job.conclusion || job.status || '').toLowerCase();
               if (!conclusion || ['success', 'skipped'].includes(conclusion)) {
@@ -223,7 +235,35 @@ jobs:
                 detailLines.push(`  - steps: ${failingSteps.join('; ')}`);
               }
               failingJobs.push(detailLines.join('\n'));
+
+              if (!triggerJob) {
+                triggerJob = job;
+                const failingStep = Array.isArray(job.steps)
+                  ? job.steps.find((step) => {
+                      const stepConclusion = (step.conclusion || step.status || '').toLowerCase();
+                      return stepConclusion && !['success', 'skipped'].includes(stepConclusion);
+                    })
+                  : null;
+                triggerStep = failingStep || null;
+              }
             }
+
+            const inferTriggerReason = (job, step) => {
+              const text = [job?.name, step?.name]
+                .filter(Boolean)
+                .map((value) => String(value).toLowerCase())
+                .join(' ');
+
+              if (!text) return 'unknown';
+              if (text.includes('mypy')) return 'mypy';
+              if (text.includes('lint') || text.includes('flake8') || text.includes('ruff')) return 'lint';
+              if (text.includes('pytest') || text.includes('test')) return 'pytest';
+              return 'unknown';
+            };
+
+            outputs.trigger_reason = inferTriggerReason(triggerJob, triggerStep);
+            outputs.trigger_job = triggerJob?.name || triggerJob?.id || '';
+            outputs.trigger_step = triggerStep?.name || '';
 
             const appendixLines = [
               `Gate run: ${run.html_url || run.id}`,
@@ -319,3 +359,140 @@ jobs:
               issue_number: prNumber,
               body,
             });
+
+  metrics:
+    name: Record autofix metrics
+    needs:
+      - prepare
+      - autofix
+    if: always()
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    steps:
+      - name: Collect metrics
+        id: collect
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number('${{ needs.prepare.outputs.pr_number || 0 }}') || 0;
+            const attemptNumber = Number('${{ needs.prepare.outputs.attempts || 0 }}') || 0;
+            const attemptLimit = Number('${{ needs.prepare.outputs.max_attempts || 0 }}') || 0;
+            const headShaBefore = '${{ needs.prepare.outputs.head_sha }}';
+            const gateConclusionBefore = '${{ needs.prepare.outputs.gate_conclusion }}' || (context.payload.workflow_run?.conclusion || '');
+            const gateRunId = '${{ needs.prepare.outputs.gate_run_id }}' || String(context.payload.workflow_run?.id || '');
+            const triggerReason = '${{ needs.prepare.outputs.trigger_reason || 'unknown' }}';
+            const triggerJob = '${{ needs.prepare.outputs.trigger_job }}';
+            const triggerStep = '${{ needs.prepare.outputs.trigger_step }}';
+            const stopReason = '${{ needs.prepare.outputs.stop_reason }}';
+            const autofixResult = '${{ needs.autofix.result }}';
+
+            const { owner, repo } = context.repo;
+            let fixApplied = false;
+            let headShaAfter = headShaBefore;
+            let gateResultAfter = gateConclusionBefore || 'unknown';
+
+            if (prNumber) {
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                });
+                headShaAfter = pr.head?.sha || headShaAfter;
+                fixApplied = Boolean(headShaBefore && headShaAfter && headShaBefore !== headShaAfter);
+
+                const gateWorkflow = 'pr-00-gate.yml';
+                const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                  owner,
+                  repo,
+                  workflow_id: gateWorkflow,
+                  head_sha: headShaAfter,
+                  per_page: 20,
+                });
+                const latestGateRun = runs[0];
+                if (latestGateRun) {
+                  gateResultAfter = latestGateRun.conclusion || latestGateRun.status || 'unknown';
+                } else {
+                  gateResultAfter = 'not-found';
+                }
+              } catch (error) {
+                core.warning(`Failed to resolve PR or gate status: ${error.message}`);
+              }
+            }
+
+            const metrics = {
+              workflow_run_id: gateRunId,
+              pr_number: prNumber,
+              attempt_number: attemptNumber,
+              attempt_limit: attemptLimit,
+              trigger_reason: triggerReason || 'unknown',
+              trigger_job: triggerJob,
+              trigger_step: triggerStep,
+              fix_applied: fixApplied,
+              gate_result_after: gateResultAfter || 'unknown',
+              gate_conclusion_before: gateConclusionBefore || 'unknown',
+              stop_reason: stopReason || '',
+              autofix_result: autofixResult || 'unknown',
+              head_sha_before: headShaBefore,
+              head_sha_after: headShaAfter,
+              recorded_at: new Date().toISOString(),
+            };
+
+            core.setOutput('metrics_json', JSON.stringify(metrics));
+
+      - name: Write summary and artifact
+        env:
+          METRICS_JSON: ${{ steps.collect.outputs.metrics_json }}
+        run: |
+          set -euo pipefail
+          if [ -z "${METRICS_JSON:-}" ]; then
+            echo "No metrics JSON captured; skipping summary."
+            exit 0
+          fi
+
+          python - <<'PY'
+          import json
+          import os
+
+          metrics = json.loads(os.environ["METRICS_JSON"])
+          order = [
+              "pr_number",
+              "attempt_number",
+              "attempt_limit",
+              "trigger_reason",
+              "trigger_job",
+              "trigger_step",
+              "fix_applied",
+              "gate_conclusion_before",
+              "gate_result_after",
+              "autofix_result",
+              "stop_reason",
+              "workflow_run_id",
+              "head_sha_before",
+              "head_sha_after",
+              "recorded_at",
+          ]
+
+          lines = ["## Autofix loop metrics", ""] + ["| Field | Value |", "| --- | --- |"]
+          for key in order:
+              value = metrics.get(key, "")
+              lines.append(f"| {key} | `{value}` |")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fp:
+                  fp.write("\n".join(lines) + "\n")
+
+          out_path = "autofix-metrics.ndjson"
+          with open(out_path, "a", encoding="utf-8") as fp:
+              fp.write(json.dumps(metrics) + "\n")
+          print(f"Wrote metrics to {out_path}")
+          PY
+
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agents-autofix-metrics
+          path: autofix-metrics.ndjson
+          retention-days: 30


### PR DESCRIPTION
## Summary
- capture the failing job/step and inferred trigger reason when evaluating Gate failures in the autofix loop
- record structured autofix metrics (attempt counters, gate status before/after, head SHAs, fix_applied flag) and expose them through the step summary
- persist NDJSON metrics artifacts with 30-day retention to support later aggregation

## Testing
- python - <<'PY'
import yaml
for path in ['.github/workflows/agents-autofix-loop.yml']:
    with open(path, 'r', encoding='utf-8') as f:
        yaml.safe_load(f)
    print(f"validated {path}")
PY


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bcf99a0f48331b9b5e5c326557a1d)

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Context / problem:
- [ ] - The agent workflows (keepalive-loop, autofix-loop, verifier) run frequently but there's no visibility into:
- [ ] - How many iterations each PR takes to complete
- [ ] - Success vs failure rates for autofix attempts
- [ ] - Which stop conditions are triggered most often
- [ ] - Average time from PR open to tasks-complete
- [ ] - Which types of failures autofix can vs cannot fix
- [ ] - Debugging loop behavior requires manually inspecting workflow run logs.
- [ ] - There's no historical trend data to identify regressions or improvements.
- [ ] Goal:
- [ ] - Add lightweight metrics collection to agent workflows.
- [ ] - Create a metrics summary that can be viewed in GitHub Actions job summaries.
- [ ] - Store historical data in a JSON artifact or repository file for trend analysis.

#### Tasks
- [ ] Add metrics emission to keepalive-loop workflow:
- [ ] Emit: pr_number, iteration_count, stop_reason, gate_conclusion, tasks_total, tasks_completed, duration_seconds
- [ ] Write to GITHUB_STEP_SUMMARY in structured format
- [ ] Append to metrics artifact (ndjson format)
- [ ] Add metrics emission to autofix-loop workflow:
- [ ] Emit: pr_number, attempt_number, trigger_reason (mypy/pytest/lint), fix_applied (bool), gate_result_after
- [ ] Track which job/step triggered the autofix
- [ ] Add metrics emission to verifier workflow:
- [ ] Emit: pr_number, verdict (pass/fail), issues_created, acceptance_criteria_count, checks_run
- [ ] Create a metrics aggregation script (scripts/aggregate_agent_metrics.py):
- [ ] Read ndjson metrics files
- [ ] Compute summary statistics (success rate, avg iterations, common stop reasons)
- [ ] Output markdown summary suitable for weekly reports
- [ ] Add a scheduled workflow (weekly) to:
- [ ] Download recent metrics artifacts
- [ ] Run aggregation script
- [ ] Post summary to a tracking issue or wiki page
- [ ] Add metrics visualization to PR comments:
- [ ] Show iteration progress bar in keepalive summary comment
- [ ] Show autofix attempt count and outcomes

#### Acceptance criteria
- [ ] - Each agent workflow run produces structured metrics in GITHUB_STEP_SUMMARY.
- [ ] - Metrics are persisted as artifacts for at least 30 days.
- [ ] - Weekly summary report is automatically generated and posted.
- [ ] - Metrics can answer: "What percentage of PRs complete via keepalive without human intervention?"

**Head SHA:** 6b04f26005e0ce5adda28c5214cd0e4f2bc5401c
**Latest Runs:** ⏳ pending — Gate
**Required:** gate: ⏳ pending

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Keepalive Loop | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20485542826) |
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20485542708) |
| CI Autofix Loop | ⏳ pending | [View run](https://github.com/stranske/Workflows/actions/runs/20485542839) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20485543383) |
| Gate | ⏳ pending | [View run](https://github.com/stranske/Workflows/actions/runs/20485542824) |
| Health 40 Sweep | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20485542729) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20485542712) |
| Maint 52 Validate Workflows | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20485542715) |
<!-- auto-status-summary:end -->