### PR TITLE
fix(keepalive): pass secrets explicitly to reusable workflow

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -125,7 +125,10 @@ jobs:
     needs: evaluate
     if: needs.evaluate.outputs.action == 'run'
     uses: ./.github/workflows/reusable-codex-run.yml
-    secrets: inherit
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
       prompt_file: .github/codex/prompts/keepalive_next_task.md
       mode: keepalive


### PR DESCRIPTION
## Summary
When the keepalive loop determines `action == 'run'`, the Codex reusable workflow call was being silently skipped. This PR fixes it by explicitly passing secrets instead of using `secrets: inherit`.

## Problem
The `run-codex` job in agents-keepalive-loop.yml was using `secrets: inherit` to pass secrets to the reusable workflow. This caused the job to be silently skipped when the workflow_run event context did not properly inherit secrets.

Evidence from workflow runs:
- Run 20486004986: action='run' but only 2 jobs (Keepalive next task missing)
- Run 20486087967: action='wait' and 3 jobs (Keepalive next task = skipped)

## Solution
Changed from `secrets: inherit` to explicitly listing each secret name that the reusable workflow needs. This matches the pattern used in agents-autofix-loop.yml.

Fixes #79 (partial - Codex CLI integration)

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Restrict triggers:
- [ ] do not run agent workflows on forked PRs
- [ ] avoid pull_request_target unless absolutely necessary
- [ ] Ensure prompts are repo-owned:
- [ ] use prompt-file from .github/codex/prompts/
- [ ] build a small “context appendix” file that includes sanitized task text
- [ ] Add allowlists:
- [ ] allow-users / allow-bots in codex-action config
- [ ] only repo collaborators can trigger
- [ ] Add denylist behaviors:
- [ ] Codex should not edit .github/workflows/** unless a special environment-approved mode is enabled
- [ ] Codex should not touch secrets or tokens (explicit instruction + sandbox limits)
- [ ] Add logging + red flags:
- [ ] if prompt contains “ignore previous”, HTML comments, base64 blobs, etc, stop and require human

#### Acceptance criteria
- [ ] - Malicious-looking issue text does not get passed verbatim into Codex execution.
- [ ] - Agent workflows only run for trusted actors and trusted events.

**Head SHA:** 11979b3e6e0945208b1c3fbd6904727fa206545f
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Keepalive Loop | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20486239288) |
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20486270213) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239250) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239849) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/20486239268) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239260) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239199) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239195) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239218) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239201) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239236) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486239208) |
<!-- auto-status-summary:end -->