### PR TITLE
fix(keepalive): add preflight secrets check before Codex call

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -140,10 +140,10 @@ jobs:
           echo "WORKFLOWS_APP_ID present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
           if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
-            echo "secrets_ok=true" >> $GITHUB_OUTPUT
+            echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Neither CODEX_AUTH_JSON nor WORKFLOWS_APP_ID is set. Cannot run Codex."
-            echo "secrets_ok=false" >> $GITHUB_OUTPUT
+            echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
Adds a preflight job to diagnose why the run-codex job is silently not appearing.

## Problem
When the keepalive loop determines action=run, the Keepalive next task job should execute. Instead:
- The job doesnt appear at all (not even as skipped)
- needs.run-codex.result evaluates to failure
- Explicitly passing secrets didnt help

## Solution
Added a preflight job that:
1. Runs in the agent-standard environment (where repository secrets should be accessible)
2. Checks if CODEX_AUTH_JSON or WORKFLOWS_APP_ID is present
3. Outputs secrets_ok flag
4. run-codex job now depends on preflight succeeding

This will show in the logs whether secrets are accessible, helping diagnose if the issue is:
- Secrets not available in workflow_run context
- Something else with the reusable workflow call

## Related
- Issue #79 (Codex CLI integration)
- PR #106 (explicit secrets passing - merged)

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Restrict triggers:
- [ ] do not run agent workflows on forked PRs
- [ ] avoid pull_request_target unless absolutely necessary
- [ ] Ensure prompts are repo-owned:
- [ ] use prompt-file from .github/codex/prompts/
- [ ] build a small “context appendix” file that includes sanitized task text
- [ ] Add allowlists:
- [ ] allow-users / allow-bots in codex-action config
- [ ] only repo collaborators can trigger
- [ ] Add denylist behaviors:
- [ ] Codex should not edit .github/workflows/** unless a special environment-approved mode is enabled
- [ ] Codex should not touch secrets or tokens (explicit instruction + sandbox limits)
- [ ] Add logging + red flags:
- [ ] if prompt contains “ignore previous”, HTML comments, base64 blobs, etc, stop and require human

#### Acceptance criteria
- [ ] - Malicious-looking issue text does not get passed verbatim into Codex execution.
- [ ] - Agent workflows only run for trusted actors and trusted events.

**Head SHA:** 58da3fba190c4a277131f5aa6c212ea07a042e22
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20486540198) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510224) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510223) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510236) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510181) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510176) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510187) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510192) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510186) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510199) |
<!-- auto-status-summary:end -->