### PR TITLE
fix(keepalive): use always() to ensure reusable workflow job is created

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -151,7 +151,7 @@ jobs:
     name: Keepalive next task
     needs:
       - evaluate
-    if: needs.evaluate.outputs.action == 'run'
+    if: ${{ always() && needs.evaluate.result == 'success' && needs.evaluate.outputs.action == 'run' }}
     uses: ./.github/workflows/reusable-codex-run.yml
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}


### PR DESCRIPTION
## Problem
After PR #109, the `Keepalive next task` job still wasn't appearing in workflow runs even when `evaluate.outputs.action == 'run'`.

## Root Cause
GitHub Actions evaluates `if:` conditions for reusable workflow jobs at workflow startup time, potentially before dependency job outputs are available. This means:
- `if: needs.evaluate.outputs.action == 'run'` is evaluated BEFORE evaluate runs
- At startup, `action` is empty/undefined, so the condition is false
- The job is never created in the workflow graph

## Evidence
- Run 20487171966: summary job shows `action: 'run'`, `reason: 'ready'`
- But only 3 jobs appeared: Evaluate, Verify secrets, Update summary
- `Keepalive next task` was missing from the job graph entirely

## Solution
Use `always()` to ensure the job is always created in the workflow graph:
```yaml
if: ${{ always() && needs.evaluate.result == 'success' && needs.evaluate.outputs.action == 'run' }}
```

The `always()` forces job creation. The rest of the condition determines if it actually runs once evaluate completes.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Restrict triggers:
- [ ] do not run agent workflows on forked PRs
- [ ] avoid pull_request_target unless absolutely necessary
- [ ] Ensure prompts are repo-owned:
- [ ] use prompt-file from .github/codex/prompts/
- [ ] build a small “context appendix” file that includes sanitized task text
- [ ] Add allowlists:
- [ ] allow-users / allow-bots in codex-action config
- [ ] only repo collaborators can trigger
- [ ] Add denylist behaviors:
- [ ] Codex should not edit .github/workflows/** unless a special environment-approved mode is enabled
- [ ] Codex should not touch secrets or tokens (explicit instruction + sandbox limits)
- [ ] Add logging + red flags:
- [ ] if prompt contains “ignore previous”, HTML comments, base64 blobs, etc, stop and require human

#### Acceptance criteria
- [ ] - Malicious-looking issue text does not get passed verbatim into Codex execution.
- [ ] - Agent workflows only run for trusted actors and trusted events.
- [ ] **Head SHA:** 58da3fba190c4a277131f5aa6c212ea07a042e22
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20486540198) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510224) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510223) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510236) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510181) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510176) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510187) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510192) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510186) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510199) |
- [ ] **Head SHA:** ea115789118808f2834899ff44eb0e85608aff94
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20487108814) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989631) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989622) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989650) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989596) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989635) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989582) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989586) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989587) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989602) |

**Head SHA:** 83cc76da8003c57c3372a11d85d1923923e59074
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20487272956) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230730) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487231037) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230722) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230732) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230688) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230704) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230707) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230700) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230710) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487230685) |
<!-- auto-status-summary:end -->