### PR TITLE
fix(keepalive): use skip input to control reusable workflow execution

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -151,13 +151,13 @@ jobs:
     name: Keepalive next task
     needs:
       - evaluate
-    if: ${{ always() && needs.evaluate.result == 'success' && needs.evaluate.outputs.action == 'run' }}
     uses: ./.github/workflows/reusable-codex-run.yml
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
+      skip: ${{ needs.evaluate.outputs.action != 'run' }}
       prompt_file: .github/codex/prompts/keepalive_next_task.md
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -3,6 +3,11 @@ name: Reusable Codex Run
 on:
   workflow_call:
     inputs:
+      skip:
+        description: 'If true, skip execution entirely. Used for conditional calls.'
+        required: false
+        default: false
+        type: boolean
       prompt_file:
         description: 'Path to the prompt file that Codex should read.'
         required: true
@@ -62,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: agent-standard
     timeout-minutes: ${{ inputs.max_runtime_minutes }}
+    if: ${{ !inputs.skip }}
     outputs:
       final-message: ${{ steps.run_codex.outputs.final-message }}
     steps:


### PR DESCRIPTION
## Problem
Reusable workflow jobs with `if:` conditions that depend on outputs from dependency jobs are not being created. GitHub Actions evaluates the condition at workflow startup before outputs are available.

## Attempts that failed
1. **PR #109**: Removed preflight dependency - job still not created
2. **PR #110**: Used `always()` in condition - job still not created

## Evidence
Run 20487293650 shows:
- Evaluate outputs `action: 'run'`, `reason: 'ready'`
- Only 3 jobs created, missing `Keepalive next task`
- `referenced_workflows` shows reusable workflow IS referenced
- But job graph doesn't include it

## Root Cause
GitHub Actions evaluates `if:` conditions for reusable workflow calls at a different time than regular jobs. The condition cannot use `needs.*.outputs.*` reliably because those are resolved before the dependent job runs.

## Solution
Move the conditional logic INTO the reusable workflow:

1. Add `skip` input to `reusable-codex-run.yml`:
   ```yaml
   skip:
     description: 'If true, skip execution entirely'
     default: false
     type: boolean
   ```

2. Add `if: ```{{ inputs.skip }}` to the `codex` job inside the reusable workflow

3. Keepalive loop passes:
   ```yaml
   with:
     skip: ${{ needs.evaluate.outputs.action != 'run' }}
   ```

This ensures the reusable workflow call is ALWAYS created in the job graph, while the actual execution is controlled by the skip input evaluated at runtime inside the reusable workflow.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Restrict triggers:
- [ ] do not run agent workflows on forked PRs
- [ ] avoid pull_request_target unless absolutely necessary
- [ ] Ensure prompts are repo-owned:
- [ ] use prompt-file from .github/codex/prompts/
- [ ] build a small “context appendix” file that includes sanitized task text
- [ ] Add allowlists:
- [ ] allow-users / allow-bots in codex-action config
- [ ] only repo collaborators can trigger
- [ ] Add denylist behaviors:
- [ ] Codex should not edit .github/workflows/** unless a special environment-approved mode is enabled
- [ ] Codex should not touch secrets or tokens (explicit instruction + sandbox limits)
- [ ] Add logging + red flags:
- [ ] if prompt contains “ignore previous”, HTML comments, base64 blobs, etc, stop and require human

#### Acceptance criteria
- [ ] - Malicious-looking issue text does not get passed verbatim into Codex execution.
- [ ] - Agent workflows only run for trusted actors and trusted events.
- [ ] **Head SHA:** 58da3fba190c4a277131f5aa6c212ea07a042e22
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20486540198) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510224) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510223) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510236) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510181) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510176) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510187) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510192) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510186) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486510199) |
- [ ] **Head SHA:** ea115789118808f2834899ff44eb0e85608aff94
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20487108814) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989631) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989622) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989650) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989596) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989635) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989582) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989586) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989587) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20486989602) |

**Head SHA:** 42befd1fadd26ee9ed2da7f0bbecc44f170197c0
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20487475432) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449589) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20487449808) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449574) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449579) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449557) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449570) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449559) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449569) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449562) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20487449560) |
<!-- auto-status-summary:end -->