### PR TITLE
test: add simple job to debug keepalive job creation

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -147,6 +147,13 @@ jobs:
             exit 1
           fi
 
+  test-job:
+    name: Test job creation
+    needs: evaluate
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Test job ran! Action was ${{ needs.evaluate.outputs.action }}"
+
   run-codex:
     name: Keepalive next task
     needs:


### PR DESCRIPTION
Testing if simple jobs after evaluate can be created. If this test-job appears but run-codex doesn't, we know the issue is specific to reusable workflows.