### PR TITLE
fix(keepalive): use full repo path for reusable workflow

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -158,7 +158,7 @@ jobs:
     name: Keepalive next task
     needs:
       - evaluate
-    uses: ./.github/workflows/reusable-codex-run.yml
+    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}


### PR DESCRIPTION
Testing if using the full repository path `stranske/Workflows/.github/workflows/reusable-codex-run.yml@main` instead of the relative path `./.github/workflows/reusable-codex-run.yml` helps GitHub Actions create the job.

Previous attempts showed:
- Test job creation: ✅ Created and ran
- run-codex job: ❌ Not created

The reusable workflow is referenced in `referenced_workflows` but the job isn't created.