### PR TITLE
test(keepalive): remove concurrency from run-codex job

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -168,9 +168,6 @@ jobs:
       prompt_file: .github/codex/prompts/keepalive_next_task.md
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}
-    concurrency:
-      group: keepalive-${{ needs.evaluate.outputs.pr_number }}
-      cancel-in-progress: false
 
   summary:
     name: Update keepalive summary


### PR DESCRIPTION
Testing if job-level concurrency on a reusable workflow caller job is preventing the job from being created.

This is a debugging experiment to understand why the `run-codex` job using a reusable workflow is never created.