### PR TITLE
fix: install Codex CLI before running

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -196,6 +196,13 @@ jobs:
 
           echo "file=${output}" >> "$GITHUB_OUTPUT"
 
+      - name: Install Codex CLI
+        run: |
+          set -euo pipefail
+          echo "Installing Codex CLI..."
+          npm install -g @openai/codex
+          codex --version
+
       - name: Setup Codex auth
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}


### PR DESCRIPTION
The direct CLI invocation requires the CLI to be installed first. The previous codex-action handled this automatically.