### PR TITLE
fix: use unique delimiter for Codex output

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -255,12 +255,13 @@ jobs:
 
           echo "Codex completed. Output written to $OUTPUT_FILE"
 
-          # Set output for downstream steps
+          # Set output for downstream steps using a unique delimiter
           if [ -f "$OUTPUT_FILE" ]; then
+            delimiter="CODEX_OUTPUT_$(date +%s)"
             {
-              echo "final-message<<EOF"
+              echo "final-message<<${delimiter}"
               cat "$OUTPUT_FILE"
-              echo "EOF"
+              echo "${delimiter}"
             } >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
The Codex output may contain 'EOF' which breaks the heredoc delimiter. Use a unique timestamp-based delimiter instead.