### PR TITLE
fix: optimize keepalive and autofix workflow configuration

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -258,7 +258,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_run == 'true'
     name: Run Codex autofix
-    uses: ./.github/workflows/reusable-codex-run.yml
+    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -158,14 +158,14 @@ jobs:
     name: Keepalive next task
     needs:
       - evaluate
+      - preflight
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
-      # TEMP: Run even when gate fails, for testing auth
-      skip: ${{ needs.evaluate.outputs.has_agent_label != 'true' }}
+      skip: ${{ needs.evaluate.outputs.action != 'run' }}
       prompt_file: .github/codex/prompts/keepalive_next_task.md
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}


### PR DESCRIPTION
## Summary

Cleanup and optimization of keepalive and autofix workflows now that Codex CLI is working.

## Changes

### agents-keepalive-loop.yml
- **Remove TEMP skip condition**: Was using `has_agent_label != 'true'` to bypass gate check for testing
- **Use proper skip logic**: Now uses `action != 'run'` which respects the full keepalive evaluation (gate success, agent label, iterations, etc.)
- **Add preflight dependency**: run-codex job now depends on preflight to ensure secrets are verified before calling Codex

### agents-autofix-loop.yml  
- **Use full repo path**: Changed from `./.github/workflows/reusable-codex-run.yml` to `stranske/Workflows/.github/workflows/reusable-codex-run.yml@main` for consistency with keepalive

## Testing

The workflows have been tested with the Codex CLI running successfully using ChatGPT auth tokens.