### PR TITLE
fix: use UUID for output delimiter to avoid collisions

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -255,9 +255,10 @@ jobs:
 
           echo "Codex completed. Output written to $OUTPUT_FILE"
 
-          # Set output for downstream steps using a unique delimiter
+          # Set output for downstream steps using a unique random delimiter (UUID)
+          # Using UUID instead of timestamp to avoid collisions with Codex output content
           if [ -f "$OUTPUT_FILE" ]; then
-            delimiter="CODEX_OUTPUT_$(date +%s)"
+            delimiter="CODEX_$(uuidgen | tr -d '-')"
             {
               echo "final-message<<${delimiter}"
               cat "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
The timestamp-based delimiter (`CODEX_OUTPUT_1766597804`) appeared in Codex output content, breaking heredoc parsing:

```
##[error]Invalid value. Matching delimiter not found 'CODEX_OUTPUT_1766597804'
```

## Fix
Use UUID instead of timestamp for the delimiter:
- `CODEX_$(uuidgen | tr -d '-')` generates a truly random 32-char hex string
- UUIDs won't appear in Codex output content

## Testing
Wait for Gate to pass, then merge to fix PR #103 Keepalive runs.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Context / problem:
- [ ] - The Automated Status Summary in PR bodies currently only shows workflow run results
- [ ] - When the CLI-based Codex (via `reusable-codex-run.yml`) completes iterations, there's no visibility into:
- [ ] - What tasks Codex completed in each round
- [ ] - The final message/output from Codex
- [ ] - How many files were changed
- [ ] - Whether commits were pushed successfully
- [ ] - This makes it hard to track CLI Codex progress vs the UI version
- [ ] - The keepalive loop evaluation outputs (iteration count, tasks remaining, etc.) are logged but not surfaced to the PR summary
- [ ] Goal:
- [ ] - Capture CLI Codex outputs and integrate them into the Automated Status Summary
- [ ] - Provide visibility into Codex iteration progress and outcomes
- [ ] - Show what changed in each round

#### Tasks
- [ ] Update `reusable-codex-run.yml` to emit structured outputs:
- [ ] Add output for `final-message` from Codex action
- [ ] Add output for `files-changed` (count of modified files)
- [ ] Add output for `commits-pushed` (boolean)
- [ ] Write iteration summary to GITHUB_STEP_SUMMARY
- [ ] Create new section in PR body for CLI Codex status:
- [ ] Add `<!-- codex-cli-status:start -->` / `<!-- codex-cli-status:end -->` markers
- [ ] Show last iteration number and outcome
- [ ] Show tasks completed this round
- [ ] Show link to workflow run logs
- [ ] Update `agents_pr_meta_update_body.js` to populate the new section:
- [ ] Fetch latest keepalive loop run results
- [ ] Extract Codex outputs from workflow artifacts or step summaries
- [ ] Format and insert into PR body
- [ ] Update `keepalive_loop.js` to pass iteration context to the summary:
- [ ] Include current iteration number in output
- [ ] Include tasks remaining count
- [ ] Include estimated rounds to completion
- [ ] Add tests for the new integration:
- [ ] Test output extraction from workflow runs
- [ ] Test PR body section formatting
- [ ] Test edge cases (no Codex runs, failed runs, etc.)

#### Acceptance criteria
- [ ] CLI Codex iterations are visible in the PR body Automated Status Summary
- [ ] Each iteration shows: round number, tasks attempted, outcome, and link to logs
- [ ] The summary updates automatically after each keepalive loop run
- [ ] Existing UI Codex tracking (if any) continues to work
- [ ] **Head SHA:** b0fe5bd6fd7c36b4f3878633bf0588f123091447
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491255255) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050781) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050772) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050778) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050751) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050742) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050750) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050739) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050763) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491050745) |

**Head SHA:** bbfc648b4d978490220fc1a30a4632661627ef93
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491259015) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163144) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163813) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163150) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163160) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163125) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163109) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163126) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163121) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163111) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491163122) |
<!-- auto-status-summary:end -->