### PR TITLE
fix(codex): use base64 encoding to avoid heredoc delimiter collision

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -57,7 +57,7 @@ on:
         required: false
     outputs:
       final-message:
-        description: 'Full Codex output message'
+        description: 'Full Codex output message (base64 encoded)'
         value: ${{ jobs.codex.outputs.final-message }}
       final-message-summary:
         description: 'First 500 chars of Codex output (safe for PR comments)'
@@ -288,13 +288,9 @@ jobs:
 
           # Set outputs for downstream steps
           if [ -f "$OUTPUT_FILE" ]; then
-            # Full message with safe delimiter (UUID)
-            delimiter="CODEX_$(uuidgen | tr -d '-')"
-            {
-              echo "final-message<<${delimiter}"
-              cat "$OUTPUT_FILE"
-              echo "${delimiter}"
-            } >> "$GITHUB_OUTPUT"
+            # Base64 encode full message to avoid heredoc delimiter issues
+            encoded=$(base64 -w 0 "$OUTPUT_FILE")
+            echo "final-message=${encoded}" >> "$GITHUB_OUTPUT"
 
             # Summary (first 500 chars, safe for PR comments)
             summary=$(head -c 500 "$OUTPUT_FILE" | tr '\n' ' ' | sed 's/"/\\"/g')


### PR DESCRIPTION
## Summary
This fixes a critical issue where Codex CLI output was failing to be captured due to heredoc delimiter collisions.

## Problem
The heredoc delimiter approach (both timestamp and UUID based) was failing with:
```
##[error]Invalid value. Matching delimiter not found 'CODEX_...'
```

The Codex output can contain patterns that match any delimiter we generate, causing GitHub Actions output parsing to fail.

## Solution
Base64 encode the full Codex output. This guarantees:
- No delimiter collision is possible (base64 output is alphanumeric + /+=)
- Single-line output (no heredoc needed)
- Deterministic parsing

The `final-message-summary` output remains plain text for direct display in PR comments.

## Testing
This fixes the failing Keepalive runs on PR #103 where Codex was running successfully (exit code 0) but the job was failing at the output capture step.

Refs: #103

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Context / problem:
- [ ] - The Automated Status Summary in PR bodies currently only shows workflow run results
- [ ] - When the CLI-based Codex (via `reusable-codex-run.yml`) completes iterations, there's no visibility into:
- [ ] - What tasks Codex completed in each round
- [ ] - The final message/output from Codex
- [ ] - How many files were changed
- [ ] - Whether commits were pushed successfully
- [ ] - This makes it hard to track CLI Codex progress vs the UI version
- [ ] - The keepalive loop evaluation outputs (iteration count, tasks remaining, etc.) are logged but not surfaced to the PR summary
- [ ] Goal:
- [ ] - Capture CLI Codex outputs and integrate them into the Automated Status Summary
- [ ] - Provide visibility into Codex iteration progress and outcomes
- [ ] - Show what changed in each round

#### Tasks
- [ ] Update `reusable-codex-run.yml` to emit structured outputs:
- [ ] Add output for `final-message` from Codex action
- [ ] Add output for `files-changed` (count of modified files)
- [ ] Add output for `commits-pushed` (boolean)
- [ ] Write iteration summary to GITHUB_STEP_SUMMARY
- [ ] Create new section in PR body for CLI Codex status:
- [ ] Add `<!-- codex-cli-status:start -->` / `<!-- codex-cli-status:end -->` markers
- [ ] Show last iteration number and outcome
- [ ] Show tasks completed this round
- [ ] Show link to workflow run logs
- [ ] Update `agents_pr_meta_update_body.js` to populate the new section:
- [ ] Fetch latest keepalive loop run results
- [ ] Extract Codex outputs from workflow artifacts or step summaries
- [ ] Format and insert into PR body
- [ ] Update `keepalive_loop.js` to pass iteration context to the summary:
- [ ] Include current iteration number in output
- [ ] Include tasks remaining count
- [ ] Include estimated rounds to completion
- [ ] Add tests for the new integration:
- [ ] Test output extraction from workflow runs
- [ ] Test PR body section formatting
- [ ] Test edge cases (no Codex runs, failed runs, etc.)

#### Acceptance criteria
- [ ] CLI Codex iterations are visible in the PR body Automated Status Summary
- [ ] Each iteration shows: round number, tasks attempted, outcome, and link to logs
- [ ] The summary updates automatically after each keepalive loop run
- [ ] Existing UI Codex tracking (if any) continues to work
- [ ] **Head SHA:** 9433378610956f7a7e90434ac481e0835252c239
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491670525) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491992) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491987) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491974) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491953) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491520133) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491969) |
- [ ] | Maint 52 Validate Workflows | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20491491958) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491972) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491491966) |

**Head SHA:** 80623c2d48509d38a31f1d808c39deea7e0e4d2b
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491671531) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639192) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639441) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639200) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639181) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639133) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639130) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639126) |
| Maint 52 Validate Workflows | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20491639151) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639140) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491639129) |
<!-- auto-status-summary:end -->