### PR TITLE
fix(codex): checkout and push to PR branch instead of main

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -292,6 +292,7 @@ async function evaluateKeepaliveLoop({ github, context, core }) {
 
   return {
     prNumber,
+    prRef: pr.head.ref || '',
     action,
     reason,
     gateConclusion,

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -24,6 +24,7 @@ jobs:
     environment: agent-standard
     outputs:
       pr_number: ${{ steps.evaluate.outputs.pr_number }}
+      pr_ref: ${{ steps.evaluate.outputs.pr_ref }}
       action: ${{ steps.evaluate.outputs.action }}
       reason: ${{ steps.evaluate.outputs.reason }}
       gate_conclusion: ${{ steps.evaluate.outputs.gate_conclusion }}
@@ -103,6 +104,7 @@ jobs:
             const result = await evaluateKeepaliveLoop({ github, context, core });
             const output = {
               pr_number: String(result.prNumber || ''),
+              pr_ref: String(result.prRef || ''),
               action: result.action || '',
               reason: result.reason || '',
               gate_conclusion: result.gateConclusion || '',
@@ -169,6 +171,7 @@ jobs:
       prompt_file: .github/codex/prompts/keepalive_next_task.md
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}
+      pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
 
   summary:
     name: Update keepalive summary

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: ''
         type: string
+      pr_ref:
+        description: 'The branch/ref to checkout and push to (e.g., refs/heads/feature-branch).'
+        required: false
+        default: ''
+        type: string
       max_runtime_minutes:
         description: 'Upper bound for the job runtime in minutes.'
         required: false
@@ -138,6 +143,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.pr_ref || github.ref }}
           token: ${{ steps.auth_token.outputs.checkout_token }}
 
       - name: Set up Python
@@ -308,12 +314,19 @@ jobs:
         env:
           MODE: ${{ inputs.mode }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          PR_REF: ${{ inputs.pr_ref }}
           PUSH_ALLOWED: ${{ steps.auth_token.outputs.push_allowed }}
           PUSH_TOKEN: ${{ steps.auth_token.outputs.push_token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Determine the target branch
+          TARGET_REF="${PR_REF:-${{ github.ref_name }}}"
+          # Strip refs/heads/ prefix if present
+          TARGET_BRANCH="${TARGET_REF#refs/heads/}"
+          echo "Target branch: ${TARGET_BRANCH}"
 
           # Count changed files
           CHANGED_FILES=$(git status --porcelain | wc -l)
@@ -347,7 +360,7 @@ jobs:
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "commit-sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
 
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${{ github.ref_name }}"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${TARGET_BRANCH}"
 
           echo "::notice::Pushed commit ${COMMIT_SHA} with ${CHANGED_FILES} file(s) changed"
 


### PR DESCRIPTION
## Summary
Fixes the critical issue where Codex changes were being pushed to `main` instead of the PR branch.

## Problem
When the Keepalive loop runs Codex via `workflow_run` trigger:
1. `github.ref` is `refs/heads/main` (the branch of the completed workflow)
2. The reusable workflow checked out and pushed to `main`
3. This fails with GH013 repository rule violations (main is protected)

## Solution
- Added `pr_ref` input to `reusable-codex-run.yml`
- Updated checkout to use `pr_ref` if provided
- Updated push to target the correct branch (PR branch, not main)
- Updated `keepalive_loop.js` to return `prRef` from PR data
- Updated `agents-keepalive-loop.yml` to pass `pr_ref` to the Codex workflow

## Testing
This will fix the failing Keepalive runs on PR #103 where Codex was making changes but failing to push them.

Refs: #103

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Context / problem:
- [ ] - The Automated Status Summary in PR bodies currently only shows workflow run results
- [ ] - When the CLI-based Codex (via `reusable-codex-run.yml`) completes iterations, there's no visibility into:
- [ ] - What tasks Codex completed in each round
- [ ] - The final message/output from Codex
- [ ] - How many files were changed
- [ ] - Whether commits were pushed successfully
- [ ] - This makes it hard to track CLI Codex progress vs the UI version
- [ ] - The keepalive loop evaluation outputs (iteration count, tasks remaining, etc.) are logged but not surfaced to the PR summary
- [ ] Goal:
- [ ] - Capture CLI Codex outputs and integrate them into the Automated Status Summary
- [ ] - Provide visibility into Codex iteration progress and outcomes
- [ ] - Show what changed in each round

#### Tasks
- [ ] Update `reusable-codex-run.yml` to emit structured outputs:
- [ ] Add output for `final-message` from Codex action
- [ ] Add output for `files-changed` (count of modified files)
- [ ] Add output for `commits-pushed` (boolean)
- [ ] Write iteration summary to GITHUB_STEP_SUMMARY
- [ ] Create new section in PR body for CLI Codex status:
- [ ] Add `<!-- codex-cli-status:start -->` / `<!-- codex-cli-status:end -->` markers
- [ ] Show last iteration number and outcome
- [ ] Show tasks completed this round
- [ ] Show link to workflow run logs
- [ ] Update `agents_pr_meta_update_body.js` to populate the new section:
- [ ] Fetch latest keepalive loop run results
- [ ] Extract Codex outputs from workflow artifacts or step summaries
- [ ] Format and insert into PR body
- [ ] Update `keepalive_loop.js` to pass iteration context to the summary:
- [ ] Include current iteration number in output
- [ ] Include tasks remaining count
- [ ] Include estimated rounds to completion
- [ ] Add tests for the new integration:
- [ ] Test output extraction from workflow runs
- [ ] Test PR body section formatting
- [ ] Test edge cases (no Codex runs, failed runs, etc.)

#### Acceptance criteria
- [ ] CLI Codex iterations are visible in the PR body Automated Status Summary
- [ ] Each iteration shows: round number, tasks attempted, outcome, and link to logs
- [ ] The summary updates automatically after each keepalive loop run
- [ ] Existing UI Codex tracking (if any) continues to work
- [ ] **Head SHA:** 2fc73617bb8fe40ae90830f27c7b4ed09ed39d84
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491866741) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836975) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836986) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836949) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836974) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836953) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836945) |
- [ ] | Maint 52 Validate Workflows | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20491836954) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836982) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491836948) |

**Head SHA:** ce6ef18842663cc8bc2d1af1554596bba7cdbbb4
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491868581) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843311) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20491843727) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843315) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843310) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843287) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843294) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843285) |
| Maint 52 Validate Workflows | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20491843283) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843292) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20491843281) |
<!-- auto-status-summary:end -->