### PR TITLE
fix: complete truncated updateKeepaliveLoopSummary script

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -317,3 +317,5 @@ jobs:
               agent_commit_sha: '${{ needs.run-codex.outputs.commit-sha }}',
               agent_files_changed: '${{ needs.run-codex.outputs.files-changed }}',
               agent_summary: process.env.CODEX_SUMMARY || '',
+            };
+            await updateKeepaliveLoopSummary({ github, context, core, inputs });


### PR DESCRIPTION
## Summary

The `Update summary comment` step in `agents-keepalive-loop.yml` was truncated, missing:
- The closing `};` for the `inputs` object  
- The `await updateKeepaliveLoopSummary({ github, context, core, inputs });` function call

This caused a `SyntaxError: Unexpected token ')'` when the workflow ran, which is why PR #124's keepalive loop failed.

## Evidence

From the workflow logs:
```
Update keepalive summary  2025-12-24T20:08:45.2193593Z SyntaxError: Unexpected token ')'
Update keepalive summary  2025-12-24T20:08:45.2235872Z ##[error]Unhandled error: SyntaxError: Unexpected token ')'
```

## Fix

Added the missing 2 lines to complete the JavaScript code block:
```javascript
            };
            await updateKeepaliveLoopSummary({ github, context, core, inputs });
```

## Testing

- Verified locally that the parser correctly identifies 33 checkboxes in PR #124's body
- Once merged, PR #124's keepalive loop should function correctly

Closes #124's blocking issue.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] After merging PR #103 (multi-agent routing infrastructure), we need to:
- [ ] 1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
- [ ] 2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
- [ ] 3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
- [ ] 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

#### Tasks
- [ ] ### Pipeline Validation
- [ ] After PR #103 merges, create a test PR with `agent:codex` label
- [ ] Verify task appendix appears in Codex prompt (check workflow logs)
- [ ] Verify Codex works on actual tasks (not random infrastructure work)
- [ ] Verify keepalive comment updates with iteration progress
- [ ] ### GITHUB_STEP_SUMMARY
- [ ] Add step summary output to `agents-keepalive-loop.yml` after agent run
- [ ] Include: iteration number, tasks completed, files changed, outcome
- [ ] Ensure summary is visible in workflow run UI
- [ ] ### Conditional Status Summary
- [ ] Modify `buildStatusBlock()` in `agents_pr_meta_update_body.js` to accept `agentType` parameter
- [ ] When `agentType` is set (CLI agent): hide workflow table, hide head SHA/required checks
- [ ] Keep Scope/Tasks/Acceptance checkboxes for all cases
- [ ] Pass agent type from workflow to the update_body job
- [ ] ### Comment Pattern Cleanup
- [ ] **For CLI agents (`agent:*` label):**
- [ ] Suppress `<!-- gate-summary: -->` comment posting (use step summary instead)
- [ ] Suppress `<!-- keepalive-round: N -->` instruction comments (task appendix replaces this)
- [ ] Update `<!-- keepalive-loop-summary -->` to be the **single source of truth**
- [ ] Ensure state marker is embedded in the summary comment (not separate)
- [ ] **For UI Codex (no `agent:*` label):**
- [ ] Keep existing comment patterns (instruction comments, connector bot reports)
- [ ] Keep `<!-- gate-summary: -->` comment
- [ ] Add `agent_type` output to detect job so downstream workflows know the mode
- [ ] Update `agents-pr-meta.yml` to conditionally skip gate summary for CLI agent PRs

#### Acceptance criteria
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] Iteration results visible in Actions workflow run summary
- [ ] PR body shows checkboxes but not workflow clutter when using CLI agents
- [ ] UI Codex path (no agent label) continues to show full status summary
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] State tracking is consolidated in the summary comment, not scattered
- [ ] ## Dependencies
- [ ] - Requires PR #103 to be merged first
- [ ] **Head SHA:** b665a4a7941de82643d86b7a09788bd839518c18
- [ ] **Latest Runs:** ❔ in progress — Agents PR meta manager
- [ ] **Required:** gate: ⏸️ not started
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493389291) |
- [ ] | CI Autofix Loop | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/20493154058) |
- [ ] | Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493154433) |
- [ ] | Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/20493154055) |

**Head SHA:** 04f263dd21750ff5d037f733b8195b40ffcd81b9
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493392161) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337036) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337289) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337037) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337048) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337030) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337010) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337008) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337028) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337035) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493337021) |
<!-- auto-status-summary:end -->