### PR TITLE
feat(keepalive): show 'running' status when agent is actively working

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -165,6 +165,37 @@ jobs:
     steps:
       - run: echo "Test job ran! Action was ${{ needs.evaluate.outputs.action }}, agent=${{ needs.evaluate.outputs.agent_type }}"
 
+  # Mark agent as running before starting the actual work
+  # This provides real-time visibility that the agent is actively engaged
+  mark-running:
+    name: Mark agent running
+    needs:
+      - evaluate
+      - preflight
+    if: needs.evaluate.outputs.action == 'run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update summary with running status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { markAgentRunning } = require('./.github/scripts/keepalive_loop.js');
+            const inputs = {
+              pr_number: '${{ needs.evaluate.outputs.pr_number }}',
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              iteration: '${{ needs.evaluate.outputs.iteration }}',
+              max_iterations: '${{ needs.evaluate.outputs.max_iterations }}',
+              tasks_total: '${{ needs.evaluate.outputs.tasks_total }}',
+              tasks_unchecked: '${{ needs.evaluate.outputs.tasks_unchecked }}',
+              trace: '${{ needs.evaluate.outputs.trace }}',
+              run_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            };
+            await markAgentRunning({ github, context, core, inputs });
+
   # Route to appropriate agent based on agent:* label
   # Currently supports: agent:codex -> CLI Codex
   # Future: agent:claude, agent:gemini, etc. will have their own jobs
@@ -173,6 +204,7 @@ jobs:
     needs:
       - evaluate
       - preflight
+      - mark-running
     # Only run for agent:codex label
     if: needs.evaluate.outputs.agent_type == 'codex'
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main


### PR DESCRIPTION
## Summary

Adds real-time visibility to the keepalive loop by showing when an agent is actively working.

## Changes

- **keepalive_loop.js**: Added `markAgentRunning()` function that updates the summary comment to show "🔄 Agent Running" status
- **agents-keepalive-loop.yml**: Added new `mark-running` job that executes before `run-codex` to mark the agent as active
- **keepalive-loop.test.js**: Added 2 tests for the new function

## What this solves

Previously, when looking at a PR like #124, it was hard to tell whether Codex CLI was actively working or not. The keepalive-loop-summary comment only updated **after** each iteration completed.

Now, **before** the agent starts running:
1. The summary comment is updated to show "🔄 Agent Running"
2. It shows which iteration is starting
3. It includes a link to the current workflow run logs
4. It shows "This comment will be updated when the agent completes"

## Example output

When agent is running:
```
## 🤖 Keepalive Loop Status

**PR #124** | Agent: **Codex** | Iteration **2/5**

### 🔄 Agent Running

**Codex is actively working on this PR** ([view logs](https://...))

| Status | Value |
|--------|-------|
| Agent | Codex |
| Iteration | 2 of 5 |
| Tasks remaining | 30/33 |
| Started | 2024-12-24 20:58:00 UTC |

_This comment will be updated when the agent completes._
```

## Testing

- All 206 tests pass including 2 new tests for `markAgentRunning()`

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] After merging PR #103 (multi-agent routing infrastructure), we need to:
- [ ] 1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
- [ ] 2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
- [ ] 3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
- [ ] 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

#### Tasks
- [ ] ### Pipeline Validation
- [ ] After PR #103 merges, create a test PR with `agent:codex` label
- [ ] Verify task appendix appears in Codex prompt (check workflow logs)
- [ ] Verify Codex works on actual tasks (not random infrastructure work)
- [ ] Verify keepalive comment updates with iteration progress
- [ ] ### GITHUB_STEP_SUMMARY
- [ ] Add step summary output to `agents-keepalive-loop.yml` after agent run
- [ ] Include: iteration number, tasks completed, files changed, outcome
- [ ] Ensure summary is visible in workflow run UI
- [ ] ### Conditional Status Summary
- [ ] Modify `buildStatusBlock()` in `agents_pr_meta_update_body.js` to accept `agentType` parameter
- [ ] When `agentType` is set (CLI agent): hide workflow table, hide head SHA/required checks
- [ ] Keep Scope/Tasks/Acceptance checkboxes for all cases
- [ ] Pass agent type from workflow to the update_body job
- [ ] ### Comment Pattern Cleanup
- [ ] **For CLI agents (`agent:*` label):**
- [ ] Suppress `<!-- gate-summary: -->` comment posting (use step summary instead)
- [ ] Suppress `<!-- keepalive-round: N -->` instruction comments (task appendix replaces this)
- [ ] Update `<!-- keepalive-loop-summary -->` to be the **single source of truth**
- [ ] Ensure state marker is embedded in the summary comment (not separate)
- [ ] **For UI Codex (no `agent:*` label):**
- [ ] Keep existing comment patterns (instruction comments, connector bot reports)
- [ ] Keep `<!-- gate-summary: -->` comment
- [ ] Add `agent_type` output to detect job so downstream workflows know the mode
- [ ] Update `agents-pr-meta.yml` to conditionally skip gate summary for CLI agent PRs

#### Acceptance criteria
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] Iteration results visible in Actions workflow run summary
- [ ] PR body shows checkboxes but not workflow clutter when using CLI agents
- [ ] UI Codex path (no agent label) continues to show full status summary
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] State tracking is consolidated in the summary comment, not scattered
- [ ] ## Dependencies
- [ ] - Requires PR #103 to be merged first
- [ ] **Head SHA:** 4c8f371c38b094b506726ea761387ec1a2071876
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493777647) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711580) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711578) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711568) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711540) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711541) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711532) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711524) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711563) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493711521) |

**Head SHA:** 190941c4a87e9dfcb9f3cd0214337068327000b3
**Latest Runs:** ⏳ queued — Gate
**Required:** gate: ⏳ queued

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778026) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493778037) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20493778299) |
| Gate | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20493778045) |
| Health 40 Sweep | ⏳ queued | [View run](https://github.com/stranske/Workflows/actions/runs/20493778059) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778021) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20493778024) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778032) |
| Maint 52 Validate Workflows | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778014) |
| PR 11 - Minimal invariant CI | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778017) |
| Selftest CI | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20493778036) |
<!-- auto-status-summary:end -->