### PR TITLE
fix(verifier): remove invalid --mode argument from codex-args

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -82,7 +82,6 @@ jobs:
           output-file: codex-output.md
           sandbox: read-only
           safety-strategy: drop-sudo
-          codex-args: --mode verifier
 
       - name: Parse verifier verdict
         id: verdict


### PR DESCRIPTION
## Problem

The Agents Verifier workflow has been failing on all PRs with:

```
error: unexpected argument '--mode' found

  tip: a similar argument exists: '--model'

Usage: codex exec --skip-git-repo-check --cd <DIR> --output-last-message <FILE> --model <MODEL> [PROMPT]
```

## Root Cause

The workflow used `codex-args: --mode verifier` but the codex CLI doesn't have a `--mode` argument.

## Solution

Removed the invalid `codex-args` line. The verifier behavior is controlled by the prompt file content, not a CLI mode flag.

## Testing

The workflow should now run without argument errors.