### PR TITLE
fix: agents-weekly-metrics uses env vars not CLI args

### DIFF
--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -41,8 +41,11 @@ jobs:
           done
 
       - name: Aggregate metrics
+        env:
+          METRICS_DIR: artifacts
+          OUTPUT_PATH: agent-weekly-metrics.md
         run: |
-          python scripts/aggregate_agent_metrics.py --artifacts-dir artifacts --output agent-weekly-metrics.md
+          python scripts/aggregate_agent_metrics.py
 
       - name: Upload weekly summary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `aggregate_agent_metrics.py` script uses environment variables (`METRICS_DIR`, `OUTPUT_PATH`), not CLI arguments. The workflow was calling it with `--artifacts-dir` and `--output` which don't exist.

Found while evaluating PR #104 (now closed as redundant).

## Changes
- Changed workflow step from CLI args to env vars

## Testing
- Local validation passes
- Script correctly reads `METRICS_DIR` and `OUTPUT_PATH` from environment

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** e64a3239f324604eafc8e9ef27a822864040bd52
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20500678059) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645647) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500646026) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645651) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645649) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645625) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645645) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645636) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645629) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645635) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500645621) |
<!-- auto-status-summary:end -->