### PR TITLE
fix: use direct codex exec instead of codex-action

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -168,18 +168,23 @@ jobs:
           set -euo pipefail
           # Run codex exec directly with the pre-configured auth.json
           # Use read-only sandbox for safety
+          # Capture the exit code so we can still process outputs before exiting.
+          set +e
           codex exec \
             --sandbox read-only \
             --skip-git-repo-check \
             --output-last-message codex-output.md \
             < "${{ steps.prepare.outputs.prompt_file }}"
+          codex_exit_code=$?
+          set -euo pipefail
 
-          echo "Codex verifier completed"
+          echo "Codex verifier completed (exit code: ${codex_exit_code})"
           if [ -f codex-output.md ]; then
             echo "=== Verifier Output ==="
             cat codex-output.md
           fi
 
+          exit "${codex_exit_code}"
       - name: Parse verifier verdict
         id: verdict
         if: steps.context.outputs.should_run == 'true'


### PR DESCRIPTION
## Problem

The `openai/codex-action` requires an API key to start its proxy server, which writes server info to a JSON file at `CODEX_HOME/<run_id>.json`. When using pre-configured `auth.json` from `CODEX_AUTH_JSON` secret (ChatGPT Pro subscription), the proxy never starts and codex-action fails with:

```
Error reading server info: Error: ENOENT: no such file or directory, open '/home/runner/work/_temp/.codex-verifier/20500473372.json'
```

## Solution

Instead of using the action, directly call `codex exec`:
- Install `@openai/codex` CLI via npm
- Call `codex exec` directly with the pre-configured auth
- Use `--sandbox read-only` for safety
- Use `--skip-git-repo-check` since we're running in CI
- Read prompt from file and write output to file

## Testing
- The workflow will be tested when this PR is merged
- Local validation passes