### PR TITLE
fix: pass prompt as positional arg to codex exec

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -166,15 +166,18 @@ jobs:
           CODEX_HOME: ${{ runner.temp }}/.codex-verifier
         run: |
           set -euo pipefail
+          PROMPT_FILE="${{ steps.prepare.outputs.prompt_file }}"
+
           # Run codex exec directly with the pre-configured auth.json
           # Use read-only sandbox for safety
+          # Pass prompt as positional argument (codex exec expects this, not stdin)
           # Capture the exit code so we can still process outputs before exiting.
           set +e
           codex exec \
             --sandbox read-only \
             --skip-git-repo-check \
             --output-last-message codex-output.md \
-            < "${{ steps.prepare.outputs.prompt_file }}"
+            "$(cat "$PROMPT_FILE")"
           codex_exit_code=$?
           set -euo pipefail
 


### PR DESCRIPTION
## Problem

The previous fix (#135) used stdin redirection to pass the prompt to `codex exec`:
```bash
codex exec ... < "$PROMPT_FILE"
```

However, the Codex CLI expects the prompt as a **positional argument**, not via stdin. This causes the CLI to exit with a usage error and never write `codex-output.md`.

## Solution

Changed to pass the prompt as a positional argument, matching the working pattern in `reusable-codex-run.yml`:
```bash
codex exec ... "$(cat "$PROMPT_FILE")"
```

## Reference
See [reusable-codex-run.yml lines 329-335](https://github.com/stranske/Workflows/blob/main/.github/workflows/reusable-codex-run.yml#L329-L335)

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 92068c53837329c2322fd7eb6d8adc3c521cb11e
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20500821779) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801202) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801498) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801223) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801227) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801207) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801214) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801206) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801194) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801197) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20500801199) |
<!-- auto-status-summary:end -->