### PR TITLE
fix(autofix): persist credentials when can_push is true

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -241,7 +241,7 @@ jobs:
           ref: ${{ env.PR_HEAD_REF || github.ref }}
           fetch-depth: 0
           token: ${{ env.AUTOFIX_TOKEN || github.token }}
-          persist-credentials: ${{ env.AUTOFIX_AUTH_MODE == 'pat' }}
+          persist-credentials: ${{ env.AUTOFIX_CAN_PUSH == 'true' }}
       - name: Guard against loops (Issue #1347)
         id: guard
         shell: bash


### PR DESCRIPTION
## Problem

After PR #138 enabled app-token pushes for same-repo PRs, autofix was failing with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Root Cause

The checkout step was only persisting git credentials when `AUTOFIX_AUTH_MODE == 'pat'`, but now that we support app-token pushes for same-repo PRs (mode='app'), we need credentials persisted for those too.

## Fix

Change the `persist-credentials` condition from checking auth mode to checking the new `AUTOFIX_CAN_PUSH` flag, which is set to true for both PAT and App modes in same-repo scenarios.

## Testing

This will be validated when re-running autofix on PR #137.

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Scope section missing from source issue.

#### Tasks
- [ ] Tasks section missing from source issue.

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.
- [ ] **Head SHA:** 075ef0e9e7e78618f14b74066942b87fc8722c5b
- [ ] **Latest Runs:** ❔ in progress — Gate
- [ ] **Required:** gate: ❔ in progress
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20501339268) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324089) |
- [ ] | Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20501324105) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324116) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324090) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324119) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324095) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324108) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324112) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501324110) |

**Head SHA:** 2bc736ae43308163ea6e86bdb9300e35ccbd8157
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20501398307) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383332) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383687) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20501383337) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383336) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383331) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383335) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383323) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383330) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383334) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20501383343) |
<!-- auto-status-summary:end -->