### PR TITLE
fix(verifier): wait for CI workflows to complete before verification

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -46,7 +46,7 @@ jobs:
 
             const ciWorkflows = [
               'selftest-ci.yml',
-              'pr-11-selftest-invariant.yml',
+              'pr-11-ci-smoke.yml',
             ];
 
             const maxWaitMs = 5 * 60 * 1000; // 5 minutes max wait


### PR DESCRIPTION
## Problem

The verifier workflow was racing against CI workflows, seeing `in_progress` status instead of completed results. This caused Issue #162 - a false negative where the verifier marked 'Selftest CI passes' as NOT MET because CI hadn't finished yet.

**Evidence from #162:**
```
| Workflow | Conclusion | Run |
| --- | --- | --- |
| Gate | success | ... |
| Selftest CI | in_progress | ... |
| PR 11 - Minimal invariant CI | in_progress | ... |
```

The verifier correctly followed its instructions ('mark NOT MET when CI results are missing/incomplete') but ran before CI completed.

## Solution

Add a 'Wait for CI workflows to complete' step that polls for CI workflow completion (up to 5 minutes) before building the verifier context. This ensures CI results are available when the verifier checks acceptance criteria.

## Acceptance Criteria

- [x] Verifier waits for Selftest CI and PR 11 CI to complete before checking results
- [x] Timeout prevents infinite waiting (5 minute max)
- [x] Graceful handling if CI runs aren't found

Closes #162

<!-- pr-preamble:start -->
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] <!-- Updated scope for this follow-up -->
- [ ] Address unmet acceptance criteria from PR #161.
- [ ] Original scope:
- [ ] The post-merge verifier (agents-verifier.yml) currently runs tests locally in a read-only sandbox to verify acceptance criteria. This approach has critical flaws exposed by PR #154:
- [ ] 1. **Stale State**: Verifier may run against incomplete merge state, causing false test failures
- [ ] 2. **No CI Access**: Cannot verify "Selftest CI passes" criterion - always marks as NOT MET
- [ ] 3. **Duplicate Work**: Re-runs tests that CI already validated, wasting compute
- [ ] 4. **False Negatives**: PR #154 created Issue #155 claiming 4 test suites failed when all 301 tests actually pass
- [ ] ### Evidence from Issue #155
- [ ] The verifier incorrectly reported:
- [ ] - `agents-verifier-context.test.js` failing (unrelated to PR scope)
- [ ] - `comment-dedupe.test.js` failing (unrelated to PR scope)
- [ ] - `coverage-normalize.test.js` failing (unrelated to PR scope)
- [ ] - `maint-post-ci.test.js` failing (unrelated to PR scope)
- [ ] Reality: All tests pass. The verifier created a bogus follow-up issue that would have caused duplicate work.

#### Tasks
- [ ] <!-- New tasks to address unmet acceptance criteria -->
- [ ] Satisfy: "Selftest CI passes" criterion can be verified as PASS when CI actually passed

#### Acceptance criteria
- [ ] <!-- Criteria verified as unmet by verifier -->
- [ ] "Selftest CI passes" criterion can be verified as PASS when CI actually passed

**Head SHA:** 3008bc008c332653bb57699fdc6fccd88c4c2783
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20515760175) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715994) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715982) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515716009) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715958) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715952) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715961) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715956) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715954) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20515715971) |
<!-- auto-status-summary:end -->