### PR TITLE
feat: Add issue templates to consumer repo sync

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -134,6 +134,12 @@ jobs:
             "prompts/keepalive_next_task.md"
           )
 
+          # Issue templates for agent automation
+          SYNC_ISSUE_TEMPLATES=(
+            "agent_task.yml"
+            "config.yml"
+          )
+
           changes=""
           sync_report=""
 
@@ -228,6 +234,24 @@ jobs:
             fi
           done
 
+          # Check issue templates
+          for template_file in "${SYNC_ISSUE_TEMPLATES[@]}"; do
+            source_file="workflows/templates/consumer-repo/.github/ISSUE_TEMPLATE/$template_file"
+            consumer_file="consumer/.github/ISSUE_TEMPLATE/$template_file"
+
+            if [ ! -f "$source_file" ]; then
+              continue
+            fi
+
+            if [ ! -f "$consumer_file" ]; then
+              changes="$changes ISSUE_TEMPLATE/$template_file"
+              sync_report="$sync_report\n- ISSUE_TEMPLATE/$template_file (missing)"
+            elif ! compare_files "$source_file" "$consumer_file" false; then
+              changes="$changes ISSUE_TEMPLATE/$template_file"
+              sync_report="$sync_report\n- ISSUE_TEMPLATE/$template_file (differs)"
+            fi
+          done
+
           if [ -n "$changes" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "changed_files=$changes" >> "$GITHUB_OUTPUT"
@@ -310,6 +334,22 @@ jobs:
           for codex_file in "${SYNC_CODEX_FILES[@]}"; do
             source="../workflows/templates/consumer-repo/.github/codex/$codex_file"
             target=".github/codex/$codex_file"
+
+            if [ -f "$source" ]; then
+              cp "$source" "$target"
+            fi
+          done
+
+          # Sync issue templates (for agent automation)
+          SYNC_ISSUE_TEMPLATES=(
+            "agent_task.yml"
+            "config.yml"
+          )
+
+          mkdir -p .github/ISSUE_TEMPLATE
+          for template_file in "${SYNC_ISSUE_TEMPLATES[@]}"; do
+            source="../workflows/templates/consumer-repo/.github/ISSUE_TEMPLATE/$template_file"
+            target=".github/ISSUE_TEMPLATE/$template_file"
 
             if [ -f "$source" ]; then
               cp "$source" "$target"

--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -59,11 +59,13 @@ Navigate to: **Settings** → **Secrets and variables** → **Actions** → **Se
 | `SERVICE_BOT_PAT` | PAT for stranske-automation-bot | Contact admin for token |
 | `ACTIONS_BOT_PAT` | PAT for workflow dispatch | Same as SERVICE_BOT_PAT or dedicated |
 | `OWNER_PR_PAT` | PAT for PR creation | Repository owner's PAT |
+| `CODEX_AUTH_JSON` | Codex CLI authentication | Export from `~/.codex/auth.json` |
 
 Add each secret:
 - [ ] `SERVICE_BOT_PAT` — Required for orchestrator and agent workflows
 - [ ] `ACTIONS_BOT_PAT` — Required for triggering workflows between repos
 - [ ] `OWNER_PR_PAT` — Required for creating PRs from agent bridge
+- [ ] `CODEX_AUTH_JSON` — Required for Codex CLI to authenticate with ChatGPT
 
 ### 2.2 Required Variables
 
@@ -178,7 +180,22 @@ These scripts MUST exist in `.github/scripts/`:
 
 - [ ] All 3 Python scripts present
 
-### 4.3 Required Templates
+### 4.3 Required Codex Prompts
+
+These files MUST exist in `.github/codex/` for the keepalive pipeline:
+
+| File | Purpose |
+|------|---------|
+| `AGENT_INSTRUCTIONS.md` | Security boundaries and operational guidelines for Codex |
+| `prompts/keepalive_next_task.md` | Prompt template for keepalive iterations |
+
+- [ ] `.github/codex/AGENT_INSTRUCTIONS.md` present
+- [ ] `.github/codex/prompts/keepalive_next_task.md` present
+
+> **Critical**: Without these files, the `reusable-codex-run.yml` workflow will
+> fail with "Base prompt file not found".
+
+### 4.4 Required Templates
 
 Templates MUST exist in `.github/templates/`:
 
@@ -327,6 +344,10 @@ inputs:
 
 ```
 .github/
+├── codex/
+│   ├── AGENT_INSTRUCTIONS.md
+│   └── prompts/
+│       └── keepalive_next_task.md
 ├── scripts/
 │   ├── decode_raw_input.py
 │   ├── fallback_split.py
@@ -351,6 +372,7 @@ inputs:
 - `SERVICE_BOT_PAT`
 - `ACTIONS_BOT_PAT`
 - `OWNER_PR_PAT`
+- `CODEX_AUTH_JSON`
 
 ### Required Variables
 

--- a/templates/consumer-repo/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/templates/consumer-repo/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,57 @@
+name: Agent Task
+description: Create a task for Codex to work on automatically
+title: "[Agent] "
+labels:
+  - agent:codex
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to create tasks that Codex will pick up automatically.
+
+        The `agent:codex` label triggers the agent pipeline which will:
+        1. Create a branch and PR from this issue
+        2. Have Codex work through the tasks iteratively
+        3. Run CI after each iteration until all tasks are complete
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What should be changed or implemented?
+      placeholder: |
+        Describe the work to be done. Be specific about files, functions, or features.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Break down the work into specific actionable items
+      placeholder: |
+        - [ ] Task 1
+        - [ ] Task 2
+        - [ ] Task 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know the work is complete?
+      placeholder: |
+        - [ ] All tests pass
+        - [ ] Feature works as described
+        - [ ] Documentation updated
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any extra information, constraints, or references
+      placeholder: |
+        Links, screenshots, or other context that helps understand the task.

--- a/templates/consumer-repo/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/consumer-repo/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Agent Workflow Guide
+    url: https://github.com/stranske/Workflows/blob/main/docs/ci/WORKFLOW_SYSTEM.md
+    about: Learn how the agent automation system works


### PR DESCRIPTION
## Summary

Adds GitHub issue templates to the consumer repo sync so that new repositories automatically get properly formatted issue templates for the agent pipeline.

## Changes

### Issue Templates Added
- `templates/consumer-repo/.github/ISSUE_TEMPLATE/agent_task.yml` - Form-based issue template with Scope, Tasks, and Acceptance Criteria sections
- `templates/consumer-repo/.github/ISSUE_TEMPLATE/config.yml` - Config with link to workflow docs

### Sync Workflow Updates
- Added `SYNC_ISSUE_TEMPLATES` array to maint-68-sync-consumer-repos.yml
- Added detection and apply logic for issue templates

### Documentation Updates
- Updated `docs/templates/SETUP_CHECKLIST.md`:
  - Added `.github/codex/` directory to minimum files list
  - Added Phase 4.3 for required codex prompts
  - Added `CODEX_AUTH_JSON` to required secrets

## Why

Consumer repos need issue templates so users can create properly formatted issues that feed into the agents-63-issue-intake workflow and keepalive pipeline. Without structured issue templates, issues may be missing required sections (Tasks, Acceptance Criteria) that the agent pipeline depends on.