### PR TITLE
feat: add AGENT_ISSUE_FORMAT.md doc to consumer repo sync

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -140,6 +140,11 @@ jobs:
             "config.yml"
           )
 
+          # Documentation files for agent pipeline
+          SYNC_DOCS=(
+            "AGENT_ISSUE_FORMAT.md"
+          )
+
           changes=""
           sync_report=""
 
@@ -252,6 +257,24 @@ jobs:
             fi
           done
 
+          # Check documentation files
+          for doc_file in "${SYNC_DOCS[@]}"; do
+            source_file="workflows/templates/consumer-repo/docs/$doc_file"
+            consumer_file="consumer/docs/$doc_file"
+
+            if [ ! -f "$source_file" ]; then
+              continue
+            fi
+
+            if [ ! -f "$consumer_file" ]; then
+              changes="$changes docs/$doc_file"
+              sync_report="$sync_report\n- docs/$doc_file (missing)"
+            elif ! compare_files "$source_file" "$consumer_file" false; then
+              changes="$changes docs/$doc_file"
+              sync_report="$sync_report\n- docs/$doc_file (differs)"
+            fi
+          done
+
           if [ -n "$changes" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "changed_files=$changes" >> "$GITHUB_OUTPUT"
@@ -350,6 +373,21 @@ jobs:
           for template_file in "${SYNC_ISSUE_TEMPLATES[@]}"; do
             source="../workflows/templates/consumer-repo/.github/ISSUE_TEMPLATE/$template_file"
             target=".github/ISSUE_TEMPLATE/$template_file"
+
+            if [ -f "$source" ]; then
+              cp "$source" "$target"
+            fi
+          done
+
+          # Sync documentation files (for LLM reference)
+          SYNC_DOCS=(
+            "AGENT_ISSUE_FORMAT.md"
+          )
+
+          mkdir -p docs
+          for doc_file in "${SYNC_DOCS[@]}"; do
+            source="../workflows/templates/consumer-repo/docs/$doc_file"
+            target="docs/$doc_file"
 
             if [ -f "$source" ]; then
               cp "$source" "$target"

--- a/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
+++ b/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
@@ -1,0 +1,162 @@
+# Agent Issue Format Guide
+
+This document defines the canonical structure for issues that feed into the Codex keepalive automation pipeline. Follow this format when creating issues for automated agent processing.
+
+## Quick Reference Template
+
+```markdown
+## Why
+
+<!-- Brief explanation of the problem or opportunity -->
+
+## Scope
+
+<!-- What this issue covers and its boundaries -->
+
+## Non-Goals
+
+<!-- What is explicitly out of scope -->
+
+## Tasks
+
+- [ ] First task description
+- [ ] Second task description
+- [ ] Third task description
+
+## Acceptance Criteria
+
+- [ ] First verifiable criterion
+- [ ] Second verifiable criterion
+
+## Implementation Notes
+
+<!-- Optional: Technical details, file paths, constraints -->
+```
+
+---
+
+## Section Details
+
+### Required Sections
+
+| Section | Purpose | Aliases |
+|---------|---------|---------|
+| **Tasks** | Work items with checkboxes | `Task List`, `Implementation` |
+| **Acceptance Criteria** | Verifiable completion conditions | `Acceptance`, `Definition of Done` |
+
+### Recommended Sections
+
+| Section | Purpose | Aliases |
+|---------|---------|---------|
+| **Why** | Context and rationale | `Goals`, `Summary`, `Motivation` |
+| **Scope** | What the issue covers | `Background`, `Context`, `Overview` |
+| **Non-Goals** | Explicit exclusions | `Out of Scope`, `Constraints` |
+| **Implementation Notes** | Technical guidance | — |
+
+---
+
+## Writing Good Tasks
+
+Each task should be:
+- **Specific** — Clear enough to verify completion
+- **Small** — Completable in one iteration
+- **Actionable** — Starts with a verb
+
+✅ Good:
+```markdown
+- [ ] Add input validation for email field in UserForm component
+- [ ] Write unit tests for calculateDiscount function
+- [ ] Update README with new API endpoints
+```
+
+❌ Bad:
+```markdown
+- [ ] Fix bugs
+- [ ] Improve code
+- [ ] Update things
+```
+
+---
+
+## Writing Good Acceptance Criteria
+
+Criteria should be:
+- **Verifiable** — Can be objectively checked
+- **Specific** — No ambiguity about pass/fail
+- **Independent** — Each criterion stands alone
+
+✅ Good:
+```markdown
+- [ ] All unit tests pass
+- [ ] API returns 400 status for invalid input
+- [ ] Documentation includes usage examples
+```
+
+❌ Bad:
+```markdown
+- [ ] Code is good
+- [ ] Works correctly
+- [ ] Meets requirements
+```
+
+---
+
+## Complete Example
+
+```markdown
+## Why
+
+The user registration flow doesn't validate email format before submission,
+leading to invalid data in the database and failed notification emails.
+
+## Scope
+
+Add client-side and server-side email validation to the registration form.
+
+## Non-Goals
+
+- Changing the email verification flow
+- Adding additional registration fields
+- Modifying the password requirements
+
+## Tasks
+
+- [ ] Add email format validation to RegisterForm component
+- [ ] Add server-side email validation in /api/register endpoint
+- [ ] Display user-friendly error message for invalid emails
+- [ ] Write tests for email validation logic
+
+## Acceptance Criteria
+
+- [ ] Invalid email formats are rejected with clear error message
+- [ ] Valid emails pass validation and registration proceeds
+- [ ] Server returns 400 status with error details for invalid email
+- [ ] Unit tests cover common invalid email patterns
+
+## Implementation Notes
+
+Files to modify:
+- `src/components/RegisterForm.tsx` - Client validation
+- `src/api/register.ts` - Server validation
+- `src/utils/validation.ts` - Shared validation logic
+
+Use existing validation utility pattern from `src/utils/validation.ts`.
+```
+
+---
+
+## Tips for LLMs Creating Issues
+
+1. **Be specific about file paths** — Include exact paths in Implementation Notes
+2. **Keep tasks atomic** — One checkbox = one discrete change
+3. **Make criteria testable** — If you can't write a test for it, rephrase it
+4. **Include context** — The Why section helps agents understand intent
+5. **Set boundaries** — Non-Goals prevent scope creep
+
+---
+
+## Using the GitHub Issue Form
+
+This repository includes an issue template at `.github/ISSUE_TEMPLATE/agent_task.yml` that enforces this structure. When creating issues through GitHub's UI, use the "Agent Task" template for proper formatting.
+
+For programmatic issue creation, follow this format directly in the issue body.


### PR DESCRIPTION
## Summary

Provides LLM-readable documentation for creating properly formatted issues that work with the keepalive pipeline.

## Changes

- Add `templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md` - comprehensive guide for creating agent-compatible issues
- Update sync workflow to include `docs/` directory sync

## Content

The new doc includes:
- Quick reference template
- Section details (required vs recommended)
- Guidelines for writing good tasks and acceptance criteria
- Complete example issue
- Tips specifically for LLMs creating issues

## Why

Consumer repos need documentation that an LLM can read to understand how to format issues correctly for the keepalive pipeline. The GitHub issue form template (`.github/ISSUE_TEMPLATE/agent_task.yml`) enforces structure via the UI, but programmatic issue creation needs a reference doc.