### PR TITLE
fix(sync): Use OWNER_PR_PAT for consumer repo sync

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.repos) }}
     env:
-      SYNC_TOKEN: ${{ secrets.CODESPACES_WORKFLOWS || secrets.SERVICE_BOT_PAT }}
+      SYNC_TOKEN: ${{ secrets.OWNER_PR_PAT || secrets.SERVICE_BOT_PAT }}
     steps:
       - name: Checkout Workflows templates
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The sync workflow was failing for `stranske/Template` with a 403 error because `SERVICE_BOT_PAT` doesn't have push access to that repo.

## Fix

Switch from `CODESPACES_WORKFLOWS || SERVICE_BOT_PAT` to `OWNER_PR_PAT || SERVICE_BOT_PAT`.

`OWNER_PR_PAT` should have access to all repos owned by the user, including Template.

## Testing

After merge, re-run Maint 68 workflow and verify Template gets a sync PR.