### PR TITLE
fix(autofix): pass GitHub App secrets to reusable workflow

### DIFF
--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -106,3 +106,5 @@ jobs:
       caller_actor: ${{ needs.resolve.outputs.caller_actor }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

Consumer repos have `WORKFLOWS_APP_ID` and `WORKFLOWS_APP_PRIVATE_KEY` secrets configured, but the `autofix.yml` template was only passing `service_bot_pat` to the reusable workflow:

```yaml
secrets:
  service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
```

This meant the reusable workflow couldn't access the app credentials and always fell back to PAT authentication.

## Solution

Add the app secrets to the template:

```yaml
secrets:
  service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
  WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
  WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
```

The reusable workflow already accepts these secrets (added previously), so consumer repos will now be able to use GitHub App authentication when the secrets are configured.

## Note

After this merges and syncs to consumer repos, the autofix workflow will use `AUTOFIX_AUTH_MODE: app` instead of `pat` when the app secrets are available.