### PR TITLE
fix: shorten comment to pass consumer-repo lint

### DIFF
--- a/.github/scripts/parse_chatgpt_topics.py
+++ b/.github/scripts/parse_chatgpt_topics.py
@@ -81,7 +81,7 @@ def _split_numbered_items(text: str) -> list[dict[str, str | list[str] | bool]]:
         if m:
             token = m.group("enum")
             title = m.group("title").strip()
-            # Clean simple markdown emphasis and stray trailing punctuation that harms GUID stability
+            # Clean markdown emphasis and trailing punctuation for GUID stability
             title = re.sub(r"^[*_`]+|[*_`]+$", "", title).strip()
             title = title.rstrip(". ")
             if current:


### PR DESCRIPTION
Line 84 in parse_chatgpt_topics.py was 101 chars, failing E501 in consumer-repo lint validation. Shortened to pass.