### PR TITLE
fix: add pyyaml to sync workflow validation

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install lint tools
         run: |
-          pip install ruff mypy black
+          pip install ruff mypy black pyyaml
 
       - name: Validate Python scripts with consumer-repo rules
         run: |


### PR DESCRIPTION
The YAML validation step in the sync workflow uses Python's yaml module but PyYAML wasn't installed.