### PR TITLE
fix: remove duplicate fi statements causing shell parse errors

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -612,8 +612,6 @@ jobs:
             if [ -f "$template" ]; then
               cp "$template" "$target"
             fi
-            fi
-            fi
           done
 
           # Previously synced full workflows here, but agents-63-issue-intake.yml


### PR DESCRIPTION
## Problem

The 'Parse and lint workflows' CI check was failing with shellcheck errors:
- SC1073: Couldn't parse this for loop
- SC1061: Couldn't find 'done' for this 'do'
- SC1062: Expected 'done' matching previously mentioned 'do'
- SC1072: Unexpected keyword/token

## Root Cause

The shell script in `maint-68-sync-consumer-repos.yml` (starting at line 569) had **two extra `fi` statements** (lines 615-616) that didn't match any `if`.

## Fix

Removed the duplicate `fi` statements. Verified all shell scripts now pass `bash -n` syntax check.