### PR TITLE
fix: configure git remote with token for consumer repo push

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -499,6 +499,7 @@ jobs:
           # This avoids exposing token in git remote URL or command output
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # shellcheck disable=SC2016 # Single quotes intentional - ${GH_TOKEN} expands at runtime in credential helper
           git config credential.helper '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
 
           # Create branch and commit


### PR DESCRIPTION
## Summary
Fix the sync workflow failing to push to consumer repos.

## Changes
- Rename `SYNC_TOKEN` to `_repo_token` (clearer it's a local alias, not a secret name)
- Add `git remote set-url` with token auth to fix push failure
- The `gh clone` command doesn't configure git credentials for push

## Root Cause
The workflow clones consumer repos successfully but `git push` fails with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

This is because `gh repo clone` doesn't set up git credentials for subsequent push operations.