### PR TITLE
chore: trigger sync workflow

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -7,6 +7,8 @@
 # POLICY: Any file intended for consumer repos MUST be listed here.
 # Files not listed will NOT be synced, even if they exist in templates/consumer-repo/.
 #
+# Last sync trigger: 2025-12-30
+#
 # Categories:
 #   workflows: Thin caller workflows that consumers run directly
 #   prompts: Codex prompt files for agent operations


### PR DESCRIPTION
Adds timestamp to manifest to trigger the sync workflow on merge.

This will create sync PRs in all consumer repos with the updated:
- keepalive-instruction.md (explicit completion markers)
- keepalive_loop.js (improved reconciliation thresholds/synonyms)
- issue_scope_parser.js (checkbox stripping from scope)