### PR TITLE
fix(sync): move scripts to correct manifest section + add templates processing

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -120,11 +120,6 @@ scripts:
   - source: .github/scripts/keepalive_loop.js
     description: "Core keepalive loop logic"
 
-# Templates required by keepalive system
-templates:
-  - source: .github/templates/keepalive-instruction.md
-    description: "Keepalive instruction template - directives for Codex on each round"
-
   - source: .github/scripts/keepalive_state.js
     description: "Keepalive state management"
 
@@ -136,6 +131,11 @@ templates:
 
   - source: .github/scripts/failure_comment_formatter.js
     description: "Formats failure comments for PR status updates"
+
+# Templates required by keepalive system
+templates:
+  - source: .github/templates/keepalive-instruction.md
+    description: "Keepalive instruction template - directives for Codex on each round"
 
 # Documentation synced to consumer repos
 docs:

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -418,6 +418,17 @@ jobs:
                   sync_directory(template_src, consumer_dst, description)
               else:
                   sync_file(template_src, consumer_dst, description)
+
+          # Process templates (markdown templates, instructions, etc.)
+          print("Processing templates...")
+          for item in manifest.get('templates', []):
+              source = item.get('source', '')
+              description = item.get('description', 'No description')
+              # Templates come from .github/templates/, same as scripts pattern
+              template_src = Path('workflows') / source
+              consumer_dst = Path('consumer') / source
+              sync_file(template_src, consumer_dst, description)
+
           # Process docs
           print("Processing docs...")
           for item in manifest.get('docs', []):


### PR DESCRIPTION
## Problem

The sync workflow was not syncing critical helper files to consumer repos:
- `error_classifier.js`
- `failure_comment_formatter.js`
- `keepalive_state.js`
- `prompt_injection_guard.js`

This caused P1 issues where `keepalive_loop.js` couldn't find its required helper modules.

## Root Cause

These script files were accidentally placed in the `templates:` section of the sync manifest instead of the `scripts:` section. The sync workflow only processes the `scripts:` section for .js files.

## Fix

1. **Moved scripts to correct section**: Moved all .js scripts from `templates:` to `scripts:` section
2. **Added templates processing**: Added handler for `templates:` section to sync `keepalive-instruction.md`

## Files Changed

- `.github/sync-manifest.yml`: Reorganized sections
- `.github/workflows/maint-68-sync-consumer-repos.yml`: Added templates section processing

## Testing

After merge, the sync workflow will include all required helper scripts in consumer repos.