### PR TITLE
fix: line too long in coverage_trend.py

### DIFF
--- a/tools/coverage_trend.py
+++ b/tools/coverage_trend.py
@@ -190,7 +190,8 @@ def main(args: list[str] | None = None) -> int:
             f.write(f"low_coverage_count={len(low_coverage)}\n")
 
     print(
-        f"Coverage: {current_coverage:.2f}% (baseline: {baseline_coverage:.2f}%, delta: {delta:+.2f}%)"
+        f"Coverage: {current_coverage:.2f}% "
+        f"(baseline: {baseline_coverage:.2f}%, delta: {delta:+.2f}%)"
     )
     if hotspots:
         print(f"Hotspots: {len(hotspots)} files with lowest coverage")


### PR DESCRIPTION
Fix E501 lint error (line > 100 chars) in coverage_trend.py that was blocking sync validation.

Split the f-string across two lines.