### PR TITLE
chore: trigger sync with tools/*.py fix

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -7,7 +7,7 @@
 # POLICY: Any file intended for consumer repos MUST be listed here.
 # Files not listed will NOT be synced, even if they exist in templates/consumer-repo/.
 #
-# Last sync trigger: 2025-12-30T19:00:00Z
+# Last sync trigger: 2025-12-30T19:30:00Z - Added tools/*.py for reusable workflow support
 #
 # Categories:
 #   workflows: Thin caller workflows that consumers run directly


### PR DESCRIPTION
Updates sync manifest timestamp to trigger a new sync after tools/*.py lint fix merged.