### PR TITLE
fix(sync): include tools/, scripts/, and manifest in hash computation

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -118,7 +118,13 @@ jobs:
       - name: Compute template hash
         id: hash
         run: |
-          hash=$(find templates/consumer-repo -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+          # Hash includes all directories that contain synced files
+          hash=$({
+            find templates/consumer-repo -type f -exec sha256sum {} \;
+            find tools -name "*.py" -type f -exec sha256sum {} \; 2>/dev/null || true
+            find .github/scripts -type f -exec sha256sum {} \;
+            sha256sum .github/sync-manifest.yml
+          } | sort | sha256sum | cut -d' ' -f1)
           echo "hash=${hash:0:12}" >> "$GITHUB_OUTPUT"
           echo "Template hash: ${hash:0:12}"
 


### PR DESCRIPTION
## Problem

When tools/ files were added to the sync manifest, existing sync PRs weren't updated because the branch name hash didn't change. The hash only computed over `templates/consumer-repo/`.

## Fix

Expand hash computation to include:
- `templates/consumer-repo/**` (existing)  
- `tools/*.py` (new - resolve_mypy_pin.py, coverage_trend.py)
- `.github/scripts/**` (new - JS helper scripts)
- `.github/sync-manifest.yml` (new - manifest itself)

This ensures a new branch/PR is created when any synced content changes.

## After Merge

1. Close existing sync PRs (154, 21, 16, 90, 783, 4005) that are missing tools/
2. New sync will create fresh PRs with all required files