### PR TITLE
fix(sync): add pyproject.toml with line-length=100 to consumer repos

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -7,7 +7,7 @@
 # POLICY: Any file intended for consumer repos MUST be listed here.
 # Files not listed will NOT be synced, even if they exist in templates/consumer-repo/.
 #
-# Last sync trigger: 2025-12-30T19:50:00Z - Add CI scripts referenced by reusable workflow
+# Last sync trigger: 2025-12-30T20:15:00Z - Add pyproject.toml with line-length=100
 #
 # Categories:
 #   workflows: Thin caller workflows that consumers run directly
@@ -15,6 +15,7 @@
 #   scripts: JavaScript/Python scripts required by workflows
 #   codex_config: Codex configuration files (AGENT_INSTRUCTIONS.md, etc.)
 #   docs: Documentation files synced to consumer repos
+#   config: Tool configuration files (pyproject.toml, etc.)
 #
 # Each entry can specify:
 #   - source: Path relative to templates/consumer-repo/ (or .github/ for reusable-only)
@@ -22,6 +23,11 @@
 #   - description: What this file does (required for documentation)
 
 version: 1
+
+# Tool configuration - ensures consistent formatting across all repos
+config:
+  - source: pyproject.toml
+    description: "Tool configuration - black, ruff, mypy settings with line-length=100"
 
 # Workflows that run in consumer repos (thin callers)
 workflows:

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -414,6 +414,14 @@ jobs:
               consumer_dst = Path('consumer') / source
               sync_file(template_src, consumer_dst, description)
 
+          # Process config (pyproject.toml, etc.)
+          print("Processing config...")
+          for item in manifest.get('config', []):
+              source = item.get('source', '')
+              description = item.get('description', 'No description')
+              template_src = Path('workflows/templates/consumer-repo') / source
+              consumer_dst = Path('consumer') / source
+              sync_file(template_src, consumer_dst, description)
 
           # Process copilot_config
           print("Processing copilot config...")

--- a/templates/consumer-repo/pyproject.toml
+++ b/templates/consumer-repo/pyproject.toml
@@ -1,0 +1,37 @@
+# Synced from Workflows repo - tool configuration for consistent formatting
+# This file is managed by the Workflows sync process.
+# Local customizations should be added in project-specific sections.
+
+[tool.black]
+line-length = 100
+target-version = ["py311", "py312"]
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  \.eggs
+  | \.git
+  | \.mypy_cache
+  | \.venv
+  | _build
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["E501"]  # Line too long - handled by black
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true


### PR DESCRIPTION
## Problem

Consumer repos have different Black line-length settings (88) than the Workflows repo (100). This causes synced scripts to fail Black formatting checks.

## Solution

Add a `pyproject.toml` template with standardized tool configuration:
- `black`: line-length=100  
- `ruff`: line-length=100
- `mypy`: standard Python 3.11 settings

This ensures all repos use consistent formatting.

## Changes

- Added `templates/consumer-repo/pyproject.toml`
- Added `config:` section to sync-manifest.yml
- Updated sync workflow to process config files