### PR TITLE
fix: add setuptools packages=[] to prevent flat-layout errors

### DIFF
--- a/templates/consumer-repo/pyproject.toml
+++ b/templates/consumer-repo/pyproject.toml
@@ -2,6 +2,10 @@
 # This file is managed by the Workflows sync process.
 # Local customizations should be added in project-specific sections.
 
+# Prevent setuptools from auto-discovering packages (avoids flat-layout errors)
+[tool.setuptools]
+packages = []
+
 [tool.black]
 line-length = 100
 target-version = ["py311", "py312"]


### PR DESCRIPTION
Consumer repos with multiple top-level directories were failing with:
```
Multiple top-level packages discovered in a flat-layout: ['ui', 'api', 'etl', 'agents', 'adapters']
```

Adding `[tool.setuptools] packages = []` prevents setuptools from auto-discovering packages.