### PR TITLE
fix(tools): resolve mypy strict mode no-any-return errors

### DIFF
--- a/tools/coverage_trend.py
+++ b/tools/coverage_trend.py
@@ -17,7 +17,10 @@ from typing import Any
 def _load_json(path: Path) -> dict[str, Any]:
     """Load JSON from a file, returning empty dict on error."""
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+        return {}
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 

--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -30,7 +30,14 @@ def get_mypy_python_version() -> str | None:
 
         content = pyproject_path.read_text()
         data = tomlkit.parse(content)
-        return data.get("tool", {}).get("mypy", {}).get("python_version")
+        tool = data.get("tool")
+        if not isinstance(tool, dict):
+            tool = {}
+        mypy = tool.get("mypy")
+        if not isinstance(mypy, dict):
+            mypy = {}
+        version = mypy.get("python_version")
+        return str(version) if version is not None else None
     except ImportError:
         pass
 


### PR DESCRIPTION
Consumer repos with strict mypy mode catch no-any-return errors.

- coverage_trend.py: add isinstance check for json.loads result  
- resolve_mypy_pin.py: add isinstance checks for tomlkit parsed data