### PR TITLE
fix(sync): prioritize create_only mode over custom_gate check

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -378,11 +378,13 @@ jobs:
                   """File exists and sync_mode is create_only"""
                   return sync_mode == 'create_only' and consumer_dst.exists()
 
+              # Determine skip function: check create_only first (covers most cases),
+              # then custom_gate for legacy repos that have completely custom Gates
               skip_fn = None
-              if 'pr-00-gate' in source:
-                  skip_fn = skip_custom_gate
-              elif sync_mode == 'create_only':
+              if sync_mode == 'create_only':
                   skip_fn = skip_create_only
+              elif 'pr-00-gate' in source and current_repo in custom_gate_repos:
+                  skip_fn = skip_custom_gate
 
               sync_file(template_src, consumer_dst, description, skip_fn)
 


### PR DESCRIPTION
The previous logic checked if `pr-00-gate` was in the source path first, which always used `skip_custom_gate()`. But PAEM wasn't in `custom_gate_repos`, so it never got skipped despite having `sync_mode: create_only` in the manifest.

Now `create_only` is checked first, allowing repos like PAEM to keep their customized `coverage-min` settings while still receiving other workflow updates.

**Changes:**
- Reorder skip logic: check `sync_mode: create_only` before `custom_gate_repos`
- Simplify condition by inlining the repo check

**Impact:**
- PAEM's `pr-00-gate.yml` (with `coverage-min: 60`) will be preserved
- No impact on trip-planner/Manager-Database (they're in `custom_gate_repos`)