### PR TITLE
fix(sync): add create_only mode to ci.yml

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -32,6 +32,7 @@ workflows:
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"
+    sync_mode: create_only  # Don't overwrite - repos customize coverage-min, python versions
 
   - source: .github/workflows/autofix.yml
     description: "Autofix workflow - automatically fixes lint/format issues"


### PR DESCRIPTION
Both `pr-00-gate.yml` and `ci.yml` can have customized `coverage-min` settings.

Adding `create_only` prevents overwriting PAEM's `coverage-min: 60` in ci.yml.

Note: This is the same pattern we already have for `pr-00-gate.yml`.