### PR TITLE
fix: install dev dependencies in devcontainer to run all tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "workflows-env",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "onCreateCommand": "sudo apt-get update && sudo apt-get install -y python3-venv",
-  "postCreateCommand": "pip install pre-commit && pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push",
+  "postCreateCommand": "pip install -e '.[dev]' && pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push",
   "postStartCommand": "pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/docs/reference/coverage-gap-analysis.md
+++ b/docs/reference/coverage-gap-analysis.md
@@ -1,8 +1,8 @@
 # Coverage Gap Analysis
 
-> **Baseline**: 2025-12-31 (main branch, post-PR #374)
-> **Overall Coverage**: 69.35%
-> **Tests**: 589 passed, 3 skipped, 3 xfailed
+> **Baseline**: 2025-12-31 (main branch, post-PR #374 + devcontainer fix)
+> **Overall Coverage**: 71.60%
+> **Tests**: 592 passed, 0 skipped, 3 xfailed
 > **Target**: 95%
 
 ## Summary
@@ -10,10 +10,10 @@
 | Metric | Value |
 |--------|-------|
 | Total Statements | 2,798 |
-| Covered Statements | 2,032 |
-| Missing Statements | 766 |
-| Coverage | 69.35% |
-| Gap to 95% | 25.65% (~717 statements) |
+| Covered Statements | 2,086 |
+| Missing Statements | 712 |
+| Coverage | 71.60% |
+| Gap to 95% | 23.40% (~654 statements) |
 
 ## Scripts by Coverage (Lowest to Highest)
 
@@ -25,38 +25,37 @@
 | `update_residual_history.py` | 25 | 0.00% | 25 |
 | `validate_version_pins.py` | 135 | 0.00% | 135 |
 
-### Tier 2: Very Low Coverage <50% (4 scripts, 302 statements missing)
+### Tier 2: Very Low Coverage <50% (3 scripts, 265 statements missing)
 
 | Script | Statements | Coverage | Missing |
 |--------|------------|----------|---------|
-| `mypy_autofix.py` | 45 | 12.31% | 37 |
 | `sync_test_dependencies.py` | 163 | 15.32% | 128 |
 | `auto_type_hygiene.py` | 139 | 34.78% | 81 |
 | `keepalive_metrics_collector.py` | 108 | 46.48% | 56 |
 
-### Tier 3: Medium Coverage 50-75% (5 scripts, 188 statements missing)
+### Tier 3: Medium Coverage 50-75% (5 scripts, 196 statements missing)
 
 | Script | Statements | Coverage | Missing |
 |--------|------------|----------|---------|
 | `keepalive_metrics_dashboard.py` | 94 | 56.67% | 40 |
 | `workflow_health_check.py` | 77 | 62.62% | 28 |
 | `classify_test_failures.py` | 123 | 62.87% | 37 |
+| `mypy_autofix.py` | 45 | 63.08% | 13 |
 | `ledger_validate.py` | 205 | 65.32% | 63 |
-| `mypy_return_autofix.py` | 89 | 69.13% | 20 |
 
-### Tier 4: High Coverage 75-95% (5 scripts, 32 statements missing)
+### Tier 4: High Coverage 75-95% (6 scripts, 35 statements missing)
 
 | Script | Statements | Coverage | Missing |
 |--------|------------|----------|---------|
+| `mypy_return_autofix.py` | 89 | 82.55% | 11 |
 | `ledger_migrate_base.py` | 134 | 85.48% | 13 |
 | `ci_failure_analyzer.py` | 108 | 87.35% | 11 |
-| `fix_numpy_asserts.py` | 38 | 87.04% | 4 |
 | `fix_cosmetic_aggregate.py` | 20 | 92.31% | 1 |
 | `coverage_history_append.py` | 53 | 92.75% | 2 |
 | `update_autofix_expectations.py` | 37 | 93.88% | 1 |
 | `workflow_validator.py` | 72 | 93.27% | 4 |
 
-### Tier 5: At Target ≥95% (13 scripts)
+### Tier 5: At Target ≥95% (14 scripts)
 
 | Script | Statements | Coverage |
 |--------|------------|----------|
@@ -66,6 +65,7 @@
 | `metrics_format_utils.py` | 16 | 100.00% |
 | `sync_status_file_ignores.py` | 94 | 100.00% |
 | `ci_cosmetic_repair.py` | 256 | 99.71% |
+| `fix_numpy_asserts.py` | 38 | 98.15% |
 | `aggregate_agent_metrics.py` | 201 | 97.23% |
 | `build_autofix_pr_comment.py` | 105 | 97.04% |
 | `generate_residual_trend.py` | 61 | 96.55% |
@@ -111,3 +111,4 @@ Check the `Cover` column in the output. A script meets its target when coverage 
 | 2025-12-31 | 64.12% | 558 | +0.95% | PR #366 merged |
 | 2025-12-31 | 67.30% | 573 | +3.18% | PR #369 merged |
 | 2025-12-31 | 69.35% | 589 | +2.05% | PR #374 merged |
+| 2025-12-31 | 71.60% | 592 | +2.25% | devcontainer fix (0 skipped) |


### PR DESCRIPTION
## Problem

The devcontainer was only installing `pre-commit`, not the full dev dependencies. This caused `isort` and `docformatter` to be missing, resulting in 3 skipped tests.

## Solution

Changed `postCreateCommand` to install the package with dev extras using `pip install -e '.[dev]'` which includes all test dependencies defined in `pyproject.toml`.

## Results

- **Before**: 589 passed, 3 skipped, 3 xfailed (69.35% coverage)
- **After**: 592 passed, 0 skipped, 3 xfailed (71.60% coverage)

The 3 previously skipped tests now run and pass:
- `test_autofix_full_pipeline.py::test_autofix_pipeline_resolves_lint_and_typing`
- `test_autofix_pipeline.py::test_autofix_pipeline_fixes_trivial_ruff_issue`
- `test_autofix_pipeline_diverse.py::test_autofix_pipeline_handles_diverse_errors`

Also updates [coverage-gap-analysis.md](docs/reference/coverage-gap-analysis.md) with current metrics.