### PR TITLE
fix: prevent blank checkboxes from HTML comments in PR bodies

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -159,6 +159,20 @@ test('ensureChecklist preserves existing checkbox formatting', () => {
   assert.strictEqual(result, '- [x] Completed task\n- [ ] Pending task');
 });
 
+test('ensureChecklist preserves HTML comments without adding checkboxes', () => {
+  const text = '<!-- Incomplete tasks from original issue -->\n- [x] Completed task\n- [ ] Pending task';
+  const result = ensureChecklist(text);
+
+  assert.strictEqual(result, '<!-- Incomplete tasks from original issue -->\n- [x] Completed task\n- [ ] Pending task');
+});
+
+test('ensureChecklist preserves section headers without adding checkboxes', () => {
+  const text = '## Tasks\n- [ ] Task one';
+  const result = ensureChecklist(text);
+
+  assert.strictEqual(result, '## Tasks\n- [ ] Task one');
+});
+
 test('ensureChecklist returns placeholder for empty input', () => {
   assert.strictEqual(ensureChecklist(''), '- [ ] —');
   assert.strictEqual(ensureChecklist('   '), '- [ ] —');

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -49,7 +49,22 @@ function ensureChecklist(text) {
     return '- [ ] —';
   }
   return lines
-    .map((line) => (line.startsWith('- [') ? line : `- [ ] ${line}`))
+    .map((line) => {
+      // Skip lines that are already checkboxes
+      if (line.startsWith('- [')) {
+        return line;
+      }
+      // Skip HTML comments - they are informational, not actionable
+      if (line.startsWith('<!--') && line.endsWith('-->')) {
+        return line;
+      }
+      // Skip section headers
+      if (line.startsWith('#')) {
+        return line;
+      }
+      // Convert other lines to checkboxes
+      return `- [ ] ${line}`;
+    })
     .join('\n');
 }
 


### PR DESCRIPTION
## Problem

The `ensureChecklist` function in `agents_pr_meta_update_body.js` was adding checkbox prefixes (`- [ ]`) to ALL non-checkbox lines, including HTML comments like:

```
<- After this merges, new sync PRs will include all required Incomplete tasks from original issue -->
<- After this merges, new sync PRs will include all required Criteria verified as unmet by verifier -->
```

This caused PRs (like #850 in PAEM) to display confusing blank checkboxes.

## Root Cause

The function's logic:
```js
lines.map((line) => (line.startsWith('- [') ? line : `- [ ] ${line}`))
```

...didn't account for HTML comments or section headers.

## Solution

Updated `ensureChecklist` to skip:
- Lines that are already checkboxes (`- [`)
- HTML comments (`<- After this merges, new sync PRs will include all required ... -->`)
- Section headers (`#`)

## Tests Added

- `ensureChecklist preserves HTML comments without adding checkboxes`
- `ensureChecklist preserves section headers without adding checkboxes`

All 32 tests pass.