### PR TITLE
fix: add pipefail to sync step to capture script exit code

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -140,6 +140,7 @@ jobs:
         id: sync
         if: steps.check.outputs.has_dev_deps == 'true'
         run: |
+          set -o pipefail  # Ensure pipeline returns first failing command's exit code
           # Copy pin file to expected location
           mkdir -p consumer/.github/workflows
           cp .github/workflows/autofix-versions.env consumer/.github/workflows/


### PR DESCRIPTION
## Problem

The dev version sync workflow wasn't creating PRs even when changes were detected.

## Root Cause

The pipeline `python ... 2>&1 | tee /tmp/sync_output.txt` always returns 0 because `tee` succeeds, even when the Python script returns 1 to indicate changes were detected. This causes the `if` statement to take the wrong branch.

## Fix

Add `set -o pipefail` to ensure the pipeline returns the Python script's actual exit code.

## Testing

After this fix, the workflow should correctly:
1. Detect when versions need updating (exit code 1 from check)
2. Run the --apply command
3. Create PRs in consumer repos