### PR TITLE
fix: remove label requirement from PR creation

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -226,7 +226,7 @@ jobs:
             --head "$branch_name" \
             --title "deps: sync dev tool versions" \
             --body "$pr_body" \
-            --label "dependencies,automated"
+            
 
       - name: Dry run summary
         if: inputs.dry_run == true && steps.sync.outputs.has_changes == 'true'


### PR DESCRIPTION
Consumer repos may not have the 'dependencies' or 'automated' labels, causing the PR creation to fail. Remove the --label flag to avoid this.