### PR TITLE
fix: use force-with-lease for sync branch push

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -200,7 +200,7 @@ jobs:
 
           This ensures consistent dev tool versions across all repos."
 
-          git push -u origin "$branch_name"
+          git push --force-with-lease -u origin "$branch_name"
 
           # Create PR
           pr_body="## Dev Tool Version Sync


### PR DESCRIPTION
If a previous workflow run pushed the branch but failed before creating the PR (e.g., due to missing labels), the branch still exists on the remote.

Using `--force-with-lease` allows us to overwrite it safely while still protecting against concurrent pushes from other sources.

**Root cause:** Run 20640403481 failed because the branch `deps/sync-dev-versions-8ac491402cc9` already existed from run 20640347708 which pushed successfully but failed on PR creation (label issue).

Error:
```
! [rejected]  deps/sync-dev-versions-8ac491402cc9 -> deps/sync-dev-versions-8ac491402cc9 (fetch first)
error: failed to push some refs to 'https://github.com/stranske/Portable-Alpha-Extension-Model.git'
```