### PR TITLE
fix: use unconditional force push for sync branches

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -200,7 +200,7 @@ jobs:
 
           This ensures consistent dev tool versions across all repos."
 
-          git push --force-with-lease -u origin "$branch_name"
+          git push --force -u origin "$branch_name"
 
           # Create PR
           pr_body="## Dev Tool Version Sync


### PR DESCRIPTION
`--force-with-lease` fails with 'stale info' when the remote branch exists but the local repo doesn't have its tracking info (since we only do a shallow clone without the branch).

Using plain `--force` is safe here because:
1. These are automated workflow branches, not user work
2. Branch names include a version hash, so different versions get different branches
3. We explicitly want to overwrite any previous failed attempt

**Error from run 20640553717:**
```
! [rejected]  deps/sync-dev-versions-8ac491402cc9 -> deps/sync-dev-versions-8ac491402cc9 (stale info)
error: failed to push some refs to 'https://github.com/stranske/Template.git'
```