### PR TITLE
fix: add .workflows-lib to PYTHONPATH in analyze_session step

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -567,9 +567,11 @@ jobs:
             COMPLETED=$(python3 -c "import json; d=json.load(open('$ANALYSIS_FILE')); print(json.dumps(d.get('completed_tasks', [])))")
             PROVIDER=$(python3 -c "import json; d=json.load(open('$ANALYSIS_FILE')); print(d.get('provider', 'unknown'))")
             CONFIDENCE=$(python3 -c "import json; d=json.load(open('$ANALYSIS_FILE')); print(d.get('confidence', 0))")
-            echo "completed-tasks=$COMPLETED" >> "$GITHUB_OUTPUT"
-            echo "provider=$PROVIDER" >> "$GITHUB_OUTPUT"
-            echo "confidence=$CONFIDENCE" >> "$GITHUB_OUTPUT"
+            {
+              echo "completed-tasks=$COMPLETED"
+              echo "provider=$PROVIDER"
+              echo "confidence=$CONFIDENCE"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push changes


### PR DESCRIPTION
The tools are checked out to .workflows-lib, so we need to include that path for the imports to work correctly in the analyze_session step.

This fixes the session analysis import errors when running in consumer repos.