### PR TITLE
fix: send logging to stderr to avoid corrupting JSON output

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -541,11 +541,12 @@ jobs:
 
           # Run full LLM analysis and save JSON output
           # Scripts are in .workflows-lib from Workflows repo checkout
+          # Note: logging goes to stderr, JSON output goes to stdout -> file
           echo "Running LLM-powered task completion analysis..."
           python3 .workflows-lib/scripts/analyze_codex_session.py \
             --session-file "$SESSION_JSONL" \
             --pr-body-file pr_body.md \
-            --output json > "$ANALYSIS_FILE" 2>&1 || {
+            --output json > "$ANALYSIS_FILE" || {
               echo "::warning::LLM analysis failed, continuing without it"
               cat "$ANALYSIS_FILE" 2>/dev/null || true  # Show error for debugging
               echo "llm-analysis-run=false" >> "$GITHUB_OUTPUT"

--- a/scripts/analyze_codex_session.py
+++ b/scripts/analyze_codex_session.py
@@ -249,10 +249,11 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Setup logging
+    # Setup logging to stderr (stdout is reserved for JSON output)
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
     )
 
     # Check session file exists

--- a/tools/codex_session_analyzer.py
+++ b/tools/codex_session_analyzer.py
@@ -247,8 +247,9 @@ def analyze_from_files(
 
 
 if __name__ == "__main__":
+    import sys
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 
     # Example usage
     sample_tasks = [

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -409,8 +409,10 @@ def check_providers() -> dict[str, bool]:
 
 
 if __name__ == "__main__":
-    # Quick test
-    logging.basicConfig(level=logging.INFO)
+    import sys
+
+    # Quick test - log to stderr
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 
     print("Provider availability:")
     for name, available in check_providers().items():


### PR DESCRIPTION
The analyze_codex_session script outputs JSON to stdout, but logging was also going to stdout by default, corrupting the JSON when trying to parse it in the workflow.

Now:
- All logging goes to stderr
- Workflow doesn't redirect stderr to the JSON file

This fixes the JSON parsing error in the LLM analysis step.