### PR TITLE
fix: shellcheck warnings in maint-39-test-llm-providers.yml

### DIFF
--- a/.github/workflows/maint-39-test-llm-providers.yml
+++ b/.github/workflows/maint-39-test-llm-providers.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## LLM Provider Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Provider test completed successfully! ✅" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## LLM Provider Test Results"
+            echo ""
+            echo "Provider test completed successfully! ✅"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixes shellcheck warnings about grouped redirects and variable quoting.