### PR TITLE
fix: sync .gitattributes to prevent pr_body.md merge conflicts

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -196,6 +196,12 @@ docs:
     target: CLAUDE.md
     description: "Context file for Claude/AI assistants"
 
+# Git configuration files for merge strategies
+git_config:
+  - source: .gitattributes
+    description: "Git attributes - merge strategies to prevent pr_body.md conflicts"
+
+
 # Files that exist in templates but are NOT synced (consumer creates their own)
 excluded:
 

--- a/templates/consumer-repo/.gitattributes
+++ b/templates/consumer-repo/.gitattributes
@@ -1,0 +1,10 @@
+# Git attributes for consumer repos synced from Workflows
+#
+# Merge strategies to prevent recurring conflicts on PR-specific files:
+# pr_body.md contains issue-specific content that differs between branches.
+# Using merge=ours keeps each branch's version during merges.
+
+pr_body.md merge=ours
+
+# CI autofix history is append-only and branch-specific
+ci/autofix/history.json merge=ours linguist-generated


### PR DESCRIPTION
## Problem

`pr_body.md` has been causing merge conflicts on virtually every PR across all consumer repos:

1. Each PR modifies `pr_body.md` with issue-specific content (tasks, acceptance criteria)
2. When PR A merges to main, main gets PR A's content
3. All other open PRs (with different issue-specific content) immediately conflict

This has required manual conflict resolution repeatedly on:
- Portable-Alpha-Extension-Model (PRs #949, #951, #952)
- Trend_Model_Project (PRs #4136, #4138)

## Solution

Add `.gitattributes` to the consumer-repo template with:
```
pr_body.md merge=ours
ci/autofix/history.json merge=ours linguist-generated
```

The `merge=ours` strategy tells Git to always keep the current branch's version during merges, eliminating conflicts.

## Files Changed

1. **`templates/consumer-repo/.gitattributes`** (new) - Template with merge strategies
2. **`.github/sync-manifest.yml`** - Added `git_config` section to sync the file

## Rollout

Once merged, the next sync cycle will push `.gitattributes` to all consumer repos, preventing future conflicts.

## Related PRs

- Portable-Alpha-Extension-Model #955 (interim fix)
- Trend_Model_Project #4140 (interim fix)