### PR TITLE
fix: exclude .workflows-lib from git commit to prevent orphaned submodule

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -768,8 +768,8 @@ jobs:
           fi
 
           git add -A
-          # Double-check exclusion after git add (safety net)
-          git reset HEAD -- codex-output*.md codex-prompt*.md codex-session-*.jsonl codex-analysis-*.json .coverage 2>/dev/null || true
+          # Exclude generated artifacts and .workflows-lib (a separate checkout that git treats as a submodule)
+          git reset HEAD -- codex-output*.md codex-prompt*.md codex-session-*.jsonl codex-analysis-*.json .coverage .workflows-lib 2>/dev/null || true
           git commit -m "$commit_message"
 
           # Capture commit SHA before push


### PR DESCRIPTION
## Root Cause

When `git add -A` runs in the codex workflow, it registers `.workflows-lib` (which contains a `.git` folder from the `actions/checkout` step) as a **submodule**. However, no `.gitmodules` file is created, resulting in an **orphaned submodule entry**.

This causes `actions/checkout@v6` to fail during cleanup across ALL consumer repos:
```
fatal: No url found for submodule path '.workflows-lib' in .gitmodules
```

## Affected Repos

- stranske/Trend_Model_Project (PR #4200, #4201)
- stranske/Workflows (PR #516)
- Any repo using reusable-codex-run.yml

## Fix

Add `.workflows-lib` to the `git reset` pattern that already excludes other generated artifacts.

## Why This Happens

`.workflows-lib` is a **separate checkout** of stranske/Workflows for scripts, NOT a submodule. But git incorrectly treats directories with `.git` folders as submodules when added with `git add -A`.

## Testing

After this merges, all affected PRs should pass CI cleanup and no more orphaned submodule entries will be created.