### PR TITLE
fix: don't delete codex-prompt files in cleanup step

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -437,9 +437,10 @@ jobs:
           fi
 
           # Remove old codex session/output files that may be untracked
+          # NOTE: Do NOT delete codex-prompt*.md - that's the input file we just created!
           # These are workflow artifacts, not user code
           echo "Removing stale workflow artifact files..."
-          rm -f codex-session*.jsonl codex-output*.md codex-prompt*.md codex-analysis*.json 2>/dev/null || true
+          rm -f codex-session*.jsonl codex-output*.md codex-analysis*.json 2>/dev/null || true
 
           # Show git status for debugging
           echo "Git status after cleanup:"


### PR DESCRIPTION
## Problem

The 'Clean workspace for Codex' step was deleting `codex-prompt*.md` files which are **INPUT files** created by the 'Assemble prompt' step just before.

This caused Codex to run with an empty prompt:
```
cat: codex-prompt-4203.md: No such file or directory
```

Which resulted in:
```
CODEX_SUMMARY: I'm ready. What do you want to work on?
```

## Root Cause

The cleanup command in 'Clean workspace for Codex' step (line 442):
```bash
rm -f codex-session*.jsonl codex-output*.md codex-prompt*.md codex-analysis*.json
```

Was deleting the prompt file that was just created by 'Assemble prompt' step (line 298).

Regression introduced in da01885f.

## Fix

Remove `codex-prompt*.md` from the cleanup list. The cleanup should only remove OUTPUT artifacts from previous runs:
- `codex-session*.jsonl` - session logs
- `codex-output*.md` - Codex responses  
- `codex-analysis*.json` - LLM analysis results

## Impact

This fix will restore keepalive functionality for PRs like:
- https://github.com/stranske/Trend_Model_Project/pull/4203
- https://github.com/stranske/Workflows/pull/519

Both were showing 'Agent Failed' with no new code because Codex received empty prompts.