### PR TITLE
fix(sync): add keepalive_prompt_routing.js to sync manifest

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -158,6 +158,9 @@ scripts:
   - source: .github/scripts/keepalive_loop.js
     description: "Core keepalive loop logic"
 
+  - source: .github/scripts/keepalive_prompt_routing.js
+    description: "Prompt routing logic for keepalive - determines which prompt template to use"
+
   - source: .github/scripts/keepalive_state.js
     description: "Keepalive state management"
 


### PR DESCRIPTION
## Problem

The sync PR that updated `keepalive_instruction_template.js` and `keepalive_loop.js` added imports for `./keepalive_prompt_routing`, but this module was not included in the sync manifest.

This caused all consumer repos receiving the sync to have broken keepalive functionality:

```
Error: Cannot find module './keepalive_prompt_routing'
```

Both scripts fail immediately on load, preventing:
- Keepalive instruction generation
- Keepalive loop evaluation

## Fix

Add `keepalive_prompt_routing.js` to the scripts section of the sync manifest so it gets synced to all consumer repos.

## Testing

After merge, trigger a sync to consumer repos and verify:
```bash
node -e "require('./.github/scripts/keepalive_instruction_template')"
node -e "require('./.github/scripts/keepalive_loop')"
```

Both should load without MODULE_NOT_FOUND errors.