### PR TITLE
fix: address bot review comments from sync PRs

### DIFF
--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -447,7 +447,9 @@ function evaluateGuard({
   const hasCodeownerApproval = hasExternalApproval || authorIsCodeowner;
 
   const hasProtectedChanges = modifiedProtectedPaths.size > 0;
-  // Allow label to bypass approval for automated PRs (dependabot, renovate)
+  // Security note: Allow `agents:allow-change` label to bypass CODEOWNER approval
+  // ONLY for automated dependency PRs from known bots (dependabot, renovate).
+  // Human PRs or other bot PRs still require CODEOWNER approval even with label.
   const isAutomatedPR = normalizedAuthor && (normalizedAuthor === 'dependabot[bot]' || normalizedAuthor === 'renovate[bot]');
   const needsApproval = hasProtectedChanges && !hasCodeownerApproval && !(hasAllowLabel && isAutomatedPR);
   const needsLabel = hasProtectedChanges && !hasAllowLabel && !hasCodeownerApproval;

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1089,7 +1089,7 @@ async function evaluateKeepaliveLoop({ github, context, core, payload: overrideP
   let action = 'wait';
   let reason = 'pending';
   const verificationStatus = normalise(state?.verification?.status);
-  const verificationDone = ['done', 'verified', 'complete'].includes(verificationStatus.toLowerCase());
+  const verificationDone = ['done', 'verified', 'complete'].includes(verificationStatus);
   const needsVerification = allComplete && !verificationDone;
 
   if (!hasAgentLabel) {

--- a/.github/scripts/keepalive_prompt_routing.js
+++ b/.github/scripts/keepalive_prompt_routing.js
@@ -31,7 +31,7 @@ const FEATURE_SCENARIOS = new Set([
   'nexttask',
 ]);
 
-const FIX_MODES = new Set(['fix', 'fix-ci', 'fix_ci', 'ci', 'ci-failure']);
+const FIX_MODES = new Set(['fix', 'fix-ci', 'fix_ci', 'ci', 'ci-failure', 'ci_failure', 'fix-ci-failure']);
 const VERIFY_MODES = new Set(['verify', 'verification', 'verify-acceptance', 'acceptance']);
 
 function resolvePromptMode({ scenario, mode, action, reason } = {}) {


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #123

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
After merging PR #103 (multi-agent routing infrastructure), we need to:
1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments
- The keepalive loop now:
- | `<!-- keepalive-loop-summary -->` | github-actions[bot] | NEW: CLI agent iteration tracking | ✅ Keep for CLI agents |
- | `<!-- keepalive-state:v1 -->` | agents-workflows-bot[bot] | State tracking | ⚠️ Multiple copies accumulate |
- | `<!-- keepalive-round: N -->` | stranske | OLD: Instruction comment | ❌ CLI agents dont need this |
- **The goal:** For CLI agents (`agent:*` label), we should have exactly **one** updating comment (`<!-- keepalive-loop-summary -->`) instead of accumulating 10+ comments per PR.
- Requires PR [#103](https://github.com/stranske/Workflows/issues/103) to be merged first
- **This round you MUST:**
- Review the Scope/Tasks/Acceptance below, identify the next incomplete task that requires code, implement it, then **post a reply comment** with the completed items using their **exact original text**.

### Related Issues/PRs
- [#103](https://github.com/stranske/Workflows/issues/103)
- [#89](https://github.com/stranske/Workflows/issues/89)
- [#123](https://github.com/stranske/Workflows/issues/123)

### References
- https://github.com/stranske/Workflows/compare/main...codex/issue-123?expand=1

### Blockers & Dependencies
- After merging PR [#103](https://github.com/stranske/Workflows/issues/103) (multi-agent routing infrastructure), we need to:
- 3. Mark a task checkbox complete ONLY after verifying the implementation works.
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### Pipeline Validation
- [ ] After PR #103 merges, create a test PR with `agent:codex` label
- [ ] Verify task appendix appears in Codex prompt (check workflow logs)
- [ ] Verify Codex works on actual tasks (not random infrastructure work)
- [ ] Verify keepalive comment updates with iteration progress
### GITHUB_STEP_SUMMARY
- [ ] Add step summary output to `agents-keepalive-loop.yml` after agent run
- [ ] Include: iteration number, tasks completed, files changed, outcome
- [ ] Ensure summary is visible in workflow run UI
### Conditional Status Summary
- [ ] Modify `buildStatusBlock()` in `agents_pr_meta_update_body.js` to accept `agentType` parameter
- [ ] When `agentType` is set (CLI agent): hide workflow table, hide head SHA/required checks
- [ ] Keep Scope/Tasks/Acceptance checkboxes for all cases
- [ ] Pass agent type from workflow to the update_body job
### Comment Pattern Cleanup
- [ ] **For CLI agents (`agent:*` label):**
- [ ] Suppress `<!-- gate-summary: -->` comment posting (use step summary instead)
- [ ] Suppress `<!-- keepalive-round: N -->` instruction comments (task appendix replaces this)
- [ ] Update `<!-- keepalive-loop-summary -->` to be the **single source of truth**
- [ ] Ensure state marker is embedded in the summary comment (not separate)
- [ ] **For UI Codex (no `agent:*` label):**
- [ ] Keep existing comment patterns (instruction comments, connector bot reports)
- [ ] Keep `<!-- gate-summary: -->` comment
- [ ] Add `agent_type` output to detect job so downstream workflows know the mode
- [ ] Update `agents-pr-meta.yml` to conditionally skip gate summary for CLI agent PRs

#### Acceptance criteria
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] Iteration results visible in Actions workflow run summary
- [ ] PR body shows checkboxes but not workflow clutter when using CLI agents
- [ ] UI Codex path (no agent label) continues to show full status summary
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] State tracking is consolidated in the summary comment, not scattered
## Dependencies
- [ ] - Requires PR #103 to be merged first

**Head SHA:** a6a57f55ebecf52c5eae937d4b9eb40e7e22aff7
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20709706778) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636536) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636542) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636521) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636434) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636465) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636450) |
| Keepalive E2E | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/20709636525) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636448) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636455) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636441) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20709636451) |
<!-- auto-status-summary:end -->