### PR TITLE
chore: trigger sync for LangChain Phase 1 rollout

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -7,7 +7,7 @@
 # POLICY: Any file intended for consumer repos MUST be listed here.
 # Files not listed will NOT be synced, even if they exist in templates/consumer-repo/.
 #
-# Last sync trigger: 2025-12-30T20:30:00Z - Revert pyproject.toml sync (breaks existing repos)
+# Last sync trigger: 2026-01-05T16:00:00Z - Add LangChain issue_formatter.py (Phase 1)
 #
 # Categories:
 #   workflows: Thin caller workflows that consumers run directly


### PR DESCRIPTION
Updates the sync manifest timestamp to trigger the maint-68-sync-consumer-repos workflow.

This will sync the LangChain issue_formatter.py and related files to consumer repos.

**No functional changes** - just updating the comment timestamp.