### PR TITLE
fix(ci): standardize black line-length 100 across all workflows

### DIFF
--- a/.github/actions/autofix/action.yml
+++ b/.github/actions/autofix/action.yml
@@ -66,7 +66,7 @@ runs:
         # docformatter before black so black enforces final layout
         docformatter -r -i src tests || true
         # black last for canonical formatting
-        black .
+        black --line-length 100 .
         echo "[autofix] Phase 1b: second ruff pass to capture post-format unlocks"
         ruff check --fix --exit-zero .
 
@@ -75,7 +75,7 @@ runs:
         ruff check --select F401,F841 --fix --unsafe-fixes --exit-zero .
         # Normalise style after unsafe edits.
         isort .
-        black .
+        black --line-length 100 .
         ruff check --fix --exit-zero .
 
         echo "[autofix] Phase 2: collect remaining ruff diagnostics (non-fatal)"

--- a/.github/workflows/maint-50-tool-version-check.yml
+++ b/.github/workflows/maint-50-tool-version-check.yml
@@ -177,7 +177,7 @@ jobs:
                 '"isort==$ISORT_VERSION" "docformatter==$DOCFORMATTER_VERSION" ' +
                 '"mypy==$MYPY_VERSION" "pytest==$PYTEST_VERSION" ' +
                 '"pytest-cov==$PYTEST_COV_VERSION" "coverage==$COVERAGE_VERSION"',
-              'black --check .',
+              'black --check --line-length 100 .',
               'ruff check .',
               'mypy src tests'
             ].join('\n');

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -559,7 +559,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          black --check .
+          black --check --line-length 100 .
 
       - name: Finalize format check
         id: finalize

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -414,7 +414,7 @@ jobs:
           echo "[autofix] Applying Ruff lint fixes"
           ruff check --fix --exit-zero "${targets[@]}"
           echo "[autofix] Normalising whitespace with Black"
-          black "${targets[@]}"
+          black --line-length 100 "${targets[@]}"
 
       - name: Clean cosmetic sweep
         if: steps.guard.outputs.skip != 'true' && steps.clean_mode.outputs.enabled == 'true'
@@ -460,7 +460,7 @@ jobs:
           printf '[autofix-clean] Target directories: %s\n' "${targets[*]}"
           ruff check "${targets[@]}" --select I --fix --exit-zero
           ruff check "${targets[@]}" --fix --exit-zero
-          black "${targets[@]}" || true
+          black --line-length 100 "${targets[@]}" || true
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/selftest-ci.yml
+++ b/.github/workflows/selftest-ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: pip install black ruff pyyaml
 
       - name: Check Black formatting
-        run: black --check .
+        run: black --check --line-length 100 .
 
       - name: Run Ruff linting
         run: ruff check .

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -3,7 +3,8 @@
 Format raw issue text into the AGENT_ISSUE_TEMPLATE structure.
 
 Run with:
-    python scripts/langchain/issue_formatter.py --input-file issue.md --output-file formatted.md
+    python scripts/langchain/issue_formatter.py \
+        --input-file issue.md --output-file formatted.md
 """
 
 from __future__ import annotations

--- a/templates/ci-basic.yml
+++ b/templates/ci-basic.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip install black ruff
 
       - name: Check formatting
-        run: black --check .
+        run: black --check --line-length 100 .
 
       - name: Run linter
         run: ruff check .

--- a/templates/ci-full.yml
+++ b/templates/ci-full.yml
@@ -66,7 +66,7 @@ jobs:
         run: pip install black ruff isort
 
       - name: Check Black formatting
-        run: black --check .
+        run: black --check --line-length 100 .
 
       - name: Check import sorting
         run: isort --check-only .


### PR DESCRIPTION
## Summary
Consumer repos were using black's default line-length of 88, causing synced files formatted for Workflows' line-length of 100 to fail CI checks.

## Changes
Updates all black invocations to explicitly use `--line-length 100`:

- **reusable-10-ci-python.yml**: format check step
- **reusable-18-autofix.yml**: autofix and clean sweep steps
- **.github/actions/autofix/action.yml**: local autofix action
- **selftest-ci.yml**: self-test workflow  
- **maint-50-tool-version-check.yml**: version check workflow
- **templates/ci-basic.yml** and **ci-full.yml**: CI templates

## Impact
- Ensures consistent formatting across Workflows and all consumer repos
- Fixes CI failures in consumer repos caused by synced files
- Once merged and synced, consumer repos will pass format checks

## Testing
- All black invocations now explicitly specify line-length
- No functional changes to CI behavior beyond consistent formatting