### PR TITLE
fix(workflow): add PYTHONPATH and fix import order in issue_formatter

### DIFF
--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -251,6 +251,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           echo "Formatting issue #${ISSUE_NUMBER} into AGENT_ISSUE_TEMPLATE structure"
 

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -94,6 +94,8 @@ def _load_prompt() -> str:
 def _get_llm_client() -> tuple[object, str] | None:
     try:
         from langchain_openai import ChatOpenAI
+
+        from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
     except ImportError:
         return None
 
@@ -101,8 +103,6 @@ def _get_llm_client() -> tuple[object, str] | None:
     openai_token = os.environ.get("OPENAI_API_KEY")
     if not github_token and not openai_token:
         return None
-
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
 
     if github_token:
         return (

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -251,6 +251,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           echo "Formatting issue #${ISSUE_NUMBER} into AGENT_ISSUE_TEMPLATE structure"
 


### PR DESCRIPTION
## Summary

Fixes the agents-issue-optimizer workflow to work in consumer repos that do not have langchain installed.

## Changes

1. **Add PYTHONPATH env var** to Phase 3 format step so Python can find the `tools` module
2. **Move `tools.llm_provider` import** inside the try/except block in `issue_formatter.py` so it gracefully falls back to regex-based formatting when langchain is not installed

## Root Cause

The workflow failed with:
```
ModuleNotFoundError: No module named 'tools'
```

This happened because:
1. PYTHONPATH was not set, so Python could not find `tools.llm_provider`
2. Even after PYTHONPATH fix, the import was outside the try/except block, so it would crash instead of falling back gracefully

## Testing

- [x] Traced full execution path to identify all failure points
- [x] Verified fallback to regex-based formatting works without langchain
- [x] Confirmed label transition logic is already present