### PR TITLE
docs: add agents:format label documentation

### DIFF
--- a/templates/consumer-repo/README.md
+++ b/templates/consumer-repo/README.md
@@ -26,6 +26,7 @@ the centralized CI and automation workflows from stranske/Workflows.
 | File | Purpose | Required Secrets |
 |------|---------|-----------------|
 | `agents-issue-intake.yml` | Creates PRs from labeled issues | `SERVICE_BOT_PAT`, `OWNER_PR_PAT` |
+| `agents-issue-optimizer.yml` | Formats issues using LangChain | `OPENAI_API_KEY` (optional) |
 | `agents-keepalive-loop.yml` | Runs Codex CLI after Gate passes | `CODEX_AUTH_JSON` or `WORKFLOWS_APP_*` |
 | `agents-pr-meta.yml` | Updates PR status summaries | `SERVICE_BOT_PAT` |
 | `agents-orchestrator.yml` | (Legacy) Scheduled keepalive sweeps | `SERVICE_BOT_PAT`, `ACTIONS_BOT_PAT` |


### PR DESCRIPTION
Add comprehensive documentation for the new LangChain Issue Formatter workflow:

- Document agents:format label (trigger) in LABELS.md
- Document agents:formatted label (result) in LABELS.md
- Add both labels to Quick Reference table
- Update Label Interaction Matrix with format workflow
- Add agents-issue-optimizer.yml to README workflow table

The workflow converts raw issue descriptions into structured AGENT_ISSUE_TEMPLATE format with Why/Scope/Non-Goals/Tasks/Acceptance Criteria sections using LLM with regex fallback.