### PR TITLE
feat: expose source_url input in consumer caller template

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: boolean
         default: false
+      source_url:
+        description: "[chatgpt_sync] URL to raw text file with topics to import"
+        required: false
+        type: string
+        default: ""
       topic_files:
         description: "[chatgpt_sync] Topic files to sync (e.g., topics.json, agents/*.md)"
         required: false
@@ -185,5 +190,6 @@ jobs:
     with:
       intake_mode: "chatgpt_sync"
       source: ${{ inputs.topic_files }}
+      source_url: ${{ inputs.source_url }}
       apply_langchain_formatting: ${{ inputs.apply_langchain_formatting && 'true' || 'false' }}
     secrets: inherit


### PR DESCRIPTION
Add source_url input to agents-issue-intake.yml template so consumer repos can provide a URL to a raw text file for chatgpt_sync mode.