### PR TITLE
fix: add models:read permission to chatgpt_sync job

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -240,6 +240,7 @@ jobs:
     permissions:
       contents: read
       issues: write # Only elevated when a sync actually mutates issues; early exits remain read-only.
+      models: read # Required for LLM-based topic splitting
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Required for LLM-based topic splitting to call GitHub Models API.