### PR TITLE
fix: enable force_mode to create PR on issue label events

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -169,6 +169,7 @@ jobs:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}
       mode: "create"
+      force_mode: true
       post_agent_comment: ${{ inputs.post_codex_comment && 'true' || 'false' }}
       agent_pr_draft: ${{ inputs.bridge_draft_pr && 'true' || 'false' }}
     secrets:


### PR DESCRIPTION
The bridge workflow defaults to invite mode on issue events, expecting the human to create the PR. Add force_mode: true to actually create the PR when labeling an issue with agent:*.