### PR TITLE
fix: Separate stderr from JSON output in verifier

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -285,8 +285,8 @@ jobs:
           fi
           args+=(--create-issue --issue-label agent:codex --issue-label verify:evaluate)
 
-          # Run evaluator
-          python .workflows-lib/scripts/langchain/pr_verifier.py "${args[@]}" > evaluation.json 2>&1 || true
+          # Run evaluator (stderr to separate file to avoid corrupting JSON)
+          python .workflows-lib/scripts/langchain/pr_verifier.py "${args[@]}" > evaluation.json 2> evaluation-stderr.log || true
 
           # Parse result
           if [ -f evaluation.json ]; then
@@ -387,8 +387,8 @@ jobs:
             args+=(--diff-file "$diff_file")
           fi
 
-          # Run comparison and capture output
-          python .workflows-lib/scripts/langchain/pr_verifier.py "${args[@]}" > comparison.json 2>&1 || true
+          # Run comparison (stderr to separate file to avoid corrupting JSON)
+          python .workflows-lib/scripts/langchain/pr_verifier.py "${args[@]}" > comparison.json 2> comparison-stderr.log || true
 
           # Parse result
           if [ -f comparison.json ]; then


### PR DESCRIPTION
## Summary
Fix JSON parsing error in verifier's LLM evaluation by separating stderr from stdout.

## Problem
The pr_verifier.py script writes status messages to stderr (e.g., 'Created follow-up issue #X'). The workflow was capturing both stdout and stderr to the same file with `2>&1`, which corrupted the JSON output and caused parsing errors:

```
Evaluation encountered an error: Expecting value: line 1 column 1 (char 0)
```

## Solution
Redirect stderr to separate log files:
- `evaluation.json` + `evaluation-stderr.log`
- `comparison.json` + `comparison-stderr.log`

This keeps the JSON output clean while still capturing any diagnostic messages.