### PR TITLE
fix: Include langchain scripts in verifier sparse checkout

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -62,6 +62,8 @@ jobs:
           sparse-checkout: |
             .github/scripts
             .github/codex/prompts
+            scripts/langchain
+            tools
           sparse-checkout-cone-mode: false
           path: .workflows-lib
           fetch-depth: 1


### PR DESCRIPTION
## Summary
The verifier's sparse checkout was missing critical directories needed for LLM evaluation:
- `scripts/langchain` (contains `pr_verifier.py`)
- `tools` (contains `llm_provider.py`)

This caused the `pr_verifier.py` script to not exist during workflow execution, resulting in an empty `evaluation.json` and parsing errors.

## Root Cause
When the verifier workflow called:
```bash
python .workflows-lib/scripts/langchain/pr_verifier.py ...
```

The script didn't exist because the sparse checkout only included:
- `.github/scripts`
- `.github/codex/prompts`

## Testing
After this fix, the LLM evaluation should:
1. Find the pr_verifier.py script
2. Successfully call the OpenAI API
3. Produce valid JSON output with evaluation results