### PR TITLE
fix: Escape JSON braces in pr_verifier prompt template

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -272,22 +272,10 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PYTHONPATH: .workflows-lib
         run: |
-          set -uo pipefail  # Note: removed -e to capture exit codes properly
+          set -euo pipefail
           context_file="${{ steps.context.outputs.context_path }}"
           diff_file="${{ steps.context.outputs.diff_summary_path }}"
           model="${{ inputs.model }}"
-
-          # Debug: Verify script exists and show environment
-          echo "=== DEBUG: Pre-execution verification ==="
-          echo "PYTHONPATH=$PYTHONPATH"
-          echo "Script location:"
-          ls -la .workflows-lib/scripts/langchain/pr_verifier.py 2>&1 || echo "Script NOT FOUND!"
-          echo "Tools directory:"
-          ls -la .workflows-lib/tools/ 2>&1 || echo "Tools dir NOT FOUND!"
-          echo "Python version:"
-          python --version
-          echo "Checking pr_verifier imports..."
-          python -c "from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL; print('Import OK - DEFAULT_MODEL:', DEFAULT_MODEL)" 2>&1 || echo "Import FAILED!"
 
           # Build args array
           args=(--context-file "$context_file" --json)
@@ -299,21 +287,8 @@ jobs:
           fi
           args+=(--create-issue --issue-label agent:codex --issue-label verify:evaluate)
 
-          echo "=== DEBUG: Running command ==="
-          echo "python .workflows-lib/scripts/langchain/pr_verifier.py ${args[*]}"
-
           # Run evaluator (stderr to separate file to avoid corrupting JSON)
-          # Use || true to capture exit code instead of failing script
           python .workflows-lib/scripts/langchain/pr_verifier.py "${args[@]}" > evaluation.json 2> evaluation-stderr.log || true
-          exit_code=$?
-          echo "Exit code: $exit_code"
-
-          # Debug: Show outputs
-          echo "=== DEBUG: evaluation-stderr.log ==="
-          cat evaluation-stderr.log 2>/dev/null || echo "(empty or missing)"
-          echo "=== DEBUG: evaluation.json (first 500 chars) ==="
-          head -c 500 evaluation.json 2>/dev/null || echo "(empty or missing)"
-          echo ""
 
           # Parse result
           if [ -f evaluation.json ]; then

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -37,19 +37,19 @@ Provide an evaluation that covers:
 - risks
 
 Respond in JSON with:
-{
+{{
   "verdict": "PASS | CONCERNS | FAIL",
   "confidence": 0.0-1.0,
-  "scores": {
+  "scores": {{
     "correctness": 0-10,
     "completeness": 0-10,
     "quality": 0-10,
     "testing": 0-10,
     "risks": 0-10
-  },
+  }},
   "concerns": ["..."],
   "summary": "concise report"
-}
+}}
 """.strip()
 
 PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "pr_evaluation.md"

--- a/scripts/langchain/prompts/pr_evaluation.md
+++ b/scripts/langchain/prompts/pr_evaluation.md
@@ -14,16 +14,16 @@ Evaluate the change against the acceptance criteria and code quality. Explicitly
 - risks (security, performance, compatibility)
 
 Respond in JSON with:
-{
+{{
   "verdict": "PASS | CONCERNS | FAIL",
   "confidence": 0.0-1.0,
-  "scores": {
+  "scores": {{
     "correctness": 0-10,
     "completeness": 0-10,
     "quality": 0-10,
     "testing": 0-10,
     "risks": 0-10
-  },
+  }},
   "concerns": ["..."],
   "summary": "concise report"
-}
+}}


### PR DESCRIPTION
## Problem
The `verify:evaluate` feature was failing with:
```
KeyError: '\n  "verdict"'
```

## Root Cause
The prompt template for `pr_verifier.py` contains JSON examples with curly braces:
```
Respond in JSON with:
{
  "verdict": "PASS | CONCERNS | FAIL",
  ...
}
```

When using Python's `str.format()` to substitute `{context}` and `{diff}`, the unescaped braces in the JSON examples were being interpreted as format placeholders.

## Solution
Escaped the JSON curly braces by doubling them (`{{` and `}}`) in:
- `PR_EVALUATION_PROMPT` constant in `pr_verifier.py`
- External prompt file `scripts/langchain/prompts/pr_evaluation.md`

## Testing
- Verified `_prepare_prompt()` works correctly with test inputs
- All existing pr_verifier tests pass
- The doubled braces become single braces after `.format()` is applied

## Also Included
Cleaned up debug logging from `reusable-agents-verifier.yml` that was added during investigation.