### PR TITLE
test: Use GPT-5.2 for verifier evaluation

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -29,7 +29,7 @@ on:
         description: 'LLM model to use for evaluation (e.g., gpt-4o, gpt-4o-mini, o1-mini). Defaults to gpt-4o-mini.'
         required: false
         type: string
-        default: 'gpt-4o-mini'
+        default: 'gpt-5.2'
     secrets:
       CODEX_AUTH_JSON:
         required: false


### PR DESCRIPTION
Temporary change to test verify:evaluate with GPT-5.2 model via OpenAI API.