### PR TITLE
feat: Add model/provider selection to verifier workflow

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -26,10 +26,15 @@ on:
         type: string
         default: 'checkbox'
       model:
-        description: 'LLM model to use for evaluation (e.g., gpt-4o, gpt-4o-mini, o1-mini). Defaults to gpt-4o-mini.'
+        description: 'LLM model to use for evaluation (e.g., gpt-4o, gpt-4o-mini, gpt-5.2, o1-mini)'
         required: false
         type: string
-        default: 'gpt-5.2'
+        default: 'gpt-4o-mini'
+      provider:
+        description: 'LLM provider: github-models (default) or openai'
+        required: false
+        type: string
+        default: 'github-models'
     secrets:
       CODEX_AUTH_JSON:
         required: false
@@ -276,6 +281,7 @@ jobs:
           context_file="${{ steps.context.outputs.context_path }}"
           diff_file="${{ steps.context.outputs.diff_summary_path }}"
           model="${{ inputs.model }}"
+          provider="${{ inputs.provider }}"
 
           # Build args array
           args=(--context-file "$context_file" --json)
@@ -284,6 +290,9 @@ jobs:
           fi
           if [ -n "$model" ]; then
             args+=(--model "$model")
+          fi
+          if [ -n "$provider" ] && [ "$provider" != "github-models" ]; then
+            args+=(--provider "$provider")
           fi
           args+=(--create-issue --issue-label agent:codex --issue-label verify:evaluate)
 

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -107,12 +107,16 @@ def _load_prompt() -> str:
     return _ensure_prompt_rubric(PR_EVALUATION_PROMPT)
 
 
-def _get_llm_client(model: str | None = None) -> tuple[object, str] | None:
+def _get_llm_client(
+    model: str | None = None, provider: str | None = None
+) -> tuple[object, str] | None:
     """Get an LLM client for evaluation.
 
     Args:
-        model: Optional model name override. If provided with OPENAI_API_KEY,
-               uses OpenAI directly. Otherwise uses GitHub Models with GITHUB_TOKEN.
+        model: Optional model name override.
+        provider: Optional provider override ('openai' or 'github-models').
+                  If not specified, uses OpenAI if OPENAI_API_KEY is set and model
+                  is specified, otherwise falls back to GitHub Models.
 
     Returns:
         Tuple of (client, provider_name) or None if no credentials available.
@@ -132,7 +136,33 @@ def _get_llm_client(model: str | None = None) -> tuple[object, str] | None:
     # Use the provided model or fall back to default
     selected_model = model or DEFAULT_MODEL
 
-    # If OPENAI_API_KEY is available and either a custom model is requested
+    # Explicit provider selection
+    if provider == "openai":
+        if not openai_token:
+            return None
+        return (
+            ChatOpenAI(
+                model=selected_model,
+                api_key=openai_token,
+                temperature=0.1,
+            ),
+            f"openai/{selected_model}",
+        )
+
+    if provider == "github-models":
+        if not github_token:
+            return None
+        return (
+            ChatOpenAI(
+                model=selected_model,
+                base_url=GITHUB_MODELS_BASE_URL,
+                api_key=github_token,
+                temperature=0.1,
+            ),
+            f"github-models/{selected_model}",
+        )
+
+    # Auto-select: If OPENAI_API_KEY is available and either a custom model is requested
     # OR GITHUB_TOKEN is not available, prefer OpenAI for better model availability
     if openai_token and (model or not github_token):
         return (
@@ -411,23 +441,27 @@ def _parse_llm_response(content: str, provider: str) -> EvaluationResult:
 
 
 def evaluate_pr(
-    context: str, diff: str | None = None, model: str | None = None
+    context: str,
+    diff: str | None = None,
+    model: str | None = None,
+    provider: str | None = None,
 ) -> EvaluationResult:
     """Evaluate a PR against its acceptance criteria.
 
     Args:
         context: The PR context markdown (issue body, PR description, etc.)
         diff: Optional PR diff or summary
-        model: Optional model name (e.g., 'gpt-4o', 'o1-mini'). Uses default if not specified.
+        model: Optional model name (e.g., 'gpt-4o', 'gpt-5.2', 'o1-mini'). Uses default if not specified.
+        provider: Optional provider ('openai' or 'github-models'). Auto-selects if not specified.
 
     Returns:
         EvaluationResult with verdict, scores, and concerns.
     """
-    resolved = _get_llm_client(model=model)
+    resolved = _get_llm_client(model=model, provider=provider)
     if resolved is None:
         return _fallback_evaluation("LLM client unavailable (missing credentials or dependency).")
 
-    client, provider = resolved
+    client, provider_name = resolved
     prompt = _prepare_prompt(context, diff)
     try:
         response = client.invoke(prompt)
@@ -435,7 +469,7 @@ def evaluate_pr(
         return _fallback_evaluation(f"LLM invocation failed: {exc}")
 
     content = getattr(response, "content", None) or str(response)
-    return _parse_llm_response(content, provider)
+    return _parse_llm_response(content, provider_name)
 
 
 def evaluate_pr_multiple(context: str, diff: str | None = None) -> list[EvaluationResult]:
@@ -616,7 +650,12 @@ def main() -> None:
     parser.add_argument("--output-file", help="Path to write evaluation output.")
     parser.add_argument(
         "--model",
-        help="LLM model to use (e.g., gpt-4o, gpt-4o-mini, o1-mini). Uses OPENAI_API_KEY if set.",
+        help="LLM model to use (e.g., gpt-4o, gpt-4o-mini, gpt-5.2, o1-mini).",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["openai", "github-models"],
+        help="LLM provider: 'openai' (requires OPENAI_API_KEY) or 'github-models' (uses GITHUB_TOKEN).",
     )
     parser.add_argument(
         "--create-issue",
@@ -654,7 +693,7 @@ def main() -> None:
             print(report)
         return
 
-    result = evaluate_pr(context, diff=diff, model=args.model)
+    result = evaluate_pr(context, diff=diff, model=args.model, provider=args.provider)
     issue_labels = args.issue_label or ["agent:codex"]
     run_url = None
     if (

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -3,12 +3,14 @@
 #
 # Triggers:
 # - Label 'verify:checkbox' added to merged PR (opt-in checkbox verification)
-# - Label 'verify:evaluate' added to merged PR (future: LLM evaluation)
+# - Label 'verify:evaluate' added to merged PR (LLM-based evaluation)
 # - Label 'verify:compare' added to merged PR (compare-based verification)
+# - Manual dispatch from Actions tab (allows model/provider selection)
 # Note: No longer runs automatically on every merge. Add a verify:* label to trigger.
 #
 # Required secrets (via secrets: inherit):
 # - CODEX_AUTH_JSON: Authentication for Codex API
+# - OPENAI_API_KEY: For OpenAI provider (optional, falls back to GitHub Models)
 # - Ensure repository/org secrets are configured for verification to work
 #
 # Note: Uses pull_request_target instead of pull_request to ensure secrets
@@ -19,6 +21,34 @@ on:
   pull_request_target:
     types:
       - labeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to verify (must be merged)'
+        required: true
+        type: number
+      mode:
+        description: 'Verification mode'
+        required: true
+        type: choice
+        options:
+          - evaluate
+          - checkbox
+          - compare
+        default: 'evaluate'
+      model:
+        description: 'LLM model (e.g., gpt-4o-mini, gpt-4o, o1). Run List LLM Models first'
+        required: false
+        type: string
+        default: 'gpt-4o-mini'
+      provider:
+        description: 'LLM provider (OpenAI requires OPENAI_API_KEY secret)'
+        required: true
+        type: choice
+        options:
+          - github-models
+          - openai
+        default: 'github-models'
 
 permissions:
   contents: read
@@ -27,18 +57,59 @@ permissions:
   actions: read
 
 jobs:
-  # Gate: only proceed if PR is merged AND has verify:* label
+  # Gate: only proceed if PR is merged AND has verify:* label (for label trigger)
+  # Or if triggered manually via workflow_dispatch
   check:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       mode: ${{ steps.check.outputs.mode }}
+      model: ${{ steps.check.outputs.model }}
+      provider: ${{ steps.check.outputs.provider }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
     steps:
       - name: Check trigger conditions
         id: check
         uses: actions/github-script@v8
         with:
           script: |
+            // Handle workflow_dispatch trigger
+            if (context.eventName === 'workflow_dispatch') {
+              const prNumber = context.payload.inputs.pr_number;
+              const mode = context.payload.inputs.mode;
+              const model = context.payload.inputs.model;
+              const provider = context.payload.inputs.provider;
+
+              // Verify PR exists and is merged
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  ...context.repo,
+                  pull_number: parseInt(prNumber),
+                });
+
+                if (!pr.merged) {
+                  const msg = `PR #${prNumber} is not merged. Verifier only runs on merged PRs.`;
+                  core.setFailed(msg);
+                  core.setOutput('should_run', 'false');
+                  return;
+                }
+
+                const logMsg = `Manual dispatch: PR #${prNumber}, mode=${mode}`;
+                core.info(`${logMsg}, model=${model}, provider=${provider}`);
+                core.setOutput('should_run', 'true');
+                core.setOutput('mode', mode);
+                core.setOutput('model', model);
+                core.setOutput('provider', provider);
+                core.setOutput('pr_number', prNumber);
+                return;
+              } catch (err) {
+                core.setFailed(`Failed to get PR #${prNumber}: ${err.message}`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+            }
+
+            // Handle pull_request_target trigger (label added)
             const pr = context.payload.pull_request;
             const label = context.payload.label;
 
@@ -67,6 +138,9 @@ jobs:
             core.info(`Verifier triggered with mode: ${mode}`);
             core.setOutput('should_run', 'true');
             core.setOutput('mode', mode);
+            core.setOutput('model', '');  // Use default
+            core.setOutput('provider', '');  // Use default
+            core.setOutput('pr_number', pr.number.toString());
 
   verifier:
     needs: check
@@ -75,6 +149,10 @@ jobs:
     with:
       # CI workflows to wait for before running verifier
       ci_workflows: '["ci.yml", "pr-00-gate.yml"]'
-      # Verification mode from label
+      # Verification mode from label or manual input
       mode: ${{ needs.check.outputs.mode }}
+      # Model selection (empty string uses default)
+      model: ${{ needs.check.outputs.model }}
+      # Provider selection (empty string uses default)
+      provider: ${{ needs.check.outputs.provider }}
     secrets: inherit

--- a/templates/consumer-repo/.github/workflows/list-llm-models.yml
+++ b/templates/consumer-repo/.github/workflows/list-llm-models.yml
@@ -1,0 +1,159 @@
+# List available LLM models from GitHub Models and OpenAI
+# Run this workflow to see what models are currently available for use with
+# the Agents Verifier workflow.
+#
+# Usage:
+# 1. Go to Actions tab
+# 2. Select "List LLM Models"
+# 3. Click "Run workflow"
+# 4. Check the workflow output for available models
+# 5. Use a model name when running Agents Verifier
+name: List LLM Models
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'Which provider to query'
+        required: true
+        type: choice
+        options:
+          - both
+          - github-models
+          - openai
+        default: 'both'
+
+permissions:
+  contents: read
+
+jobs:
+  list-models:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List GitHub Models
+        if: inputs.provider == 'both' || inputs.provider == 'github-models'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "## GitHub Models (via GITHUB_TOKEN)"
+          echo ""
+          echo "Fetching available models from GitHub Models API..."
+          echo ""
+
+          # Query GitHub Models API
+          response=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://models.inference.ai.azure.com/models" 2>/dev/null || \
+            echo '{"error": "Failed to fetch"}')
+
+          if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+            echo "⚠️  Could not fetch GitHub Models list. Common models include:"
+            echo ""
+            echo "| Model | Description |"
+            echo "|-------|-------------|"
+            echo "| gpt-4o | GPT-4o - fast, multimodal |"
+            echo "| gpt-4o-mini | GPT-4o Mini - fast, cost-effective |"
+            echo "| o1 | O1 - advanced reasoning |"
+            echo "| o1-mini | O1 Mini - efficient reasoning |"
+            echo "| o3-mini | O3 Mini - latest reasoning |"
+            echo ""
+          else
+            echo "### Available Models"
+            echo ""
+            echo "| Model ID | Owned By |"
+            echo "|----------|----------|"
+            echo "$response" | jq -r '.data[]? | "| \(.id) | \(.owned_by // "N/A") |"' \
+              2>/dev/null || \
+              echo "$response" | jq -r '.[]? | "| \(.id // .name) | N/A |"' \
+              2>/dev/null || echo "| (Could not parse response) | |"
+            echo ""
+          fi
+
+          echo "---"
+          echo ""
+
+      - name: List OpenAI Models
+        if: inputs.provider == 'both' || inputs.provider == 'openai'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          echo "## OpenAI Models (via OPENAI_API_KEY)"
+          echo ""
+
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "⚠️  OPENAI_API_KEY secret not configured. Add it to use OpenAI models."
+            echo ""
+            echo "Common OpenAI models:"
+            echo ""
+            echo "| Model | Description |"
+            echo "|-------|-------------|"
+            echo "| gpt-4o | GPT-4o - flagship multimodal |"
+            echo "| gpt-4o-mini | GPT-4o Mini - affordable |"
+            echo "| gpt-4-turbo | GPT-4 Turbo - 128k context |"
+            echo "| gpt-5.2 | GPT-5.2 - latest generation |"
+            echo "| o1 | O1 - reasoning model |"
+            echo "| o1-mini | O1 Mini - fast reasoning |"
+            echo "| o3-mini | O3 Mini - efficient reasoning |"
+            exit 0
+          fi
+
+          echo "Fetching available models from OpenAI API..."
+          echo ""
+
+          response=$(curl -s -H "Authorization: Bearer $OPENAI_API_KEY" \
+            "https://api.openai.com/v1/models" 2>/dev/null || \
+            echo '{"error": "Failed to fetch"}')
+
+          if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+            error_msg=$(echo "$response" | \
+              jq -r '.error.message // .error // "Unknown error"')
+            echo "❌ Error fetching models: $error_msg"
+            exit 1
+          fi
+
+          echo "### Chat/Completion Models (recommended for verifier)"
+          echo ""
+          echo "| Model ID | Created |"
+          echo "|----------|---------|"
+          # Filter for GPT and O-series models, sorted by creation date (newest first)
+          echo "$response" | jq -r '
+            .data
+            | map(select(.id | test("^(gpt-|o1|o3|chatgpt)"; "i")))
+            | sort_by(.created) | reverse
+            | .[]
+            | "| \(.id) | \(.created | strftime("%Y-%m-%d")) |"
+          ' 2>/dev/null | head -30
+
+          echo ""
+          echo "### All Available Models"
+          echo ""
+          echo "<details>"
+          echo "<summary>Click to expand full model list</summary>"
+          echo ""
+          echo "| Model ID | Owned By |"
+          echo "|----------|----------|"
+          echo "$response" | jq -r \
+            '.data | sort_by(.id) | .[] | "| \(.id) | \(.owned_by) |"' 2>/dev/null
+          echo ""
+          echo "</details>"
+
+      - name: Usage Instructions
+        run: |
+          echo ""
+          echo "---"
+          echo ""
+          echo "## How to Use"
+          echo ""
+          echo "1. Copy a model ID from the lists above"
+          echo "2. Go to **Actions** → **Agents Verifier**"
+          echo "3. Click **Run workflow**"
+          echo "4. Enter the PR number, select mode, paste the model ID, and choose provider"
+          echo "5. Click **Run workflow**"
+          echo ""
+          echo "### Example"
+          echo ""
+          echo '```'
+          echo "PR number: 123"
+          echo "Mode: evaluate"
+          echo "Model: gpt-4o"
+          echo "Provider: openai"
+          echo '```'


### PR DESCRIPTION
## Summary
Adds the ability to run the Agents Verifier workflow manually from the GitHub Actions tab with customizable model and provider selection.

## Changes

### New `workflow_dispatch` trigger for Agents Verifier
Users can now go to **Actions** → **Agents Verifier** → **Run workflow** and specify:
- **PR number**: Which merged PR to verify
- **Mode**: Which verification to run (summary, topics, evaluate, checkbox, compare)
- **Model**: LLM model to use (freeform text - run 'List LLM Models' to see options)
- **Provider**: Either `github-models` (free, uses GITHUB_TOKEN) or `openai` (requires OPENAI_API_KEY)

### New `List LLM Models` workflow
A helper workflow that queries the APIs to show currently available models:
- Lists GitHub Models available via GITHUB_TOKEN
- Lists OpenAI models available via OPENAI_API_KEY (if configured)
- Displays results in formatted tables

### Updated `pr_verifier.py`
- Added `--provider` CLI argument (`openai` or `github-models`)
- Updated `_get_llm_client()` to route to correct API based on provider
- OpenAI provider uses `api.openai.com`, GitHub Models uses `models.inference.ai.azure.com`

## Usage

### To see available models:
1. Go to Actions → List LLM Models → Run workflow
2. Select which provider(s) to query
3. Check the output for available model names

### To run the verifier with a specific model:
1. Go to Actions → Agents Verifier → Run workflow
2. Enter PR number (must be merged)
3. Select mode (e.g., `evaluate`)
4. Enter model name (e.g., `gpt-4o`, `gpt-5.2`, `o1-mini`)
5. Select provider (`openai` or `github-models`)
6. Click Run workflow

## Testing
- [x] Pre-commit hooks pass
- [ ] CI tests