### PR TITLE
fix: use correct action versions in agents-63-issue-intake

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -243,7 +243,7 @@ jobs:
       models: read # Required for LLM-based topic splitting
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Echo received inputs
         run: |
@@ -315,7 +315,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: ${{ always() && needs.normalize_inputs.outputs.debug == 'true' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: chatgpt-sync-debug
           path: |
@@ -333,7 +333,7 @@ jobs:
 
       - name: Checkout topic splitter from Workflows repo
         if: needs.normalize_inputs.outputs.apply_langchain_formatting == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: stranske/Workflows
           sparse-checkout: |


### PR DESCRIPTION
## Problem

The workflow was failing with `startup_failure` because it referenced action versions that don't exist:
- `actions/checkout@v6` (doesn't exist, latest is v4)
- `actions/upload-artifact@v6` (doesn't exist, latest is v4)

## Solution

Changed all references to use the correct v4 versions:
- `actions/checkout@v4`
- `actions/upload-artifact@v4`

## Impact

This fix allows the chatgpt_sync functionality to work when called from consumer repos like Travel-Plan-Permission.