### PR TITLE
fix: add checkboxes to acceptance criteria section

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -860,7 +860,7 @@ jobs:
                 lines.push('## Non-Goals', ensureContent(topic.sections.non_goals), '');
               }
               lines.push('## Tasks', formatTasks(topic.sections?.tasks || ''), '');
-              lines.push('## Acceptance Criteria', ensureContent(topic.sections?.acceptance_criteria || ''), '');
+              lines.push('## Acceptance Criteria', formatTasks(topic.sections?.acceptance_criteria || ''), '');
               lines.push('## Implementation Notes', ensureContent(topic.sections?.implementation_notes || ''));
               if (topic.extras && topic.extras.trim()) {
                 lines.push('', '## Additional Context', ensureContent(topic.extras));


### PR DESCRIPTION
## Why

The buildBody function was using formatTasks() for the Tasks section (which adds checkboxes) but ensureContent() for Acceptance Criteria (which doesn't add checkboxes).

## Changes

- Updated line 863 to use formatTasks() for acceptance_criteria instead of ensureContent()
- Now both Tasks and Acceptance Criteria will have bullet points converted to checkboxes

## Testing

This will be automatically synced to consumer repos via the sync workflow.