### PR TITLE
fix: Use GPT-5.2 for OpenAI in compare mode

### DIFF
--- a/docs/MODEL_MANAGEMENT.md
+++ b/docs/MODEL_MANAGEMENT.md
@@ -1,0 +1,124 @@
+# Model Management Guide
+
+## Keeping Model Lists Current
+
+The workflows support various LLM models from different providers. This guide explains how to keep the model lists up-to-date.
+
+## Quick Update Process
+
+```bash
+# Set your OpenAI API key
+export OPENAI_API_KEY="sk-..."
+
+# Run the update script
+./scripts/update_model_list.sh
+```
+
+This will fetch the current list of available models from OpenAI's API and display them categorized by series.
+
+## Manual API Query
+
+You can also query the API directly:
+
+```bash
+curl https://api.openai.com/v1/models \
+  -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[].id' | sort
+```
+
+## Model Selection Guidelines
+
+### High Quality Models (for critical evaluation)
+- **o1**: Latest reasoning model from OpenAI
+- **gpt-4o**: Current flagship multimodal model
+- **gpt-4-turbo**: Fast, capable GPT-4 variant
+
+### Efficient Models (for rapid iteration)
+- **o3-mini**: Small reasoning model
+- **o1-mini**: Smaller reasoning model  
+- **gpt-4o-mini**: Fast, cost-effective GPT-4o
+- **gpt-3.5-turbo**: Budget-friendly option
+
+### GitHub Models vs OpenAI
+
+**GitHub Models API** (`https://models.inference.ai.azure.com`):
+- Uses GITHUB_TOKEN (no additional API key needed)
+- Provides access to various models including Meta-Llama
+- May have different model availability than OpenAI
+
+**OpenAI API** (`https://api.openai.com`):
+- Requires OPENAI_API_KEY
+- Direct access to all OpenAI models
+- Generally has latest models first
+
+## Updating Workflow Configurations
+
+After checking current models, update these files:
+
+### 1. Consumer Template Workflow
+**File**: `templates/consumer-repo/.github/workflows/agents-verifier.yml`
+
+Update the model descriptions:
+```yaml
+model:
+  description: >-
+    GitHub Models: [list here] | OpenAI: [list here]
+```
+
+Update default values for compare mode (lines ~155-156):
+```javascript
+core.setOutput('model', 'gpt-4o');  // High quality model
+core.setOutput('model2', 'o1');     // Different high quality model
+```
+
+### 2. Reusable Workflow (if needed)
+**File**: `.github/workflows/reusable-agents-verifier.yml`
+
+Update input descriptions if model lists change significantly.
+
+### 3. Sync Changes
+After updating templates:
+```bash
+git add templates/consumer-repo/.github/workflows/agents-verifier.yml
+git commit -m "Update model lists to current OpenAI offerings"
+git push
+```
+
+The sync workflow will automatically propagate changes to consumer repos.
+
+## Testing New Models
+
+Before setting as defaults, test new models:
+
+```bash
+# Test with pr_verifier locally
+python scripts/langchain/pr_verifier.py \
+  --repo owner/repo \
+  --pr 123 \
+  --mode evaluate \
+  --model "new-model-name" \
+  --json
+```
+
+Or trigger workflow manually with `workflow_dispatch` and specify the model.
+
+## Model Naming Notes
+
+- **Base names** (e.g., `gpt-4o`) point to latest stable version
+- **Dated versions** (e.g., `gpt-4o-2024-08-06`) are frozen snapshots
+- Use base names in workflows for automatic updates
+- Use dated versions when reproducibility is critical
+
+## Resources
+
+- **OpenAI Models Docs**: https://platform.openai.com/docs/models
+- **OpenAI API Reference**: https://platform.openai.com/docs/api-reference/models
+- **GitHub Models**: GitHub.com → Settings → GitHub Models (for available models)
+
+## Scheduled Updates
+
+Recommend checking for model updates:
+- Monthly for production stability
+- Weekly if using cutting-edge features
+- After OpenAI announces new releases
+
+Run `./scripts/update_model_list.sh` to check current availability.

--- a/scripts/update_model_list.sh
+++ b/scripts/update_model_list.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Update model list from OpenAI API and GitHub Models API
+# Run this periodically to keep model information current
+# Requires: OPENAI_API_KEY and/or GITHUB_TOKEN environment variables
+
+set -e
+
+echo "======================================================================"
+echo "Model List Update - $(date '+%Y-%m-%d %H:%M:%S')"
+echo "======================================================================"
+echo ""
+
+# Check GitHub Models first (always available in workflows)
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Fetching GitHub Models..."
+    curl -s https://models.inference.ai.azure.com/models \
+      -H "Authorization: Bearer $GITHUB_TOKEN" | \
+    python3 << 'PYEOF'
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+    if isinstance(data, list):
+        models = sorted([m.get('id', m.get('name', str(m))) for m in data])
+        print("GitHub Models API:")
+        print("-" * 60)
+        # Extract just the model names (after last /)
+        gpt_models = []
+        llama_models = []
+        other_models = []
+
+        for m in models:
+            if '/models/' in m:
+                parts = m.split('/models/')
+                if len(parts) > 1:
+                    model_name = parts[1].split('/')[0]
+                    if 'gpt' in model_name.lower():
+                        gpt_models.append(model_name)
+                    elif 'llama' in model_name.lower():
+                        llama_models.append(model_name)
+                    else:
+                        other_models.append(model_name)
+
+        if gpt_models:
+            print("GPT Models:")
+            for m in sorted(set(gpt_models)):
+                print(f"  - {m}")
+            print()
+
+        if llama_models:
+            print("Meta Llama Models:")
+            for m in sorted(set(llama_models)):
+                print(f"  - {m}")
+            print()
+
+        if other_models:
+            print("Other Models:")
+            for m in sorted(set(other_models)):
+                print(f"  - {m}")
+        print()
+except Exception as e:
+    print(f"Error fetching GitHub Models: {e}", file=sys.stderr)
+PYEOF
+else
+    echo "GitHub Models: GITHUB_TOKEN not set (skipped)"
+    echo ""
+fi
+
+# Check OpenAI models
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "OpenAI Models: OPENAI_API_KEY not set (skipped)"
+    echo "Get your API key from: https://platform.openai.com/account/api-keys"
+    echo ""
+else
+    echo "Fetching OpenAI models..."
+    curl -s https://api.openai.com/v1/models \
+      -H "Authorization: Bearer $OPENAI_API_KEY" | \
+    python3 << 'PYEOF'
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+
+    if 'error' in data:
+        print(f"Error: {data['error']['message']}", file=sys.stderr)
+        sys.exit(1)
+
+    models = sorted([m['id'] for m in data['data']])
+
+    # Categorize models for easier review
+    gpt_4_models = [m for m in models if m.startswith('gpt-4') and not m.startswith('gpt-4o')]
+    gpt_4o_models = [m for m in models if m.startswith('gpt-4o')]
+    gpt_3_models = [m for m in models if m.startswith('gpt-3')]
+    o_models = [m for m in models if m.startswith('o1') or m.startswith('o3')]
+    other_models = [m for m in models if not any(m.startswith(p) for p in ['gpt-4', 'gpt-3', 'o1', 'o3'])]
+
+    print("OpenAI API:")
+    print("-" * 60)
+
+    if o_models:
+        print("O-Series (Reasoning Models):")
+        for m in o_models:
+            print(f"  - {m}")
+        print()
+
+    if gpt_4o_models:
+        print("GPT-4o (Omni) Series:")
+        for m in gpt_4o_models:
+            print(f"  - {m}")
+        print()
+
+    if gpt_4_models:
+        print("GPT-4 Series:")
+        for m in gpt_4_models:
+            print(f"  - {m}")
+        print()
+
+    if gpt_3_models:
+        print("GPT-3.5 Series:")
+        for m in gpt_3_models:
+            print(f"  - {m}")
+        print()
+
+    if other_models:
+        print("Other Models:")
+        for m in other_models:
+            print(f"  - {m}")
+        print()
+except Exception as e:
+    print(f"Error: {e}", file=sys.stderr)
+PYEOF
+fi
+
+echo "======================================================================"
+echo ""
+echo "Recommendations for workflow configuration:"
+echo "  - High Quality: o1, gpt-4o, gpt-4-turbo"
+echo "  - Efficient: o3-mini (if available), o1-mini, gpt-4o-mini, gpt-3.5-turbo"
+echo ""
+echo "Note: Models with suffixes like -YYYY-MM-DD are dated snapshots"
+echo "      Base names (e.g., 'gpt-4o') point to the latest stable version"
+echo ""
+echo "To update workflow configurations:"
+echo "  1. Review the model list above"
+echo "  2. Update templates/consumer-repo/.github/workflows/agents-verifier.yml"
+echo "  3. Update .github/workflows/reusable-agents-verifier.yml if needed"
+echo "  4. Commit and push changes"
+echo "  5. Sync to consumer repos via sync workflow"

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -38,16 +38,20 @@ on:
         default: 'evaluate'
       model:
         description: >-
-          GitHub Models: gpt-5, gpt-4o, gpt-4.1, o1, o3-mini, Meta-Llama-3.1-405B,
-          gpt-4o-mini, o1-mini | OpenAI: gpt-5, gpt-4o, gpt-4-turbo, o1, o3-mini,
-          gpt-4o-mini, o1-mini
+          Model for evaluation. GitHub Models: gpt-4o, gpt-4o-mini,
+          text-embedding-3-large, text-embedding-3-small, Meta-Llama-3.1-405B-Instruct,
+          Meta-Llama-3.1-70B-Instruct, Meta-Llama-3-70B-Instruct |
+          OpenAI: gpt-5.2, o1, o1-preview, o1-mini, o3-mini (if available), gpt-4o, gpt-4o-mini,
+          gpt-4-turbo, gpt-4, gpt-3.5-turbo. Use script scripts/update_model_list.sh
+          to check current availability.
         required: false
         type: string
         default: 'gpt-4o-mini'
       model2:
         description: >-
-          Second model for compare (GitHub: gpt-5, gpt-4.1, o1 |
-          OpenAI: gpt-5, gpt-4o, gpt-4-turbo)
+          Second model for compare mode. High quality options:
+          GitHub Models: gpt-4o, Meta-Llama-3.1-405B-Instruct |
+          OpenAI: gpt-5.2, o1, gpt-4o, gpt-4-turbo. Efficient: gpt-4o-mini, o1-mini
         required: false
         type: string
         default: ''
@@ -153,8 +157,8 @@ jobs:
             core.setOutput('mode', mode);
             // For compare mode, use high-quality models from different providers
             if (mode === 'compare') {
-              core.setOutput('model', 'gpt-5');  // GitHub Models - GPT-5 series
-              core.setOutput('model2', 'gpt-5');  // OpenAI - GPT-5 series
+              core.setOutput('model', 'gpt-4o');   // GitHub Models - current flagship
+              core.setOutput('model2', 'gpt-5.2'); // OpenAI - GPT-5.2
             } else {
               core.setOutput('model', '');  // Use default
               core.setOutput('model2', '');


### PR DESCRIPTION
Updates compare mode to use gpt-5.2 from OpenAI API.

- Set compare defaults: gpt-4o (GitHub Models) vs gpt-5.2 (OpenAI)
- Add gpt-5.2 to model lists
- Add scripts/update_model_list.sh for fetching current models
- Add docs/MODEL_MANAGEMENT.md for model update process

Tested gpt-5.2 model creation successfully.