### PR TITLE
fix: enable automatic PR creation in consumer repo template

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -164,7 +164,8 @@ jobs:
     with:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}
-      mode: "invite"
+      mode: "create"
+      force_mode: true
       post_agent_comment: ${{ inputs.post_codex_comment && 'true' || 'false' }}
       agent_pr_draft: ${{ inputs.bridge_draft_pr && 'true' || 'false' }}
     secrets:


### PR DESCRIPTION
## Problem

Consumer repos are experiencing startup_failure when issues are labeled with `agent:codex` because the template is using `mode: 'invite'` without `force_mode`, causing the reusable workflow to prevent automatic bootstrap PR creation.

## Root Cause

The reusable-agents-issue-bridge.yml workflow has logic (line 257-268) that overrides the mode to 'invite' for issue events, unless `force_mode: true` is explicitly set. This was intended to wait for human intervention, but it breaks the desired automatic PR creation workflow.

## Changes

**Template file:** `templates/consumer-repo/.github/workflows/agents-issue-intake.yml`

- Change `mode` from 'invite' to 'create' in bridge job
- Add `force_mode: true` to override issue event defaults

## Impact

This change will be synced to **all consumer repos** including:
- Travel-Plan-Permission
- Trend_Model_Project  
- Manager-Database
- trip-planner
- Template
- And others (~7 total repos)

## Expected Behavior After Sync

When issues are labeled with `agent:codex` or similar labels:
1. Bootstrap PR will be automatically created
2. Agent can start working immediately  
3. No more startup_failure errors
4. Consistent behavior across all consumer repos

## Related Issues

- Trend_Model_Project#4185 (reported the startup_failure)
- This completes the fix started in PR #606 by updating the template

## Testing

After sync, verify in any consumer repo:
1. Create an issue
2. Label it with `agent:codex`
3. Workflow should automatically create a bootstrap PR
4. No startup_failure errors