### PR TITLE
fix: revert force_mode default to false

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -40,7 +40,7 @@ on:
         description: "Force mode override (ignore issue event defaults)"
         required: false
         type: boolean
-        default: true
+        default: false
       post_agent_comment:
         description: "Auto-post '@<agent> start' command (true/false)"
         required: false


### PR DESCRIPTION
Testing if the reusable workflow default change is causing startup_failure