### PR TITLE
fix: remove concurrency block causing startup_failure

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -67,9 +67,6 @@ permissions:
   issues: write
   pull-requests: write
 
-concurrency:
-  group: issue-intake-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   # Determine which mode to run


### PR DESCRIPTION
## Problem

All consumer repos experience startup_failure when the agents-issue-intake workflow is triggered.

## Root Cause

The concurrency block added to the consumer template is causing GitHub Actions to reject the workflow with startup_failure when calling reusable workflows.

From testing:
- Workflow worked on Jan 6 WITHOUT concurrency block
- After adding concurrency block, all runs fail with startup_failure
- No other changes explain the failure

## Solution

Remove the concurrency block from consumer template. The reusable workflow has its own concurrency handling if needed.

## Testing

After sync, label issue with agent:codex and verify:
- No startup_failure
- Workflow executes successfully
- Bootstrap PR is created automatically