### PR TITLE
fix: Add check_capability alias for workflow compatibility

### DIFF
--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -275,5 +275,9 @@ def main() -> int:
     return 0
 
 
+# Alias for backward compatibility with workflow
+check_capability = classify_capabilities
+
+
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Problem
The `agents-capability-check.yml` workflow imports `check_capability` but the function is named `classify_capabilities`.

## Solution
Add an alias at the end of the module:
```python
# Alias for backward compatibility with workflow
check_capability = classify_capabilities
```

## Testing
- [x] Local import test
- [ ] Workflow test after merge