### PR TITLE
fix: Disable automatic follow-up issue creation in verifier

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -318,9 +318,11 @@ jobs:
           fi
           echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
 
+      # DISABLED: Automatic follow-up issue creation
+      # Use verify:create-issue label on PRs with CONCERNS to manually create follow-up issues
       - name: Open follow-up issue on verifier failure
         id: failure_issue
-        if: steps.context.outputs.should_run == 'true' && steps.verdict.outputs.verdict == 'fail'
+        if: false  # Disabled - use agents-verify-to-issue.yml with verify:create-issue label instead
         uses: actions/github-script@v8
         env:
           PR_URL: ${{ steps.context.outputs.pr_html_url }}

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -461,9 +461,11 @@ jobs:
           echo "verdict=$final_verdict" >> "$GITHUB_OUTPUT"
           echo "Final verdict: $final_verdict"
 
+      # DISABLED: Automatic follow-up issue creation
+      # Use verify:create-issue label on PRs with CONCERNS to manually create follow-up issues
       - name: Open follow-up issue on verifier failure
         id: failure_issue
-        if: steps.context.outputs.should_run == 'true' && (steps.unified_verdict.outputs.verdict == 'fail' || steps.unified_verdict.outputs.verdict == 'error' || steps.unified_verdict.outputs.verdict == 'FAIL' || steps.unified_verdict.outputs.verdict == 'CONCERNS')
+        if: false  # Disabled - use agents-verify-to-issue.yml with verify:create-issue label instead
         uses: actions/github-script@v8
         env:
           PR_URL: ${{ steps.context.outputs.pr_html_url }}


### PR DESCRIPTION
## Problem
The verifier workflow was automatically creating follow-up issues whenever the verdict was `CONCERNS`, `fail`, or `error`. This was **repeatedly requested to be disabled** but kept creating unwanted issues like #4276.

## Solution
Changed the `if` condition to `false` on the follow-up issue creation step in both:
- `agents-verifier.yml`
- `reusable-agents-verifier.yml`

## How to Create Follow-up Issues Now
Users who want follow-up issues can **manually opt-in** by adding the `verify:create-issue` label to a PR, which triggers the `agents-verify-to-issue.yml` workflow.

This puts the user in control rather than automatically spamming the repo.