### PR TITLE
fix: escape curly braces in prompt examples

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -152,7 +152,7 @@ Generate SPECIFIC, TESTABLE acceptance criteria for the follow-up issue.
 - "The `calculateTax()` function returns correct values for all test cases in `test_tax.py`"
 - "All Python files pass `ruff check` with no errors"
 - "The README.md contains installation instructions with at least 3 steps"
-- "API endpoint `/users/{id}` returns 404 status code when user doesn't exist"
+- "API endpoint `/users/{{id}}` returns 404 status code when user doesn't exist"
 
 **BAD acceptance criteria (NEVER write these):**
 - "All verification concerns are addressed" (not specific)


### PR DESCRIPTION
The example `/users/{id}` in GENERATE_ACCEPTANCE_CRITERIA_PROMPT was being interpreted as a Python format placeholder, causing `KeyError: 'id'` during prompt formatting.

Fixed by escaping as `/users/{{id}}`.