### PR TITLE
fix: exclude metadata labels from agent assignment detection

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -516,6 +516,11 @@ jobs:
             const normalizeLabel = (label) => label.trim().toLowerCase();
             const agentPrefixes = ['agent:', 'agents:'];
             const inviteSuffix = '-invite';
+            // Metadata labels that aren't actual agent assignments
+            const metadataLabels = new Set([
+              'keepalive', 'formatted', 'optimize', 'allow-change',
+              'apply-suggestions', 'debug', 'format', 'sync-failed', 'sync-required'
+            ]);
             const analyzeAgentLabels = (rawLabels) => {
               const entries = new Map();
               for (const raw of rawLabels || []) {
@@ -526,7 +531,7 @@ jobs:
                 const prefix = agentPrefixes.find((candidate) => lower.startsWith(candidate));
                 if (!prefix) continue;
                 let suffix = lower.slice(prefix.length).trim();
-                if (!suffix || suffix === 'keepalive') continue;
+                if (!suffix || metadataLabels.has(suffix)) continue;
                 let base = suffix;
                 let invite = false;
                 if (base.endsWith(inviteSuffix)) {
@@ -1206,7 +1211,10 @@ jobs:
                 .map(name => name.toLowerCase());
             }
             // Control labels that should not be counted as agent assignments
-            const controlLabelSuffixes = ['keepalive'];
+            const controlLabelSuffixes = [
+              'keepalive', 'formatted', 'optimize', 'allow-change',
+              'apply-suggestions', 'debug', 'format', 'sync-failed', 'sync-required'
+            ];
             const codexGuardLabels = ['agent:codex', 'agents:codex'];
             const agentLabels = labels
               .filter(name => /^agents?:[a-z0-9-]+$/.test(name))

--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -130,6 +130,19 @@ jobs:
             const inviteSuffix = '-invite';
             const candidates = new Map();
 
+            // Metadata labels that aren't actual agent assignments
+            const metadataLabels = new Set([
+              'keepalive',
+              'formatted',
+              'optimize',
+              'allow-change',
+              'apply-suggestions',
+              'debug',
+              'format',
+              'sync-failed',
+              'sync-required',
+            ]);
+
             for (const label of rawLabels) {
               const name = (typeof label === 'string' ? label : label?.name || '').trim();
               if (!name) continue;
@@ -138,7 +151,7 @@ jobs:
               if (!prefix) continue;
               let suffix = lower.slice(prefix.length).trim();
               // Skip metadata labels that aren't actual agent assignments
-              if (!suffix || suffix === 'keepalive' || suffix === 'formatted') {
+              if (!suffix || metadataLabels.has(suffix)) {
                 continue;
               }
               let base = suffix;

--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -126,21 +126,36 @@ jobs:
             let issueNumber = '${{ inputs.issue_number }}' || '';
             let agent = '${{ inputs.bridge_agent }}' || 'codex';
 
+            // Metadata labels that aren't actual agent assignments
+            const metadataLabels = new Set([
+              'keepalive', 'formatted', 'optimize', 'allow-change',
+              'apply-suggestions', 'debug', 'format', 'sync-failed', 'sync-required'
+            ]);
+
             if (eventName === 'issues') {
               const issue = context.payload.issue;
               issueNumber = String(issue.number);
 
               // Extract agent from labels (agent:codex, agents:codex, etc.)
+              // Skip metadata labels that aren't actual agent assignments
               const labels = issue.labels.map(l => l.name);
-              const agentLabel = labels.find(
-                l => /^agents?:[a-z]+$/i.test(l) && !l.includes('keepalive')
-              );
+              const agentLabel = labels.find(l => {
+                const match = l.match(/^agents?:([a-z-]+)$/i);
+                if (!match) return false;
+                const suffix = match[1].toLowerCase();
+                return !metadataLabels.has(suffix);
+              });
               if (agentLabel) {
                 agent = agentLabel.replace(/^agents?:/, '').toLowerCase();
               }
 
-              // Check if any agent label exists
-              const hasAgentLabel = labels.some(l => /^agents?:/.test(l));
+              // Check if any actual agent assignment label exists (not metadata)
+              const hasAgentLabel = labels.some(l => {
+                const match = l.match(/^agents?:([a-z-]+)$/i);
+                if (!match) return false;
+                const suffix = match[1].toLowerCase();
+                return !metadataLabels.has(suffix);
+              });
               if (!hasAgentLabel) {
                 core.setOutput('should_run', 'false');
                 return;


### PR DESCRIPTION
## Problem

The bridge workflow was failing with:
```
Expected exactly one agent:* label but found multiple: agent:codex, agents:optimize
```

Issue #4293 has both `agent:codex` (agent assignment) and `agents:optimize` (metadata label added by follow-up issue generator). The bridge workflow incorrectly treats both as agent assignments.

## Solution

Add full list of metadata labels to skip when detecting agent assignments:
- `keepalive` (existing)
- `formatted` (existing)  
- `optimize` (NEW - added by follow-up issue generator)
- `allow-change`, `apply-suggestions`, `debug`, `format`, `sync-failed`, `sync-required`

## Changes

- **reusable-agents-issue-bridge.yml**: Use `metadataLabels` Set for cleaner skip logic
- **agents-63-issue-intake.yml**: Update both skip list locations
- **templates/consumer-repo/.github/workflows/agents-issue-intake.yml**: Update label detection

## Testing

After merge, re-trigger the workflow on issue #4293 by removing and re-adding `agent:codex` label.

Fixes: stranske/Trend_Model_Project#4293 bootstrap not triggering