### PR TITLE
fix: pass app secrets to reusable workflow and fix prData undefined

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -958,6 +958,18 @@ jobs:
                 core.warning(`Failed to locate PR for branch ${branch}: ${error.message}`);
               }
             }
+
+            // Fetch PR data if we have a PR number
+            let prData = null;
+            if (prNumber) {
+              try {
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+                prData = data;
+              } catch (error) {
+                core.warning(`Failed to fetch PR #${prNumber}: ${error.message}`);
+              }
+            }
+
             if (summaryNeedsWarning && missingSections.length) {
               core.warning(`Issue template missing sections: ${missingSections.join(', ')}`);
             } else if (summaryNeedsWarning && warningDetails.length) {

--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -183,6 +183,8 @@ jobs:
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
       owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 
   # ChatGPT sync mode: Call the Workflows repo reusable workflow with sync capability
   sync:


### PR DESCRIPTION
Two bugs fixed:

1. **Missing app secrets**: Template was not passing `WORKFLOWS_APP_ID` and `WORKFLOWS_APP_PRIVATE_KEY` to the reusable issue bridge workflow, causing app token minting to fail with 'appId option is required'.

2. **prData undefined**: The 'Post issue context on PR' step referenced `prData` but never declared/fetched it, causing `ReferenceError: prData is not defined` when trying to update PR body.