### PR TITLE
fix: dedupe issue content in PR body by making full text collapsible

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -611,6 +611,18 @@ jobs:
 
               if (bodyIsEmpty || (!hasMetaMarker && !hasStatusSummary)) {
                 // Build a proper PR body with issue content
+                // When we have a status summary, wrap full issue body in collapsible details
+                // to avoid duplicate content (summary already extracts Tasks/Acceptance Criteria)
+                const issueDetailsSection = statusSummaryBlock && issueBody
+                  ? [
+                      '<details>',
+                      '<summary>Full Issue Text</summary>',
+                      '',
+                      issueBody,
+                      '',
+                      '</details>',
+                    ].join('\n')
+                  : issueBody || '_(No issue body)_';
                 const prBodySections = [
                   keepaliveHeader,
                   metaMarker,
@@ -624,9 +636,7 @@ jobs:
                   '',
                   `Source: ${issueUrl}`,
                   '',
-                  '### Issue Details',
-                  '',
-                  issueBody || '_(No issue body)_',
+                  issueDetailsSection,
                 ];
 
                 const newPrBody = prBodySections.join('\n').trim();
@@ -781,9 +791,20 @@ jobs:
                 if (statusSummaryBlock) {
                   sections.push(statusSummaryBlock);
                 }
+                // When we have a status summary, wrap full issue body in collapsible details
+                // to avoid duplicate content (summary already extracts Tasks/Acceptance Criteria)
                 if (issueBody && issueBody.trim()) {
-                  sections.push('### Issue Details');
-                  sections.push(issueBody.trim());
+                  if (statusSummaryBlock) {
+                    sections.push('<details>');
+                    sections.push('<summary>Full Issue Text</summary>');
+                    sections.push('');
+                    sections.push(issueBody.trim());
+                    sections.push('');
+                    sections.push('</details>');
+                  } else {
+                    sections.push('### Issue Details');
+                    sections.push(issueBody.trim());
+                  }
                 }
                 return sections.join('\n\n');
               })();
@@ -1021,8 +1042,14 @@ jobs:
             if (summaryNeedsWarning && warningLines.length) {
               parts.push('', ...warningLines);
             }
+            // When we have a status summary, wrap full issue body in collapsible details
+            // to avoid duplicate content (summary already extracts Tasks/Acceptance Criteria)
             if (issueBody) {
-              parts.push('', '#### Full Issue Text', '', issueBody.trim());
+              if (statusSummaryBlock) {
+                parts.push('', '<details>', '<summary>Full Issue Text</summary>', '', issueBody.trim(), '', '</details>');
+              } else {
+                parts.push('', '#### Full Issue Text', '', issueBody.trim());
+              }
             }
 
             const body = parts.join('\n').trim();


### PR DESCRIPTION
## Problem

After recent updates to the Agent Issue Bridge, bootstrap PRs like [Portable-Alpha-Extension-Model#1049](https://github.com/stranske/Portable-Alpha-Extension-Model/pull/1049) show duplicate issue material:

1. The `<- auto-status-summary -->` section contains extracted Tasks and Acceptance Criteria
2. The `### Issue Details` section contains the full issue body, which ALSO has Tasks and Acceptance Criteria

This makes the PR body cluttered and confusing.

## Solution

When the status summary block is present (extracted Tasks/Acceptance Criteria), wrap the full issue body in a collapsible `<details>` section instead of showing it inline. This way:

- The key actionable items (Tasks/Acceptance Criteria) are prominently displayed in the summary
- The full issue text is still available if needed, just collapsed by default

## Changes

- Updated `issueDetailsBlock` construction to use collapsible details when status summary exists
- Updated PR body update logic to use collapsible details
- Updated "Post issue context on PR" step to use collapsible details in comments

## Testing

New PRs created by the Agent Issue Bridge will have clean bodies without duplicate content.