### PR TITLE
fix: enable conflict and fix action modes in keepalive workflow

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -67,6 +67,8 @@ jobs:
       agent_type: ${{ steps.evaluate.outputs.agent_type }}
       task_appendix: ${{ steps.evaluate.outputs.task_appendix }}
       trace: ${{ steps.evaluate.outputs.trace }}
+      prompt_file: ${{ steps.evaluate.outputs.prompt_file }}
+      prompt_mode: ${{ steps.evaluate.outputs.prompt_mode }}
       start_ts: ${{ steps.timestamps.outputs.start_ts }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
@@ -239,6 +241,8 @@ jobs:
               has_agent_label: String(result.hasAgentLabel || false),
               agent_type: String(result.agentType || ''),
               trace: String(result.config?.trace || ''),
+              prompt_file: result.promptFile || '',
+              prompt_mode: result.promptMode || 'normal',
             };
             for (const [key, value] of Object.entries(output)) {
               core.setOutput(key, value);
@@ -249,7 +253,7 @@ jobs:
   preflight:
     name: Verify secrets available
     needs: evaluate
-    if: needs.evaluate.outputs.action == 'run'
+    if: contains(fromJSON('["run", "fix", "conflict"]'), needs.evaluate.outputs.action)
     runs-on: ubuntu-latest
     environment: agent-standard
     outputs:
@@ -279,7 +283,7 @@ jobs:
     needs:
       - evaluate
       - preflight
-    if: needs.evaluate.outputs.action == 'run'
+    if: contains(fromJSON('["run", "fix", "conflict"]'), needs.evaluate.outputs.action)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Workflows scripts
@@ -324,9 +328,9 @@ jobs:
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
-      skip: ${{ needs.evaluate.outputs.action != 'run' }}
-      prompt_file: .github/codex/prompts/keepalive_next_task.md
-      mode: keepalive
+      skip: ${{ !contains(fromJSON('["run", "fix", "conflict"]'), needs.evaluate.outputs.action) }}
+      prompt_file: ${{ needs.evaluate.outputs.prompt_file }}
+      mode: ${{ needs.evaluate.outputs.prompt_mode }}
       pr_number: ${{ needs.evaluate.outputs.pr_number }}
       pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
       appendix: ${{ needs.evaluate.outputs.task_appendix }}


### PR DESCRIPTION
## Summary

This PR enables the keepalive workflow to properly handle conflict and fix action modes.

## Changes

- Add `prompt_file` and `prompt_mode` to evaluate job outputs
- Update `preflight` condition to include `conflict` and `fix` actions  
- Update `mark-running` condition to include `conflict` and `fix` actions
- Use dynamic `prompt_file` from evaluate outputs (instead of hardcoded)
- Use dynamic `mode` from evaluate outputs

## Why This Matters

Previously, the keepalive workflow would detect conflicts or CI failures and set `action: conflict` or `action: fix`, but the downstream jobs only ran when `action == run`. This meant:

1. Conflict detection worked ✅
2. Prompt routing worked ✅  
3. But Codex never got dispatched because the job conditions blocked it ❌

Now the workflow properly handles all three action modes:
- `run` → `keepalive_next_task.md`
- `fix` → `fix_ci_failures.md`
- `conflict` → `fix_merge_conflicts.md`

## Testing

To test, trigger the keepalive on conflicting PRs:
- Trend_Model_Project PR #4301
- Portable-Alpha-Extension-Model PR #1049

Both should now dispatch Codex with the `fix_merge_conflicts.md` prompt.