### PR TITLE
fix: auto-start coding agent for issue-triggered PRs

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -178,7 +178,7 @@ jobs:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}
       mode: "create"
-      post_agent_comment: ${{ inputs.post_codex_comment && 'true' || 'false' }}
+      post_agent_comment: ${{ github.event_name == 'workflow_dispatch' && (inputs.post_codex_comment && 'true' || 'false') || 'true' }}
       agent_pr_draft: ${{ inputs.bridge_draft_pr && 'true' || 'false' }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}


### PR DESCRIPTION
## Problem

When PRs are created from issues (e.g., via `verify:create-issue` label), the Issue Intake workflow in consumer repos was always passing `post_agent_comment: false`, preventing the coding agent from automatically starting work.

This caused PRs to be stuck in `agent-run-skipped` state because:
1. Issue event triggers have undefined `inputs`
2. Template evaluates `inputs.post_codex_comment && 'true' || 'false'` → `'false'`
3. No `@codex start` comment is posted
4. Keepalive loop skips agent execution

## Solution

Changed the consumer repo template to:
- Default to `'true'` for issue events (auto-start agent)
- Respect `inputs.post_codex_comment` only for `workflow_dispatch`
- Matches the reusable workflow's default behavior

## Impact

All consumer repos using this template will now auto-start the coding agent when PRs are created from labeled issues, fixing:
- PRs from verify:create-issue workflow
- PRs from agent:codex labeled issues
- Any issue-triggered PR creation

## Testing

Tested the logic:
- Issue event: `post_agent_comment` → `'true'` (auto-start)
- Manual dispatch with `post_codex_comment: false`: → `'false'` (no auto-start)
- Manual dispatch with `post_codex_comment: true`: → `'true'` (auto-start)

Resolves the issue affecting:
- stranske/Portable-Alpha-Extension-Model#1067
- stranske/Portable-Alpha-Extension-Model#1066  
- stranske/Trend_Model_Project#4309