### PR TITLE
fix: add always() to run-codex job to handle skipped dependency

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -414,6 +414,10 @@ jobs:
       - mark-running
       - resolve-trivial-conflicts
     if: |
+      always() &&
+      needs.evaluate.result == 'success' &&
+      needs.preflight.result == 'success' &&
+      needs.mark-running.result == 'success' &&
       needs.evaluate.outputs.agent_type == 'codex' &&
       (needs.resolve-trivial-conflicts.result == 'skipped' ||
        needs.resolve-trivial-conflicts.outputs.remaining_conflicts != '0')


### PR DESCRIPTION
## Problem

The `run-codex` job in `agents-keepalive-loop.yml` depends on `resolve-trivial-conflicts`, which is skipped when `action` is `'run'` (rather than `'conflict'`). 

In GitHub Actions, when a job you depend on is skipped, your job is **also skipped** without evaluating its `if` condition—unless you use `always()`.

### Root Cause

```yaml
run-codex:
  needs:
    - evaluate
    - preflight
    - mark-running
    - resolve-trivial-conflicts  # <-- This is skipped when action='run'
  if: |
    needs.evaluate.outputs.agent_type == 'codex' &&
    (needs.resolve-trivial-conflicts.result == 'skipped' || ...)  # Never evaluated!
```

Even though the condition checks for `result == 'skipped'`, GitHub Actions never reaches the `if` evaluation because the dependency was skipped.

### Evidence

From run [20857158812](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/20857158812):

| Job | Conclusion |
|-----|------------|
| Evaluate keepalive loop | success |
| Verify secrets available | success |  
| Mark agent running | success |
| Auto-resolve PR-specific files | **skipped** |
| **Keepalive next task (Codex)** | **skipped** ← Bug! |

The Codex job was skipped even though:
- `agent_type = 'codex'` ✓
- `resolve-trivial-conflicts.result = 'skipped'` ✓ (which should allow run)

## Solution

Add `always()` and explicitly check that upstream jobs succeeded:

```yaml
if: |
  always() &&
  needs.evaluate.result == 'success' &&
  needs.preflight.result == 'success' &&
  needs.mark-running.result == 'success' &&
  needs.evaluate.outputs.agent_type == 'codex' &&
  (needs.resolve-trivial-conflicts.result == 'skipped' ||
   needs.resolve-trivial-conflicts.outputs.remaining_conflicts != '0')
```

## Affected PRs

This will unblock:
- stranske/Portable-Alpha-Extension-Model#1067
- stranske/Portable-Alpha-Extension-Model#1066
- stranske/Trend_Model_Project#4309

## Testing

After merging this PR and syncing to consumer repos, trigger keepalive on any stuck PR and verify the Codex job runs.