### PR TITLE
fix: always install dev tools in CI regardless of lock file presence

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -489,57 +489,41 @@ jobs:
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
           fi
 
-          if [ "$has_lock_file" = "false" ]; then
-            if [ "$format_enabled" = "true" ]; then
-              add_tool "$black_spec" "black"
-              add_tool "$docformatter_spec" "docformatter"
-              add_tool "$isort_spec" "isort"
+          # Always install dev tools - lock files only contain runtime deps, not dev tools
+          if [ "$format_enabled" = "true" ]; then
+            add_tool "$black_spec" "black"
+            add_tool "$docformatter_spec" "docformatter"
+            add_tool "$isort_spec" "isort"
           else
-              skip_tool "black (format_check disabled)"
-              skip_tool "docformatter (format_check disabled)"
-              skip_tool "isort (format_check disabled)"
-            fi
+            skip_tool "black (format_check disabled)"
+            skip_tool "docformatter (format_check disabled)"
+            skip_tool "isort (format_check disabled)"
+          fi
 
-            if [ "$lint_enabled" = "true" ]; then
-              add_tool "$ruff_spec" "ruff"
-            else
-              skip_tool "ruff (lint disabled)"
-            fi
-
-            if [ "$mypy_enabled" = "true" ]; then
-              add_tool "$mypy_spec" "mypy"
-            else
-              skip_tool "mypy (typecheck disabled)"
-            fi
-
-            add_tool "$pytest_spec" "pytest"
-            add_tool "$pytest_xdist_spec" "pytest-xdist"
-            for spec in "${base_test_specs[@]}"; do
-              add_tool "$spec" "$spec"
-            done
-
-            if [ "$coverage_enabled" = "true" ]; then
-              add_tool "$pytest_cov_spec" "pytest-cov"
-              add_tool "$coverage_spec" "coverage"
-            else
-              skip_tool "pytest-cov (coverage disabled)"
-              skip_tool "coverage (coverage disabled)"
-            fi
+          if [ "$lint_enabled" = "true" ]; then
+            add_tool "$ruff_spec" "ruff"
           else
-            # When lock file exists, mark tools as coming from lock file for reporting
-            if [ "$format_enabled" = "true" ]; then
-              tools_installed+=("black (from lock)" "docformatter (from lock)" "isort (from lock)")
-            fi
-            if [ "$lint_enabled" = "true" ]; then
-              tools_installed+=("ruff (from lock)")
-            fi
-            if [ "$mypy_enabled" = "true" ]; then
-              tools_installed+=("mypy (from lock)")
-            fi
-            tools_installed+=("pytest (from lock)" "pytest-xdist (from lock)")
-            if [ "$coverage_enabled" = "true" ]; then
-              tools_installed+=("pytest-cov (from lock)" "coverage (from lock)")
-            fi
+            skip_tool "ruff (lint disabled)"
+          fi
+
+          if [ "$mypy_enabled" = "true" ]; then
+            add_tool "$mypy_spec" "mypy"
+          else
+            skip_tool "mypy (typecheck disabled)"
+          fi
+
+          add_tool "$pytest_spec" "pytest"
+          add_tool "$pytest_xdist_spec" "pytest-xdist"
+          for spec in "${base_test_specs[@]}"; do
+            add_tool "$spec" "$spec"
+          done
+
+          if [ "$coverage_enabled" = "true" ]; then
+            add_tool "$pytest_cov_spec" "pytest-cov"
+            add_tool "$coverage_spec" "coverage"
+          else
+            skip_tool "pytest-cov (coverage disabled)"
+            skip_tool "coverage (coverage disabled)"
           fi
 
           if [ ${#specs[@]} -eq 0 ]; then
@@ -789,57 +773,41 @@ jobs:
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
           fi
 
-          if [ "$has_lock_file" = "false" ]; then
-            if [ "$format_enabled" = "true" ]; then
-              add_tool "$black_spec" "black"
-              add_tool "$docformatter_spec" "docformatter"
-              add_tool "$isort_spec" "isort"
+          # Always install dev tools - lock files only contain runtime deps, not dev tools
+          if [ "$format_enabled" = "true" ]; then
+            add_tool "$black_spec" "black"
+            add_tool "$docformatter_spec" "docformatter"
+            add_tool "$isort_spec" "isort"
           else
-              skip_tool "black (format_check disabled)"
-              skip_tool "docformatter (format_check disabled)"
-              skip_tool "isort (format_check disabled)"
-            fi
+            skip_tool "black (format_check disabled)"
+            skip_tool "docformatter (format_check disabled)"
+            skip_tool "isort (format_check disabled)"
+          fi
 
-            if [ "$lint_enabled" = "true" ]; then
-              add_tool "$ruff_spec" "ruff"
-            else
-              skip_tool "ruff (lint disabled)"
-            fi
-
-            if [ "$mypy_enabled" = "true" ]; then
-              add_tool "$mypy_spec" "mypy"
-            else
-              skip_tool "mypy (typecheck disabled)"
-            fi
-
-            add_tool "$pytest_spec" "pytest"
-            add_tool "$pytest_xdist_spec" "pytest-xdist"
-            for spec in "${base_test_specs[@]}"; do
-              add_tool "$spec" "$spec"
-            done
-
-            if [ "$coverage_enabled" = "true" ]; then
-              add_tool "$pytest_cov_spec" "pytest-cov"
-              add_tool "$coverage_spec" "coverage"
-            else
-              skip_tool "pytest-cov (coverage disabled)"
-              skip_tool "coverage (coverage disabled)"
-            fi
+          if [ "$lint_enabled" = "true" ]; then
+            add_tool "$ruff_spec" "ruff"
           else
-            # When lock file exists, mark tools as coming from lock file for reporting
-            if [ "$format_enabled" = "true" ]; then
-              tools_installed+=("black (from lock)" "docformatter (from lock)" "isort (from lock)")
-            fi
-            if [ "$lint_enabled" = "true" ]; then
-              tools_installed+=("ruff (from lock)")
-            fi
-            if [ "$mypy_enabled" = "true" ]; then
-              tools_installed+=("mypy (from lock)")
-            fi
-            tools_installed+=("pytest (from lock)" "pytest-xdist (from lock)")
-            if [ "$coverage_enabled" = "true" ]; then
-              tools_installed+=("pytest-cov (from lock)" "coverage (from lock)")
-            fi
+            skip_tool "ruff (lint disabled)"
+          fi
+
+          if [ "$mypy_enabled" = "true" ]; then
+            add_tool "$mypy_spec" "mypy"
+          else
+            skip_tool "mypy (typecheck disabled)"
+          fi
+
+          add_tool "$pytest_spec" "pytest"
+          add_tool "$pytest_xdist_spec" "pytest-xdist"
+          for spec in "${base_test_specs[@]}"; do
+            add_tool "$spec" "$spec"
+          done
+
+          if [ "$coverage_enabled" = "true" ]; then
+            add_tool "$pytest_cov_spec" "pytest-cov"
+            add_tool "$coverage_spec" "coverage"
+          else
+            skip_tool "pytest-cov (coverage disabled)"
+            skip_tool "coverage (coverage disabled)"
           fi
 
           if [ ${#specs[@]} -eq 0 ]; then
@@ -1098,57 +1066,41 @@ jobs:
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
           fi
 
-          if [ "$has_lock_file" = "false" ]; then
-            if [ "$format_enabled" = "true" ]; then
-              add_tool "$black_spec" "black"
-              add_tool "$docformatter_spec" "docformatter"
-              add_tool "$isort_spec" "isort"
+          # Always install dev tools - lock files only contain runtime deps, not dev tools
+          if [ "$format_enabled" = "true" ]; then
+            add_tool "$black_spec" "black"
+            add_tool "$docformatter_spec" "docformatter"
+            add_tool "$isort_spec" "isort"
           else
-              skip_tool "black (format_check disabled)"
-              skip_tool "docformatter (format_check disabled)"
-              skip_tool "isort (format_check disabled)"
-            fi
+            skip_tool "black (format_check disabled)"
+            skip_tool "docformatter (format_check disabled)"
+            skip_tool "isort (format_check disabled)"
+          fi
 
-            if [ "$lint_enabled" = "true" ]; then
-              add_tool "$ruff_spec" "ruff"
-            else
-              skip_tool "ruff (lint disabled)"
-            fi
-
-            if [ "$mypy_enabled" = "true" ]; then
-              add_tool "$mypy_spec" "mypy"
-            else
-              skip_tool "mypy (typecheck disabled)"
-            fi
-
-            add_tool "$pytest_spec" "pytest"
-            add_tool "$pytest_xdist_spec" "pytest-xdist"
-            for spec in "${base_test_specs[@]}"; do
-              add_tool "$spec" "$spec"
-            done
-
-            if [ "$coverage_enabled" = "true" ]; then
-              add_tool "$pytest_cov_spec" "pytest-cov"
-              add_tool "$coverage_spec" "coverage"
-            else
-              skip_tool "pytest-cov (coverage disabled)"
-              skip_tool "coverage (coverage disabled)"
-            fi
+          if [ "$lint_enabled" = "true" ]; then
+            add_tool "$ruff_spec" "ruff"
           else
-            # When lock file exists, mark tools as coming from lock file for reporting
-            if [ "$format_enabled" = "true" ]; then
-              tools_installed+=("black (from lock)" "docformatter (from lock)" "isort (from lock)")
-            fi
-            if [ "$lint_enabled" = "true" ]; then
-              tools_installed+=("ruff (from lock)")
-            fi
-            if [ "$mypy_enabled" = "true" ]; then
-              tools_installed+=("mypy (from lock)")
-            fi
-            tools_installed+=("pytest (from lock)" "pytest-xdist (from lock)")
-            if [ "$coverage_enabled" = "true" ]; then
-              tools_installed+=("pytest-cov (from lock)" "coverage (from lock)")
-            fi
+            skip_tool "ruff (lint disabled)"
+          fi
+
+          if [ "$mypy_enabled" = "true" ]; then
+            add_tool "$mypy_spec" "mypy"
+          else
+            skip_tool "mypy (typecheck disabled)"
+          fi
+
+          add_tool "$pytest_spec" "pytest"
+          add_tool "$pytest_xdist_spec" "pytest-xdist"
+          for spec in "${base_test_specs[@]}"; do
+            add_tool "$spec" "$spec"
+          done
+
+          if [ "$coverage_enabled" = "true" ]; then
+            add_tool "$pytest_cov_spec" "pytest-cov"
+            add_tool "$coverage_spec" "coverage"
+          else
+            skip_tool "pytest-cov (coverage disabled)"
+            skip_tool "coverage (coverage disabled)"
           fi
 
           if [ ${#specs[@]} -eq 0 ]; then
@@ -1450,57 +1402,41 @@ jobs:
             echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
           fi
 
-          if [ "$has_lock_file" = "false" ]; then
-            if [ "$format_enabled" = "true" ]; then
-              add_tool "$black_spec" "black"
-              add_tool "$docformatter_spec" "docformatter"
-              add_tool "$isort_spec" "isort"
+          # Always install dev tools - lock files only contain runtime deps, not dev tools
+          if [ "$format_enabled" = "true" ]; then
+            add_tool "$black_spec" "black"
+            add_tool "$docformatter_spec" "docformatter"
+            add_tool "$isort_spec" "isort"
           else
-              skip_tool "black (format_check disabled)"
-              skip_tool "docformatter (format_check disabled)"
-              skip_tool "isort (format_check disabled)"
-            fi
+            skip_tool "black (format_check disabled)"
+            skip_tool "docformatter (format_check disabled)"
+            skip_tool "isort (format_check disabled)"
+          fi
 
-            if [ "$lint_enabled" = "true" ]; then
-              add_tool "$ruff_spec" "ruff"
-            else
-              skip_tool "ruff (lint disabled)"
-            fi
-
-            if [ "$mypy_enabled" = "true" ]; then
-              add_tool "$mypy_spec" "mypy"
-            else
-              skip_tool "mypy (typecheck disabled)"
-            fi
-
-            add_tool "$pytest_spec" "pytest"
-            add_tool "$pytest_xdist_spec" "pytest-xdist"
-            for spec in "${base_test_specs[@]}"; do
-              add_tool "$spec" "$spec"
-            done
-
-            if [ "$coverage_enabled" = "true" ]; then
-              add_tool "$pytest_cov_spec" "pytest-cov"
-              add_tool "$coverage_spec" "coverage"
-            else
-              skip_tool "pytest-cov (coverage disabled)"
-              skip_tool "coverage (coverage disabled)"
-            fi
+          if [ "$lint_enabled" = "true" ]; then
+            add_tool "$ruff_spec" "ruff"
           else
-            # When lock file exists, mark tools as coming from lock file for reporting
-            if [ "$format_enabled" = "true" ]; then
-              tools_installed+=("black (from lock)" "docformatter (from lock)" "isort (from lock)")
-            fi
-            if [ "$lint_enabled" = "true" ]; then
-              tools_installed+=("ruff (from lock)")
-            fi
-            if [ "$mypy_enabled" = "true" ]; then
-              tools_installed+=("mypy (from lock)")
-            fi
-            tools_installed+=("pytest (from lock)" "pytest-xdist (from lock)")
-            if [ "$coverage_enabled" = "true" ]; then
-              tools_installed+=("pytest-cov (from lock)" "coverage (from lock)")
-            fi
+            skip_tool "ruff (lint disabled)"
+          fi
+
+          if [ "$mypy_enabled" = "true" ]; then
+            add_tool "$mypy_spec" "mypy"
+          else
+            skip_tool "mypy (typecheck disabled)"
+          fi
+
+          add_tool "$pytest_spec" "pytest"
+          add_tool "$pytest_xdist_spec" "pytest-xdist"
+          for spec in "${base_test_specs[@]}"; do
+            add_tool "$spec" "$spec"
+          done
+
+          if [ "$coverage_enabled" = "true" ]; then
+            add_tool "$pytest_cov_spec" "pytest-cov"
+            add_tool "$coverage_spec" "coverage"
+          else
+            skip_tool "pytest-cov (coverage disabled)"
+            skip_tool "coverage (coverage disabled)"
           fi
 
           if [ ${#specs[@]} -eq 0 ]; then


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #123

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
After merging PR #103 (multi-agent routing infrastructure), we need to:
1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments
- The keepalive loop now:
- | `<!-- keepalive-loop-summary -->` | github-actions[bot] | NEW: CLI agent iteration tracking | ✅ Keep for CLI agents |
- | `<!-- keepalive-state:v1 -->` | agents-workflows-bot[bot] | State tracking | ⚠️ Multiple copies accumulate |
- | `<!-- keepalive-round: N -->` | stranske | OLD: Instruction comment | ❌ CLI agents dont need this |
- **The goal:** For CLI agents (`agent:*` label), we should have exactly **one** updating comment (`<!-- keepalive-loop-summary -->`) instead of accumulating 10+ comments per PR.
- Requires PR [#103](https://github.com/stranske/Workflows/issues/103) to be merged first
- **This round you MUST:**
- Review the Scope/Tasks/Acceptance below, identify the next incomplete task that requires code, implement it, then **post a reply comment** with the completed items using their **exact original text**.

### Related Issues/PRs
- [#103](https://github.com/stranske/Workflows/issues/103)
- [#89](https://github.com/stranske/Workflows/issues/89)
- [#123](https://github.com/stranske/Workflows/issues/123)

### References
- https://github.com/stranske/Workflows/compare/main...codex/issue-123?expand=1

### Blockers & Dependencies
- After merging PR [#103](https://github.com/stranske/Workflows/issues/103) (multi-agent routing infrastructure), we need to:
- 3. Mark a task checkbox complete ONLY after verifying the implementation works.
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### Pipeline Validation
- [ ] After PR #103 merges, create a test PR with `agent:codex` label
- [ ] Verify task appendix appears in Codex prompt (check workflow logs)
- [ ] Verify Codex works on actual tasks (not random infrastructure work)
- [ ] Verify keepalive comment updates with iteration progress
### GITHUB_STEP_SUMMARY
- [ ] Add step summary output to `agents-keepalive-loop.yml` after agent run
- [ ] Include: iteration number, tasks completed, files changed, outcome
- [ ] Ensure summary is visible in workflow run UI
### Conditional Status Summary
- [ ] Modify `buildStatusBlock()` in `agents_pr_meta_update_body.js` to accept `agentType` parameter
- [ ] When `agentType` is set (CLI agent): hide workflow table, hide head SHA/required checks
- [ ] Keep Scope/Tasks/Acceptance checkboxes for all cases
- [ ] Pass agent type from workflow to the update_body job
### Comment Pattern Cleanup
- [ ] **For CLI agents (`agent:*` label):**
- [ ] Suppress `<!-- gate-summary: -->` comment posting (use step summary instead)
- [ ] Suppress `<!-- keepalive-round: N -->` instruction comments (task appendix replaces this)
- [ ] Update `<!-- keepalive-loop-summary -->` to be the **single source of truth**
- [ ] Ensure state marker is embedded in the summary comment (not separate)
- [ ] **For UI Codex (no `agent:*` label):**
- [ ] Keep existing comment patterns (instruction comments, connector bot reports)
- [ ] Keep `<!-- gate-summary: -->` comment
- [ ] Add `agent_type` output to detect job so downstream workflows know the mode
- [ ] Update `agents-pr-meta.yml` to conditionally skip gate summary for CLI agent PRs

#### Acceptance criteria
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] Iteration results visible in Actions workflow run summary
- [ ] PR body shows checkboxes but not workflow clutter when using CLI agents
- [ ] UI Codex path (no agent label) continues to show full status summary
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] State tracking is consolidated in the summary comment, not scattered
## Dependencies
- [ ] - Requires PR #103 to be merged first

**Head SHA:** b292531e522097b91842887f016ce0c503c0dc68
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20858767467) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/20858714280) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714486) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20858715276) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714522) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714503) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714404) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714450) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714417) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714423) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714454) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714418) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20858714410) |
<!-- auto-status-summary:end -->