### PR TITLE
fix(maint-72): extract repo name from owner/repo format

### DIFF
--- a/.github/workflows/maint-72-fix-pr-body-conflicts.yml
+++ b/.github/workflows/maint-72-fix-pr-body-conflicts.yml
@@ -65,6 +65,7 @@ jobs:
           fi
 
       - name: Extract repo name
+        if: steps.check.outputs.skip != 'true'
         id: repo-info
         run: |
           echo "repo_name=$(echo '${{ matrix.repo }}' | cut -d'/' -f2)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The maint-72 workflow was failing with 404 errors when trying to create GitHub App tokens:

```
Failed to create token for "stranske/Collab-Admin" (attempt 1): Not Found
url: 'https://api.github.com/repos/stranske/stranske%2FCollab-Admin/installation'
```

The issue is that `actions/create-github-app-token@v2` expects the `repositories` parameter to be just the repo name (e.g., `Collab-Admin`), not `owner/repo` format (e.g., `stranske/Collab-Admin`).

## Solution

Added a step to extract just the repo name from `matrix.repo` by splitting on `/` and taking the second field.

## Testing

After merge, manually trigger the workflow:
```bash
gh workflow run maint-72-fix-pr-body-conflicts.yml --repo stranske/Workflows --field dry_run=false
```

This will fix pr_body.md conflicts across all 7 consumer repos.