### PR TITLE
fix: Handle rate limits gracefully in verifier CI wait

### DIFF
--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -104,12 +104,15 @@ jobs:
             const maxWaitMs = Number(process.env.CI_WAIT_TIMEOUT_MS) || 300000;
             const pollIntervalMs = 15000;
             const startTime = Date.now();
+            let rateLimitHits = 0;
+            const maxRateLimitHits = 3;  // Give up after 3 consecutive rate limits
 
             core.info(`Waiting for CI workflows to complete for SHA ${targetSha}...`);
 
             while (Date.now() - startTime < maxWaitMs) {
               let allComplete = true;
               let anyFound = false;
+              let hitRateLimit = false;
 
               for (const workflowFile of ciWorkflows) {
                 try {
@@ -128,8 +131,24 @@ jobs:
                       allComplete = false;
                     }
                   }
+                  rateLimitHits = 0;  // Reset on success
                 } catch (err) {
-                  core.warning(`Failed to check ${workflowFile}: ${err.message}`);
+                  // Check for rate limit error
+                  if (err.message && err.message.includes('rate limit')) {
+                    hitRateLimit = true;
+                    core.warning(`Rate limited checking ${workflowFile}, will skip CI wait`);
+                  } else {
+                    core.warning(`Failed to check ${workflowFile}: ${err.message}`);
+                  }
+                }
+              }
+
+              // If rate limited, skip CI wait - verifier runs on merged PRs, CI is already done
+              if (hitRateLimit) {
+                rateLimitHits++;
+                if (rateLimitHits >= maxRateLimitHits) {
+                  core.info(`Rate limited ${rateLimitHits} times, skipping CI wait (PR is already merged, CI is done)`);
+                  return;
                 }
               }
 


### PR DESCRIPTION
## Problem

The verifier's CI wait step was hitting rate limits and then continuously polling for 5 minutes, exhausting API quota without making progress. This caused `verify:compare` to fail on multiple PRs:
- stranske/Trend_Model_Project#4315
- stranske/Workflows#699
- stranske/Workflows#696
- stranske/Workflows#697

## Solution

When rate limited, skip the CI wait instead of continuing to poll. This is safe because:
- The verifier only runs on **merged PRs**
- CI has already completed before the PR was merged
- The CI wait is just a safety check, not a requirement

## Changes

- Track consecutive rate limit hits (reset on successful API call)
- After 3 rate limit errors, skip CI wait and proceed with verification
- Log a clear message explaining the skip

## Testing

After merge, retrigger `verify:compare` on the affected PRs.