### PR TITLE
fix(auto-pilot): Add agent labels to PR after creation

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -504,15 +504,28 @@ jobs:
 
               core.info(`Created PR #${pr.number}`);
 
-              // Add standard agent labels to the PR
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: ['agent:codex', 'agents:keepalive', 'autofix']
-              });
+              // Add standard agent labels to the PR (separate try-catch to not fail PR creation)
+              let labelsAdded = false;
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ['agent:codex', 'agents:keepalive', 'autofix']
+                });
+                labelsAdded = true;
+                core.info(`Added agent labels to PR #${pr.number}`);
+              } catch (labelError) {
+                core.warning(
+                  `Failed to add labels to PR #${pr.number}: ${
+                    labelError && labelError.message ? labelError.message : labelError
+                  }`
+                );
+              }
 
-              core.info(`Added agent labels to PR #${pr.number}`);
+              const labelStatus = labelsAdded
+                ? '✅ Added labels: `agent:codex`, `agents:keepalive`, `autofix`'
+                : '⚠️ Could not add labels (add manually)';
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -521,7 +534,7 @@ jobs:
                 body: `🤖 **Auto-pilot step ${stepCount}**: PR created!
 
             ✅ Created PR #${pr.number} from branch \`${branchName}\`
-            ✅ Added labels: \`agent:codex\`, \`agents:keepalive\`, \`autofix\`
+            ${labelStatus}
 
             The PR will now go through CI checks. Auto-pilot will continue monitoring.`
               });

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -509,15 +509,28 @@ jobs:
 
               core.info(`Created PR #${pr.number}`);
 
-              // Add standard agent labels to the PR
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: ['agent:codex', 'agents:keepalive', 'autofix']
-              });
+              // Add standard agent labels to the PR (separate try-catch to not fail PR creation)
+              let labelsAdded = false;
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ['agent:codex', 'agents:keepalive', 'autofix']
+                });
+                labelsAdded = true;
+                core.info(`Added agent labels to PR #${pr.number}`);
+              } catch (labelError) {
+                core.warning(
+                  `Failed to add labels to PR #${pr.number}: ${
+                    labelError && labelError.message ? labelError.message : labelError
+                  }`
+                );
+              }
 
-              core.info(`Added agent labels to PR #${pr.number}`);
+              const labelStatus = labelsAdded
+                ? '✅ Added labels: `agent:codex`, `agents:keepalive`, `autofix`'
+                : '⚠️ Could not add labels (add manually)';
 
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -526,7 +539,7 @@ jobs:
                 body: `🤖 **Auto-pilot step ${stepCount}**: PR created!
 
             ✅ Created PR #${pr.number} from branch \`${branchName}\`
-            ✅ Added labels: \`agent:codex\`, \`agents:keepalive\`, \`autofix\`
+            ${labelStatus}
 
             The PR will now go through CI checks. Auto-pilot will continue monitoring.`
               });


### PR DESCRIPTION
## Summary

Adds the standard agent labels to PRs created by the auto-pilot workflow.

## Changes

After creating a PR, auto-pilot now adds:
- `agent:codex` - Identifies this as a Codex agent PR
- `agents:keepalive` - Enables keepalive loop to continue work
- `autofix` - Enables autofix to handle CI failures

## Why

Without these labels, the keepalive and autofix loops don't engage on auto-pilot created PRs, leaving them stalled after creation.

## Files Changed

- `.github/workflows/agents-auto-pilot.yml`
- `templates/consumer-repo/.github/workflows/agents-auto-pilot.yml`