### PR TITLE
fix: Allow Codex worker to run for conflict action

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -165,7 +165,7 @@ jobs:
   preflight:
     name: Verify secrets available
     needs: evaluate
-    if: needs.evaluate.outputs.action == 'run' || needs.evaluate.outputs.action == 'fix'
+    if: needs.evaluate.outputs.action == 'run' || needs.evaluate.outputs.action == 'fix' || needs.evaluate.outputs.action == 'conflict'
     runs-on: ubuntu-latest
     environment: agent-standard
     outputs:
@@ -203,7 +203,7 @@ jobs:
     needs:
       - evaluate
       - preflight
-    if: needs.evaluate.outputs.action == 'run' || needs.evaluate.outputs.action == 'fix'
+    if: needs.evaluate.outputs.action == 'run' || needs.evaluate.outputs.action == 'fix' || needs.evaluate.outputs.action == 'conflict'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -244,7 +244,7 @@ jobs:
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
-      skip: ${{ needs.evaluate.outputs.action != 'run' && needs.evaluate.outputs.action != 'fix' }}
+      skip: ${{ needs.evaluate.outputs.action != 'run' && needs.evaluate.outputs.action != 'fix' && needs.evaluate.outputs.action != 'conflict' }}
       prompt_file: ${{ needs.evaluate.outputs.prompt_file }}
       mode: keepalive
       pr_number: ${{ needs.evaluate.outputs.pr_number }}


### PR DESCRIPTION
Fixes the keepalive deadlock where merge conflicts were detected but never resolved.

The keepalive loop was correctly detecting merge conflicts and setting action='conflict', but the preflight, mark-running, and run-codex jobs were only configured to run for action='run' or action='fix'.

This meant conflicts were detected but never resolved because the Codex worker was skipped.

Changes:
- Add 'conflict' to action checks in preflight job
- Add 'conflict' to action checks in mark-running job  
- Add 'conflict' to skip condition in run-codex job

This completes the conflict resolution flow by allowing Codex to run when conflicts are detected.