### PR TITLE
fix: Replace Mistral-large-2407 with Meta-Llama-3.1-405B-Instruct

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -38,7 +38,7 @@ on:
         default: 'evaluate'
       model:
         description: >-
-          Model for evaluation. GitHub Models: gpt-4o (default), Mistral-large-2407,
+          Model for evaluation. GitHub Models: gpt-4o (default),
           Meta-Llama-3.1-405B-Instruct | OpenAI (requires key): o1, gpt-5.2.
           For stricter evaluation, use compare mode with different model families.
         required: false
@@ -47,11 +47,11 @@ on:
       model2:
         description: >-
           Second model for compare mode (cross-provider verification).
-          Default: Mistral-large-2407 (GitHub Models) paired with gpt-5.2 (OpenAI).
+          Default: Meta-Llama-3.1-405B-Instruct (GitHub Models) paired with gpt-5.2 (OpenAI).
           Using different providers ensures diverse evaluation perspectives.
         required: false
         type: string
-        default: 'Mistral-large-2407'
+        default: 'Meta-Llama-3.1-405B-Instruct'
       provider:
         description: 'LLM provider (OpenAI requires OPENAI_API_KEY secret)'
         required: true
@@ -156,8 +156,8 @@ jobs:
             // For compare mode, use models from different families/providers
             // model1 goes to GitHub Models, model2 goes to OpenAI
             if (mode === 'compare') {
-              // Mistral-large (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
-              core.setOutput('model', 'Mistral-large-2407');
+              // Llama 3.1 405B (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
+              core.setOutput('model', 'Meta-Llama-3.1-405B-Instruct');
               core.setOutput('model2', 'gpt-5.2');
             } else {
               core.setOutput('model', '');  // Use default (gpt-4o)

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: 'checkbox'
       model:
-        description: 'LLM model to use for evaluation (e.g., gpt-4o, Mistral-large-2407, gpt-5.2)'
+        description: 'LLM model to use for evaluation (e.g., gpt-4o, Meta-Llama-3.1-405B-Instruct, gpt-5.2)'
         required: false
         type: string
         default: 'gpt-4o'

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -38,7 +38,7 @@ on:
         default: 'evaluate'
       model:
         description: >-
-          Model for evaluation. GitHub Models: gpt-4o (default), Mistral-large-2407,
+          Model for evaluation. GitHub Models: gpt-4o (default),
           Meta-Llama-3.1-405B-Instruct | OpenAI (requires key): o1, gpt-5.2.
           For stricter evaluation, use compare mode with different model families.
         required: false
@@ -47,11 +47,11 @@ on:
       model2:
         description: >-
           Second model for compare mode (cross-provider verification).
-          Default: Mistral-large-2407 (GitHub Models) paired with gpt-5.2 (OpenAI).
+          Default: Meta-Llama-3.1-405B-Instruct (GitHub Models) paired with gpt-5.2 (OpenAI).
           Using different providers ensures diverse evaluation perspectives.
         required: false
         type: string
-        default: 'Mistral-large-2407'
+        default: 'Meta-Llama-3.1-405B-Instruct'
       provider:
         description: 'LLM provider (OpenAI requires OPENAI_API_KEY secret)'
         required: true
@@ -156,8 +156,8 @@ jobs:
             // For compare mode, use models from different families/providers
             // model1 goes to GitHub Models, model2 goes to OpenAI
             if (mode === 'compare') {
-              // Mistral-large (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
-              core.setOutput('model', 'Mistral-large-2407');
+              // Llama 3.1 405B (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
+              core.setOutput('model', 'Meta-Llama-3.1-405B-Instruct');
               core.setOutput('model2', 'gpt-5.2');
             } else {
               core.setOutput('model', '');  // Use default (gpt-4o)


### PR DESCRIPTION
## Problem

`Mistral-large-2407` returns `Unknown model: mistral-large-2407` error on GitHub Models API. This appears to be a case-sensitivity issue - the API lists the model as `Mistral-large-2407` but returns error with lowercase `mistral-large-2407`.

Error from PR #1099 on Portable-Alpha-Extension-Model:
```
Error code: 400 - {'error': {'code': 'unknown_model', 'message': 'Unknown model: mistral-large-2407'}}
```

## Solution

Replace with **Meta-Llama-3.1-405B-Instruct** - Meta's 405 billion parameter model which is the best non-OpenAI reasoning model available on GitHub Models.

## Changes

- Update `agents-verifier.yml` template to use Llama 3.1 405B as default for compare mode
- Update model description examples in both template and reusable workflow
- Keep `gpt-5.2` as the OpenAI comparison model (it works fine)

## After Merge

Run sync workflow to push updated templates to consumer repos.