### PR TITLE
fix: Use gpt-4o for compare mode (non-OpenAI models return 404)

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -38,20 +38,20 @@ on:
         default: 'evaluate'
       model:
         description: >-
-          Model for evaluation. GitHub Models: gpt-4o (default),
-          Meta-Llama-3.1-405B-Instruct | OpenAI (requires key): o1, gpt-5.2.
-          For stricter evaluation, use compare mode with different model families.
+          Model for evaluation. GitHub Models: gpt-4o (default).
+          OpenAI (requires key): o1, gpt-5.2.
+          For stricter evaluation, use compare mode with different providers.
         required: false
         type: string
         default: 'gpt-4o'
       model2:
         description: >-
           Second model for compare mode (cross-provider verification).
-          Default: Meta-Llama-3.1-405B-Instruct (GitHub Models) paired with gpt-5.2 (OpenAI).
+          Default: gpt-4o (GitHub Models) paired with gpt-5.2 (OpenAI).
           Using different providers ensures diverse evaluation perspectives.
         required: false
         type: string
-        default: 'Meta-Llama-3.1-405B-Instruct'
+        default: 'gpt-4o'
       provider:
         description: 'LLM provider (OpenAI requires OPENAI_API_KEY secret)'
         required: true
@@ -156,8 +156,8 @@ jobs:
             // For compare mode, use models from different families/providers
             // model1 goes to GitHub Models, model2 goes to OpenAI
             if (mode === 'compare') {
-              // Llama 3.1 405B (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
-              core.setOutput('model', 'Meta-Llama-3.1-405B-Instruct');
+              // gpt-4o (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
+              core.setOutput('model', 'gpt-4o');
               core.setOutput('model2', 'gpt-5.2');
             } else {
               core.setOutput('model', '');  // Use default (gpt-4o)

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: 'checkbox'
       model:
-        description: 'LLM model to use for evaluation (e.g., gpt-4o, Meta-Llama-3.1-405B-Instruct, gpt-5.2)'
+        description: 'LLM model to use for evaluation (e.g., gpt-4o, gpt-5.2)'
         required: false
         type: string
         default: 'gpt-4o'

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -38,20 +38,20 @@ on:
         default: 'evaluate'
       model:
         description: >-
-          Model for evaluation. GitHub Models: gpt-4o (default),
-          Meta-Llama-3.1-405B-Instruct | OpenAI (requires key): o1, gpt-5.2.
-          For stricter evaluation, use compare mode with different model families.
+          Model for evaluation. GitHub Models: gpt-4o (default).
+          OpenAI (requires key): o1, gpt-5.2.
+          For stricter evaluation, use compare mode with different providers.
         required: false
         type: string
         default: 'gpt-4o'
       model2:
         description: >-
           Second model for compare mode (cross-provider verification).
-          Default: Meta-Llama-3.1-405B-Instruct (GitHub Models) paired with gpt-5.2 (OpenAI).
+          Default: gpt-4o (GitHub Models) paired with gpt-5.2 (OpenAI).
           Using different providers ensures diverse evaluation perspectives.
         required: false
         type: string
-        default: 'Meta-Llama-3.1-405B-Instruct'
+        default: 'gpt-4o'
       provider:
         description: 'LLM provider (OpenAI requires OPENAI_API_KEY secret)'
         required: true
@@ -156,8 +156,8 @@ jobs:
             // For compare mode, use models from different families/providers
             // model1 goes to GitHub Models, model2 goes to OpenAI
             if (mode === 'compare') {
-              // Llama 3.1 405B (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
-              core.setOutput('model', 'Meta-Llama-3.1-405B-Instruct');
+              // gpt-4o (GitHub Models) + gpt-5.2 (OpenAI) for cross-provider comparison
+              core.setOutput('model', 'gpt-4o');
               core.setOutput('model2', 'gpt-5.2');
             } else {
               core.setOutput('model', '');  // Use default (gpt-4o)


### PR DESCRIPTION
## Problem

Testing showed that **all non-OpenAI models** on GitHub Models return 404 errors:
- `Meta-Llama-3.1-405B-Instruct` → 404 model_not_found
- `Meta-Llama-3.1-70B-Instruct` → 404 model_not_found  
- `Mistral-large-2407` → 400 unknown_model
- `Mistral-Nemo` → 404 model_not_found

Only `gpt-4o` works reliably on GitHub Models.

## Test Results

| Model | Provider | Result |
|-------|----------|--------|
| gpt-4o | github-models | ✅ PASS with detailed analysis |
| Meta-Llama-3.1-405B-Instruct | github-models | ❌ 404 model_not_found |
| Meta-Llama-3.1-70B-Instruct | github-models | ❌ 404 model_not_found |
| Mistral-Nemo | github-models | ❌ 404 model_not_found |
| gpt-5.2 | openai | ✅ Works (from PR #1099 results) |

## Solution

Compare mode now uses:
- **gpt-4o** via GitHub Models (model1)
- **gpt-5.2** via OpenAI API (model2)

This still provides cross-provider verification value since requests go through different APIs and infrastructure.

## Changes

- Update `agents-verifier.yml` (Workflows repo)
- Update `agents-verifier.yml` template (consumer repos)
- Update `reusable-agents-verifier.yml` model description