### PR TITLE
docs: Add dual-location file sync gotcha guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ These get **synced** to consumer repos via `maint-68-sync-consumer-repos.yml`:
 
 ### ⚠️ IMPORTANT: After Syncing, Use the Merge Workflow
 
+> **🚨 CRITICAL**: Before updating any files in `.github/`, read [**Dual-Location Sync Gotcha Guide**](docs/guides/dual-location-sync-gotcha.md) to prevent consumers from receiving outdated versions!
+
+
+
+
 **ALWAYS** use `Merge Sync PRs` workflow (maint-71-merge-sync-prs.yml) to:
 - Auto-merge sync PRs that pass CI checks
 - Close stale/duplicate sync PRs

--- a/docs/guides/dual-location-sync-gotcha.md
+++ b/docs/guides/dual-location-sync-gotcha.md
@@ -1,0 +1,75 @@
+# ⚠️ CRITICAL: Dual-Location File Sync Gotcha
+
+## Problem
+
+Files in Workflows repo exist in **TWO locations**:
+- `.github/codex/prompts/*.md` (Workflows own copy - used for self-testing)
+- `templates/consumer-repo/.github/codex/prompts/*.md` (synced to consumers)
+
+**The sync manifest declares the path as `.github/codex/prompts/file.md`**, but the sync workflow **prepends `templates/consumer-repo/`** when reading files. This means:
+
+1. You update `.github/codex/prompts/fix_merge_conflicts.md` (for Workflows self-testing)
+2. Sync reads from `templates/consumer-repo/.github/codex/prompts/fix_merge_conflicts.md` (old version)
+3. **Consumers get the OLD version, not your changes!**
+
+## How to Prevent This
+
+**RULE**: When updating files in `.github/`, ALSO update the corresponding file in `templates/consumer-repo/.github/`:
+
+```bash
+# After updating a prompt in .github/codex/prompts/
+cp .github/codex/prompts/fix_merge_conflicts.md \
+   templates/consumer-repo/.github/codex/prompts/fix_merge_conflicts.md
+
+# Or for scripts:
+cp .github/scripts/conflict_detector.js \
+   templates/consumer-repo/.github/scripts/conflict_detector.js
+```
+
+**Files affected by this gotcha:**
+- All `.github/codex/prompts/*.md` files
+- All `.github/scripts/*.js` files that are also in sync manifest
+- Any other file declared in sync manifest with `.github/` path
+
+## Why This Happens
+
+The sync workflow (maint-68-sync-consumer-repos.yml) has this logic:
+```python
+template_src = Path('workflows/templates/consumer-repo') / source
+```
+
+It takes the `source` from sync-manifest.yml and prepends `workflows/templates/consumer-repo/`. So even though the manifest says `.github/codex/prompts/file.md`, it actually reads from `templates/consumer-repo/.github/codex/prompts/file.md`.
+
+## Verification Checklist
+
+Before committing changes to dual-location files:
+
+- [ ] Updated file in `.github/` (for Workflows self-testing)
+- [ ] Updated file in `templates/consumer-repo/.github/` (for consumer sync)
+- [ ] Verified both files match: `diff .github/path/file templates/consumer-repo/.github/path/file`
+- [ ] Committed both files in same PR
+- [ ] Triggered sync workflow: `gh workflow run "Maint 68 Sync Consumer Repos" --repo stranske/Workflows`
+- [ ] Merged resulting sync PRs: `gh workflow run "Merge Sync PRs" --repo stranske/Workflows`
+
+## Real-World Example: Conflict Resolution Prompt
+
+On 2026-01-10, the conflict resolution prompt was updated in `.github/codex/prompts/fix_merge_conflicts.md` with a critical fix:
+- OLD: "Check `git status` first and exit if clean"
+- NEW: "Do NOT check git status first! Conflicts only appear DURING merge"
+
+But `templates/consumer-repo/.github/codex/prompts/fix_merge_conflicts.md` was not updated. Result:
+- Workflows repo worked fine (used `.github/` copy)
+- Consumer repos got old version via sync
+- PRs with conflicts failed because agents exited early
+- Issue discovered 2026-01-11 when PR #4339 in Trend_Model_Project had conflicts
+
+**Fix**: Always update BOTH locations when making changes.
+
+## Quick Reference
+
+| Location | Used By | Purpose |
+|----------|---------|---------|
+| `.github/` | Workflows repo | Self-testing and validation |
+| `templates/consumer-repo/.github/` | Consumer repos | What gets synced via maint-68 |
+
+**Remember**: Sync manifest paths are misleading! They declare `.github/` but actually read from `templates/consumer-repo/`.


### PR DESCRIPTION
## Problem

Files in Workflows repo exist in TWO locations:
- `.github/` (used by Workflows itself for self-testing)
- `templates/consumer-repo/.github/` (what gets synced to consumers)

When you update `.github/codex/prompts/fix_merge_conflicts.md`, the sync system actually reads from `templates/consumer-repo/.github/codex/prompts/fix_merge_conflicts.md` — so consumers get the OLD version!

## Root Cause

The sync manifest declares paths as `.github/codex/prompts/file.md`, but maint-68-sync-consumer-repos.yml prepends `templates/consumer-repo/` when reading files:

```python
template_src = Path('workflows/templates/consumer-repo') / source
```

This architectural disconnect causes systematic drift.

## Solution

New standalone guide at [docs/guides/dual-location-sync-gotcha.md](https://github.com/stranske/Workflows/blob/docs/sync-two-location-gotcha/docs/guides/dual-location-sync-gotcha.md) documents:
- ⚠️ The two-location architecture problem
- 🔧 How to prevent: Always update BOTH locations
- ✅ Verification checklist for dual-location files
- 📚 Real-world example from PR #4339 incident
- 📊 Quick reference table

CLAUDE.md now has **prominent 🚨 CRITICAL callout** linking to this guide right after the sync section heading — impossible to miss!

## Real-World Impact

On 2026-01-10, the conflict resolution prompt was updated with a critical fix in `.github/codex/prompts/fix_merge_conflicts.md`:
- OLD: "Check `git status` first and exit if clean"
- NEW: "Do NOT check git status first! Conflicts only appear DURING merge"

But `templates/consumer-repo/` version wasn't updated → consumers got old version → PR #4339 in Trend_Model_Project had unresolved conflicts.

## Files Affected

This gotcha affects:
- All `.github/codex/prompts/*.md` files
- All `.github/scripts/*.js` files in sync manifest
- Any other file declared with `.github/` path in sync manifest

## Next Steps

After merging this PR:
1. Update `templates/consumer-repo/.github/codex/prompts/fix_merge_conflicts.md` to match `.github/` version
2. Trigger sync to propagate fix to all consumer repos

Ref: stranske/Trend_Model_Project#4339