### PR TITLE
fix: Use relative imports in langchain scripts

### DIFF
--- a/scripts/langchain/integration_layer.py
+++ b/scripts/langchain/integration_layer.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from scripts.langchain import label_matcher
+from . import label_matcher
 
 
 @dataclass

--- a/scripts/langchain/issue_dedup.py
+++ b/scripts/langchain/issue_dedup.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from scripts.langchain import semantic_matcher
+from . import semantic_matcher
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -349,7 +349,7 @@ def _apply_task_decomposition(formatted: str, *, use_llm: bool) -> str:
     if not tasks:
         return formatted
 
-    from scripts.langchain import task_decomposer
+    from . import task_decomposer
 
     suggestions: list[dict[str, Any]] = []
     for task in tasks:
@@ -360,7 +360,7 @@ def _apply_task_decomposition(formatted: str, *, use_llm: bool) -> str:
     if not suggestions:
         return formatted
 
-    from scripts.langchain import issue_optimizer
+    from . import issue_optimizer
 
     return issue_optimizer._apply_task_decomposition(formatted, {"task_splitting": suggestions})
 

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -474,7 +474,7 @@ def _is_large_task(task: str) -> bool:
 
 
 def _detect_task_splitting(tasks: list[str], *, use_llm: bool = False) -> list[dict[str, Any]]:
-    from scripts.langchain import task_decomposer
+    from . import task_decomposer
 
     results: list[dict[str, Any]] = []
     for task in tasks:
@@ -500,7 +500,7 @@ def _ensure_task_decomposition(
     if not task_splitting:
         return task_splitting
 
-    from scripts.langchain import task_decomposer
+    from . import task_decomposer
 
     updated: list[dict[str, Any]] = []
     for entry in task_splitting:
@@ -691,7 +691,7 @@ def _apply_task_decomposition(formatted_body: str, suggestions: dict[str, Any]) 
     if not isinstance(raw_entries, list) or not raw_entries:
         return formatted_body
 
-    from scripts.langchain import task_decomposer
+    from . import task_decomposer
 
     decomposition_map: dict[str, list[str]] = {}
     for entry in raw_entries:
@@ -835,7 +835,7 @@ def apply_suggestions(
                             file=sys.stderr,
                         )
 
-    from scripts.langchain import issue_formatter
+    from . import issue_formatter
 
     fallback = issue_formatter.format_issue_body(issue_body, use_llm=False)
     formatted = _apply_task_decomposition(fallback["formatted_body"], suggestions)

--- a/scripts/langchain/label_matcher.py
+++ b/scripts/langchain/label_matcher.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from scripts.langchain import semantic_matcher
+from . import semantic_matcher
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #820

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
## Problem

The `agents:apply-suggestions` label is failing in all consumer repos with:
```
ImportError: cannot import name 'task_decomposer' from 'scripts.langchain'
```

**Root cause**: Consumer repos have a stale `scripts/langchain/` directory that conflicts with the Workflows repo version. When Python resolves imports, it finds the consumer repo's incomplete copy first, which is missing required modules like `task_decomposer.py`.

## Solution

Add `scripts/langchain/` to the consumer repo .gitignore template. These scripts should ONLY exist in the Workflows repo and be used via sparse checkout to `workflows-scripts/`.

## Impact

Fixes issue automation features:

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- Add `scripts/langchain/` to the consumer repo .gitignore template. These scripts should ONLY exist in the Workflows repo and be used via sparse checkout to `workflows-scripts/`.
- <!-- keepalive-loop-summary -->
- | Keepalive | ❌ disabled |
- <!-- keepalive-state:v1 {"trace":"","pr_number":820,"iteration":0,"max_iterations":5,"last_action":"wait","last_reason":"missing-agent-label-transient","failure":{},"error_type":"infrastructure","error_category":"resource","tasks":{"total":6,"unchecked":6},"gate_conclusion":"success","failure_threshold":3,"needs_task_reconciliation":false,"last_files_changed":0,"prev_files_changed":0,"last_effort_score":0,"last_data_quality":"","attempted_tasks":[],"last_focus":"`agents:apply-suggestions` (currently broken)","verification":{},"timeout":{"resolved_minutes":45,"default_minutes":45,"extended_minutes":90,"override_minutes":null,"source":"default","label":null,"elapsed_minutes":1,"remaining_minutes":44,"usage_ratio":0.042365925925925925,"warning":null},"attempts":[{"iteration":0,"action":"wait","reason":"missing-agent-label-transient","run_result":"skipped","prompt_mode":"normal","prompt_file":".github/codex/prompts/keepalive_next_task.md","gate":"success","error_category":"resource","error_type":"infrastructure"}],"version":"v1"} -->

### Related Issues/PRs
- [stranske/Trend_Model_Project#4188](https://github.com/stranske/Trend_Model_Project/issues/4188)
- [#820](https://github.com/stranske/Workflows/issues/820)

### References
- https://github.com/stranske/Trend_Model_Project/actions/runs/20906120333

### Blockers & Dependencies
- After this PR merges:
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] - `agents:apply-suggestions` (currently broken)
- [ ] - `agents:optimize` (analysis phase works, apply phase broken)
- [ ] - `agents:format` (broken if it tries to import from issue_formatter)

#### Acceptance criteria
- [ ] 1. Sync .gitignore to all consumer repos
- [ ] 2. Create PRs to remove `scripts/langchain/` from each consumer repo
- [ ] 3. Test `agents:apply-suggestions` on stranske/Trend_Model_Project#4188

**Head SHA:** f34bd865ec61937626d7bf9ee94d48130f10bcd9
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20906463504) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/20906443043) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443110) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20906443475) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20906443087) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443082) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443048) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443054) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443049) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443059) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443057) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20906443053) |
<!-- auto-status-summary:end -->