### PR TITLE
fix: Use direct imports instead of relative in langchain scripts

### DIFF
--- a/scripts/langchain/integration_layer.py
+++ b/scripts/langchain/integration_layer.py
@@ -13,7 +13,7 @@ from typing import Any
 try:
     import label_matcher
 except ModuleNotFoundError:
-    from scripts.langchain import label_matcher
+    from . import label_matcher
 
 
 @dataclass

--- a/scripts/langchain/issue_dedup.py
+++ b/scripts/langchain/issue_dedup.py
@@ -13,7 +13,7 @@ from typing import Any
 try:
     import semantic_matcher
 except ModuleNotFoundError:
-    from scripts.langchain import semantic_matcher
+    from . import semantic_matcher
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -350,9 +350,9 @@ def _apply_task_decomposition(formatted: str, *, use_llm: bool) -> str:
         return formatted
 
     try:
-    import task_decomposer
-except ModuleNotFoundError:
-    from scripts.langchain import task_decomposer
+        import task_decomposer
+    except ModuleNotFoundError:
+        from . import task_decomposer
 
     suggestions: list[dict[str, Any]] = []
     for task in tasks:
@@ -364,9 +364,9 @@ except ModuleNotFoundError:
         return formatted
 
     try:
-    import issue_optimizer
-except ModuleNotFoundError:
-    from scripts.langchain import issue_optimizer
+        import issue_optimizer
+    except ModuleNotFoundError:
+        from . import issue_optimizer
 
     return issue_optimizer._apply_task_decomposition(formatted, {"task_splitting": suggestions})
 

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -475,9 +475,9 @@ def _is_large_task(task: str) -> bool:
 
 def _detect_task_splitting(tasks: list[str], *, use_llm: bool = False) -> list[dict[str, Any]]:
     try:
-    import task_decomposer
-except ModuleNotFoundError:
-    from scripts.langchain import task_decomposer
+        import task_decomposer
+    except ModuleNotFoundError:
+        from . import task_decomposer
 
     results: list[dict[str, Any]] = []
     for task in tasks:
@@ -504,9 +504,9 @@ def _ensure_task_decomposition(
         return task_splitting
 
     try:
-    import task_decomposer
-except ModuleNotFoundError:
-    from scripts.langchain import task_decomposer
+        import task_decomposer
+    except ModuleNotFoundError:
+        from . import task_decomposer
 
     updated: list[dict[str, Any]] = []
     for entry in task_splitting:
@@ -700,9 +700,9 @@ def _apply_task_decomposition(formatted_body: str, suggestions: dict[str, Any]) 
         return formatted_body
 
     try:
-    import task_decomposer
-except ModuleNotFoundError:
-    from scripts.langchain import task_decomposer
+        import task_decomposer
+    except ModuleNotFoundError:
+        from . import task_decomposer
 
     decomposition_map: dict[str, list[str]] = {}
     for entry in raw_entries:
@@ -850,9 +850,9 @@ def apply_suggestions(
                         )
 
     try:
-    import issue_formatter
-except ModuleNotFoundError:
-    from scripts.langchain import issue_formatter
+        import issue_formatter
+    except ModuleNotFoundError:
+        from . import issue_formatter
 
     fallback = issue_formatter.format_issue_body(issue_body, use_llm=False)
     formatted = _apply_task_decomposition(fallback["formatted_body"], suggestions)

--- a/scripts/langchain/label_matcher.py
+++ b/scripts/langchain/label_matcher.py
@@ -14,7 +14,7 @@ from typing import Any
 try:
     import semantic_matcher
 except ModuleNotFoundError:
-    from scripts.langchain import semantic_matcher
+    from . import semantic_matcher
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The workflow uses inline python -c commands which don't establish a package context for relative imports. Since sys.path.insert adds scripts/langchain to the path, we can use direct imports without any prefix.

Fixes: ImportError: attempted relative import with no known parent package