### PR TITLE
fix: prevent false-positive conflict detection from blocking fix_ci mode

### DIFF
--- a/.github/scripts/conflict_detector.js
+++ b/.github/scripts/conflict_detector.js
@@ -59,15 +59,19 @@ function shouldIgnoreConflictFile(filename) {
   });
 }
 
+// Only match definitive merge conflict markers, not general text mentioning conflicts.
+// The phrase "merge conflict" can appear in commit messages, comments, and other text
+// without indicating an actual active conflict. We require git-generated markers.
 const CONFLICT_PATTERNS = [
-  /merge conflict/i,
-  /CONFLICT \(content\)/i,
-  /Automatic merge failed/i,
-  /fix conflicts and then commit/i,
-  /Merge branch .* into .* failed/i,
+  // Git conflict markers (highly reliable)
   /<<<<<<< HEAD/,
-  /=======\n/,
-  />>>>>>> /,
+  />>>>>>> [a-f0-9]{7,40}/,  // Conflict marker with SHA
+  />>>>>>> origin\//,         // Conflict marker with remote branch
+  // Git merge failure messages (from actual merge operations, not log text)
+  /CONFLICT \(content\):/,    // Note: requires colon to be more specific
+  /CONFLICT \(add\/add\):/,
+  /CONFLICT \(modify\/delete\):/,
+  /Automatic merge failed; fix conflicts and then commit/,  // Full message
 ];
 
 /**


### PR DESCRIPTION
## Problem

The conflict detector was incorrectly triggering on text in CI logs that mentioned 'merge conflict' (from commit messages, comments, etc.), which caused the keepalive loop to use conflict resolution mode instead of fix_ci mode when Gate was actually failing due to mypy/test errors.

## Fix

1. **Tightened CONFLICT_PATTERNS** in `conflict_detector.js` to only match definitive git conflict markers (`<<<<<<< HEAD`, `>>>>>>> SHA`), not general text like 'merge conflict' which appears everywhere

2. **Updated priority logic** in `keepalive_loop.js` to only treat GitHub API conflicts (`mergeable_state === 'dirty'`) as definitive - CI-log-based detection now doesn't block `fix_ci` mode

## Testing

Already tested and verified working in stranske/Trend_Model_Project:
- PRs #4353 and #4355 were stuck in conflict mode despite having mypy errors
- After fix, keepalive correctly uses `fix_ci` mode with `fix_ci_failures.md` prompt
- Codex is now actively fixing the mypy errors

## Consumer Repos

Consumer repos that have local copies of these scripts will need to sync from this repo.