### PR TITLE
fix: resolve isort conflict in issue_formatter.py for consumer repos

### DIFF
--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -93,8 +93,8 @@ def _load_prompt() -> str:
 
 def _get_llm_client() -> tuple[object, str] | None:
     try:
-        from langchain_openai import ChatOpenAI
-
+        # Keep imports contiguous; consumer repos treat both as third-party
+        from langchain_openai import ChatOpenAI  # noqa: I001
         from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
     except ImportError:
         return None


### PR DESCRIPTION
Fixes I001 lint error in consumer repos by adding noqa comment to keep imports contiguous.

Consumer repos treat both `langchain_openai` and `tools.llm_provider` as third-party imports (no blank line between them), while Workflows treats `tools` as first-party (blank line expected). The `noqa: I001` comment resolves this conflict.

Blocks sync PRs from merging until this is synced.