### PR TITLE
fix: show 'ALL TASKS COMPLETE' status when all tasks done

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1719,6 +1719,7 @@ async function updateKeepaliveLoopSummary({ github, context, core, inputs }) {
   const errorType = failureDetails.type;
   const errorRecovery = failureDetails.recovery;
   const tasksComplete = Math.max(0, tasksTotal - tasksUnchecked);
+  const allTasksComplete = tasksUnchecked === 0 && tasksTotal > 0;
   const metricsIteration = action === 'run' ? currentIteration + 1 : currentIteration;
   const durationMs = resolveDurationMs({
     durationMs: toOptionalNumber(inputs.duration_ms ?? inputs.durationMs),
@@ -1784,7 +1785,7 @@ async function updateKeepaliveLoopSummary({ github, context, core, inputs }) {
     } |`,
     `| Action | ${action || 'unknown'} (${actionReason || 'n/a'}) |`,
     ...(dispositionLabel ? [`| Disposition | ${dispositionLabel} |`] : []),
-    ...(runFailed ? [`| Agent status | ❌ AGENT FAILED |`] : []),
+    ...(allTasksComplete ? [`| Agent status | ✅ ALL TASKS COMPLETE |`] : runFailed ? [`| Agent status | ❌ AGENT FAILED |`] : []),
     `| Gate | ${gateConclusion || 'unknown'} |`,
     `| Tasks | ${tasksComplete}/${tasksTotal} complete |`,
     `| Timeout | ${formatTimeoutMinutes(timeoutStatus.resolvedMinutes)} min (${timeoutStatus.source || 'default'}) |`,


### PR DESCRIPTION
## Problem

PR #4353 in Trend_Model_Project shows "❌ AGENT FAILED" in the Keepalive Loop Status, even though all 10/10 tasks are complete. This is confusing because the work is DONE.

## Root Cause

The summary generation shows "AGENT FAILED" based solely on `runFailed`, without checking if all tasks are complete. When verification fails but all work is done, it incorrectly shows failure status.

## Solution

When `tasksUnchecked === 0` (all tasks complete), show "✅ ALL TASKS COMPLETE" instead of "❌ AGENT FAILED", regardless of the last run result.

A failed verification run doesn't mean the PR failed - it means optional verification didn't pass, but all required work is complete.

## Changes

- Add `allTasksComplete` check: `tasksUnchecked === 0 && tasksTotal > 0`
- Update Agent status line to prioritize ALL TASKS COMPLETE over AGENT FAILED
- Status priority: ALL TASKS COMPLETE > AGENT FAILED > (hidden)

## Syncing

This fix is in `keepalive_loop.js` which is already in the sync manifest and will propagate to all consumer repos via the sync workflow.