### PR TITLE
chore: ignore keepalive status files in consumer template

### DIFF
--- a/templates/consumer-repo/.gitignore
+++ b/templates/consumer-repo/.gitignore
@@ -159,6 +159,8 @@ ci/autofix/history.json
 ci/autofix/diagnostics.json
 
 # Metrics/history files (MEDIUM conflict risk)
+keepalive_status.md
+docs/keepalive/status/
 keepalive-metrics.ndjson
 coverage-trend-history.ndjson
 metrics-history.ndjson


### PR DESCRIPTION
## Problem

Autofix workflow fails with "safe sweep produced changes outside allowed globs" when keepalive status files are tracked in git. These files appear in PR #4355 and others:
- `keepalive_status.md`
- `docs/keepalive/status/PR*_Status.md`

## Root Cause

These files are auto-generated by keepalive workflow and update on every keepalive run. When tracked in git, they:
1. Cause autofix safe-sweep violations
2. Create merge conflicts
3. Add noise to PRs

## Solution

Add these patterns to consumer template `.gitignore`:
- `keepalive_status.md`
- `docs/keepalive/status/`

## Syncing

This change is in the consumer template `.gitignore` which is synced to all consumer repos via the sync workflow.