### PR TITLE
fix(auto-pilot): re-dispatch after create-pr

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -1079,8 +1079,10 @@ jobs:
         if: |
           steps.context.outputs.should_continue == 'true' &&
           steps.cycles.outputs.exceeded != 'true' &&
-          contains(fromJSON('["format","optimize","apply","capability-check","monitor-pr"]'),
-          steps.next.outputs.next_step)
+          contains(
+            fromJSON('["format","optimize","apply","capability-check","create-pr","monitor-pr"]'),
+            steps.next.outputs.next_step
+          )
         uses: actions/github-script@v8
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -1097,16 +1099,17 @@ jobs:
               'optimize': 'apply',
               'apply': 'capability-check',
               'capability-check': 'auto',  // Let it detect agent/PR state
+              'create-pr': 'auto',  // Re-evaluate after branch/PR creation
               'monitor-pr': 'auto'  // Let it check PR completion
             };
             const nextStep = nextStepMap[currentStep] || 'auto';
 
-            // For monitor-pr, add delay to avoid tight polling loop
-            // Keepalive updates arrive slowly while CI runs; without delay
+            // For monitor-pr or create-pr, add delay to avoid tight polling loops
+            // Keepalive updates and branch creation can take time; without delay
             // we'd spam Actions with rapid re-dispatches
-            if (currentStep === 'monitor-pr') {
-              const waitTime = 120000;  // 2 minutes between monitor checks
-              core.info(`Waiting ${waitTime/1000}s for keepalive update...`);
+            if (currentStep === 'monitor-pr' || currentStep === 'create-pr') {
+              const waitTime = currentStep === 'monitor-pr' ? 120000 : 60000;
+              core.info(`Waiting ${waitTime/1000}s before re-dispatch...`);
               await new Promise(resolve => setTimeout(resolve, waitTime));
             }
             // Other steps dispatch immediately - explicit force_step

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -1082,8 +1082,10 @@ jobs:
         if: |
           steps.context.outputs.should_continue == 'true' &&
           steps.cycles.outputs.exceeded != 'true' &&
-          contains(fromJSON('["format","optimize","apply","capability-check","monitor-pr"]'),
-          steps.next.outputs.next_step)
+          contains(
+            fromJSON('["format","optimize","apply","capability-check","create-pr","monitor-pr"]'),
+            steps.next.outputs.next_step
+          )
         uses: actions/github-script@v8
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
@@ -1100,16 +1102,17 @@ jobs:
               'optimize': 'apply',
               'apply': 'capability-check',
               'capability-check': 'auto',  // Let it detect agent/PR state
+              'create-pr': 'auto',  // Re-evaluate after branch/PR creation
               'monitor-pr': 'auto'  // Let it check PR completion
             };
             const nextStep = nextStepMap[currentStep] || 'auto';
 
-            // For monitor-pr, add delay to avoid tight polling loop
-            // Keepalive updates arrive slowly while CI runs; without delay
+            // For monitor-pr or create-pr, add delay to avoid tight polling loops
+            // Keepalive updates and branch creation can take time; without delay
             // we'd spam Actions with rapid re-dispatches
-            if (currentStep === 'monitor-pr') {
-              const waitTime = 120000;  // 2 minutes between monitor checks
-              core.info(`Waiting ${waitTime/1000}s for keepalive update...`);
+            if (currentStep === 'monitor-pr' || currentStep === 'create-pr') {
+              const waitTime = currentStep === 'monitor-pr' ? 120000 : 60000;
+              core.info(`Waiting ${waitTime/1000}s before re-dispatch...`);
               await new Promise(resolve => setTimeout(resolve, waitTime));
             }
             // Other steps dispatch immediately - explicit force_step


### PR DESCRIPTION
## Summary\n- re-dispatch auto-pilot after the create-pr step\n- add a short delay when waiting on branch creation\n- keep consumer template in sync\n\n## Testing\n- not run (workflow change)