### PR TITLE
feat: add GitHub App token support to mitigate rate limits

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -62,6 +62,32 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate App Token
+        id: app_token
+        if: steps.check.outputs.should_run == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+      - name: Select Token
+        id: token
+        if: steps.check.outputs.should_run == 'true'
+        env:
+          APP_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "Using GitHub App token (5000/hr pool)"
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "source=app" >> "$GITHUB_OUTPUT"
+          else
+            echo "Falling back to GITHUB_TOKEN (1000/hr shared pool)"
+            echo "token=$GITHUB_TOKEN_FALLBACK" >> "$GITHUB_OUTPUT"
+            echo "source=github_token" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         if: steps.check.outputs.should_run == 'true'
         uses: actions/checkout@v6
@@ -95,7 +121,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         id: get_issue
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${ISSUE_NUMBER}" > /tmp/issue.json
@@ -153,7 +179,7 @@ jobs:
       - name: Advisory issue dedup check
         if: steps.check.outputs.should_run == 'true' && steps.check.outputs.phase == 'analyze'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -216,7 +242,7 @@ jobs:
         id: apply
         env:
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           PYTHONPATH: ${{ github.workspace }}/workflows-scripts
         run: |
           echo "Extracting suggestions from comments on issue #${ISSUE_NUMBER}"
@@ -272,7 +298,7 @@ jobs:
         id: format
         env:
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}/workflows-scripts
@@ -307,7 +333,7 @@ jobs:
       - name: Manage labels
         if: steps.check.outputs.should_run == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
           PHASE: ${{ steps.check.outputs.phase }}
         run: |
@@ -322,4 +348,21 @@ jobs:
             gh issue edit "${ISSUE_NUMBER}" --remove-label "agents:format"
             gh issue edit "${ISSUE_NUMBER}" --add-label "agents:formatted"
             echo "Labels updated: removed format, added formatted"
+          fi
+
+      - name: Report workflow failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -n "${ISSUE_NUMBER}" ]; then
+            gh issue comment "${ISSUE_NUMBER}" --body "⚠️ **Workflow failed**
+
+The agents-issue-optimizer workflow encountered an error.
+
+**Details**: [View workflow run](${RUN_URL})
+
+Please check the logs and retry if needed." || true
           fi

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -186,16 +186,16 @@ jobs:
         id: check
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
-          HAS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID != '' }}
-          HAS_APP_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY != '' }}
+          HAS_APP_ID: ${{ secrets.KEEPALIVE_APP_ID != '' || secrets.WORKFLOWS_APP_ID != '' }}
+          HAS_APP_KEY: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY != '' || secrets.WORKFLOWS_APP_PRIVATE_KEY != '' }}
         run: |
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
-          echo "WORKFLOWS_APP_ID present: $HAS_APP_ID"
+          echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
           if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
             echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::Neither CODEX_AUTH_JSON nor WORKFLOWS_APP_ID is set. Cannot run Codex."
+            echo "::error::Neither CODEX_AUTH_JSON nor KEEPALIVE_APP_ID/WORKFLOWS_APP_ID is set. Cannot run Codex."
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -261,8 +261,10 @@ jobs:
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
-      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
-      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+      # Use dedicated KEEPALIVE_APP for isolated rate limit pool (5000/hr)
+      # Falls back to WORKFLOWS_APP if KEEPALIVE_APP not configured
+      WORKFLOWS_APP_ID: ${{ secrets.KEEPALIVE_APP_ID || secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY || secrets.WORKFLOWS_APP_PRIVATE_KEY }}
     with:
       skip: >-
         ${{ needs.evaluate.outputs.action != 'run' &&

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -109,15 +109,25 @@ jobs:
           echo "description=${description}" >> "$GITHUB_OUTPUT"
           echo "[Gate] State: ${state}, Description: ${description}"
 
+      - name: Generate App Token for commit status
+        id: app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
       - name: Report Gate commit status
         if: ${{ always() }}
         uses: actions/github-script@v8
         env:
           STATE: ${{ steps.summarize.outputs.state || 'pending' }}
           DESCRIPTION: ${{ steps.summarize.outputs.description || 'Gate status pending' }}
-          TARGET_URL: >-
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          APP_TOKEN: ${{ steps.app_token.outputs.token }}
         with:
+          # Use app token if available (5000/hr pool) to avoid rate limits
+          github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
## Summary

Add dedicated GitHub App token support to three consumer workflow templates to address API rate limit exhaustion.

## Changes

### 1. agents-issue-optimizer.yml
- Add WORKFLOWS_APP token generation with fallback to GITHUB_TOKEN
- Updates all GH_TOKEN usages to use the selected token
- Add workflow failure notification on issues

### 2. agents-keepalive-loop.yml
- Support dedicated KEEPALIVE_APP for isolated rate limit pool (5000/hr)
- Falls back to WORKFLOWS_APP if KEEPALIVE_APP not configured
- Update preflight secrets check to detect either app

### 3. pr-00-gate.yml
- Add app token generation for commit status creation
- Prevents rate limit failures on high-volume repos

## Token Pool Distribution After Change
| App | Rate Limit | Workflows |
|-----|------------|-----------|
| KEEPALIVE_APP | 5000/hr | keepalive-loop (isolated) |
| WORKFLOWS_APP | 5000/hr | autofix-loop, issue-optimizer, gate, issue-intake |
| GH_APP | 5000/hr | bot-comment-handler |

## Problem Addressed

API rate limit failures observed in:
- Gate workflow (7 failures)
- Keepalive Loop (6 failures)
- Autofix (5 failures)
- Issue Optimizer (1 failure)

The GITHUB_TOKEN has only 1000/hr shared across all workflow runs. Using dedicated GitHub App tokens provides:
- 5000/hr per app
- Isolated pools prevent one workflow from exhausting another's budget

## Testing
Consumer repos need these secrets configured:
- `WORKFLOWS_APP_ID` / `WORKFLOWS_APP_PRIVATE_KEY` (most workflows)
- `KEEPALIVE_APP_ID` / `KEEPALIVE_APP_PRIVATE_KEY` (optional, for keepalive isolation)

**Reference**: stranske/Trend_Model_Project#4194 (rate limit during apply-suggestions)