### PR TITLE
fix(gate): add GITHUB_TOKEN fallback when App lacks statuses permission

### DIFF
--- a/docs/keepalive/SETUP_CHECKLIST.md
+++ b/docs/keepalive/SETUP_CHECKLIST.md
@@ -86,6 +86,7 @@ The Workflows GitHub App provides secure, scoped authentication without personal
    - **Issues**: Read and write  
    - **Pull requests**: Read and write
    - **Workflows**: Read and write
+   - **Commit statuses**: Read and write
    - **Metadata**: Read (auto-selected)
 3. [ ] Install App on your consumer repository
 

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -124,7 +124,9 @@ jobs:
           STATE: ${{ steps.summarize.outputs.state || 'pending' }}
           DESCRIPTION: ${{ steps.summarize.outputs.description || 'Gate status pending' }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          APP_TOKEN: ${{ steps.app_token.outputs.token }}
+          # Pass both tokens so script can fallback if App lacks permission
+          APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
+          GITHUB_TOKEN_FALLBACK: ${{ github.token }}
         with:
           # Use app token if available (5000/hr pool) to avoid rate limits
           github-token: ${{ steps.app_token.outputs.token || github.token }}
@@ -142,8 +144,9 @@ jobs:
                 : rawDescription;
             const targetUrl = process.env.TARGET_URL;
 
-            try {
-              await github.rest.repos.createCommitStatus({
+            // Helper to create commit status
+            async function createStatus(octokit, tokenName) {
+              await octokit.rest.repos.createCommitStatus({
                 owner,
                 repo,
                 sha,
@@ -152,12 +155,35 @@ jobs:
                 description,
                 target_url: targetUrl,
               });
-              console.log(`Created commit status: ${state} - ${description}`);
+              console.log(`Created commit status with ${tokenName}: ${state} - ${description}`);
+            }
+
+            // Try with primary token first (App token or GITHUB_TOKEN based on with.github-token)
+            try {
+              await createStatus(github, 'primary token');
             } catch (error) {
-              const hitRateLimit =
+              const isPermissionError =
+                error?.status === 403 &&
+                /resource not accessible/i.test(error?.message || '');
+              const isRateLimitError =
                 error?.status === 403 &&
                 /rate limit/i.test(error?.message || '');
-              if (hitRateLimit) {
+
+              if (isPermissionError && process.env.APP_TOKEN) {
+                // App token lacks statuses:write permission, try GITHUB_TOKEN
+                core.warning('App token lacks statuses permission, falling back to GITHUB_TOKEN');
+                const { Octokit } = require('@octokit/rest');
+                const fallbackOctokit = new Octokit({
+                  auth: process.env.GITHUB_TOKEN_FALLBACK,
+                  baseUrl: 'https://api.github.com',
+                });
+                try {
+                  await createStatus(fallbackOctokit, 'GITHUB_TOKEN');
+                } catch (fallbackError) {
+                  core.error(`Fallback also failed: ${fallbackError.message}`);
+                  throw fallbackError;
+                }
+              } else if (isRateLimitError) {
                 core.warning('Rate limit prevented Gate from updating the commit status.');
               } else {
                 throw error;


### PR DESCRIPTION
## Summary

When the WORKFLOWS_APP token lacks the `statuses:write` permission, the commit status creation fails with 'Resource not accessible by integration' (403 error).

## Root Cause

The GitHub API response header `x-accepted-github-permissions: statuses=write` confirmed the endpoint requires `statuses:write`. The App token authenticates successfully but lacks this specific permission.

## Changes

### pr-00-gate.yml
- Detects permission error (403 + 'resource not accessible by integration')
- Falls back to `GITHUB_TOKEN` which has `statuses:write` via workflow permissions block
- Logs a warning to help diagnose the configuration issue

### docs/keepalive/SETUP_CHECKLIST.md
- Added 'Commit statuses: Read and write' as a required GitHub App permission

## Testing

This will be tested when the sync propagates to consumer repos. The failing PR #4431 in Trend_Model_Project will pass after this fix is merged and synced.

## Related

- Fixes gate-summary failure in stranske/Trend_Model_Project#4431
- Related to PR #919 (app token support)