### PR TITLE
fix(auto-pilot): only detect linked PRs from same repository

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -247,6 +247,7 @@ jobs:
             for (const event of timelineEvents) {
               // Handle both cross-referenced and connected events
               if ((event.event === 'cross-referenced' || event.event === 'connected') &&
+                  event.source?.issue?.repository?.full_name === `${context.repo.owner}/${context.repo.repo}` &&
                   event.source?.issue?.pull_request) {
                 linkedPR = event.source.issue.number;
               }


### PR DESCRIPTION
## Problem

The auto-pilot workflow incorrectly detects linked PRs from **other repositories**. When a PR in repo A mentions an issue in repo B (e.g., in its body with `#1159`), the cross-reference event causes the auto-pilot to think repo B's issue already has a linked PR.

**Specific case:** [stranske/Workflows#939](https://github.com/stranske/Workflows/pull/939) mentioned `Portable-Alpha-Extension-Model#1159` in its PR body. This created a cross-reference event on issue #1159, causing auto-pilot to think a PR already existed when it didn't.

## Root Cause

The linked PR detection code only checked:
```javascript
if ((event.event === 'cross-referenced' || event.event === 'connected') &&
    event.source?.issue?.pull_request) {
  linkedPR = event.source.issue.number;
}
```

It didn't verify the PR was in the **same repository**.

## Fix

Added repository check:
```javascript
if ((event.event === 'cross-referenced' || event.event === 'connected') &&
    event.source?.issue?.repository?.full_name === `${context.repo.owner}/${context.repo.repo}` &&
    event.source?.issue?.pull_request) {
  linkedPR = event.source.issue.number;
}
```

## Testing

After merge and sync, re-trigger auto-pilot on [Portable-Alpha-Extension-Model#1159](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1159).