### PR TITLE
fix: use compact JSON format in consumer activity step

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -427,10 +427,10 @@ jobs:
             queued=$(echo "$runs_data" | jq '[.workflow_runs[] | select(.status == "queued")] | length')
             completed=$(echo "$runs_data" | jq '[.workflow_runs[] | select(.status == "completed")] | length')
 
-            # Get most common workflows
-            workflow_counts=$(echo "$runs_data" | jq -r '[.workflow_runs[].name] | group_by(.) | map({name: .[0], count: length}) | sort_by(-.count) | .[0:5]')
+            # Get most common workflows (use -c for compact output)
+            workflow_counts=$(echo "$runs_data" | jq -c '[.workflow_runs[].name] | group_by(.) | map({name: .[0], count: length}) | sort_by(-.count) | .[0:5]')
 
-            repo_json=$(jq -n \
+            repo_json=$(jq -cn \
               --arg repo "$repo" \
               --argjson total_runs "$total_runs" \
               --argjson in_progress "$in_progress" \
@@ -446,13 +446,14 @@ jobs:
                 top_workflows: $workflows
               }')
 
-            activity_json=$(echo "$activity_json" | jq --argjson repo "$repo_json" '. + [$repo]')
+            activity_json=$(echo "$activity_json" | jq -c --argjson repo "$repo_json" '. + [$repo]')
 
             echo "  Runs (last hour): $total_runs (in_progress: $in_progress, queued: $queued)"
 
           done <<< "$REGISTERED_CONSUMER_REPOS"
 
-          # Use single-line format to avoid heredoc parsing issues
+          # Compact the final JSON and output
+          activity_json=$(echo "$activity_json" | jq -c '.')
           printf 'activity_json=%s\n' "$activity_json" >> "$GITHUB_OUTPUT"
 
           echo "::endgroup::"


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #958

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
After merging PR #103 (multi-agent routing infrastructure), we need to:

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments
- The keepalive loop now:
- | `<!-- keepalive-loop-summary -->` | github-actions[bot] | NEW: CLI agent iteration tracking | ✅ Keep for CLI agents |
- | `<!-- keepalive-state:v1 -->` | agents-workflows-bot[bot] | State tracking | ⚠️ Multiple copies accumulate |
- | `<!-- keepalive-round: N -->` | stranske | OLD: Instruction comment | ❌ CLI agents dont need this |
- **The goal:** For CLI agents (`agent:*` label), we should have exactly **one** updating comment (`<!-- keepalive-loop-summary -->`) instead of accumulating 10+ comments per PR.
- Requires PR [#103](https://github.com/stranske/Workflows/issues/103) to be merged first
- **This round you MUST:**
- Review the Scope/Tasks/Acceptance below, identify the next incomplete task that requires code, implement it, then **post a reply comment** with the completed items using their **exact original text**.
- <!-- keepalive-loop-summary -->
- | Keepalive | ❌ disabled |
- <!-- keepalive-state:v1 {"trace":"","pr_number":957,"iteration":0,"max_iterations":5,"last_action":"wait","last_reason":"missing-agent-label-transient","failure":{},"error_type":"infrastructure","error_category":"resource","tasks":{"total":10,"unchecked":10},"gate_conclusion":"success","failure_threshold":3,"needs_task_reconciliation":false,"last_files_changed":0,"prev_files_changed":0,"last_effort_score":0,"last_data_quality":"","attempted_tasks":[],"last_focus":"Validate the CLI agent pipeline works end-to-end with the new task-focused prompts","verification":{},"timeout":{"resolved_minutes":45,"default_minutes":45,"extended_minutes":90,"override_minutes":null,"source":"default","label":null,"elapsed_minutes":1,"remaining_minutes":44,"usage_ratio":0.044255555555555555,"warning":null},"attempts":[{"iteration":0,"action":"wait","reason":"missing-agent-label-transient","run_result":"skipped","prompt_mode":"normal","prompt_file":".github/codex/prompts/keepalive_next_task.md","gate":"success","error_category":"resource","error_type":"infrastructure"}],"version":"v1"} -->
- <!-- keepalive-state:v1 {"trace":"","pr_number":958,"iteration":0,"max_iterations":5,"last_action":"wait","last_reason":"missing-agent-label-transient","failure":{},"error_type":"infrastructure","error_category":"resource","tasks":{"total":16,"unchecked":16},"gate_conclusion":"success","failure_threshold":3,"needs_task_reconciliation":false,"last_files_changed":0,"prev_files_changed":0,"last_effort_score":0,"last_data_quality":"","attempted_tasks":[],"last_focus":"1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts","verification":{},"timeout":{"resolved_minutes":45,"default_minutes":45,"extended_minutes":90,"override_minutes":null,"source":"default","label":null,"elapsed_minutes":1,"remaining_minutes":44,"usage_ratio":0.042995185185185185,"warning":null},"attempts":[{"iteration":0,"action":"wait","reason":"missing-agent-label-transient","run_result":"skipped","prompt_mode":"normal","prompt_file":".github/codex/prompts/keepalive_next_task.md","gate":"success","error_category":"resource","error_type":"infrastructure"}],"version":"v1"} -->

### Related Issues/PRs
- [#957](https://github.com/stranske/Workflows/issues/957)
- [#103](https://github.com/stranske/Workflows/issues/103)
- [#123](https://github.com/stranske/Workflows/issues/123)
- [#89](https://github.com/stranske/Workflows/issues/89)
- [stranske/Workflows#103](https://github.com/stranske/Workflows/issues/103)
- [stranske/Workflows#89](https://github.com/stranske/Workflows/issues/89)
- [stranske/Workflows#123](https://github.com/stranske/Workflows/issues/123)
- [#958](https://github.com/stranske/Workflows/issues/958)
- [stranske/Workflows#957](https://github.com/stranske/Workflows/issues/957)

### References
- https://github.com/stranske/Workflows/issues/103
- https://github.com/stranske/Workflows/issues/123
- https://github.com/stranske/Workflows/issues/89
- https://github.com/stranske/Workflows/issues/957
- https://github.com/stranske/Workflows/compare/main...codex/issue-123?expand=1
- https://github.com/stranske/Workflows/actions/runs/21126265776
- https://github.com/stranske/Workflows/actions/runs/21126408957
- https://github.com/stranske/Workflows/actions/runs/21126369373
- https://github.com/stranske/Workflows/actions/runs/21126369421
- https://github.com/stranske/Workflows/actions/runs/21126370948
- https://github.com/stranske/Workflows/actions/runs/21126369424
- https://github.com/stranske/Workflows/actions/runs/21126369409
- https://github.com/stranske/Workflows/actions/runs/21126369376
- https://github.com/stranske/Workflows/actions/runs/21126369371
- https://github.com/stranske/Workflows/actions/runs/21126369345
- https://github.com/stranske/Workflows/actions/runs/21126369369
- https://github.com/stranske/Workflows/actions/runs/21126369367
- https://github.com/stranske/Workflows/actions/runs/21126369398
- https://github.com/stranske/Workflows/actions/runs/21126369400

### Blockers & Dependencies
- After merging PR [#103](https://github.com/stranske/Workflows/issues/103) (multi-agent routing infrastructure), we need to:
- After merging PR [#103](https://github.com/stranske/Workflows/issues/103) (multi-agent routing infrastructure), we need to:
- 3. Mark a task checkbox complete ONLY after verifying the implementation works.
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] 1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
- [ ] 2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
- [ ] 3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
- [ ] 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

#### Acceptance criteria
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] Iteration results visible in Actions workflow run summary
- [ ] PR body shows checkboxes but not workflow clutter when using CLI agents
- [ ] UI Codex path (no agent label) continues to show full status summary
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] State tracking is consolidated in the summary comment, not scattered
- [ ] **Head SHA:** bbb348052b231b7088b835c6e9fe4f59afbd2a2e
- [ ] **Latest Runs:** ❔ in progress — Agents PR meta manager
- [ ] **Required:** gate: ⏸️ not started
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21126265776) |
- [ ] **Head SHA:** 378a72c33b44563ef132815aea835994cdee9fde
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success
- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21126408957) |
- [ ] | Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/21126369373) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369421) |
- [ ] | Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21126370948) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369424) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369409) |
- [ ] | Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369376) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369371) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369345) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369369) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369367) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369398) |
- [ ] | Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126369400) |

**Head SHA:** 28c5415a3690e9ab9b153a50f2713bb404b7b67a
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21126519510) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/21126484389) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484438) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126486321) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484442) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484478) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484414) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484425) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484411) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484413) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484405) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484408) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21126484415) |
<!-- auto-status-summary:end -->