### PR TITLE
feat(health-75): add historical reporting with custom date ranges

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -949,7 +949,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
 
             # List recent runs with links
-            cat /tmp/runs.json | jq -r '.[:10][] | "- [\(.created_at | split("T")[0])] Run #\(.run_number) - [View Details]('"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"'/actions/runs/\(.id))"' >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.[:10][] | "- [\(.created_at | split("T")[0])] Run #\(.run_number) - [View Details]('"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"'/actions/runs/\(.id))"' /tmp/runs.json >> "$GITHUB_STEP_SUMMARY"
 
             if [ "$RUN_COUNT" -gt 10 ]; then
               echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Adds ability to run the API Rate Diagnostic over user-specified time periods.

## New Inputs
| Input | Description | Default | Examples |
|-------|-------------|---------|----------|
| `report_mode` | Choose 'current' (live snapshot) or 'historical' (date range) | current | |
| `start_date` | Start of period | 1w | `1d`, `1w`, `1m`, `2026-01-11` |
| `end_date` | End of period | now | `now`, `2026-01-13` |

## Usage Examples

### Last Week
```
report_mode: historical
start_date: 1w
end_date: now
```

### Specific Date Range (Jan 11-13)
```
report_mode: historical
start_date: 2026-01-11
end_date: 2026-01-13
```

### Last Month
```
report_mode: historical
start_date: 1m
end_date: now
```

## How It Works
1. Parses the date range (relative or absolute)
2. Queries workflow runs that completed successfully in that period
3. Generates a summary report with links to individual run details
4. Each run's step summary contains the full rate limit snapshot

## Notes
- Historical data is only available for periods when the diagnostic workflow ran
- The workflow runs every 4 hours by default, providing ~6 data points per day
- For trend analysis, users can click through to individual runs