### PR TITLE
fix(followup_issue_generator): address agent review feedback from sync PRs

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -531,16 +531,19 @@ def _resolve_section(label: str) -> str | None:
 def _parse_sections(body: str) -> dict[str, list[str]]:
     """Parse issue body into recognized sections.
 
-    Splits the body by headings and maps content to known section keys.
-    Unrecognized headings terminate the current section (content is discarded).
+    Splits the body by top-level headings (# or ##) and maps content to known section keys.
+    Unrecognized top-level headings terminate the current section.
+    Subheadings (###, ####, etc.) within a section are preserved as content.
     """
     sections: dict[str, list[str]] = {key: [] for key in SECTION_TITLES}
     current: str | None = None
     for line in body.splitlines():
-        heading_match = re.match(r"^\s*#{1,6}\s+(.*)$", line)
+        # Only match top-level section headings (# or ## but not ### or deeper)
+        # Subheadings (###, ####) are kept as content within the current section
+        heading_match = re.match(r"^\s*#{1,2}\s+(.*)$", line)
         if heading_match:
             section_key = _resolve_section(heading_match.group(1))
-            # Always update current - set to None for unrecognized headings
+            # Update current - set to None for unrecognized top-level headings
             # This prevents content under "## Random Notes" etc. from being
             # appended to the previous recognized section
             current = section_key


### PR DESCRIPTION
## Summary
Fixes issues identified by agent bot code reviews on sync PRs across consumer repos.

**Affected PRs (all 7 consumer repos):**
- stranske/Portable-Alpha-Extension-Model#1165
- stranske/Travel-Plan-Permission#431
- stranske/Template#211
- stranske/trip-planner#208
- stranske/Manager-Database#332
- stranske/Trend_Model_Project#4439
- stranske/Collab-Admin#205

## Changes

### 1. Add missing `non_goals` section
The SECTION_ALIASES was missing `non_goals` which exists in `issue_formatter.py`. This caused inconsistent parsing when issues contained "## Non-Goals" or "## Out of scope" sections.

### 2. Fix section capture at unrecognized headings
Previously, when `_parse_sections` hit an unrecognized heading (e.g., "## Random Notes"), it would keep the previous `current` section active and append subsequent content to it. Now it properly resets to `None`, preventing unrelated content from being appended.

**Before:** Content under "## Out of scope" would be appended to Tasks
**After:** Content under unrecognized headings is discarded

### 3. Add docstrings to helper functions
Added documentation to: `_normalize_heading`, `_resolve_section`, `_parse_sections`, `_strip_checkbox`, `_parse_checklist`

### 4. Fix redundant regex matching
`_parse_checklist` was calling `LIST_ITEM_REGEX.match()` twice per line (once directly, once inside `_strip_checkbox`). Now passes the pre-computed match object.

## Testing
All 18 existing tests pass.