### PR TITLE
Add retry wrapper to belt dispatcher

### DIFF
--- a/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -155,6 +155,8 @@ jobs:
       - name: Checkout (for retry helpers)
         uses: actions/checkout@v6
         with:
+          repository: stranske/Workflows
+          ref: main
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js
           sparse-checkout-cone-mode: false

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -155,6 +155,8 @@ jobs:
       - name: Checkout (for retry helpers)
         uses: actions/checkout@v6
         with:
+          repository: stranske/Workflows
+          ref: main
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1033

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`agents-71-codex-belt-dispatcher.yml` makes direct API calls without retry protection. PR #1027 introduced a load balancer that should be adopted to prevent rate limit failures.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- `agents-71-codex-belt-dispatcher.yml` makes direct API calls without retry protection. PR [#1027](https://github.com/stranske/Workflows/issues/1027) introduced a load balancer that should be adopted to prevent rate limit failures.
- `agents:keepalive` (95% confidence)
- `agent:rate-limited` (95% confidence)

### Related Issues/PRs
- [#1027](https://github.com/stranske/Workflows/issues/1027)
- [#1035](https://github.com/stranske/Workflows/issues/1035)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Import `withRetry` from `.github/scripts/github-api-with-retry.js`
- [ ] Wrap `github.rest.issues.get()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.addLabels()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.removeLabel()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.createComment()` calls with `withRetry()`

#### Acceptance criteria
- [ ] All `github.rest.*` calls wrapped with `withRetry()`
- [ ] No direct unwrapped API calls remain
- [ ] Workflow executes successfully in CI

**Head SHA:** 2d5ca07de5d69d6c2bf538ec30b46637e41ab3d4
**Latest Runs:** ❔ in progress — Agents PR meta manager
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21266813756) |
<!-- auto-status-summary:end -->