### PR TITLE
Integrate retry helpers in keepalive loop

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -92,8 +92,8 @@ jobs:
 
             // Remove agent:retry label (so it can be used again later)
             try {
-              await withRetry(() =>
-                retryGithub.rest.issues.removeLabel({
+              await withRetry((client) =>
+                client.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
@@ -111,8 +111,8 @@ jobs:
 
             // Remove agent:rate-limited label if present
             try {
-              await withRetry(() =>
-                retryGithub.rest.issues.removeLabel({
+              await withRetry((client) =>
+                client.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
@@ -164,8 +164,8 @@ jobs:
               const prs = payload.workflow_run.pull_requests || [];
               if (prs[0]?.number) {
                 prNumber = prs[0].number;
-                const { data } = await withRetry(() =>
-                  retryGithub.rest.pulls.get({
+                const { data } = await withRetry((client) =>
+                  client.rest.pulls.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: prNumber,
@@ -419,8 +419,8 @@ jobs:
               task: 'keepalive-loop',
               capabilities: ['pull-requests:read'],
             });
-            const { data: commits } = await withRetry(() =>
-              retryGithub.rest.pulls.listCommits({
+            const { data: commits } = await withRetry((client) =>
+              client.rest.pulls.listCommits({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
@@ -449,8 +449,8 @@ jobs:
               task: 'keepalive-loop',
               capabilities: ['pull-requests:read'],
             });
-            const { data: pr } = await withRetry(() =>
-              retryGithub.rest.pulls.get({
+            const { data: pr } = await withRetry((client) =>
+              client.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
@@ -559,8 +559,8 @@ jobs:
               '_The review evaluates whether recent work is advancing toward the acceptance criteria._',
             ].join('\n');
 
-            await withRetry(() =>
-              retryGithub.rest.issues.createComment({
+            await withRetry((client) =>
+              client.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
@@ -572,8 +572,8 @@ jobs:
             if (recommendation === 'STOP') {
               core.warning('Progress review recommends STOP - agent work appears unaligned');
               try {
-                await withRetry(() =>
-                  retryGithub.rest.issues.removeLabel({
+                await withRetry((client) =>
+                  client.rest.issues.removeLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: prNumber,

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -101,8 +101,8 @@ jobs:
               const prs = payload.workflow_run.pull_requests || [];
               if (prs[0]?.number) {
                 prNumber = prs[0].number;
-                const { data } = await withRetry(() =>
-                  retryGithub.rest.pulls.get({
+                const { data } = await withRetry((client) =>
+                  client.rest.pulls.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: prNumber,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1032

<!-- pr-preamble:end -->

## Summary
- Use token-aware retry helpers for keepalive-loop inline GitHub API calls.
- Remove manual fallback rate-limit logic in favor of centralized retry/load balancing.
- Update template workflow to match.

## Testing
- Pre-commit hooks (workflow validation)

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
While `keepalive_loop.js` script properly checks `isInitialized()` for the load balancer, the workflow YAML inline scripts make direct API calls without using the retry wrapper. This bypasses the load balancer protection.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- While `keepalive_loop.js` script properly checks `isInitialized()` for the load balancer, the workflow YAML inline scripts make direct API calls without using the retry wrapper. This bypasses the load balancer protection.
- Add `withRetry()` wrappers to all inline GitHub API calls in `agents-keepalive-loop.yml` workflow steps.
- Modifying `keepalive_loop.js` (already has proper load balancer integration)
- Changing keepalive logic or job structure
- `.github/workflows/agents-keepalive-loop.yml`
- Note: The underlying `keepalive_loop.js` already implements `isInitialized()` check from PR [#1027](https://github.com/stranske/Workflows/issues/1027) correctly.
- `agents:keepalive` (95% confidence)
- `agent:rate-limited` (95% confidence)

### Related Issues/PRs
- [#1027](https://github.com/stranske/Workflows/issues/1027)
- [#1030](https://github.com/stranske/Workflows/issues/1030)
- [#1031](https://github.com/stranske/Workflows/issues/1031)
- [#1035](https://github.com/stranske/Workflows/issues/1035)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Import `withRetry` from `.github/scripts/github-api-with-retry.js` in workflow script steps
- [ ] Wrap `github.rest.issues.get()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.listComments()` calls with `withRetry()`
- [ ] Wrap `github.rest.repos.get()` calls with `withRetry()`
- [ ] Remove manual retry/fallback logic in favor of centralized load balancer

#### Acceptance criteria
- [ ] All workflow YAML `github.rest.*` calls wrapped with `withRetry()`
- [ ] Manual retry logic replaced with load balancer
- [ ] No direct unwrapped API calls remain in workflow steps
- [ ] Workflow executes successfully in CI

**Head SHA:** 866097a318102e05d5f02080aa709dd457783fd4
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21277831214) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780611) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780615) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780623) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780581) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780560) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780572) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780576) |
| Keepalive E2E | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/21277780619) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780568) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780577) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780570) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21277780575) |
<!-- auto-status-summary:end -->