### PR TITLE
Integrate retry helpers in reusable codex run

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -1101,7 +1101,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const { withRetry } = require('./.github/scripts/github-api-with-retry.js');
+            const { withRetry } = require('./.workflows-lib/.github/scripts/github-api-with-retry.js');
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             if (!prNumber || prNumber <= 0) {
               console.log('No valid PR number, skipping comment');
@@ -1191,7 +1191,7 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
-            const { withRetry } = require('./.github/scripts/github-api-with-retry.js');
+            const { withRetry } = require('./.workflows-lib/.github/scripts/github-api-with-retry.js');
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             if (!prNumber || prNumber <= 0) return;
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1034

<!-- pr-preamble:end -->

## Summary
- Wrap reusable Codex run workflow GitHub API calls with `withRetry`.
- Ensure failure comments/labels use retry wrapper.

## Testing
- Pre-commit hooks (workflow validation)

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`reusable-codex-run.yml` makes direct API calls without retry protection. As a reusable workflow, failures here impact multiple callers. PR #1027 introduced a load balancer that should be adopted.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Design Decisions & Constraints
- `reusable-codex-run.yml` makes direct API calls without retry protection. As a reusable workflow, failures here impact multiple callers. PR [#1027](https://github.com/stranske/Workflows/issues/1027) introduced a load balancer that should be adopted.
- `agent:rate-limited` (95% confidence)

### Related Issues/PRs
- [#1027](https://github.com/stranske/Workflows/issues/1027)
- [#1035](https://github.com/stranske/Workflows/issues/1035)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Import `withRetry` from `.github/scripts/github-api-with-retry.js`
- [ ] Wrap `github.rest.repos.get()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.get()` calls with `withRetry()`
- [ ] Wrap `github.rest.pulls.get()` calls with `withRetry()`
- [ ] Wrap `github.rest.issues.createComment()` calls with `withRetry()`

#### Acceptance criteria
- [ ] All `github.rest.*` calls wrapped with `withRetry()`
- [ ] No direct unwrapped API calls remain
- [ ] Workflow executes successfully in CI

**Head SHA:** 64e5c37e8b7333ffa044b777134b2c599930fd23
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21278176488) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102720) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102711) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102681) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/21278102643) |
| Health 45 Agents Guard | ⏳ pending | [View run](https://github.com/stranske/Workflows/actions/runs/21278102636) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102625) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102612) |
| Keepalive E2E | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/21278102705) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102611) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102641) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102635) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/21278102638) |
<!-- auto-status-summary:end -->