### PR TITLE
fix: install js-yaml for label sync

### DIFF
--- a/.github/workflows/maint-69-sync-labels.yml
+++ b/.github/workflows/maint-69-sync-labels.yml
@@ -42,7 +42,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install js-yaml
-        run: npm install js-yaml
+        run: npm install -g js-yaml
 
       - name: Parse labels-core.yml
         id: parse


### PR DESCRIPTION
## Summary\n- install js-yaml in maint-69-sync-labels workflow so label sync can parse .github/labels-core.yml\n\n## Testing\n- not run (workflow-only change)