### PR TITLE
fix(autopilot): run when agent labels already present

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -69,7 +69,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.action == 'labeled' && (
         github.event.label.name == 'agents:auto-pilot' ||
-        github.event.label.name == 'agent:codex'
+        github.event.label.name == 'agent:codex' ||
+        contains(github.event.issue.labels.*.name, 'agents:auto-pilot') ||
+        contains(github.event.issue.labels.*.name, 'agent:codex') ||
+        contains(github.event.pull_request.labels.*.name, 'agents:auto-pilot') ||
+        contains(github.event.pull_request.labels.*.name, 'agent:codex')
       )) ||
       (github.event.action == 'closed' &&
        contains(github.event.issue.labels.*.name, 'agents:auto-pilot'))
@@ -97,8 +101,9 @@ jobs:
               labels = context.payload.pull_request.labels.map(l => l.name);
             }
 
-            const hasAutoPilot = labels.includes('agents:auto-pilot');
-            if (!hasAutoPilot && labelName !== 'agents:auto-pilot') {
+            const hasAutoPilot = labels.includes('agents:auto-pilot') || labels.includes('agent:codex');
+            const isAutoPilotTrigger = labelName === 'agents:auto-pilot' || labelName === 'agent:codex';
+            if (!hasAutoPilot && !isAutoPilotTrigger) {
               core.info(`Skipping: auto-pilot not enabled (trigger: ${labelName})`);
               core.setOutput('enabled', 'false');
               return;

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -72,7 +72,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.action == 'labeled' && (
         github.event.label.name == 'agents:auto-pilot' ||
-        github.event.label.name == 'agent:codex'
+        github.event.label.name == 'agent:codex' ||
+        contains(github.event.issue.labels.*.name, 'agents:auto-pilot') ||
+        contains(github.event.issue.labels.*.name, 'agent:codex') ||
+        contains(github.event.pull_request.labels.*.name, 'agents:auto-pilot') ||
+        contains(github.event.pull_request.labels.*.name, 'agent:codex')
       )) ||
       (github.event.action == 'closed' &&
        contains(github.event.issue.labels.*.name, 'agents:auto-pilot'))
@@ -100,8 +104,9 @@ jobs:
               labels = context.payload.pull_request.labels.map(l => l.name);
             }
 
-            const hasAutoPilot = labels.includes('agents:auto-pilot');
-            if (!hasAutoPilot && labelName !== 'agents:auto-pilot') {
+            const hasAutoPilot = labels.includes('agents:auto-pilot') || labels.includes('agent:codex');
+            const isAutoPilotTrigger = labelName === 'agents:auto-pilot' || labelName === 'agent:codex';
+            if (!hasAutoPilot && !isAutoPilotTrigger) {
               core.info(`Skipping: auto-pilot not enabled (trigger: ${labelName})`);
               core.setOutput('enabled', 'false');
               return;


### PR DESCRIPTION
## Why
Auto-pilot was skipping runs when an issue already had `agents:auto-pilot`/`agent:codex` but the triggering label was different. This caused issue-labeled runs to complete with no jobs.

## What
- Allow auto-pilot job to run when the issue/PR already has `agents:auto-pilot` or `agent:codex`.
- Align enablement guard with `agent:codex` as well as `agents:auto-pilot`.

## Notes
- Template updated for consumer repos.
