### PR TITLE
fix: ensure retry helpers checked out

### DIFF
--- a/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -152,6 +152,12 @@ jobs:
         run: |
           echo "dry_run=${{ inputs.dry_run }}" >>"$GITHUB_OUTPUT"
 
+      - name: Checkout repo (for retry helpers)
+        uses: actions/checkout@v6
+        with:
+          token: ${{ env.GH_DISPATCH_TOKEN }}
+          fetch-depth: 1
+
       - name: Resolve Workflows default branch
         id: workflows_ref
         uses: actions/github-script@v8

--- a/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/.github/workflows/agents-72-codex-belt-worker.yml
@@ -284,6 +284,12 @@ jobs:
               ])
               .write();
 
+      - name: Checkout repo (for retry helpers)
+        uses: actions/checkout@v6
+        with:
+          token: ${{ env.GH_BELT_TOKEN }}
+          fetch-depth: 1
+
       - name: Resolve Workflows default branch
         id: workflows_ref
         uses: actions/github-script@v8

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -152,6 +152,12 @@ jobs:
         run: |
           echo "dry_run=${{ inputs.dry_run }}" >>"$GITHUB_OUTPUT"
 
+      - name: Checkout repo (for retry helpers)
+        uses: actions/checkout@v6
+        with:
+          token: ${{ env.GH_DISPATCH_TOKEN }}
+          fetch-depth: 1
+
       - name: Resolve Workflows default branch
         id: workflows_ref
         uses: actions/github-script@v8

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -284,6 +284,12 @@ jobs:
               ])
               .write();
 
+      - name: Checkout repo (for retry helpers)
+        uses: actions/checkout@v6
+        with:
+          token: ${{ env.GH_BELT_TOKEN }}
+          fetch-depth: 1
+
       - name: Resolve Workflows default branch
         id: workflows_ref
         uses: actions/github-script@v8


### PR DESCRIPTION
Fixes checkout ordering so retry helpers are available before github-script requires them in Codex belt dispatcher/worker. Updates consumer templates.