### PR TITLE
issue-4558 fix: use pat for historical runs

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -1233,7 +1233,7 @@ jobs:
       - name: Fetch historical workflow runs
         id: history
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CODESPACES_WORKFLOWS || github.token }}
           START_DATE: ${{ steps.dates.outputs.start_date }}
           END_DATE: ${{ steps.dates.outputs.end_date }}
         run: |


### PR DESCRIPTION
## Summary
- use CODESPACES_WORKFLOWS token for historical run queries

## Testing
- not run (workflow change)