### PR TITLE
fix(health-75): use query param instead of -F for GET request

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -630,7 +630,7 @@ jobs:
             fi
 
             local output
-            output=$(GH_TOKEN="$token" gh api -i "repos/$GITHUB_REPOSITORY/actions/workflows/health-75-api-rate-diagnostic.yml/runs" -F per_page=1 2>&1 || true)
+            output=$(GH_TOKEN="$token" gh api -i "repos/$GITHUB_REPOSITORY/actions/workflows/health-75-api-rate-diagnostic.yml/runs?per_page=1" 2>&1 || true)
             local status
             status=$(echo "$output" | head -n1)
             local accepted
@@ -1323,20 +1323,17 @@ jobs:
           echo "Workflow ID: $workflow_id"
 
           # Fetch runs in date range (GitHub API uses created filter)
-          if ! runs=$(GH_TOKEN="$primary_token" gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id/runs" \
+          # Note: Use query params instead of -F flags to keep this a GET request
+          if ! runs=$(GH_TOKEN="$primary_token" gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id/runs?created=>=${START_DATE}&status=completed" \
             --paginate \
-            -F "created=>=$START_DATE" \
-            -F "status=completed" \
             --jq '[.workflow_runs[] | select(.conclusion == "success") | {
               id: .id,
               created_at: .created_at,
               run_number: .run_number
             }]'); then
             echo "Primary token could not access workflow runs. Retrying with GITHUB_TOKEN." >&2
-            runs=$(GH_TOKEN="$FALLBACK_GH_TOKEN" gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id/runs" \
+            runs=$(GH_TOKEN="$FALLBACK_GH_TOKEN" gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id/runs?created=>=${START_DATE}&status=completed" \
               --paginate \
-              -F "created=>=$START_DATE" \
-              -F "status=completed" \
               --jq '[.workflow_runs[] | select(.conclusion == "success") | {
                 id: .id,
                 created_at: .created_at,


### PR DESCRIPTION
## Problem

The Health 75 diagnostic step was returning HTTP 404 for **all** tokens when checking Actions runs access. This made it appear that none of the PATs or GitHub Apps had proper permissions.

## Root Cause

The `gh api` command used `-F per_page=1` which converts the HTTP method from **GET to POST**. The Actions runs endpoint only accepts GET requests, so all requests failed with 404.

**Before (broken):**
```bash
gh api -i "repos/.../actions/workflows/{id}/runs" -F per_page=1
# -F flag → POST request → 404 Not Found
```

**After (fixed):**
```bash
gh api -i "repos/.../actions/workflows/{id}/runs?per_page=1"
# Query param → GET request → 200 OK
```

## Verification

Tested from Codespaces:
- `gh api -F per_page=1 ...` → **404 Not Found** ❌
- `gh api ...?per_page=1` → **200 OK** ✅

## Impact

This fix will allow the Health 75 diagnostic to correctly report which tokens have Actions read permissions.