### PR TITLE
fix: install octokit deps for load-sharing check

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -795,6 +795,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install load balancer dependencies
+        run: |
+          set -euo pipefail
+          npm install --no-save @octokit/rest @octokit/auth-app
+
       - name: Export load balancer tokens
         uses: ./.github/actions/export-load-balancer-tokens
         with:


### PR DESCRIPTION
## Summary\n- install @octokit/rest and @octokit/auth-app for load-sharing verification job\n- ensure token registry refresh can run during diagnostics\n\n## Testing\n- pending (workflow run after merge)