### PR TITLE
chore: run api rate diagnostic every 30 minutes

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -6,7 +6,7 @@ name: Health 75 API Rate Diagnostic
 
 on:
   schedule:
-    - cron: '0 */4 * * *'  # Every 4 hours for continuous monitoring
+    - cron: '*/30 * * * *'  # Every 30 minutes for continuous monitoring
   workflow_dispatch:
     inputs:
       include_consumer_repos:


### PR DESCRIPTION
## Summary\n- change Health 75 API Rate Diagnostic schedule to every 30 minutes\n\n## Testing\n- not run (workflow schedule change only)