### PR TITLE
fix: ensure diagnostic deps resolve

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -804,6 +804,7 @@ jobs:
         run: |
           set -euo pipefail
           npm install --no-save --no-package-lock --prefix "$RUNNER_TEMP/load-balancer" @octokit/rest @octokit/auth-app
+          echo "NODE_PATH=$RUNNER_TEMP/load-balancer/node_modules" >> "$GITHUB_ENV"
 
       - name: Export load balancer tokens
         uses: ./.github/actions/export-load-balancer-tokens


### PR DESCRIPTION
## Summary\n- set NODE_PATH for temp-installed @octokit dependencies in the API rate diagnostic workflow\n\n## Testing\n- not run (workflow change only)