### PR TITLE
fix: issue-4160 install diagnostic deps in workspace

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -803,8 +803,7 @@ jobs:
       - name: Install load balancer dependencies
         run: |
           set -euo pipefail
-          npm install --no-save --no-package-lock --prefix "$RUNNER_TEMP/load-balancer" @octokit/rest @octokit/auth-app
-          echo "NODE_PATH=$RUNNER_TEMP/load-balancer/node_modules" >> "$GITHUB_ENV"
+          npm install --no-save --no-package-lock @octokit/rest @octokit/auth-app
 
       - name: Export load balancer tokens
         uses: ./.github/actions/export-load-balancer-tokens


### PR DESCRIPTION
## Summary
- install @octokit deps in the workspace so token load balancer imports resolve in the API rate diagnostic

## Testing
- not run (workflow change only)