### PR TITLE
fix: load balancer action path

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -266,7 +266,7 @@ jobs:
           path: workflows-lib
           fetch-depth: 1
       - name: Export load balancer tokens
-        uses: ./.github/actions/export-load-balancer-tokens
+        uses: ./workflows-lib/.github/actions/export-load-balancer-tokens
         with:
           github_token: ${{ github.token }}
           token_rotation_json: ${{ secrets.TOKEN_ROTATION_JSON }}


### PR DESCRIPTION
Use the Workflows checkout for the load balancer action before the caller repo is checked out.