### PR TITLE
fix(autofix): include guard dependency

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -50,6 +50,7 @@ jobs:
             .github/scripts/prompt_injection_guard.js
             .github/actions/export-load-balancer-tokens
             .github/scripts/github-api-with-retry.js
+            .github/scripts/github-rate-limited-wrapper.js
           sparse-checkout-cone-mode: false
 
       - name: Export load balancer tokens

--- a/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
@@ -55,6 +55,7 @@ jobs:
             .github/scripts/prompt_injection_guard.js
             .github/actions/export-load-balancer-tokens
             .github/scripts/github-api-with-retry.js
+            .github/scripts/github-rate-limited-wrapper.js
           sparse-checkout-cone-mode: false
 
       - name: Export load balancer tokens


### PR DESCRIPTION
Add github-rate-limited-wrapper.js to the autofix loop security gate sparse checkout so prompt_injection_guard.js can load its dependency.