### PR TITLE
fix(autofix): include token load balancer

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -51,6 +51,7 @@ jobs:
             .github/actions/export-load-balancer-tokens
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
+            .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
 
       - name: Export load balancer tokens

--- a/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
@@ -56,6 +56,7 @@ jobs:
             .github/actions/export-load-balancer-tokens
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
+            .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
 
       - name: Export load balancer tokens


### PR DESCRIPTION
Add token_load_balancer.js to the autofix loop security gate sparse checkout so github-api-with-retry can load its dependency.