### PR TITLE
fix: escape backticks in auto-pilot

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -1606,15 +1606,15 @@ jobs:
 
                     **Reason:** Branch was not created after ${stallCount} attempts.
 
-                    Expected branch: `${branchName}`
+                    Expected branch: \`${branchName}\`
 
                     **Possible causes:**
                     - Agent failed before branch creation
                     - Workflow dispatch failed silently
                     - Permissions or token issues
 
-                    **To resume:** Remove `agents:auto-pilot-pause` and
-                    `needs-human` labels, then re-add `agents:auto-pilot`.`
+                    **To resume:** Remove \`agents:auto-pilot-pause\` and
+                    \`needs-human\` labels, then re-add \`agents:auto-pilot\`.`
         }));
 
                 const failMsg = `Auto-pilot stalled: ${stallCount} branch creation attempts`;

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -1207,15 +1207,15 @@ jobs:
 
                     **Reason:** Branch was not created after ${stallCount} attempts.
 
-                    Expected branch: `${branchName}`
+                    Expected branch: \`${branchName}\`
 
                     **Possible causes:**
                     - Agent failed before branch creation
                     - Workflow dispatch failed silently
                     - Permissions or token issues
 
-                    **To resume:** Remove `agents:auto-pilot-pause` and
-                    `needs-human` labels, then re-add `agents:auto-pilot`.`
+                    **To resume:** Remove \`agents:auto-pilot-pause\` and
+                    \`needs-human\` labels, then re-add \`agents:auto-pilot\`.`
                 });
 
                 const failMsg = `Auto-pilot stalled: ${stallCount} branch creation attempts`;


### PR DESCRIPTION
## Summary
- escape markdown backticks inside JS template strings in auto-pilot
- update consumer template to avoid GitHub Script syntax errors

## Impact
Prevents `Unexpected identifier '$'` errors that halted auto-pilot PR creation.
