### PR TITLE
fix(health-75): correct here-doc NODE delimiter indentation

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -1124,7 +1124,7 @@ jobs:
             console.error(error);
             process.exit(1);
           });
-            NODE
+          NODE
 
   check-consumer-repos:
     name: Check Consumer Repo Activity


### PR DESCRIPTION
The here-doc delimiter `NODE` had extra leading whitespace causing a syntax error:
```
ReferenceError: NODE is not defined
```

This fix aligns the delimiter with the proper indentation level.

**Testing**: Health 75 run should now pass the token rotation validation step.