### PR TITLE
fix(health-75): correct consumer repo check here-doc delimiter

### DIFF
--- a/.github/workflows/health-75-api-rate-diagnostic.yml
+++ b/.github/workflows/health-75-api-rate-diagnostic.yml
@@ -1205,7 +1205,7 @@ jobs:
               console.error(error);
               process.exit(1);
             });
-            NODE
+          NODE
 
             total_runs=$(echo "$runs_data" | jq '.total_count // 0')
             in_progress=$(echo "$runs_data" | jq '[.workflow_runs[] | select(.status == "in_progress")] | length')


### PR DESCRIPTION
Fixes additional here-doc delimiter issue in the 'Check Consumer Repo Activity' job.

Line 1208 had extra indentation causing syntax error.