### PR TITLE
fix: use GitHub App token for checkouts to avoid API rate limits

### DIFF
--- a/.github/workflows/reusable-20-pr-meta.yml
+++ b/.github/workflows/reusable-20-pr-meta.yml
@@ -111,12 +111,12 @@ jobs:
     steps:
       # Mint GitHub App token early to use for checkouts (avoids rate limits)
       - name: Mint GitHub App Token
-        id: app_token
+        id: app_token_dispatch
         uses: actions/create-github-app-token@v2
-        if: secrets.WORKFLOWS_APP_ID != ''
+        continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
           owner: ${{ github.repository_owner }}
 
       # Dual checkout pattern: consumer repo for context, Workflows repo for scripts
@@ -125,7 +125,7 @@ jobs:
         with:
           fetch-depth: 1
           path: consumer
-          token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
+          token: ${{ steps.app_token_dispatch.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -190,7 +190,7 @@ jobs:
           sparse-checkout-cone-mode: false
           path: workflows-lib
           fetch-depth: 1
-          token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
+          token: ${{ steps.app_token_dispatch.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
 
       - name: Set scripts path
         run: |
@@ -274,12 +274,12 @@ jobs:
       AGENTS_AUTOMATION_PAT: ${{ secrets.AGENTS_AUTOMATION_PAT || '' }}
     steps:
       - name: Mint GitHub App Token
-        id: app_token
+        id: app_token_orchestrator
         uses: actions/create-github-app-token@v2
-        if: secrets.WORKFLOWS_APP_ID != ''
+        continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Workflows scripts
@@ -292,7 +292,7 @@ jobs:
             .github/actions/setup-api-client
           sparse-checkout-cone-mode: false
           path: workflows-lib
-          token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
+          token: ${{ steps.app_token_orchestrator.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
           fetch-depth: 1
 
       - name: Set scripts path
@@ -306,7 +306,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Mint GitHub App token (preferred)
-        id: app_token
+        id: app_token_orchestrator_preferred
         continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
@@ -318,7 +318,7 @@ jobs:
         env:
           INSTRUCTION_BODY: ${{ needs.keepalive_dispatch.outputs.instruction_body }}
         with:
-          github-token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.SERVICE_BOT_PAT || secrets.AGENTS_AUTOMATION_PAT || github.token }}
+          github-token: ${{ steps.app_token_orchestrator_preferred.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.SERVICE_BOT_PAT || secrets.AGENTS_AUTOMATION_PAT || github.token }}
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH;
             const { runKeepaliveOrchestrator } = require(`${scriptsPath}/.github/scripts/agents_pr_meta_orchestrator.js`);
@@ -354,12 +354,12 @@ jobs:
       reason: ${{ steps.gate.outputs.reason }}
     steps:
       - name: Mint GitHub App Token
-        id: app_token
+        id: app_token_from_gate
         uses: actions/create-github-app-token@v2
-        if: secrets.WORKFLOWS_APP_ID != ''
+        continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Workflows scripts
@@ -372,7 +372,7 @@ jobs:
             .github/actions/setup-api-client
           sparse-checkout-cone-mode: false
           path: workflows-lib
-          token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
+          token: ${{ steps.app_token_from_gate.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
           fetch-depth: 1
 
       - name: Set scripts path
@@ -504,12 +504,12 @@ jobs:
     if: inputs.event_name == 'pull_request'
     steps:
       - name: Mint GitHub App Token
-        id: app_token
+        id: app_token_body_update
         uses: actions/create-github-app-token@v2
-        if: secrets.WORKFLOWS_APP_ID != ''
+        continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Workflows scripts
@@ -522,7 +522,7 @@ jobs:
             .github/actions/setup-api-client
           sparse-checkout-cone-mode: false
           path: workflows-lib
-          token: ${{ steps.app_token.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
+          token: ${{ steps.app_token_body_update.outputs.token || secrets.ACTIONS_BOT_PAT || secrets.service_bot_pat || github.token }}
           fetch-depth: 1
 
       - name: Set scripts path


### PR DESCRIPTION
## Summary
Systematically fixes API rate limit failures across ALL workflows by using GitHub App tokens for checkout and API operations.

## Problem
Multiple workflows failing with "API rate limit exceeded for installation" errors:
- Trend_Model_Project PRs #4647 and #4641: reusable-20-pr-meta.yml failures
- Trend_Model_Project Issue #4654: agents-auto-pilot.yml failures
- 80+ other workflows vulnerable to same issue

Root cause: workflows using default GITHUB_TOKEN for early checkout/API operations hit installation rate limits before setup-api-client can provide better tokens.

## Solution
Systematic fix applied to **51 workflows**:
1. Add GitHub App token minting step at beginning of each job
2. Update all checkout@v6 actions to use minted token
3. Update all github-script@v8 actions to use minted token
4. Use `continue-on-error: true` for repos without GitHub App configured
5. Token fallback chain: `steps.app_token.outputs.token || github.token`

## Affected Workflows
- **agents-***: auto-pilot, codex belt, issue intake, keepalive, verifier, etc.
- **health-***: security scan, template sync, actionlint, branch protection, etc.
- **maint-***: release, consumer sync, label management, etc.
- **reusable-***: CI workflows, agent runners, autofix, etc.
- **pr-***: gate, smoke tests, etc.

## Changes
- 51 workflow files modified
- 676 lines added (token minting + token usage)
- Resolves actionlint errors from PR review
- Each job gets unique app_token step ID to avoid conflicts

## Context
Completes API rate limit remediation started in PR #1183. That PR added setup-api-client but it ran AFTER checkouts. This fix ensures all workflows use rate-limit-safe tokens from the start.

## Testing
After merge and v1 tag refresh:
1. Re-run Trend_Model_Project PRs #4647 and #4641 (reusable-20-pr-meta)
2. Re-trigger Issue #4654 (agents-auto-pilot)
3. All consumer repo workflows will automatically inherit fix via template sync