### PR TITLE
fix: normalize secrets case in reusable-agents-issue-bridge.yml

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -58,10 +58,10 @@ on:
       owner_pr_pat:
         description: "PAT for PR creation operations"
         required: false
-      WORKFLOWS_APP_ID:
+      workflows_app_id:
         description: "GitHub App ID for minting installation tokens"
         required: false
-      WORKFLOWS_APP_PRIVATE_KEY:
+      workflows_app_private_key:
         description: "GitHub App private key for minting installation tokens"
         required: false
 
@@ -95,8 +95,8 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.workflows_app_id }}
+          private-key: ${{ secrets.workflows_app_private_key }}
 
       - name: Checkout retry helpers
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`agents-63-issue-intake.yml` (the agent:codex workflow) was failing with `startup_failure` - no jobs would run.

## Root Cause

The reusable workflow `reusable-agents-issue-bridge.yml` declared secrets as:
- `WORKFLOWS_APP_ID` (UPPERCASE)
- `WORKFLOWS_APP_PRIVATE_KEY` (UPPERCASE)

But the caller `agents-63-issue-intake.yml` passed:
- `workflows_app_id` (lowercase)
- `workflows_app_private_key` (lowercase)

GitHub workflow_call secrets are **case-sensitive**. This mismatch caused GitHub to fail the workflow at startup because it couldn't match the declared secrets.

## Fix

Changed the reusable workflow declarations to lowercase to match the caller's convention:
- `workflows_app_id`
- `workflows_app_private_key`

This also aligns with other similar workflows like `reusable-agents-verifier.yml` which uses lowercase.

## Testing

After merging, trigger the issue intake workflow by adding `agent:codex` label to an issue. It should now successfully start instead of failing with `startup_failure`.