### PR TITLE
fix: remove top-level permissions to fix startup_failure

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -110,11 +110,10 @@ on:
       workflows_app_private_key:
         required: false
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  models: read
+# NOTE: Top-level permissions block removed intentionally.
+# When a workflow_call reusable workflow has top-level permissions, it causes
+# "startup_failure" with no jobs started when callers have their own permissions.
+# Jobs that need specific permissions declare them at job level.
 
 concurrency:
   group: issue-intake-${{ github.event.issue.number || github.run_id }}

--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -64,11 +64,10 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  models: read
+# NOTE: Top-level permissions block removed intentionally.
+# When caller workflows have top-level permissions AND call reusable workflows,
+# it can cause "startup_failure" with no jobs started.
+# Jobs that need specific permissions declare them at job level.
 
 jobs:
   # Determine which mode to run


### PR DESCRIPTION
## Problem

`agents-issue-intake` workflows have been failing with `startup_failure` since January 25, 2026.

**Root cause**: Commit 848be79 added a top-level `permissions:` block to `agents-63-issue-intake.yml`. According to `docs/INTEGRATION_GUIDE.md`:

> **Cause:** Caller workflow has a top-level `permissions:` block when calling a reusable workflow.
> **Symptoms:** `startup_failure`, no logs, zero jobs started

When a `workflow_call` reusable workflow has a top-level permissions block AND callers also define permissions, GitHub fails to start any jobs.

## Changes

1. **`.github/workflows/agents-63-issue-intake.yml`** - Removed top-level `permissions:` block. Jobs that need specific permissions already have them at job level.

2. **`templates/consumer-repo/.github/workflows/agents-issue-intake.yml`** - Removed top-level `permissions:` block. The `sync` job already has job-level permissions.

## Testing

After merge:
1. Workflow should run successfully without `startup_failure`
2. Template sync will push the fix to all consumer repos

## Timeline

- **Jan 23 06:31 UTC**: Last successful run of agents-63-issue-intake.yml
- **Jan 25 06:34 UTC**: 848be79 added `models: read` with top-level permissions block
- **Jan 30 onwards**: All runs show `startup_failure`