### PR TITLE
test: remove models permission to debug startup_failure

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -69,7 +69,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  models: read
+  # models: read - commented out to test if this causes startup_failure
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Testing if the `models: read` permission in reusable workflows is causing `startup_failure`.

This is a diagnostic change - will revert if not the cause.