### PR TITLE
fix: restore models:read and add workflow debugging skill

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -69,7 +69,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  # models: read - commented out to test if this causes startup_failure
+  models: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. Restore `models:read` to `reusable-agents-issue-bridge.yml`

PR #1203 incorrectly removed `models:read` while debugging `startup_failure`. That was wrong because:

- **Pure `workflow_call` reusables CAN have top-level permissions** - they define what the reusable needs
- **The actual problem was hybrid workflows** (`workflow_call` + `workflow_dispatch`) having top-level permissions
- Removing `models:read` would have broken LLM features silently

### 2. Add 'Debugging Workflow Failures' skill to synced docs

Added to:
- `templates/consumer-repo/.github/copilot-instructions.md`
- `templates/consumer-repo/CLAUDE.md`

The skill **enforces historical analysis BEFORE making fixes**:
1. Find the boundary between success and failure
2. Find commits in that window  
3. Fix ONLY what the diff changed

**Anti-patterns explicitly called out:**
- ❌ Theorizing without data
- ❌ Removing features to fix symptoms
- ❌ Broad changes affecting many files
- ❌ Fixing what already worked

## Why This Matters

This skill will sync to all consumer repos and be loaded into agent context, reducing the chance of repeating the same debugging mistakes.

## Testing

After merge, run sync to propagate docs to consumer repos.