### PR TITLE
fix: move reusable-agents-issue-bridge permissions to job level

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -65,11 +65,9 @@ on:
         description: "GitHub App private key for minting installation tokens"
         required: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  models: read
+# NOTE: Top-level permissions removed - moved to job level.
+# When this reusable is called by another workflow_call workflow (like agents-63-issue-intake),
+# having top-level permissions with models:read causes startup_failure.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -78,6 +76,11 @@ concurrency:
 jobs:
   bridge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      models: read
     outputs:
       issue: ${{ steps.ctx.outputs.issue }}
       has_issue: ${{ steps.ctx.outputs.has_issue }}


### PR DESCRIPTION
## Problem

`agents-63-issue-intake` workflow gets `startup_failure` when `reusable-agents-issue-bridge.yml` has top-level permissions with `models:read`.

## Root Cause Analysis

Following the workflow debugging skill:

1. **Boundary**: 
   - Run 21593220772 (1c9b892) - `failure` (jobs ran)
   - Run 21593897670 (3bef927) - `startup_failure` (no jobs)

2. **Diff**: 3bef927 restored `models:read` to `reusable-agents-issue-bridge.yml`

3. **Pattern**: 
   - `reusable-agents-verifier.yml` has top-level `models:read` and works
   - But it's called by `agents-verifier.yml` which is NOT a `workflow_call` workflow
   - `reusable-agents-issue-bridge.yml` is called by `agents-63-issue-intake.yml` which IS a `workflow_call` workflow
   - **Nested `workflow_call` with top-level `models:read` causes `startup_failure`**

## Fix

Move permissions from top-level to job-level in `reusable-agents-issue-bridge.yml`.

This preserves the needed permissions (`models:read` for LangChain context extraction) while avoiding the nested workflow_call permissions conflict.

## Testing

After merge, dispatch `Agents 63 Issue Intake` and verify it doesn't get `startup_failure`.