### PR TITLE
ci: exclude node_modules from black

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -563,7 +563,7 @@ jobs:
         run: |
           set -euo pipefail
           # Exclude .workflows-lib since it's synced from source repo with different config
-          black --check --line-length 100 --exclude '\.workflows-lib' .
+          black --check --line-length 100 --exclude '(\.workflows-lib|node_modules)' .
 
       - name: Finalize format check
         id: finalize


### PR DESCRIPTION
Exclude node_modules from Black format checks to prevent CI failures when Node tooling is installed during workflows.