### PR TITLE
fix: remove node lockfile before sweep

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -483,6 +483,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -f node_modules/.package-lock.json ]; then
+            rm -f node_modules/.package-lock.json
+          fi
           echo "[autofix-clean] Running clean cosmetic sweep"
           # === Dynamic Python Target Detection ===
           # shellcheck disable=SC2016 # Single quotes intentional - literal regex pattern


### PR DESCRIPTION
## Summary
- delete node_modules/.package-lock.json right before safe sweep diff checks
- prevents autofix failure from untracked npm lockfile churn

## Testing
- not run (workflow change)