### PR TITLE
docs: update consumer repo audit status

### DIFF
--- a/docs/fixes/sparse-checkout-audit-2026-02-03.csv
+++ b/docs/fixes/sparse-checkout-audit-2026-02-03.csv
@@ -33,13 +33,13 @@ templates/consumer-repo,agents-verify-to-issue-v2.yml,token_load_balancer.js,Fix
 templates/consumer-repo,agents-verify-to-new-pr.yml,token_load_balancer.js,Fixed,Sparse-checkout dependency
 templates/consumer-repo,maint-coverage-guard.yml,token_load_balancer.js,Fixed,Sparse-checkout dependency
 Manager-Database,agents-71-codex-belt-dispatcher.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
-Manager-Database,agents-autofix-loop.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
+Manager-Database,agents-autofix-loop.yml,token_load_balancer.js,Fixed,Sparse-checkout dependency
 Manager-Database,agents-verifier.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Manager-Database,agents-verify-to-issue-v2.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Manager-Database,agents-verify-to-new-pr.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Manager-Database,maint-coverage-guard.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Trend_Model_Project,agents-71-codex-belt-dispatcher.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
-Trend_Model_Project,agents-autofix-loop.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
+Trend_Model_Project,agents-autofix-loop.yml,token_load_balancer.js,Fixed,Sparse-checkout dependency
 Trend_Model_Project,agents-verifier.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Trend_Model_Project,agents-verify-to-issue-v2.yml,token_load_balancer.js,Missing,Sparse-checkout dependency
 Trend_Model_Project,agents-verify-to-new-pr.yml,token_load_balancer.js,Missing,Sparse-checkout dependency


### PR DESCRIPTION
## Summary
- update audit CSV with post-sync verification results for consumer repos

## Testing
- not run (docs-only)
