### PR TITLE
fix: token-aware retry in auto-pilot context

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -209,9 +209,14 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { withRetry, paginateWithRetry } = require(
+            const { createTokenAwareRetry } = require(
               `${scriptsPath}/.github/scripts/github-api-with-retry.js`
             );
+            const { withRetry, paginateWithRetry } = await createTokenAwareRetry({
+              github,
+              core,
+              task: 'auto-pilot-determine-context',
+            });
 
             let issueNumber, issue, pr;
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -195,9 +195,14 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { withRetry, paginateWithRetry } = require(
+            const { createTokenAwareRetry } = require(
               `${scriptsPath}/.github/scripts/github-api-with-retry.js`
             );
+            const { withRetry, paginateWithRetry } = await createTokenAwareRetry({
+              github,
+              core,
+              task: 'auto-pilot-determine-context',
+            });
 
             let issueNumber, issue, pr;
 


### PR DESCRIPTION
## Summary
- use token-aware retry for auto-pilot context fetching to avoid app rate-limit failures
- mirror change in consumer workflow template

## Testing
- not run (workflow-only change)