### PR TITLE
Exclude node_modules from autofix summary

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -653,7 +653,16 @@ jobs:
               }
               exit 1
             fi
-            file_list_payload=$(printf '%s\n' "${changed_paths[@]}" | sort -u)
+            filtered_paths=()
+            for path in "${changed_paths[@]}"; do
+              if [[ "$path" == node_modules/* ]] || [[ "$path" == */node_modules/* ]]; then
+                continue
+              fi
+              filtered_paths+=("$path")
+            done
+            if [ ${#filtered_paths[@]} -gt 0 ]; then
+              file_list_payload=$(printf '%s\n' "${filtered_paths[@]}" | sort -u)
+            fi
           fi
 
           AUTOFIX_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Summary
- exclude node_modules entries from autofix safe-sweep summary comments

## Testing
- pre-commit dev-check (fast validation)
