### PR TITLE
Fix keepalive API deps setup

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -233,6 +233,11 @@ jobs:
           ref: ${{ inputs.pr_ref || github.ref }}
           token: ${{ steps.auth_token.outputs.checkout_token }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
       # Checkout Workflows repo scripts for post-completion, error handling, and LLM analysis
       # These scripts are in stranske/Workflows but need to be available when
       # this reusable workflow runs in consumer repos

--- a/docs/fixes/RATE_LIMIT_REMEDIATION_PLAN.md
+++ b/docs/fixes/RATE_LIMIT_REMEDIATION_PLAN.md
@@ -458,6 +458,8 @@ Update these workflows to use the new action:
 4. `agents-70-orchestrator.yml` - ALL jobs
 5. `reusable-70-orchestrator-main.yml` - ALL jobs
 
+**2026-02-04 update:** `reusable-codex-run.yml` now sets up Node.js before `setup-api-client` to ensure npm installs run for `.workflows-lib/.github/scripts` and NODE_PATH is exported consistently.
+
 ### Phase C: Fix Status Reporting (Priority: High)
 
 #### Task C.1: Update keepalive state reporting
@@ -501,6 +503,8 @@ With when rate-limited:
 #### Task E.2: Add verbose logging (failure-only)
 
 Only log token selection details when an API call fails.
+
+**2026-02-04 validation:** keepalive + API-rate-limit unit coverage executed (keepalive workflow, PR meta, guard utils, post work, metrics integration, keepalive loop rate-limit, and GitHub API retry standard) — all passing locally.
 
 ### Phase F: Maintenance Workflows (Priority: Medium)
 


### PR DESCRIPTION
## Summary\n- ensure Node.js is available before setup-api-client in reusable-codex-run\n- document keepalive/api-limit validation in rate limit remediation plan\n\n## Testing\n- /workspaces/Workflows/.venv/bin/python -m pytest tests/workflows/test_keepalive_workflow.py tests/workflows/test_agents_pr_meta_keepalive.py tests/workflows/test_keepalive_guard_utils.py tests/workflows/test_keepalive_post_work.py tests/scripts/test_keepalive_metrics_integration.py\n- /workspaces/Workflows/.venv/bin/python -m pytest tests/workflows/test_keepalive_loop_rate_limit.py tests/workflows/test_github_api_retry_standard.py