### PR TITLE
fix: authorize completion bots and warn on unknowns

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -12,6 +12,7 @@ const {
   fetchConnectorCheckboxStates,
   findUnauthorizedCompletionAuthors,
   buildCompletionAuthorWarningBody,
+  upsertCompletionAuthorWarning,
   buildStatusBlock,
   resolveAgentType,
   stripPrTemplateContent,
@@ -522,6 +523,68 @@ test('buildCompletionAuthorWarningBody includes marker and logins', () => {
 
   assert.ok(body.includes('<!-- completion-author-warning -->'));
   assert.ok(body.includes('custom-bot[bot]'));
+});
+
+test('upsertCompletionAuthorWarning creates comment for unauthorized authors', async () => {
+  const calls = { create: 0, update: 0, lastBody: '' };
+  const github = {
+    rest: {
+      issues: {
+        createComment: async ({ body }) => {
+          calls.create += 1;
+          calls.lastBody = body;
+        },
+        updateComment: async () => {
+          calls.update += 1;
+        },
+      },
+    },
+  };
+
+  await upsertCompletionAuthorWarning({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 42,
+    comments: [],
+    unauthorizedLogins: ['custom-bot[bot]'],
+    core: { info: () => {}, warning: () => {} },
+  });
+
+  assert.strictEqual(calls.create, 1);
+  assert.strictEqual(calls.update, 0);
+  assert.ok(calls.lastBody.includes('custom-bot[bot]'));
+});
+
+test('upsertCompletionAuthorWarning resolves existing warning comment', async () => {
+  const calls = { create: 0, update: 0, lastBody: '' };
+  const github = {
+    rest: {
+      issues: {
+        createComment: async () => {
+          calls.create += 1;
+        },
+        updateComment: async ({ body }) => {
+          calls.update += 1;
+          calls.lastBody = body;
+        },
+      },
+    },
+  };
+
+  await upsertCompletionAuthorWarning({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 42,
+    comments: [{ id: 99, body: '<!-- completion-author-warning -->' }],
+    unauthorizedLogins: [],
+    core: { info: () => {}, warning: () => {} },
+  });
+
+  assert.strictEqual(calls.create, 0);
+  assert.strictEqual(calls.update, 1);
+  assert.ok(calls.lastBody.includes('Completion Comment Authors Authorized'));
 });
 
 test('resolveAgentType prefers explicit inputs over labels', () => {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -577,47 +577,61 @@ function buildCompletionAuthorWarningBody(logins, { resolved = false } = {}) {
 }
 
 async function upsertCompletionAuthorWarning({ github, owner, repo, prNumber, comments, unauthorizedLogins, core }) {
-  const list = Array.isArray(unauthorizedLogins) ? unauthorizedLogins.filter(Boolean) : [];
-  const existing = (Array.isArray(comments) ? comments : [])
-    .find((comment) => comment?.body && comment.body.includes(COMPLETION_WARNING_MARKER));
-  if (list.length === 0) {
-    if (existing) {
-      const body = buildCompletionAuthorWarningBody([], { resolved: true });
-      await github.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existing.id,
-        body,
-      });
-      if (core) {
-        core.info('Updated completion author warning comment to resolved state.');
+  try {
+    const list = Array.isArray(unauthorizedLogins) ? unauthorizedLogins.filter(Boolean) : [];
+    const existing = (Array.isArray(comments) ? comments : [])
+      .find((comment) => comment?.body && comment.body.includes(COMPLETION_WARNING_MARKER));
+    const updateComment = async (commentId, body, label) => {
+      await withRetries(
+        () => github.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: commentId,
+          body,
+        }),
+        { description: label, core },
+      );
+    };
+    const createComment = async (body, label) => {
+      await withRetries(
+        () => github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body,
+        }),
+        { description: label, core },
+      );
+    };
+
+    if (list.length === 0) {
+      if (existing) {
+        const body = buildCompletionAuthorWarningBody([], { resolved: true });
+        await updateComment(existing.id, body, `issues.updateComment #${existing.id}`);
+        if (core) {
+          core.info('Updated completion author warning comment to resolved state.');
+        }
       }
+      return;
     }
-    return;
-  }
 
-  const body = buildCompletionAuthorWarningBody(list);
-  if (existing) {
-    await github.rest.issues.updateComment({
-      owner,
-      repo,
-      comment_id: existing.id,
-      body,
-    });
+    const body = buildCompletionAuthorWarningBody(list);
+    if (existing) {
+      await updateComment(existing.id, body, `issues.updateComment #${existing.id}`);
+      if (core) {
+        core.info('Updated completion author warning comment.');
+      }
+      return;
+    }
+
+    await createComment(body, `issues.createComment #${prNumber}`);
     if (core) {
-      core.info('Updated completion author warning comment.');
+      core.info('Posted completion author warning comment.');
     }
-    return;
-  }
-
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body,
-  });
-  if (core) {
-    core.info('Posted completion author warning comment.');
+  } catch (error) {
+    if (core) {
+      core.warning(`Failed to upsert completion author warning: ${error.message}`);
+    }
   }
 }
 
@@ -1255,15 +1269,19 @@ async function run({github: rawGithub, context, core, inputs}) {
   // Fetch checkbox states from connector bot comments to merge into status summary
   const connectorStates = parseConnectorCheckboxStatesFromComments(issueComments, core);
   const unauthorizedAuthors = findUnauthorizedCompletionAuthors(issueComments);
-  await upsertCompletionAuthorWarning({
-    github,
-    owner,
-    repo,
-    prNumber: pr.number,
-    comments: issueComments,
-    unauthorizedLogins: unauthorizedAuthors,
-    core,
-  });
+  try {
+    await upsertCompletionAuthorWarning({
+      github,
+      owner,
+      repo,
+      prNumber: pr.number,
+      comments: issueComments,
+      unauthorizedLogins: unauthorizedAuthors,
+      core,
+    });
+  } catch (error) {
+    core.warning(`Completion author warning skipped: ${error.message}`);
+  }
 
   const agentType = resolveAgentType({ inputs, env: process.env, pr });
 

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -577,47 +577,61 @@ function buildCompletionAuthorWarningBody(logins, { resolved = false } = {}) {
 }
 
 async function upsertCompletionAuthorWarning({ github, owner, repo, prNumber, comments, unauthorizedLogins, core }) {
-  const list = Array.isArray(unauthorizedLogins) ? unauthorizedLogins.filter(Boolean) : [];
-  const existing = (Array.isArray(comments) ? comments : [])
-    .find((comment) => comment?.body && comment.body.includes(COMPLETION_WARNING_MARKER));
-  if (list.length === 0) {
-    if (existing) {
-      const body = buildCompletionAuthorWarningBody([], { resolved: true });
-      await github.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existing.id,
-        body,
-      });
-      if (core) {
-        core.info('Updated completion author warning comment to resolved state.');
+  try {
+    const list = Array.isArray(unauthorizedLogins) ? unauthorizedLogins.filter(Boolean) : [];
+    const existing = (Array.isArray(comments) ? comments : [])
+      .find((comment) => comment?.body && comment.body.includes(COMPLETION_WARNING_MARKER));
+    const updateComment = async (commentId, body, label) => {
+      await withRetries(
+        () => github.rest.issues.updateComment({
+          owner,
+          repo,
+          comment_id: commentId,
+          body,
+        }),
+        { description: label, core },
+      );
+    };
+    const createComment = async (body, label) => {
+      await withRetries(
+        () => github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body,
+        }),
+        { description: label, core },
+      );
+    };
+
+    if (list.length === 0) {
+      if (existing) {
+        const body = buildCompletionAuthorWarningBody([], { resolved: true });
+        await updateComment(existing.id, body, `issues.updateComment #${existing.id}`);
+        if (core) {
+          core.info('Updated completion author warning comment to resolved state.');
+        }
       }
+      return;
     }
-    return;
-  }
 
-  const body = buildCompletionAuthorWarningBody(list);
-  if (existing) {
-    await github.rest.issues.updateComment({
-      owner,
-      repo,
-      comment_id: existing.id,
-      body,
-    });
+    const body = buildCompletionAuthorWarningBody(list);
+    if (existing) {
+      await updateComment(existing.id, body, `issues.updateComment #${existing.id}`);
+      if (core) {
+        core.info('Updated completion author warning comment.');
+      }
+      return;
+    }
+
+    await createComment(body, `issues.createComment #${prNumber}`);
     if (core) {
-      core.info('Updated completion author warning comment.');
+      core.info('Posted completion author warning comment.');
     }
-    return;
-  }
-
-  await github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body,
-  });
-  if (core) {
-    core.info('Posted completion author warning comment.');
+  } catch (error) {
+    if (core) {
+      core.warning(`Failed to upsert completion author warning: ${error.message}`);
+    }
   }
 }
 
@@ -1255,15 +1269,19 @@ async function run({github: rawGithub, context, core, inputs}) {
   // Fetch checkbox states from connector bot comments to merge into status summary
   const connectorStates = parseConnectorCheckboxStatesFromComments(issueComments, core);
   const unauthorizedAuthors = findUnauthorizedCompletionAuthors(issueComments);
-  await upsertCompletionAuthorWarning({
-    github,
-    owner,
-    repo,
-    prNumber: pr.number,
-    comments: issueComments,
-    unauthorizedLogins: unauthorizedAuthors,
-    core,
-  });
+  try {
+    await upsertCompletionAuthorWarning({
+      github,
+      owner,
+      repo,
+      prNumber: pr.number,
+      comments: issueComments,
+      unauthorizedLogins: unauthorizedAuthors,
+      core,
+    });
+  } catch (error) {
+    core.warning(`Completion author warning skipped: ${error.message}`);
+  }
 
   const agentType = resolveAgentType({ inputs, env: process.env, pr });
 


### PR DESCRIPTION
## Summary
- authorize completion checkpoint bots (keepalive + workflows app)
- add early warning PR comment when completion checkpoint author is not authorized
- share logic across Workflows scripts + consumer template

## Testing
- not run (defer until sync PRs merge)