### PR TITLE
fix: avoid task_appendix secret scanner blocking

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -312,7 +312,29 @@ jobs:
               core.setOutput(key, value);
             }
             // Task appendix needs special handling due to multiline content
+            // Write to file to avoid GitHub's secret scanner blocking job outputs
             core.setOutput('task_appendix', result.taskAppendix || '');
+
+      - name: Write task appendix to file
+        if: steps.evaluate.outputs.action == 'run' || steps.evaluate.outputs.action == 'fix' || steps.evaluate.outputs.action == 'conflict'
+        run: |
+          mkdir -p /tmp/keepalive-artifacts
+          if [ -n "$TASK_APPENDIX" ]; then
+            printf '%s\n' "$TASK_APPENDIX" > /tmp/keepalive-artifacts/task-appendix.txt
+          else
+            touch /tmp/keepalive-artifacts/task-appendix.txt
+          fi
+          echo "Task appendix written ($(wc -c < /tmp/keepalive-artifacts/task-appendix.txt) bytes)"
+        env:
+          TASK_APPENDIX: ${{ steps.evaluate.outputs.task_appendix }}
+
+      - name: Upload task appendix artifact
+        if: steps.evaluate.outputs.action == 'run' || steps.evaluate.outputs.action == 'fix' || steps.evaluate.outputs.action == 'conflict'
+        uses: actions/upload-artifact@v6
+        with:
+          name: keepalive-task-appendix-${{ steps.evaluate.outputs.pr_number }}
+          path: /tmp/keepalive-artifacts/task-appendix.txt
+          retention-days: 1
 
   preflight:
     name: Verify secrets available

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -439,12 +439,22 @@ jobs:
             echo "Guard script not found, skipping integrity check"
           fi
 
+      - name: Download task appendix artifact
+        id: download_appendix
+        if: inputs.mode == 'keepalive' && inputs.pr_number != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          name: keepalive-task-appendix-${{ inputs.pr_number }}
+          path: /tmp/keepalive-artifacts
+
       - name: Assemble prompt
         id: prompt
         env:
           BASE_PROMPT: ${{ inputs.prompt_file }}
           APPENDIX: ${{ inputs.appendix }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
           base="${BASE_PROMPT}"
@@ -475,11 +485,21 @@ jobs:
             cat "$base" > "$output"
           fi
 
-          if [ -n "$APPENDIX" ]; then
+          # For keepalive mode, prefer artifact file to avoid secret scanner blocking
+          appendix_content=""
+          if [ "$MODE" = "keepalive" ] && [ -f "/tmp/keepalive-artifacts/task-appendix.txt" ]; then
+            echo "Reading task appendix from artifact file"
+            appendix_content=$(cat /tmp/keepalive-artifacts/task-appendix.txt)
+          elif [ -n "$APPENDIX" ]; then
+            echo "Using task appendix from input parameter"
+            appendix_content="$APPENDIX"
+          fi
+
+          if [ -n "$appendix_content" ]; then
             {
               echo
               echo "## Run context"
-              printf '%s\n' "$APPENDIX"
+              printf '%s\n' "$appendix_content"
             } >> "$output"
           fi
 


### PR DESCRIPTION
## Problem

GitHub Actions' secret scanner is blocking the `task_appendix` job output when it contains long or repetitive content (e.g., duplicate tasks in PR bodies). This causes the output to be censored, resulting in an empty appendix being passed to Codex—which means the agent has no idea what tasks to work on.

**Evidence**: PR stranske/Trend_Model_Project#4742 had 16 duplicate tasks, causing the workflow logs to show:
```
##[warning]Skip output 'task_appendix' since it may contain secret.
```

This resulted in complete task drift where the agent made 10 commits of unrelated work (cache configuration) because it never received the actual task list.

## Solution

Instead of passing `task_appendix` as a job output (which gets scanned), write it to a file and upload as an artifact:

1. **agents-keepalive-loop.yml**: Write task_appendix to file, upload artifact
2. **reusable-codex-run.yml**: Download artifact, read from file (fallback to input for backward compat)

## Benefits

- ✅ Avoids false positive secret detection
- ✅ Handles arbitrarily large task lists  
- ✅ Backward compatible (falls back to input parameter)
- ✅ Only applies to keepalive mode where blocking occurs

## Testing

- Workflows repo PRs: No blocking observed (normal-sized task lists)
- Trend_Model_Project PR #4742: Was blocked, should work after this fix
- Trend_Model_Project PR #4737: No blocking (verification)

## Changes

**agents-keepalive-loop.yml**:
- Add step to write task_appendix to `/tmp/keepalive-artifacts/task-appendix.txt`
- Upload as artifact with name `keepalive-task-appendix-{PR_NUMBER}`
- Retention: 1 day (ephemeral, only needed for workflow duration)

**reusable-codex-run.yml**:
- Add step to download artifact before assembling prompt
- Prefer artifact file content over input parameter in keepalive mode
- Fall back to input parameter for backward compatibility

## Related

- Blocked PR: stranske/Trend_Model_Project#4742
- Immediate fix: Deduplicated PR #4742 body (16→8 items)