### PR TITLE
fix: add PYTHONPATH to verify-to-new-pr for tools module import

### DIFF
--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -206,6 +206,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         continue-on-error: true
         env:
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -206,6 +206,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         continue-on-error: true
         env:
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}


### PR DESCRIPTION
## Problem

Issue #1299 was created by the `verify:create-new-pr` workflow with poor quality content. The issue body contains 10 tasks that are just raw verification concerns prepended with "Address:" — not the LLM-refined, actionable tasks the workflow is designed to produce.

Additionally, the continuation workflow (`agents-verify-to-new-pr-autopilot.yml`) that dispatches auto-pilot to create a PR from the follow-up issue failed due to the committed `node_modules/` issue (fixed in PR #1302).

## Root Cause

Commit 3fa371d ("Add Claude slot config and LangChain client updates") changed `followup_issue_generator.py` from directly importing `langchain_openai` to using the shared `tools.langchain_client` module:

```python
# Before (worked)
from langchain_openai import ChatOpenAI

# After (broken — tools not on sys.path)
from tools.langchain_client import build_chat_client
```

When the workflow runs `python scripts/langchain/followup_issue_generator.py`, Python sets `sys.path[0]` to `scripts/langchain/` (the script's directory), not the repo root. The `tools/` package can't be found, so the script falls back to `_generate_without_llm()` which produces low-quality mechanical extraction.

Every other workflow that uses `tools.*` sets `PYTHONPATH: ${{ github.workspace }}`. This was simply missing from the verify-to-new-pr workflow.

## Fix

Add `PYTHONPATH: ${{ github.workspace }}` to the "Generate follow-up issue" step's `env` block in both:
- `.github/workflows/agents-verify-to-new-pr.yml`
- `templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml`

## Summary of #1299 Issues

| Problem | Root Cause | Fix |
|---------|-----------|-----|
| Poor issue body quality | Missing PYTHONPATH → fell back to non-LLM mode | **This PR** |
| No PR created from follow-up issue | Continuation workflow failed on committed `node_modules/` | PR #1302 (merged) |

Closes #1299