### PR TITLE
fix: update faiss-cpu to 1.13.2 to resolve numpy compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ langchain-core==1.2.9
 langchain-community==0.4.1
 langchain-openai==1.1.7
 langchain-anthropic==1.3.2
-faiss-cpu==1.8.0.post1; python_version < "3.12"
+faiss-cpu==1.13.2; python_version < "3.12"


### PR DESCRIPTION
## Problem

`agents-auto-pilot.yml` fails at the **Install Python dependencies** step with:

```
ERROR: Cannot install -r requirements.txt and faiss-cpu==1.8.0.post1
because these package versions have conflicting dependencies.
The conflict is caused by:
    faiss-cpu 1.8.0.post1 depends on numpy<2.0
    requirements.txt pins numpy==2.4.2
```

This blocks the entire auto-pilot pipeline from creating PRs.

**Failed runs:**
- https://github.com/stranske/Workflows/actions/runs/21805404428
- https://github.com/stranske/Workflows/actions/runs/21805376767

## Fix

Update `faiss-cpu==1.8.0.post1` → `faiss-cpu==1.13.2` in `requirements.txt`.

- `faiss-cpu 1.13.2` supports `numpy>=2.0`, resolving the conflict
- Compatible with `pyproject.toml` range (`faiss-cpu>=1.8,<2.0`)
- Verified via `pip install --dry-run` with full requirements.txt — all deps resolve cleanly

## Verification

```bash
pip install --dry-run 'faiss-cpu==1.13.2' 'numpy==2.4.2'
# Would install faiss-cpu-1.13.2 numpy-2.4.2 ✓
```

Fixes #1393