### PR TITLE
fix: section parser boundary logic — ### subsections no longer break #### sections

### DIFF
--- a/.github/scripts/__tests__/issue_scope_parser.test.js
+++ b/.github/scripts/__tests__/issue_scope_parser.test.js
@@ -796,3 +796,72 @@ test('handles multiple code blocks - preserves content without adding checkboxes
   assert.ok(result.includes('  - YAML example task'));  // preserved as-is
   assert.ok(!result.includes('- [ ] YAML example task'));  // no checkbox added
 });
+
+// --- Issue #1361: ### subsection headers inside #### sections ---
+
+test('parseScopeTasksAcceptanceSections includes items under ### subsections in #### Tasks', () => {
+  const body = [
+    '#### Tasks',
+    '### Phase 1',
+    '- [x] Task A',
+    '### Phase 2',
+    '- [ ] Task B',
+    '- [ ] Task C',
+    '#### Acceptance criteria',
+    '### AC Group 1',
+    '- [ ] AC 1',
+    '- [ ] AC 2',
+  ].join('\n');
+
+  const result = parseScopeTasksAcceptanceSections(body);
+  // All tasks appear in the tasks section
+  assert.ok(result.tasks.includes('Task A'));
+  assert.ok(result.tasks.includes('Task B'));
+  assert.ok(result.tasks.includes('Task C'));
+  // All acceptance criteria in the acceptance section
+  assert.ok(result.acceptance.includes('AC 1'));
+  assert.ok(result.acceptance.includes('AC 2'));
+  // No cross-contamination
+  assert.ok(!result.tasks.includes('AC 1'));
+  assert.ok(!result.acceptance.includes('Task A'));
+  assert.ok(!result.acceptance.includes('Task B'));
+});
+
+test('### subsection headers are preserved as content', () => {
+  const body = [
+    '#### Tasks',
+    '### Phase 1: Setup',
+    '- [ ] Install deps',
+    '### Phase 2: Build',
+    '- [ ] Compile',
+    '#### Acceptance criteria',
+    '- [ ] All phases pass',
+  ].join('\n');
+
+  const result = parseScopeTasksAcceptanceSections(body);
+  assert.ok(result.tasks.includes('### Phase 1: Setup'));
+  assert.ok(result.tasks.includes('### Phase 2: Build'));
+  assert.ok(result.tasks.includes('Install deps'));
+  assert.ok(result.tasks.includes('Compile'));
+});
+
+test('countCheckboxes counts all checkboxes from #### sections with ### subsections', () => {
+  const body = [
+    '#### Tasks',
+    '### Phase 1',
+    '- [x] Task A',
+    '- [ ] Task B',
+    '### Phase 2',
+    '- [ ] Task C',
+    '#### Acceptance criteria',
+    '### Group 1',
+    '- [ ] AC 1',
+    '- [x] AC 2',
+  ].join('\n');
+
+  const result = parseScopeTasksAcceptanceSections(body);
+  // Count checkboxes manually
+  const allContent = result.tasks + '\n' + result.acceptance;
+  const checkboxes = allContent.match(/- \[[ x]\]/g) || [];
+  assert.equal(checkboxes.length, 5);
+});

--- a/.github/scripts/issue_scope_parser.js
+++ b/.github/scripts/issue_scope_parser.js
@@ -585,19 +585,21 @@ function collectSections(source) {
       continue; // Skip missing sections instead of failing
     }
     // Find the boundary for this section's content:
-    // 1. Next heading at SAME LEVEL or HIGHER (allows subsections to be included)
+    // 1. Next heading at the SAME level (e.g., another ## for a ## section)
+    //    This catches structural headings that divide the document at the
+    //    same depth, while allowing subsection headers at different levels
+    //    (e.g., ### Phase 1 inside #### Tasks) to remain as content.
     // 2. OR next recognized section heading (even if it's a subsection level)
     //    Example: ## Scope followed by ### Tasks should stop at ### Tasks
-    const headingIndexSet = new Set(headings.map(h => h.index));
-    const nextSameLevelOrHigher = allHeadings
-      .filter((entry) => entry.index > header.index && entry.level <= header.level)
+    const nextSameLevel = allHeadings
+      .filter((entry) => entry.index > header.index && entry.level === header.level)
       .sort((a, b) => a.index - b.index)[0];
     const nextRecognizedSection = headings
       .filter((entry) => entry.index > header.index && entry.title !== header.title)
       .sort((a, b) => a.index - b.index)[0];
     
     // Use whichever boundary comes first
-    const boundaries = [nextSameLevelOrHigher, nextRecognizedSection].filter(Boolean);
+    const boundaries = [nextSameLevel, nextRecognizedSection].filter(Boolean);
     const nextHeader = boundaries.length > 0 
       ? boundaries.sort((a, b) => a.index - b.index)[0]
       : null;

--- a/templates/consumer-repo/.github/scripts/issue_scope_parser.js
+++ b/templates/consumer-repo/.github/scripts/issue_scope_parser.js
@@ -585,19 +585,21 @@ function collectSections(source) {
       continue; // Skip missing sections instead of failing
     }
     // Find the boundary for this section's content:
-    // 1. Next heading at SAME LEVEL or HIGHER (allows subsections to be included)
+    // 1. Next heading at the SAME level (e.g., another ## for a ## section)
+    //    This catches structural headings that divide the document at the
+    //    same depth, while allowing subsection headers at different levels
+    //    (e.g., ### Phase 1 inside #### Tasks) to remain as content.
     // 2. OR next recognized section heading (even if it's a subsection level)
     //    Example: ## Scope followed by ### Tasks should stop at ### Tasks
-    const headingIndexSet = new Set(headings.map(h => h.index));
-    const nextSameLevelOrHigher = allHeadings
-      .filter((entry) => entry.index > header.index && entry.level <= header.level)
+    const nextSameLevel = allHeadings
+      .filter((entry) => entry.index > header.index && entry.level === header.level)
       .sort((a, b) => a.index - b.index)[0];
     const nextRecognizedSection = headings
       .filter((entry) => entry.index > header.index && entry.title !== header.title)
       .sort((a, b) => a.index - b.index)[0];
     
     // Use whichever boundary comes first
-    const boundaries = [nextSameLevelOrHigher, nextRecognizedSection].filter(Boolean);
+    const boundaries = [nextSameLevel, nextRecognizedSection].filter(Boolean);
     const nextHeader = boundaries.length > 0 
       ? boundaries.sort((a, b) => a.index - b.index)[0]
       : null;


### PR DESCRIPTION
## Problem

`collectSections()` in `issue_scope_parser.js` uses `entry.level <= header.level` to find section boundaries. When `#### Tasks` (level 4) contains `### Phase 1` (level 3), the condition `3 <= 4` evaluates to true, terminating the section at the first `###` subsection header.

**Result:** Items after the first `###` subsection are lost or misattributed. TMP PR #4799 counted 8/74 checkboxes (89% lost).

## Root Cause

```javascript
// BEFORE: catches ### (level 3) as boundary for #### (level 4)  
const nextSameLevelOrHigher = allHeadings
  .filter((entry) => entry.index > header.index && entry.level <= header.level)
```

## Fix

Changed `entry.level <= header.level` to `entry.level === header.level`:

```javascript
// AFTER: only same-level headings terminate (another #### stops ####)
const nextSameLevel = allHeadings
  .filter((entry) => entry.index > header.index && entry.level === header.level)
```

This means:
- `###` inside `####` → **NOT** a boundary (fix)
- Another `####` after `####` → **IS** a boundary (preserved)
- Next recognized section (e.g., `#### Acceptance criteria`) → still terminates correctly via `nextRecognizedSection`

## Changes

- `.github/scripts/issue_scope_parser.js` — boundary logic fix
- `templates/consumer-repo/.github/scripts/issue_scope_parser.js` — same fix (template sync)
- `.github/scripts/__tests__/issue_scope_parser.test.js` — 3 new tests

## Test Results

All 37 tests pass (34 existing + 3 new):
1. `parseScopeTasksAcceptanceSections includes items under ### subsections in #### Tasks`
2. `### subsection headers are preserved as content`
3. `countCheckboxes counts all checkboxes from #### sections with ### subsections`

Fixes #1361