### PR TITLE
fix: expand sync triggers, audit manifest, add missing processing sections

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -7,7 +7,7 @@
 # POLICY: Any file intended for consumer repos MUST be listed here.
 # Files not listed will NOT be synced, even if they exist in templates/consumer-repo/.
 #
-# Last sync trigger: 2026-01-27T06:05:00Z - fix removals manifest entry
+# Last sync trigger: 2026-02-10 - manifest audit + sync trigger expansion
 #
 # Categories:
 #   workflows: Thin caller workflows that consumers run directly
@@ -351,6 +351,15 @@ scripts:
   - source: .github/scripts/bot-comment-dismiss.js
     description: "Collects ignored bot review comments for auto-dismiss handling"
 
+  - source: .github/scripts/bot-comment-handler.js
+    description: "Bot comment handler logic - processes bot review comments for dispatch"
+
+  - source: .github/scripts/autofix_emit_report.py
+    description: "Emits autofix report - required by reusable-18-autofix.yml"
+
+  - source: .github/scripts/gate_summary.py
+    description: "Gate summary renderer - generates PR gate check summary"
+
   - source: .github/scripts/should-post-review.js
     description: "Evaluates whether a progress review comment should be posted"
 
@@ -400,6 +409,12 @@ scripts:
 
   - source: scripts/langchain/issue_dedup.py
     description: "Issue deduplication - finds similar open issues"
+
+  - source: scripts/langchain/injection_guard.py
+    description: "Prompt injection guard - validates prompts before LLM submission"
+
+  - source: scripts/langchain/progress_reviewer.py
+    description: "Progress reviewer - evaluates agent progress for keepalive rounds"
 
   # Context and semantic analysis
   - source: scripts/langchain/context_extractor.py
@@ -451,6 +466,15 @@ scripts:
   - source: scripts/langchain/prompts/pr_evaluation.md
     description: "Prompt template for PR evaluation/verification"
 
+  - source: scripts/langchain/prompts/refine_tasks.md
+    description: "Prompt template for task refinement and validation"
+
+  - source: scripts/langchain/verdict_extract.py
+    description: "Verdict extractor - parses verification verdicts from LLM output"
+
+  - source: scripts/langchain/verdict_policy.py
+    description: "Verdict policy engine - applies pass/fail rules to verification results"
+
   - source: tools/llm_provider.py
     description: "LLM provider configuration - GitHub Models and OpenAI client setup"
 
@@ -491,6 +515,9 @@ llm_config:
     description: "LLM slot configuration - defines provider/model slots for multi-provider workflows"
     sync_mode: create_only  # Don't overwrite - repos may customize provider preferences
 
+  - source: config/model_registry.json
+    description: "Model registry - available LLM models and their capabilities"
+
 # Documentation synced to consumer repos
 docs:
   - source: docs/AGENT_ISSUE_FORMAT.md
@@ -505,9 +532,27 @@ docs:
     target: docs/LABELS.md
     description: "Label definitions and usage"
 
+  - source: docs/CODEX_TOKEN_REFRESH.md
+    target: docs/CODEX_TOKEN_REFRESH.md
+    description: "Codex OAuth token refresh guide"
+
   - source: CLAUDE.md
     target: CLAUDE.md
     description: "Context file for Claude/AI assistants"
+
+# Issue templates synced to consumer repos
+issue_templates:
+  - source: .github/ISSUE_TEMPLATE/agent_task.yml
+    description: "Agent task issue template - structured format for agent-compatible issues"
+
+  - source: .github/ISSUE_TEMPLATE/config.yml
+    description: "Issue template chooser config - controls which templates appear in the UI"
+
+# User-facing documentation
+user_docs:
+  - source: WORKFLOW_USER_GUIDE.md
+    target: WORKFLOW_USER_GUIDE.md
+    description: "Workflow user guide - explains the CI/agent system for repo consumers"
 
 # Git configuration files for merge strategies
 git_config:
@@ -524,6 +569,8 @@ excluded:
     reason: "Repo-specific documentation"
   - path: config/coverage-baseline.json
     reason: "Each repo maintains its own coverage baseline - template provided for reference"
+  - path: scripts/__pycache__
+    reason: "Python bytecode cache - never synced"
 
 # Copilot configuration - skills and instructions for AI assistants
 copilot_config:

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -16,6 +16,38 @@ on:
     paths:
       - 'templates/consumer-repo/**'
       - '.github/sync-manifest.yml'
+      # All directories referenced by sync-manifest.yml as source paths.
+      # The sync is idempotent (hash-compares before creating PRs), so extra
+      # triggers only cost a ~30s no-op run when nothing actually changed.
+      - '.github/scripts/**'
+      - '.github/codex/**'
+      - '.github/actions/setup-api-client/**'
+      - '.github/actions/export-load-balancer-tokens/**'
+      - '.github/copilot-instructions.md'
+      - '.github/copilot-skills/**'
+      - '.github/dependabot.yml'
+      - '.github/templates/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'scripts/langchain/**'
+      - 'scripts/sync_dev_dependencies.py'
+      - 'scripts/sync_test_dependencies.py'
+      - 'scripts/check_test_dependencies.sh'
+      - 'scripts/autopilot_step_timer.py'
+      - 'scripts/autopilot_metrics_collector.py'
+      - 'scripts/ci_*.py'
+      - 'scripts/coverage_history_append.py'
+      - 'tools/resolve_mypy_pin.py'
+      - 'tools/coverage_trend.py'
+      - 'tools/llm_provider.py'
+      - 'tools/langchain_client.py'
+      - 'config/llm_slots.json'
+      - 'config/model_registry.json'
+      - 'docs/AGENT_ISSUE_FORMAT.md'
+      - 'docs/CI_SYSTEM_GUIDE.md'
+      - 'docs/LABELS.md'
+      - 'docs/CODEX_TOKEN_REFRESH.md'
+      - 'CLAUDE.md'
+      - '.gitattributes'
   workflow_dispatch:
     inputs:
       repos:
@@ -134,6 +166,10 @@ jobs:
           print(f"  - {len(manifest.get('codex_config', []))} codex configs")
           print(f"  - {len(manifest.get('actions', []))} actions")
           print(f"  - {len(manifest.get('docs', []))} docs")
+          print(f"  - {len(manifest.get('llm_config', []))} llm configs")
+          print(f"  - {len(manifest.get('git_config', []))} git configs")
+          print(f"  - {len(manifest.get('issue_templates', []))} issue templates")
+          print(f"  - {len(manifest.get('user_docs', []))} user docs")
           MANIFEST_SCRIPT
 
       - name: Compute template hash
@@ -515,6 +551,47 @@ jobs:
           # Process docs
           print("Processing docs...")
           for item in manifest.get('docs', []):
+              source = item.get('source', '')
+              target = item.get('target', source)
+              description = item.get('description', 'No description')
+              template_src = Path('workflows/templates/consumer-repo') / source
+              consumer_dst = Path('consumer') / target
+              sync_file(template_src, consumer_dst, description)
+
+          # Process llm_config
+          print("Processing llm config...")
+          for item in manifest.get('llm_config', []):
+              source = item.get('source', '')
+              description = item.get('description', 'No description')
+              sync_mode = item.get('sync_mode', 'sync')
+              template_src = Path('workflows/templates/consumer-repo') / source
+              consumer_dst = Path('consumer') / source
+              skip_fn = None
+              if sync_mode == 'create_only':
+                  skip_fn = lambda: consumer_dst.exists()
+              sync_file(template_src, consumer_dst, description, skip_fn)
+
+          # Process git_config
+          print("Processing git config...")
+          for item in manifest.get('git_config', []):
+              source = item.get('source', '')
+              description = item.get('description', 'No description')
+              template_src = Path('workflows/templates/consumer-repo') / source
+              consumer_dst = Path('consumer') / source
+              sync_file(template_src, consumer_dst, description)
+
+          # Process issue_templates
+          print("Processing issue templates...")
+          for item in manifest.get('issue_templates', []):
+              source = item.get('source', '')
+              description = item.get('description', 'No description')
+              template_src = Path('workflows/templates/consumer-repo') / source
+              consumer_dst = Path('consumer') / source
+              sync_file(template_src, consumer_dst, description)
+
+          # Process user_docs
+          print("Processing user docs...")
+          for item in manifest.get('user_docs', []):
               source = item.get('source', '')
               target = item.get('target', source)
               description = item.get('description', 'No description')

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -74,7 +74,20 @@ def main() -> int:
         return 1
 
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-    sections = ["workflows", "prompts", "scripts", "codex_config", "docs"]
+    sections = [
+        "workflows",
+        "prompts",
+        "scripts",
+        "codex_config",
+        "docs",
+        "copilot_config",
+        "templates",
+        "actions",
+        "llm_config",
+        "git_config",
+        "issue_templates",
+        "user_docs",
+    ]
 
     session = requests.Session()
     session.headers.update(


### PR DESCRIPTION
## Summary

Three root-cause problems that allowed consumer-repo drift, all fixed together:

### 1. Sync trigger paths too narrow
The `maint-68-sync-consumer-repos.yml` workflow only triggered on changes to `templates/consumer-repo/**` and the manifest file. But the manifest references sources from `.github/scripts/`, `scripts/`, `tools/`, `docs/`, `config/`, and more — changes to those files never triggered a sync.

**Fix:** Expanded `on.push.paths` to cover every directory referenced in the manifest. Since sync is idempotent (hash-compares files before creating PRs), extra triggers cost only ~30s of no-op CI when nothing changed.

### 2. Manifest missing entries
Comprehensive audit found **8 scripts** referenced by synced workflows but absent from the manifest:
- `bot-comment-handler.js` (used by 4 workflows)
- `autofix_emit_report.py`, `gate_summary.py`
- `injection_guard.py`, `progress_reviewer.py`, `verdict_extract.py`, `verdict_policy.py`
- `refine_tasks.md` prompt

Plus template files: `ISSUE_TEMPLATE/`, `model_registry.json`, `WORKFLOW_USER_GUIDE.md`, `CODEX_TOKEN_REFRESH.md`.

### 3. Unprocessed manifest categories
`llm_config` and `git_config` were declared in the manifest but had **zero processing code** in the sync workflow — `config/llm_slots.json` and `.gitattributes` were silently skipped. Added processing sections for:
- `llm_config` (with `create_only`/`sync_mode` support)
- `git_config`
- `issue_templates` (new category)
- `user_docs` (new category)

Also updated drift-check script (`check_consumer_sync_drift.py`) to include all new categories.

## Files changed
- `.github/workflows/maint-68-sync-consumer-repos.yml` — trigger paths + 4 new processing sections
- `.github/sync-manifest.yml` — 12+ new entries across multiple categories
- `scripts/check_consumer_sync_drift.py` — expanded sections list

## Testing
- All manifest source files verified to exist on disk
- YAML and Python syntax validated
- Pre-commit hooks pass (black, ruff, mypy, workflow validation)