### PR TITLE
fix(sync): use git add --force to bypass consumer .gitignore

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -736,7 +736,9 @@ jobs:
 
           # Create branch and commit
           git checkout -b "$branch_name"
-          git add -A
+          # Use --force so consumer .gitignore rules (e.g. *.txt) cannot
+          # silently exclude files that the sync manifest declares.
+          git add --force -A
 
           if git diff --cached --quiet; then
             echo "No changes to commit after sync; skipping PR creation."


### PR DESCRIPTION
## Why

TMP's `.gitignore` has a blanket `*.txt` rule that silently excluded `tools/requirements-llm.txt` from sync commits. The sync script wrote the file correctly via `shutil.copy2()`, but `git add -A` respected the consumer's `.gitignore` and skipped it. This caused **all auto-pilot runs in TMP to fail** after PR #4874 was merged.

## Root Cause Chain

1. **PR #1453** (Workflows) replaced floating `pip install langchain ...` with `pip install -r tools/requirements-llm.txt`
2. **PR #1456** (Workflows) added `tools/requirements-llm.txt` to sync manifest + template
3. **Sync PR #4874** (TMP) delivered the updated workflow but NOT the requirements file
4. `*.txt` in TMP's `.gitignore` → `git add -A` silently excluded the file

## Fix

Replace `git add -A` with `git add --force -A` in the sync commit step. This ensures all manifest-declared files are committed regardless of consumer repo gitignore rules.

## Companion PR

- TMP: stranske/Trend_Model_Project#4877 (adds gitignore negation + the missing file)