### PR TITLE
fix(maint-71): stop github-script core redeclare

### DIFF
--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -116,9 +116,8 @@ jobs:
                   paginateWithRetry: (githubInstance, method, params) =>
                     githubInstance.paginate(method, params),
                 };
-            const core = require('@actions/core');
             const { createTokenAwareRetry } = retryHelpers;
-            const { github: api, withRetry } = createTokenAwareRetry
+            const { withRetry } = createTokenAwareRetry
               ? await createTokenAwareRetry({
                   github,
                   core,


### PR DESCRIPTION
Fixes Merge Sync PRs failure on main: actions/github-script already provides core in scope, and the workflow redeclared it, causing SyntaxError: Identifier core has already been declared. This removes the redeclare and drops an unused variable.