### PR TITLE
fix: make agents-80 pr-event-hub workflow valid

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -167,53 +167,47 @@ jobs:
       pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
     secrets: inherit
 
-  handlers:
-    name: Run PR handlers
+  pr_meta:
+    name: PR meta handler
     needs: [resolve, pr_context]
     if: |
       needs.resolve.outputs.pr_number != '' &&
-      (needs.resolve.outputs.run_pr_meta == 'true' ||
-       needs.resolve.outputs.run_bot_comments == 'true')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        handler: [pr-meta, bot-comments]
-    steps:
-      - name: PR meta handler
-        if: matrix.handler == 'pr-meta' && needs.resolve.outputs.run_pr_meta == 'true'
-        uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
-        with:
-          pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
-          comment_id: ${{ needs.resolve.outputs.comment_id }}
-          comment_body: ${{ needs.resolve.outputs.comment_body }}
-          event_name: ${{ needs.resolve.outputs.event_name }}
-          event_action: ${{ needs.resolve.outputs.event_action }}
-          allowed_keepalive_logins: ${{ vars.ALLOWED_KEEPALIVE_LOGINS }}
-          allow_replay: ${{ needs.resolve.outputs.event_name == 'workflow_run' }}
-          dry_run: ${{ needs.resolve.outputs.debug == 'true' }}
-        secrets: inherit
+      needs.resolve.outputs.run_pr_meta == 'true'
+    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    with:
+      pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
+      comment_id: ${{ needs.resolve.outputs.comment_id }}
+      comment_body: ${{ needs.resolve.outputs.comment_body }}
+      event_name: ${{ needs.resolve.outputs.event_name }}
+      event_action: ${{ needs.resolve.outputs.event_action }}
+      allowed_keepalive_logins: ${{ vars.ALLOWED_KEEPALIVE_LOGINS }}
+      allow_replay: ${{ needs.resolve.outputs.event_name == 'workflow_run' }}
+      dry_run: ${{ needs.resolve.outputs.debug == 'true' }}
+    secrets: inherit
 
-      - name: Bot comment handler
-        if: |
-          matrix.handler == 'bot-comments' &&
-          needs.resolve.outputs.run_bot_comments == 'true' &&
-          (
-            needs.resolve.outputs.event_name != 'workflow_run' ||
-            (needs.resolve.outputs.gate_conclusion == 'success' &&
-             needs.pr_context.outputs.has_agent_label == 'true')
-          )
-        uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
-        with:
-          pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
-          dry_run: ${{ needs.resolve.outputs.dry_run == 'true' }}
-        secrets:
-          service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
-          gh_app_id: ${{ secrets.GH_APP_ID }}
-          gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+  bot_comments:
+    name: Bot comment handler
+    needs: [resolve, pr_context]
+    if: |
+      needs.resolve.outputs.pr_number != '' &&
+      needs.resolve.outputs.run_bot_comments == 'true' &&
+      (
+        needs.resolve.outputs.event_name != 'workflow_run' ||
+        (needs.resolve.outputs.gate_conclusion == 'success' &&
+         needs.pr_context.outputs.has_agent_label == 'true')
+      )
+    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    with:
+      pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
+      dry_run: ${{ needs.resolve.outputs.dry_run == 'true' }}
+    secrets:
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      gh_app_id: ${{ secrets.GH_APP_ID }}
+      gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   cleanup_bot_comment_label:
     name: Cleanup bot comment label
-    needs: [resolve, handlers]
+    needs: [resolve, bot_comments]
     if: |
       always() &&
       needs.resolve.outputs.run_bot_comments == 'true' &&


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #84

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- [ ] Context / problem:
- [ ] - Current orchestration depends on PATs and/or mixed identities, which is fragile and painful to maintain.
- [ ] - GitHub Actions has recursion protection: pushes/labels/comments made with GITHUB_TOKEN generally will NOT trigger other workflows.
- [ ] - A GitHub App installation token is the cleanest way to get predictable “workflow triggers workflow” behavior without tying everything to a human PAT.
- [ ] Goal:
- [ ] - Create a GitHub App (single org/user app) that can be installed on your repos.
- [ ] - Mint short-lived installation tokens inside workflows.
- [ ] - Replace all PAT usage in orchestrator + keepalive + dispatch workflows with the App token.

#### Tasks
- [ ] Create GitHub App (UI, not code): name it "agents-workflows-bot" (or similar)
- [ ] Set App permissions (minimal but sufficient):
- [ ] Contents: Read & write
- [ ] Pull requests: Read & write
- [ ] Issues: Read & write
- [ ] Actions: Read & write (for dispatching / reading runs)
- [ ] Metadata: Read-only
- [ ] Install the App on: Workflows, Workflows-Integration-Tests, Travel-Plan-Permission, Portable-Alpha-Extension-Model, Trend_Model_Project
- [ ] Add secrets to Workflows repo (or org secrets):
- [ ] WORKFLOWS_APP_ID
- [ ] WORKFLOWS_APP_PRIVATE_KEY  (the PEM contents)
- [ ] Update all workflows that currently use PATs to: mint app token export GH_TOKEN to that token
- [ ] (optional) checkout using that token so git push is clean
- [ ] Add a “compat mode” fallback (temporarily) so you can flip back to PAT if needed during rollout

#### Acceptance criteria
- [ ] - No workflow in Workflows repo requires a PAT for:
- [ ] - labeling PRs/issues
- [ ] - creating comments
- [ ] - pushing commits to PR branches
- [ ] - dispatching workflows
- [ ] - A commit pushed by the bot identity reliably triggers the Gate workflow (no “dead loop”).
- [ ] - Secrets inventory is reduced: only App ID + private key (and OPENAI_API_KEY) are required for the automation system.
- [ ] Rollout / safety:
- [ ] - Roll out in Workflows-Integration-Tests first, then Workflows, then consumer repos.
- [ ] - Add CODEOWNERS for .github/workflows/** and .github/scripts/** so this can’t get silently corrupted later.

- [ ] **Head SHA:** cee233294fe0bd6851679f2eb5dcb2df8c83eb72
- [ ] **Latest Runs:** ✅ success — Gate
- [ ] **Required:** gate: ✅ success

- [ ] | Workflow / Job | Result | Logs |
- [ ] |----------------|--------|------|
- [ ] | Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20482590168) |
- [ ] | CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482560003) |
- [ ] | Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/20482560086) |
- [ ] | Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482560001) |
- [ ] | Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482560036) |
- [ ] | Health 44 Gate Branch Protection | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/20482559943) |
- [ ] | Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482559940) |
- [ ] | Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482559963) |
- [ ] | Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482559959) |
- [ ] | PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482559941) |
- [ ] | Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/20482559971) |

**Head SHA:** 62f64e8bb6a8495abd5bef35dcc58a907214064d
**Latest Runs:** ❔ in progress — Agents PR meta manager
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/22006905280) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/22006247517) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22006249930) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22006247476) |
<!-- auto-status-summary:end -->