### PR TITLE
Fix langchain HumanMessage import to satisfy consumer Ruff

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -988,9 +988,11 @@ def _invoke_llm(
 ) -> str:
     """Invoke LLM and return response text."""
     try:
-        from langchain_core.messages import HumanMessage
+        import langchain_core.messages as lc_messages
     except ModuleNotFoundError:
-        HumanMessage = None  # type: ignore[assignment]
+        human_message_cls = None
+    else:
+        human_message_cls = lc_messages.HumanMessage
 
     config = _build_llm_config(
         operation=operation,
@@ -1027,8 +1029,8 @@ def _invoke_llm(
             return json.dumps(content, ensure_ascii=False, sort_keys=True)
         return str(content)
 
-    if HumanMessage is not None:
-        messages: list[Any] = [HumanMessage(content=prompt)]
+    if human_message_cls is not None:
+        messages: list[Any] = [human_message_cls(content=prompt)]
         try:
             response = client.invoke(messages, config=config)
         except TypeError as exc:


### PR DESCRIPTION
Some consumer repos enable Ruff N806 in a way that flags CamelCase names imported inside functions as local variables (e.g., `HumanMessage`).

This changes `_invoke_llm` in `scripts/langchain/followup_issue_generator.py` to import `langchain_core.messages` as a lowercase module and reference `lc_messages.HumanMessage`, avoiding N806/N813 issues while preserving behavior.

Follow-up: a future template sync should eliminate the need for manual consumer hotfix commits.
