### PR TITLE
CI: honor autofix-versions.env with requirements.lock

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -835,7 +835,8 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
-          if [ -f "$autofix_env" ] && [ "$has_lock_file" = "false" ]; then
+          # Always honor tool pins when present. Lock files typically only capture runtime deps.
+          if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
             black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
@@ -1138,7 +1139,8 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
-          if [ -f "$autofix_env" ] && [ "$has_lock_file" = "false" ]; then
+          # Always honor tool pins when present. Lock files typically only capture runtime deps.
+          if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
             black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")
@@ -1482,7 +1484,8 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
-          if [ -f "$autofix_env" ] && [ "$has_lock_file" = "false" ]; then
+          # Always honor tool pins when present. Lock files typically only capture runtime deps.
+          if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
             source "$autofix_env"
             black_spec=$(resolve_spec "black" "${BLACK_VERSION:-}" "")


### PR DESCRIPTION
Fixes a recurring CI drift where reusable Python CI ignored .github/workflows/autofix-versions.env whenever requirements.lock was present.

Root cause: the reusable workflow only sourced autofix-versions.env when no lockfile existed, but lockfiles typically do not include dev tools like Black/Ruff.

Change: always honor autofix-versions.env when present, regardless of requirements.lock.