### PR TITLE
Fix sync PR CI blockers

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -463,6 +463,7 @@ jobs:
           WORKDIR: ${{ inputs['working-directory'] || '.' }}
           INPUT_LINT: ${{ inputs.lint }}
           INPUT_FORMAT_CHECK: ${{ inputs.format_check }}
+          INPUT_INSTALL_PROJECT_DEPS: 'false'
           INPUT_TYPECHECK: 'false'
           INPUT_RUN_MYPY: 'false'
           INPUT_COVERAGE: 'false'
@@ -488,6 +489,7 @@ jobs:
           typecheck_enabled=$(to_bool "$INPUT_TYPECHECK")
           run_mypy_enabled=$(to_bool "$INPUT_RUN_MYPY")
           coverage_enabled=$(to_bool "$INPUT_COVERAGE")
+          install_project_deps=$(to_bool "${INPUT_INSTALL_PROJECT_DEPS:-true}")
           mypy_enabled="false"
           if [ "$typecheck_enabled" = "true" ] && [ "$run_mypy_enabled" = "true" ]; then
             mypy_enabled="true"
@@ -512,13 +514,18 @@ jobs:
           has_lock_file=false
           if [ -f requirements.lock ]; then
             has_lock_file=true
-            specs+=('-r' 'requirements.lock')
           fi
 
-          if [ -f pyproject.toml ]; then
-            specs+=('-e' '.[app,dev]')
-          elif [ -f setup.cfg ] || [ -f setup.py ]; then
-            specs+=('-e' '.[app,dev]')
+          if [ "$install_project_deps" = "true" ]; then
+            if [ -f requirements.lock ]; then
+              specs+=('-r' 'requirements.lock')
+            fi
+
+            if [ -f pyproject.toml ]; then
+              specs+=('-e' '.[app,dev]')
+            elif [ -f setup.cfg ] || [ -f setup.py ]; then
+              specs+=('-e' '.[app,dev]')
+            fi
           fi
 
           black_spec="black"
@@ -751,6 +758,7 @@ jobs:
           WORKDIR: ${{ inputs['working-directory'] || '.' }}
           INPUT_LINT: ${{ inputs.lint }}
           INPUT_FORMAT_CHECK: 'false'
+          INPUT_INSTALL_PROJECT_DEPS: 'false'
           INPUT_TYPECHECK: 'false'
           INPUT_RUN_MYPY: 'false'
           INPUT_COVERAGE: 'false'
@@ -776,6 +784,7 @@ jobs:
           typecheck_enabled=$(to_bool "$INPUT_TYPECHECK")
           run_mypy_enabled=$(to_bool "$INPUT_RUN_MYPY")
           coverage_enabled=$(to_bool "$INPUT_COVERAGE")
+          install_project_deps=$(to_bool "${INPUT_INSTALL_PROJECT_DEPS:-true}")
           mypy_enabled="false"
           if [ "$typecheck_enabled" = "true" ] && [ "$run_mypy_enabled" = "true" ]; then
             mypy_enabled="true"
@@ -800,13 +809,18 @@ jobs:
           has_lock_file=false
           if [ -f requirements.lock ]; then
             has_lock_file=true
-            specs+=('-r' 'requirements.lock')
           fi
 
-          if [ -f pyproject.toml ]; then
-            specs+=('-e' '.[app,dev]')
-          elif [ -f setup.cfg ] || [ -f setup.py ]; then
-            specs+=('-e' '.[app,dev]')
+          if [ "$install_project_deps" = "true" ]; then
+            if [ -f requirements.lock ]; then
+              specs+=('-r' 'requirements.lock')
+            fi
+
+            if [ -f pyproject.toml ]; then
+              specs+=('-e' '.[app,dev]')
+            elif [ -f setup.cfg ] || [ -f setup.py ]; then
+              specs+=('-e' '.[app,dev]')
+            fi
           fi
 
           black_spec="black"

--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -302,10 +302,10 @@ llm-has-completions: "false"
 
 ## See Also
 
-- [Provider-Agnostic Coding Agents Plan](../plans/provider-agnostic-coding-agents.md)
-- [Agent Registry Schema](.github/agents/registry.yml)
-- [Keepalive Goals and Plumbing](../keepalive/GoalsAndPlumbing.md)
-- [Multi-Agent Routing Architecture](../keepalive/MULTI_AGENT_ROUTING.md)
+- [Provider-Agnostic Coding Agents Plan](https://github.com/stranske/Workflows/blob/main/docs/plans/provider-agnostic-coding-agents.md)
+- [Agent Registry Schema](../../.github/agents/registry.yml)
+- [Keepalive Goals and Plumbing](https://github.com/stranske/Workflows/blob/main/docs/keepalive/GoalsAndPlumbing.md)
+- [Multi-Agent Routing Architecture](https://github.com/stranske/Workflows/blob/main/docs/keepalive/MULTI_AGENT_ROUTING.md)
 
 ---
 

--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -31,11 +31,13 @@ def _resolve_chat_prompt_template() -> Any | None:
         return ChatPromptTemplate
 
     try:  # pragma: no cover - exercised indirectly
-        from langchain_core.prompts import ChatPromptTemplate as imported
+        from langchain_core.prompts import (
+            ChatPromptTemplate as ImportedChatPromptTemplate,
+        )
     except ImportError:  # pragma: no cover - handled by caller
         return None
 
-    return imported
+    return ImportedChatPromptTemplate
 
 
 AGENT_CAPABILITY_CHECK_PROMPT = """

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -6,6 +6,8 @@ Run with:
     python scripts/langchain/issue_optimizer.py --input-file issue.md --json
 """
 
+# ruff: noqa: I001
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -6,6 +6,8 @@ Run with:
     python scripts/langchain/pr_verifier.py --context-file verifier-context.md --json
 """
 
+# ruff: noqa: I001
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
Fixes sync PR merge blockers by: (1) removing ruff N813 alias issue in scripts/langchain/capability_check.py; (2) making docs/contracts/agent-runner-output.md links resolvable in consumer repos; (3) preventing lint jobs in reusable-10-ci-python.yml from installing project deps (avoids ruff version conflicts); and (4) adding narrow I001 ignores for shared langchain scripts to avoid consumer isort config drift.