### PR TITLE
ci: allow claude review on bot PRs

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -80,6 +80,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
           plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           prompt: >-


### PR DESCRIPTION
Fixes claude-review failures on bot-opened PRs (e.g. auto/sync-action-versions) where anthropics/claude-code-action aborts with: 'Workflow initiated by non-human actor...'.

Change: pass allowed_bots: '*' to the action so the step can run (still non-blocking via continue-on-error).