### PR TITLE
ci: fix maint sync action versions vars

### DIFF
--- a/.github/workflows/maint-sync-action-versions.yml
+++ b/.github/workflows/maint-sync-action-versions.yml
@@ -87,14 +87,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          CHECKOUT_VERSION="${{ steps.extract.outputs.checkout }}"
-          GITHUB_SCRIPT_VERSION="${{ steps.extract.outputs.github_script }}"
-          UPLOAD_ARTIFACT_VERSION="${{ steps.extract.outputs.upload_artifact }}"
-          DOWNLOAD_ARTIFACT_VERSION="${{ steps.extract.outputs.download_artifact }}"
-          CACHE_VERSION="${{ steps.extract.outputs.cache }}"
-
-          export CHECKOUT_VERSION GITHUB_SCRIPT_VERSION UPLOAD_ARTIFACT_VERSION \
-            DOWNLOAD_ARTIFACT_VERSION CACHE_VERSION
+          checkout="${{ steps.extract.outputs.checkout }}"
+          github_script="${{ steps.extract.outputs.github_script }}"
+          upload_artifact="${{ steps.extract.outputs.upload_artifact }}"
+          download_artifact="${{ steps.extract.outputs.download_artifact }}"
+          cache="${{ steps.extract.outputs.cache }}"
 
           # Update all YAML files in templates/ (using find -exec for SC2044)
           find templates/ -name "*.yml" -type f -exec sh -c '


### PR DESCRIPTION
Fix maint-sync-action-versions.yml failure: the update step exported CHECKOUT_VERSION etc but passed lowercase //... to the sh helper under set -u.

This makes the workflow succeed again so we can regenerate a single fresh sync PR and close the stale duplicates.