### PR TITLE
fix(phase4): verifier + follow-up chain use registry defaults

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -338,7 +338,13 @@ jobs:
                 };
             const { withRetry } = retryHelpers;
 
-            let agentKey = 'codex';
+            // Resolve agent from PR labels; fall back to registry default
+            let _defaultAgent = 'codex';
+            try {
+              const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
+              _defaultAgent = loadAgentRegistry('./.github/agents/registry.yml').default_agent || 'codex';
+            } catch (_) {}
+            let agentKey = _defaultAgent;
             try {
               const { resolveAgentFromLabels } = require('./.github/scripts/agent_registry.js');
               const prLabels = context.payload.pull_request?.labels || [];
@@ -347,11 +353,11 @@ jobs:
               });
             } catch (err) {
               core.warning(
-                `Failed to resolve agent from PR labels; defaulting to codex: ${err.message}`
+                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ${err.message}`
               );
-              agentKey = 'codex';
+              agentKey = _defaultAgent;
             }
-            const normalized = String(agentKey || 'codex').trim().toLowerCase() || 'codex';
+            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             const agentLabel = `agent:${normalized}`;
             const fromLabel = `from:${normalized}`;
 

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -738,7 +738,13 @@ jobs:
               return;
             }
 
-            let agentKey = 'codex';
+            // Resolve agent from PR labels; fall back to registry default
+            let _defaultAgent = 'codex';
+            try {
+              const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
+              _defaultAgent = loadAgentRegistry('./.github/agents/registry.yml').default_agent || 'codex';
+            } catch (_) {}
+            let agentKey = _defaultAgent;
             try {
               const { resolveAgentFromLabels } = require('./.github/scripts/agent_registry.js');
               const labels =
@@ -748,11 +754,11 @@ jobs:
               });
             } catch (err) {
               core.warning(
-                `Failed to resolve agent from PR labels; defaulting to codex: ${err.message}`
+                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ${err.message}`
               );
-              agentKey = 'codex';
+              agentKey = _defaultAgent;
             }
-            const normalized = String(agentKey || 'codex').trim().toLowerCase() || 'codex';
+            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             const agentLabel = `agent:${normalized}`;
             const fromLabel = `from:${normalized}`;
 

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -3,7 +3,7 @@
 #
 # This workflow:
 # 1. Builds context from merged PR and linked issues
-# 2. Runs Codex in verifier mode to check acceptance criteria
+# 2. Runs the agent verifier to check acceptance criteria
 # 3. Opens a follow-up issue if criteria weren't met
 name: Reusable Agents Verifier
 
@@ -307,7 +307,13 @@ jobs:
             const registryPath = './.workflows-lib/.github/agents/registry.yml';
             const resolverPath = './.workflows-lib/.github/scripts/agent_registry.js';
 
-            let agentKey = 'codex';
+            // Resolve agent from PR labels; fall back to registry default
+            let _defaultAgent = 'codex';
+            try {
+              const { loadAgentRegistry } = require(resolverPath);
+              _defaultAgent = loadAgentRegistry({ registryPath }).default_agent || 'codex';
+            } catch (_) {}
+            let agentKey = _defaultAgent;
             try {
               const { resolveAgentFromLabels } = require(resolverPath);
               const rawPrNumber = Number('${{ steps.context.outputs.pr_number }}');
@@ -326,14 +332,14 @@ jobs:
             } catch (err) {
                 core.warning(
                   [
-                    'Failed to resolve agent from PR labels; defaulting to codex:',
+                    `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}:`,
                     err.message,
                   ].join(' '),
                 );
-              agentKey = 'codex';
+              agentKey = _defaultAgent;
             }
 
-            const normalized = String(agentKey || 'codex').trim().toLowerCase() || 'codex';
+            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             core.setOutput('agent_key', normalized);
             core.setOutput('agent_label', `agent:${normalized}`);
             core.setOutput('from_label', `from:${normalized}`);
@@ -990,10 +996,12 @@ jobs:
             const prUrl = process.env.PR_URL || '';
             const runUrl = process.env.RUN_URL || '';
 
-            const agentLabel = '${{ steps.agent.outputs.agent_label }}' || 'agent:codex';
-            const fromLabel = '${{ steps.agent.outputs.from_label }}' || 'from:codex';
+            // Agent labels resolved in the 'agent' step; derive from agent_key if label output missing
+            const agentKey = '${{ steps.agent.outputs.agent_key }}' || 'codex';
+            const agentLabel = '${{ steps.agent.outputs.agent_label }}' || `agent:${agentKey}`;
+            const fromLabel = '${{ steps.agent.outputs.from_label }}' || `from:${agentKey}`;
 
-            // Handle Codex crash/error case
+            // Handle agent crash/error case
             if (verdict === 'error') {
               const title = prNumber
                 ? `[Verifier Error] PR #${prNumber} verification failed`

--- a/docs/plans/provider-agnostic-coding-agents.md
+++ b/docs/plans/provider-agnostic-coding-agents.md
@@ -8,7 +8,7 @@
 - ✅ Phase 1 — Agent registry + resolver helper
 - ✅ Phase 2 — Registry-driven PR automation routing (keepalive/autofix done; bot-comment uses registry; `reusable-16-agents`/`reusable-pr-context` widened)
 - ✅ Phase 3 — Registry-driven issue→PR path (belt 71/72/73 refactored; auto-pilot/auto-label/orchestrators fixed; issue bridge assignees use registry; `agents_belt_scan.js` generalized; all backing scripts use registry-driven defaults; **API contracts preserved**)
-- ⚠️ Phase 4 — Verifier + follow-up chain (reusable verifier done; verify-assignment generalized; **verify-to-issue text cosmetic only**)
+- ✅ Phase 4 — Verifier + follow-up chain (verifier/verify-to-issue/verify-to-new-pr all use registry-driven defaults; verify-assignment generalized; **Codex CLI runner section intentionally unchanged**)
 - 🟡 Phase 5 — Delegation / re-routing between agents (5A mostly complete: keepalive-loop + gate-followups both have run-claude; `agent:auto` label semantics established)
 
 ### Scripts refactored (Feb 18, session 2)


### PR DESCRIPTION
## Summary
- Update `reusable-agents-verifier.yml`, `agents-verify-to-issue-v2.yml`, and `agents-verify-to-new-pr.yml` to resolve agent key from the registry instead of hardcoding `'codex'` fallbacks
- Verifier description updated from "Runs Codex in verifier mode" to "Runs the agent verifier"
- Fallback labels in follow-up issue creation now use registry-driven agent key
- Codex CLI runner section (install, auth, `codex exec`) intentionally unchanged — it is the actual Codex verifier implementation

## Test plan
- [x] JS tests pass locally (agent-registry, keepalive-contract, agents-belt-scan)
- [x] Python bootstrap tests pass locally (test_bootstrap_requires_single_label, test_bootstrap_step_defaults_label_when_missing)
- [ ] CI checks pass

https://claude.ai/code/session_01JLX4faT4ts5VGuheq6s7NE