### PR TITLE
fix: setup workflows deps before keepalive install

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -280,13 +280,6 @@ jobs:
             scripts
           token: ${{ steps.auth_token.outputs.checkout_token }}
 
-      - name: Setup Workflows API client
-        uses: ./.github/actions/setup-api-client
-        with:
-          secrets: ${{ toJSON(secrets) }}
-          github_token: ${{ github.token }}
-          install_dir: ${{ github.workspace }}/.workflows-lib/.github/scripts
-
       - name: Ensure Workflows script deps
         run: |
           set -euo pipefail
@@ -351,6 +344,13 @@ jobs:
               @octokit/auth-app@6.0.3
             popd >/dev/null
           fi
+
+      - name: Setup Workflows API client
+        uses: ./.github/actions/setup-api-client
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          github_token: ${{ github.token }}
+          install_dir: ${{ github.workspace }}/.workflows-lib/.github/scripts
 
       - name: Validate workflows tooling
         run: |


### PR DESCRIPTION
## Summary
- move the reusable Codex run step that installs API client deps for `.workflows-lib` until after we ensure the vendored node_modules directory exists
- this keeps the `file:node_modules/...` alias path valid so npm no longer fails trying to load `.github/scripts/minimatch/package.json`

## Testing
- not run (workflow-only change)
