### PR TITLE
sync: include vendored alias helper in templates

### DIFF
--- a/templates/consumer-repo/.github/actions/setup-api-client/action.yml
+++ b/templates/consumer-repo/.github/actions/setup-api-client/action.yml
@@ -94,16 +94,23 @@ runs:
         declare -a VENDORED_ALIAS_DIRS=()
 
         cleanup_vendor_aliases() {
-          if [ "${#VENDORED_ALIAS_DIRS[@]}" -gt 0 ]; then
-            for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
-              rm -rf "$vendored_alias" || true
-              local parent
-              parent=$(dirname "$vendored_alias")
-              if [ "$parent" != "." ]; then
-                rmdir "$parent" 2>/dev/null || true
-              fi
-            done
+          if [ "${#VENDORED_ALIAS_DIRS[@]}" -eq 0 ]; then
+            return 0
           fi
+
+          for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
+            if [ -z "$vendored_alias" ]; then
+              continue
+            fi
+            rm -rf "$vendored_alias" || true
+            local parent_dir
+            parent_dir=$(dirname "$vendored_alias")
+            # Remove empty parent directories that may have been created for scoped packages
+            while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
+              rmdir "$parent_dir" 2>/dev/null || break
+              parent_dir=$(dirname "$parent_dir")
+            done
+          done
         }
 
         trap cleanup_vendor_aliases EXIT
@@ -113,31 +120,33 @@ runs:
             return 0
           fi
 
-          local aliases=()
-          mapfile -t aliases < <(
-            node -e 'const fs=require("fs");const path=require("path");const pkgPath=path.resolve("package.json");if(!fs.existsSync(pkgPath)){process.exit(0);}const pkg=JSON.parse(fs.readFileSync(pkgPath,"utf8"));const sections=[pkg.dependencies||{},pkg.devDependencies||{}];const seen=new Set();for(const section of sections){for(const spec of Object.values(section)){if(typeof spec==="string"&&spec.startsWith("file:node_modules/")){const trimmed=spec.slice("file:node_modules/".length).replace(/\/+$/,"");if(trimmed){seen.add(trimmed);}}}}process.stdout.write(Array.from(seen).join("\n"));'
-          )
+          local alias_tmp
+          alias_tmp=$(mktemp)
 
-          for vendored_alias in "${aliases[@]}"; do
+          local helper_root="${GITHUB_ACTION_PATH:-${GITHUB_WORKSPACE}/.github/actions/setup-api-client}"
+          local alias_helper="${helper_root}/create_vendor_aliases.js"
+          if [ ! -f "$alias_helper" ]; then
+            echo "::error::Missing vendored alias helper: $alias_helper"
+            rm -f "$alias_tmp"
+            return 1
+          fi
+
+          if node "$alias_helper" "$INSTALL_DIR" >"$alias_tmp"; then
+            :
+          else
+            echo "::warning::Failed to prepare vendored dependency aliases"
+            rm -f "$alias_tmp"
+            return 1
+          fi
+
+          while IFS= read -r vendored_alias; do
             if [ -z "$vendored_alias" ]; then
               continue
             fi
-            local source_path="node_modules/${vendored_alias}"
-            if [ ! -d "$source_path" ]; then
-              continue
-            fi
-            if [ -e "$vendored_alias" ]; then
-              continue
-            fi
-            local parent_dir
-            parent_dir=$(dirname "$vendored_alias")
-            if [ "$parent_dir" != "." ]; then
-              mkdir -p "$parent_dir"
-            fi
-            rm -rf "$vendored_alias" || true
-            cp -R "$source_path" "$vendored_alias"
             VENDORED_ALIAS_DIRS+=("$vendored_alias")
-          done
+          done <"$alias_tmp"
+
+          rm -f "$alias_tmp"
         }
 
         create_vendor_aliases
@@ -176,22 +185,23 @@ runs:
           # Install with pinned versions for consistency
           # Capture stderr for debugging if the command fails
           npm_output=$(mktemp)
-          if npm install --no-save --location=project \
+          npm_cmd=(npm install --no-save --location=project \
             @octokit/rest@20.0.2 \
             @octokit/plugin-retry@6.0.1 \
             @octokit/plugin-paginate-rest@9.1.5 \
-            @octokit/auth-app@6.0.3 \
-            2>"$npm_output"; then
+            @octokit/auth-app@6.0.3)
+          if "${npm_cmd[@]}" 2>"$npm_output"; then
             rm -f "$npm_output"
           else
             echo "::warning::npm install failed with: $(cat "$npm_output")"
             echo "::warning::Retrying with --legacy-peer-deps"
             rm -f "$npm_output"
-            npm install --no-save --legacy-peer-deps --location=project \
+            npm_cmd=(npm install --no-save --legacy-peer-deps --location=project \
               @octokit/rest@20.0.2 \
               @octokit/plugin-retry@6.0.1 \
               @octokit/plugin-paginate-rest@9.1.5 \
-              @octokit/auth-app@6.0.3
+              @octokit/auth-app@6.0.3)
+            "${npm_cmd[@]}"
           fi
 
           # Restore vendored package metadata that npm may have overwritten
@@ -212,7 +222,6 @@ runs:
 
         cleanup_vendor_aliases
         trap - EXIT
-
     - name: Export NODE_PATH for shared deps
       shell: bash
       run: |

--- a/templates/consumer-repo/.github/actions/setup-api-client/create_vendor_aliases.js
+++ b/templates/consumer-repo/.github/actions/setup-api-client/create_vendor_aliases.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const installDirArg = process.argv[2];
+
+if (!installDirArg) {
+  console.error('Usage: create_vendor_aliases.js <install_dir>');
+  process.exit(1);
+}
+
+const installDir = path.resolve(installDirArg);
+const pkgPath = path.join(installDir, 'package.json');
+
+if (!fs.existsSync(pkgPath)) {
+  process.exit(0);
+}
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const sections = [pkg.dependencies || {}, pkg.devDependencies || {}];
+const seen = new Set();
+
+for (const section of sections) {
+  for (const spec of Object.values(section)) {
+    if (typeof spec === 'string' && spec.startsWith('file:node_modules/')) {
+      const trimmed = spec.slice('file:node_modules/'.length).replace(/\/+$/, '');
+      if (trimmed) {
+        seen.add(trimmed);
+      }
+    }
+  }
+}
+
+const sanitize = (value) => {
+  if (typeof value !== 'string') {
+    throw new Error('Vendored alias must be a string');
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error('Vendored alias cannot be empty');
+  }
+  if (normalized.startsWith('/') || normalized.startsWith('./') || normalized.startsWith('../')) {
+    throw new Error(`Vendored alias must be relative: "${normalized}"`);
+  }
+  if (normalized.includes('\\')) {
+    throw new Error(`Vendored alias must not contain backslashes: "${normalized}"`);
+  }
+
+  const segments = normalized.split('/');
+  if (segments[0].startsWith('@')) {
+    if (!/^@[A-Za-z0-9._-]+$/.test(segments[0])) {
+      throw new Error(`Invalid scope in vendored alias: "${normalized}"`);
+    }
+    if (segments.length < 2) {
+      throw new Error(`Scoped vendored alias must include a package name: "${normalized}"`);
+    }
+  }
+
+  const segmentPattern = /^[A-Za-z0-9._-]+$/;
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (!segment || segment === '.' || segment === '..') {
+      throw new Error(`Invalid path segment "${segment}" in "${normalized}"`);
+    }
+    if (segment.startsWith('@')) {
+      if (i !== 0 || !/^@[A-Za-z0-9._-]+$/.test(segment)) {
+        throw new Error(`Invalid scope segment "${segment}" in "${normalized}"`);
+      }
+      continue;
+    }
+    if (!segmentPattern.test(segment)) {
+      throw new Error(`Vendored alias segment "${segment}" contains invalid characters in "${normalized}"`);
+    }
+  }
+
+  return segments.join('/');
+};
+
+const created = [];
+for (const alias of seen) {
+  const sanitized = sanitize(alias);
+  const source = path.join(installDir, 'node_modules', sanitized);
+  if (!fs.existsSync(source)) {
+    console.warn(`::warning::Vendored dependency not found: ${sanitized}`);
+    continue;
+  }
+  const destination = path.join(installDir, sanitized);
+  const normalizedDestination = path.normalize(destination);
+  if (!normalizedDestination.startsWith(installDir + path.sep) && normalizedDestination !== installDir) {
+    throw new Error(`Resolved vendored alias outside install dir: "${sanitized}"`);
+  }
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.cpSync(source, destination, { recursive: true });
+  created.push(sanitized);
+}
+
+process.stdout.write(created.join('\n'));


### PR DESCRIPTION
## Summary
- copy the updated setup-api-client action and helper into templates/consumer-repo so sync PRs receive the vendored alias script
- keep the helper executable so npm install runs with sanitized aliases

## Testing
- python - <<'PY' ... yaml.safe_load('templates/consumer-repo/.github/actions/setup-api-client/action.yml') ...