### PR TITLE
fix: harden vendored alias cleanup

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -98,19 +98,28 @@ runs:
             return 0
           fi
 
-          for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
-            if [ -z "$vendored_alias" ]; then
-              continue
-            fi
-            rm -rf "$vendored_alias" || true
-            local parent_dir
-            parent_dir=$(dirname "$vendored_alias")
-            # Remove empty parent directories that may have been created for scoped packages
-            while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
-              rmdir "$parent_dir" 2>/dev/null || break
-              parent_dir=$(dirname "$parent_dir")
+          local cleanup_dir="$INSTALL_DIR"
+          if [ -z "$cleanup_dir" ]; then
+            echo "::warning::Install dir is empty, skipping vendored alias cleanup"
+            return 0
+          fi
+
+          (
+            cd "$cleanup_dir" 2>/dev/null || exit 0
+            for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
+              if [ -z "$vendored_alias" ]; then
+                continue
+              fi
+              rm -rf "$vendored_alias" || true
+              local parent_dir
+              parent_dir=$(dirname "$vendored_alias")
+              # Remove empty parent directories that may have been created for scoped packages
+              while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
+                rmdir "$parent_dir" 2>/dev/null || break
+                parent_dir=$(dirname "$parent_dir")
+              done
             done
-          done
+          )
         }
 
         trap cleanup_vendor_aliases EXIT

--- a/.github/actions/setup-api-client/create_vendor_aliases.js
+++ b/.github/actions/setup-api-client/create_vendor_aliases.js
@@ -88,7 +88,7 @@ for (const alias of seen) {
   }
   const destination = path.join(installDir, sanitized);
   const normalizedDestination = path.normalize(destination);
-  if (!normalizedDestination.startsWith(installDir + path.sep) && normalizedDestination !== installDir) {
+  if (!normalizedDestination.startsWith(installDir + path.sep)) {
     throw new Error(`Resolved vendored alias outside install dir: "${sanitized}"`);
   }
   fs.rmSync(destination, { recursive: true, force: true });

--- a/templates/consumer-repo/.github/actions/setup-api-client/action.yml
+++ b/templates/consumer-repo/.github/actions/setup-api-client/action.yml
@@ -98,19 +98,28 @@ runs:
             return 0
           fi
 
-          for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
-            if [ -z "$vendored_alias" ]; then
-              continue
-            fi
-            rm -rf "$vendored_alias" || true
-            local parent_dir
-            parent_dir=$(dirname "$vendored_alias")
-            # Remove empty parent directories that may have been created for scoped packages
-            while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
-              rmdir "$parent_dir" 2>/dev/null || break
-              parent_dir=$(dirname "$parent_dir")
+          local cleanup_dir="$INSTALL_DIR"
+          if [ -z "$cleanup_dir" ]; then
+            echo "::warning::Install dir is empty, skipping vendored alias cleanup"
+            return 0
+          fi
+
+          (
+            cd "$cleanup_dir" 2>/dev/null || exit 0
+            for vendored_alias in "${VENDORED_ALIAS_DIRS[@]}"; do
+              if [ -z "$vendored_alias" ]; then
+                continue
+              fi
+              rm -rf "$vendored_alias" || true
+              local parent_dir
+              parent_dir=$(dirname "$vendored_alias")
+              # Remove empty parent directories that may have been created for scoped packages
+              while [ "$parent_dir" != "." ] && [ "$parent_dir" != "/" ]; do
+                rmdir "$parent_dir" 2>/dev/null || break
+                parent_dir=$(dirname "$parent_dir")
+              done
             done
-          done
+          )
         }
 
         trap cleanup_vendor_aliases EXIT

--- a/templates/consumer-repo/.github/actions/setup-api-client/create_vendor_aliases.js
+++ b/templates/consumer-repo/.github/actions/setup-api-client/create_vendor_aliases.js
@@ -88,7 +88,7 @@ for (const alias of seen) {
   }
   const destination = path.join(installDir, sanitized);
   const normalizedDestination = path.normalize(destination);
-  if (!normalizedDestination.startsWith(installDir + path.sep) && normalizedDestination !== installDir) {
+  if (!normalizedDestination.startsWith(installDir + path.sep)) {
     throw new Error(`Resolved vendored alias outside install dir: "${sanitized}"`);
   }
   fs.rmSync(destination, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- ensure the bash cleanup helper always operates inside the install directory so vendored alias deletions cannot escape if another command changes working directories
- tighten the Node helper to reject any alias that would resolve to the install directory root itself
- sync the updated action + helper into the consumer template copy so future sync PRs include the safeguards

## Testing
- python - <<'PY' ... yaml.safe_load('.github/actions/setup-api-client/action.yml') ...
- python - <<'PY' ... yaml.safe_load('templates/consumer-repo/.github/actions/setup-api-client/action.yml') ...