### PR TITLE
fix: run Ensure Workflows script deps before Setup Workflows API client

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -262,13 +262,6 @@ jobs:
             scripts
           token: ${{ steps.auth_token.outputs.checkout_token }}
 
-      - name: Setup Workflows API client
-        uses: ./.github/actions/setup-api-client
-        with:
-          secrets: ${{ toJSON(secrets) }}
-          github_token: ${{ github.token }}
-          install_dir: ${{ github.workspace }}/.workflows-lib/.github/scripts
-
       - name: Ensure Workflows script deps
         run: |
           set -euo pipefail
@@ -328,6 +321,13 @@ jobs:
               @octokit/auth-app@6.0.3
             popd >/dev/null
           fi
+
+      - name: Setup Workflows API client
+        uses: ./.github/actions/setup-api-client
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          github_token: ${{ github.token }}
+          install_dir: ${{ github.workspace }}/.workflows-lib/.github/scripts
 
       - name: Validate workflows tooling
         run: |


### PR DESCRIPTION
Swaps step order in reusable-claude-run.yml to match reusable-codex-run.yml. setup-api-client was running before node_modules existed, hitting the file:node_modules/minimatch reference in .github/scripts/package.json and failing with exit 254. Running Ensure Workflows script deps first installs node_modules directly (no package.json involved), so setup-api-client finds it already present and skips npm entirely.