### PR TITLE
fix: remove broken require in keepalive Resolve Workflows default branch step

### DIFF
--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -871,18 +871,14 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({
-              github,
-              core,
-              env: process.env,
-              task: 'reusable-agents-resolve-workflows-ref',
-              capabilities: ['contents:read']
-            });
-            const { data } = await withRetry((client) => client.rest.repos.get({
+            // NOTE: github-api-with-retry.js is NOT available here because the
+            // Workflows repo hasn't been checked out yet (that happens in the next
+            // step). Use a plain GitHub API call — no retry wrapper needed for this
+            // single low-risk read.
+            const { data } = await github.rest.repos.get({
               owner: 'stranske',
               repo: 'Workflows'
-            }));
+            });
             if (!data?.default_branch) {
               core.setFailed('Could not determine Workflows default branch');
               return;


### PR DESCRIPTION
## Problem

The Agents Orchestrator / **Codex Keepalive Sweep** job was failing on every run with:

```
Error: Cannot find module '.../github-api-with-retry.js'
```

**Root cause**: The "Resolve Workflows default branch" step calls `require('./.github/scripts/github-api-with-retry.js')`, but at that point:
- Consumer repo is checked out to `consumer/` (explicit `path: consumer`)
- Workflows repo has **not** been checked out yet (next step)
- Therefore `.github/scripts/github-api-with-retry.js` does **not** exist at workspace root

This was causing Agents Orchestrator to fail on all consumer repos (Trend_Model_Project, Manager-Database, Travel-Plan-Permission, etc.).

## Fix

Replace the `createTokenAwareRetry` wrapper with a direct `github.rest.repos.get()` call. The `github-script` action already provides the `github` client — no retry wrapper needed for this single low-risk read.

## Impact

- Fixes Agents Orchestrator Codex Keepalive Sweep on all consumer repos
- No behaviour change — still resolves the Workflows default branch and sets the output

## Test

Next Agents Orchestrator scheduled run should complete Codex Keepalive Sweep without MODULE_NOT_FOUND.
