### PR TITLE
fix: explicitly install lru-cache to unblock GitHub App token minting

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -176,8 +176,9 @@ runs:
           CREATED_PACKAGE_JSON=true
         fi
 
-        # Check if already installed
-        if [ -d "node_modules/@octokit/rest" ]; then
+        # Check if already installed (including lru-cache, a required transitive dep
+        # of @octokit/auth-app used for GitHub App token minting).
+        if [ -d "node_modules/@octokit/rest" ] && [ -d "node_modules/lru-cache" ]; then
           echo "✅ @octokit/rest already installed"
         else
           # Snapshot vendored package metadata before npm install.
@@ -196,14 +197,18 @@ runs:
             echo "📸 Snapshotted vendored package metadata"
           fi
 
-          # Install with pinned versions for consistency
+          # Install with pinned versions for consistency.
+          # lru-cache is an explicit transitive dep of @octokit/auth-app required for
+          # GitHub App token minting; pin it here so npm always hoists it to the top
+          # level even if a prior cached node_modules state is missing it.
           # Capture stderr for debugging if the command fails
           npm_output=$(mktemp)
           npm_cmd=(npm install --no-save --location=project \
             @octokit/rest@20.0.2 \
             @octokit/plugin-retry@6.0.1 \
             @octokit/plugin-paginate-rest@9.1.5 \
-            @octokit/auth-app@6.0.3)
+            @octokit/auth-app@6.0.3 \
+            lru-cache@^10.0.0)
           if "${npm_cmd[@]}" 2>"$npm_output"; then
             rm -f "$npm_output"
           else
@@ -214,7 +219,8 @@ runs:
               @octokit/rest@20.0.2 \
               @octokit/plugin-retry@6.0.1 \
               @octokit/plugin-paginate-rest@9.1.5 \
-              @octokit/auth-app@6.0.3)
+              @octokit/auth-app@6.0.3 \
+              lru-cache@^10.0.0)
             "${npm_cmd[@]}"
           fi
 


### PR DESCRIPTION
## Problem

Keepalive runs were failing with:
```
Failed to mint app token for KEEPALIVE_APP: Cannot find module
'.../.github/scripts/node_modules/lru-cache/dist/commonjs/index.js'
```
This cascaded into git exit 128 failures across all keepalive jobs.

## Root Cause

lru-cache@^10 is a direct dep of @octokit/auth-app@6.0.3 required to mint GitHub App tokens. Two conditions caused it to go missing:

1. **Stale npm cache**: If a prior cache has @octokit/rest but not lru-cache, the skip guard fires and npm install is skipped entirely.
2. **npm nesting**: Without an explicit top-level install, npm may nest lru-cache inside @octokit/auth-app/node_modules/ making it unreachable via NODE_PATH.

## Fix

1. Updated skip guard to also check for lru-cache directory.
2. Added lru-cache@^10.0.0 to both npm install invocations (primary and --legacy-peer-deps fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)