### PR TITLE
fix: rebase before push and replace --force-with-lease in early-exit paths

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -988,9 +988,33 @@ jobs:
                 COMMIT_SHA=$(git rev-parse HEAD)
                 echo "commit-sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
               fi
-              git push --force-with-lease "$REMOTE_URL" "HEAD:${target_branch}"
-              echo "::notice::Pushed ${UNPUSHED_COMMITS} commit(s) from Claude (SHA: ${COMMIT_SHA})"
-              exit 0
+              # Use plain push (not --force-with-lease) because git fetch <URL>
+              # updates FETCH_HEAD but not the local tracking ref, causing
+              # --force-with-lease to reject with "stale info".
+              for attempt in 1 2 3; do
+                echo "Push attempt ${attempt}/3 (unpushed commits path)..."
+                if git push "$REMOTE_URL" "HEAD:${target_branch}"; then
+                  echo "::notice::Pushed ${UNPUSHED_COMMITS} commit(s) from Claude (attempt ${attempt}, SHA: ${COMMIT_SHA})"
+                  exit 0
+                fi
+                echo "::warning::Push failed (attempt ${attempt})"
+                if [ "$attempt" -lt 3 ]; then
+                  sleep $((attempt * 5))
+                  git fetch "$REMOTE_URL" "$target_branch" 2>/dev/null || true
+                  if git rev-parse "FETCH_HEAD" >/dev/null 2>&1; then
+                    if ! git rebase FETCH_HEAD; then
+                      echo "::warning::Rebase failed on retry; attempting merge."
+                      git rebase --abort 2>/dev/null || true
+                      git pull --no-rebase "$REMOTE_URL" "$target_branch" \
+                        --allow-unrelated-histories || true
+                    fi
+                    COMMIT_SHA="$(git rev-parse HEAD)"
+                    echo "commit-sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+                  fi
+                fi
+              done
+              echo "::error::Failed to push unpushed commits after 3 attempts."
+              exit 1
             fi
 
             echo "No uncommitted changes and no unpushed commits."
@@ -1062,9 +1086,49 @@ jobs:
               echo "changes-made=true" >> "$GITHUB_OUTPUT"
               AGENT_FILES=$(git diff --name-only FETCH_HEAD..HEAD | wc -l | tr -d ' ')
               echo "files-changed=${AGENT_FILES:-1}" >> "$GITHUB_OUTPUT"
-              git push --force-with-lease "$REMOTE_URL" "HEAD:${target_branch}"
-              echo "::notice::Pushed ${UNPUSHED} commit(s) (SHA: ${sha})"
-              exit 0
+              # Rebase onto the remote tip so the push is a fast-forward.
+              # Without this, Claude's commit sits on the stale checkout base
+              # and the push is non-fast-forward when the branch has advanced.
+              if git rev-parse "FETCH_HEAD" >/dev/null 2>&1; then
+                echo "Rebasing unpushed commits onto ${target_branch} before push."
+                if ! git rebase FETCH_HEAD; then
+                  echo "::warning::Rebase failed; attempting merge strategy before push."
+                  git rebase --abort 2>/dev/null || true
+                  if ! git pull --no-rebase "$REMOTE_URL" "$target_branch" \
+                    --allow-unrelated-histories; then
+                    echo "::error::Merge fallback failed; refusing to push an inconsistent state."
+                    exit 1
+                  fi
+                fi
+                sha="$(git rev-parse HEAD)"
+                echo "commit-sha=${sha}" >> "$GITHUB_OUTPUT"
+              fi
+              # Plain push with retry (not --force-with-lease, which fails
+              # after bare fetch due to stale local tracking ref).
+              for attempt in 1 2 3; do
+                echo "Push attempt ${attempt}/3 (post-filter unpushed path)..."
+                if git push "$REMOTE_URL" "HEAD:${target_branch}"; then
+                  echo "::notice::Pushed ${UNPUSHED} commit(s) (attempt ${attempt}, SHA: ${sha})"
+                  exit 0
+                fi
+                echo "::warning::Push failed (attempt ${attempt})"
+                if [ "$attempt" -lt 3 ]; then
+                  sleep $((attempt * 5))
+                  git fetch "$REMOTE_URL" "$target_branch" 2>/dev/null || true
+                  if git rev-parse "FETCH_HEAD" >/dev/null 2>&1; then
+                    if ! git rebase FETCH_HEAD; then
+                      echo "::warning::Rebase failed on retry; attempting merge."
+                      git rebase --abort 2>/dev/null || true
+                      git pull --no-rebase "$REMOTE_URL" "$target_branch" \
+                        --allow-unrelated-histories || true
+                    fi
+                    sha="$(git rev-parse HEAD)"
+                    echo "commit-sha=${sha}" >> "$GITHUB_OUTPUT"
+                  fi
+                fi
+              done
+              echo "::error::Failed to push after 3 attempts (post-filter path)."
+              exit 1
             fi
             echo "changes-made=false" >> "$GITHUB_OUTPUT"
             echo "commit-sha=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -1237,9 +1237,33 @@ jobs:
                 COMMIT_SHA=$(git rev-parse HEAD)
                 echo "commit-sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
               fi
-              git push --force-with-lease "${REMOTE_URL}" "HEAD:${TARGET_BRANCH}"
-              echo "::notice::Pushed ${UNPUSHED_COMMITS} commit(s) from Codex (SHA: ${COMMIT_SHA})"
-              exit 0
+              # Use plain push (not --force-with-lease) because git fetch <URL>
+              # updates FETCH_HEAD but not the local tracking ref, causing
+              # --force-with-lease to reject with "stale info".
+              for attempt in 1 2 3; do
+                echo "Push attempt ${attempt}/3 (unpushed commits path)..."
+                if git push "${REMOTE_URL}" "HEAD:${TARGET_BRANCH}"; then
+                  echo "::notice::Pushed ${UNPUSHED_COMMITS} commit(s) from Codex (attempt ${attempt}, SHA: ${COMMIT_SHA})"
+                  exit 0
+                fi
+                echo "::warning::Push failed (attempt ${attempt})"
+                if [ "$attempt" -lt 3 ]; then
+                  sleep $((attempt * 5))
+                  git fetch "${REMOTE_URL}" "${TARGET_BRANCH}" 2>/dev/null || true
+                  if git rev-parse "FETCH_HEAD" >/dev/null 2>&1; then
+                    if ! git rebase FETCH_HEAD; then
+                      echo "::warning::Rebase failed on retry; attempting merge."
+                      git rebase --abort 2>/dev/null || true
+                      git pull --no-rebase "${REMOTE_URL}" "${TARGET_BRANCH}" \
+                        --allow-unrelated-histories || true
+                    fi
+                    COMMIT_SHA="$(git rev-parse HEAD)"
+                    echo "commit-sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+                  fi
+                fi
+              done
+              echo "::error::Failed to push unpushed commits after 3 attempts."
+              exit 1
             fi
 
             echo "No uncommitted changes and no unpushed commits."


### PR DESCRIPTION
## Summary

- Add missing rebase-onto-FETCH_HEAD in the post-filter push path — **the actual root cause**
- Replace `git push --force-with-lease` with plain `git push` + 3-attempt retry in all early-exit push paths (both Claude and Codex runners)

## Root cause analysis

Counter_Risk [run 22338070510](https://github.com/stranske/Counter_Risk/actions/runs/22338070510/job/64635133039) failed at the "Commit and push changes" step:

```
No non-artifact changes to commit after filtering.
Found 1 unpushed commit(s) from Claude — pushing them.
! [rejected]  HEAD -> claude/issue-217 (stale info)
```

The "Commit and push changes" step has three push code paths:
1. `CHANGED_FILES==0`, unpushed commits detected
2. All changes were artifacts (post-filter), unpushed commits detected ← **this is the path that failed**
3. Main path: workflow commits new changes

Path 3 already rebased + used plain `git push` with retry. Paths 1 and 2 had two bugs:

**Bug 1 (path 2 — the actual failure): No rebase before push.** Claude's commit (`37e2f40`) was built on the checkout base from ~18 minutes prior. The remote branch advanced during the run. Without rebasing onto the current remote tip, the push is non-fast-forward and fails regardless of push flags.

**Bug 2 (paths 1 and 2): `--force-with-lease` with no retry.** `git fetch <URL> <branch>` updates `FETCH_HEAD` but does **not** update the local tracking ref (`refs/remotes/origin/<branch>`). `--force-with-lease` compares the remote against the stale tracking ref and rejects with "stale info" even after a successful rebase.

## Changes

| File | Path | Fix |
|------|------|-----|
| `reusable-claude-run.yml` | post-artifact-filter unpushed path | **Add rebase onto FETCH_HEAD** + plain push + 3x retry |
| `reusable-claude-run.yml` | CHANGED_FILES==0 unpushed path | `--force-with-lease` → plain push + 3x retry (rebase already existed) |
| `reusable-codex-run.yml` | CHANGED_FILES==0 unpushed path | `--force-with-lease` → plain push + 3x retry (rebase already existed) |

## Test plan

- [ ] Verify actionlint / shellcheck CI passes
- [ ] Re-run the Counter_Risk keepalive loop to confirm Claude commits push successfully when the branch has advanced during the run
- [ ] Verify Codex runner still pushes successfully on a concurrent branch update

https://claude.ai/code/session_012WnYCcttvFEY3FETnhVcNL