### PR TITLE
fix: correct verification retry prompt routing and status lifecycle

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -3582,7 +3582,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       : {};
     if (tasksUnchecked > 0) {
       verification = {};
-    } else if (reason === 'verify-acceptance' || reason === 'fix-verification-gaps') {
+    } else if (reason === 'verify-acceptance') {
       const previousAttemptCount = toNumber(verification?.attempt_count, 0);
       verification = {
         status: runResult === 'success' ? 'done' : 'failed',
@@ -3591,6 +3591,26 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         last_result: runResult || '',
         updated_at: new Date().toISOString(),
       };
+    } else if (reason === 'fix-verification-gaps') {
+      const previousAttemptCount = toNumber(verification?.attempt_count, 0);
+      if (runResult === 'success') {
+        // A successful fix run doesn't prove acceptance criteria are met.
+        // Clear verification state (except attempt_count) so that
+        // needsVerification triggers a fresh verifier pass next iteration.
+        verification = {
+          attempt_count: previousAttemptCount + 1,
+        };
+      } else {
+        // Fix failed — keep as failed so needsVerificationRetry can
+        // decide whether to retry or exhaust.
+        verification = {
+          status: 'failed',
+          iteration: nextIteration,
+          attempt_count: previousAttemptCount + 1,
+          last_result: runResult || '',
+          updated_at: new Date().toISOString(),
+        };
+      }
     }
 
     const newState = {

--- a/.github/scripts/keepalive_prompt_routing.js
+++ b/.github/scripts/keepalive_prompt_routing.js
@@ -68,11 +68,11 @@ function resolvePromptMode({ scenario, mode, action, reason } = {}) {
   if (actionValue === 'conflict' || reasonValue.startsWith('conflict') || reasonValue.includes('merge-conflict')) {
     return 'conflict';
   }
+  if (actionValue === 'verify' || reasonValue === 'verify-acceptance' || reasonValue === 'fix-verification-gaps') {
+    return 'verify';
+  }
   if (actionValue === 'fix' || reasonValue.startsWith('fix-')) {
     return 'fix_ci';
-  }
-  if (actionValue === 'verify' || reasonValue === 'verify-acceptance') {
-    return 'verify';
   }
 
   const scenarioValue = normalise(scenario);

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -3582,7 +3582,7 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
       : {};
     if (tasksUnchecked > 0) {
       verification = {};
-    } else if (reason === 'verify-acceptance' || reason === 'fix-verification-gaps') {
+    } else if (reason === 'verify-acceptance') {
       const previousAttemptCount = toNumber(verification?.attempt_count, 0);
       verification = {
         status: runResult === 'success' ? 'done' : 'failed',
@@ -3591,6 +3591,26 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         last_result: runResult || '',
         updated_at: new Date().toISOString(),
       };
+    } else if (reason === 'fix-verification-gaps') {
+      const previousAttemptCount = toNumber(verification?.attempt_count, 0);
+      if (runResult === 'success') {
+        // A successful fix run doesn't prove acceptance criteria are met.
+        // Clear verification state (except attempt_count) so that
+        // needsVerification triggers a fresh verifier pass next iteration.
+        verification = {
+          attempt_count: previousAttemptCount + 1,
+        };
+      } else {
+        // Fix failed — keep as failed so needsVerificationRetry can
+        // decide whether to retry or exhaust.
+        verification = {
+          status: 'failed',
+          iteration: nextIteration,
+          attempt_count: previousAttemptCount + 1,
+          last_result: runResult || '',
+          updated_at: new Date().toISOString(),
+        };
+      }
     }
 
     const newState = {

--- a/templates/consumer-repo/.github/scripts/keepalive_prompt_routing.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_prompt_routing.js
@@ -68,11 +68,11 @@ function resolvePromptMode({ scenario, mode, action, reason } = {}) {
   if (actionValue === 'conflict' || reasonValue.startsWith('conflict') || reasonValue.includes('merge-conflict')) {
     return 'conflict';
   }
+  if (actionValue === 'verify' || reasonValue === 'verify-acceptance' || reasonValue === 'fix-verification-gaps') {
+    return 'verify';
+  }
   if (actionValue === 'fix' || reasonValue.startsWith('fix-')) {
     return 'fix_ci';
-  }
-  if (actionValue === 'verify' || reasonValue === 'verify-acceptance') {
-    return 'verify';
   }
 
   const scenarioValue = normalise(scenario);


### PR DESCRIPTION
## Summary
- **P1 fix**: `fix-verification-gaps` reason was incorrectly routed through the `fix_ci` prompt (matched `fix-` prefix) instead of the `verify` prompt. Reordered checks so verification reasons take priority.
- **P1 fix**: After a successful fix-verification-gaps run, `verification.status` was set to `done`, allowing the PR to stop without a fresh verifier pass. Now a successful fix clears verification state (preserving `attempt_count`) so `needsVerification` triggers a proper re-verification.

## Test plan
- [x] All 812 JS tests pass
- [x] All 113 keepalive + cascade tests pass
- [x] Prompt routing tests pass (7/7)

https://claude.ai/code/session_01VtzHmRoYTL2kcxaacDgSqQ