### PR TITLE
Fix upsertBlock to deduplicate marker pairs from race conditions

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -870,8 +870,9 @@ Footer`;
   assert.ok(!result.includes('First copy'));
   assert.ok(!result.includes('Second copy'));
 
-  // Should preserve surrounding content
+  // Should preserve surrounding content including text between duplicates
   assert.ok(result.includes('Preamble'));
+  assert.ok(result.includes('Middle content'));
   assert.ok(result.includes('Footer'));
 });
 
@@ -912,4 +913,17 @@ After`;
   // No triple+ newlines should remain
   assert.ok(!result.match(/\n{3,}/), 'should not have triple+ newlines');
   assert.ok(result.includes('After'));
+});
+
+test('upsertBlock preserves triple newlines in single-pair case (no duplicates)', () => {
+  const body = `Before\n\n\n<!-- m:start -->\nOld\n<!-- m:end -->\n\n\nAfter`;
+
+  const result = upsertBlock(body, 'm', '<!-- m:start -->\nNew\n<!-- m:end -->');
+
+  // Triple newlines outside the managed block should be preserved
+  // when no duplicate removal occurred
+  assert.ok(result.includes('Before'));
+  assert.ok(result.includes('New'));
+  assert.ok(result.includes('After'));
+  assert.ok(result.includes('\n\n\n'), 'should preserve existing triple newlines when no duplicates removed');
 });

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -710,19 +710,21 @@ function upsertBlock(body, marker, replacement) {
     let result = `${body.slice(0, startIndex)}${replacement}${body.slice(endIndex + end.length)}`;
 
     // Remove any duplicate marker pairs left by concurrent writers
+    let hadDuplicates = false;
     let limit = 10;
     while (limit-- > 0) {
       const dupStart = result.indexOf(start, startIndex + replacement.length);
-      const dupEnd = result.indexOf(end, dupStart + 1);
+      const dupEnd = result.indexOf(end, dupStart + start.length);
       if (dupStart !== -1 && dupEnd !== -1 && dupEnd > dupStart) {
         result = `${result.slice(0, dupStart)}${result.slice(dupEnd + end.length)}`;
+        hadDuplicates = true;
       } else {
         break;
       }
     }
 
     // Collapse triple+ newlines left by removed blocks
-    return result.replace(/\n{3,}/g, '\n\n');
+    return hadDuplicates ? result.replace(/\n{3,}/g, '\n\n') : result;
   }
 
   const trimmed = body.trimEnd();

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -710,19 +710,21 @@ function upsertBlock(body, marker, replacement) {
     let result = `${body.slice(0, startIndex)}${replacement}${body.slice(endIndex + end.length)}`;
 
     // Remove any duplicate marker pairs left by concurrent writers
+    let hadDuplicates = false;
     let limit = 10;
     while (limit-- > 0) {
       const dupStart = result.indexOf(start, startIndex + replacement.length);
-      const dupEnd = result.indexOf(end, dupStart + 1);
+      const dupEnd = result.indexOf(end, dupStart + start.length);
       if (dupStart !== -1 && dupEnd !== -1 && dupEnd > dupStart) {
         result = `${result.slice(0, dupStart)}${result.slice(dupEnd + end.length)}`;
+        hadDuplicates = true;
       } else {
         break;
       }
     }
 
     // Collapse triple+ newlines left by removed blocks
-    return result.replace(/\n{3,}/g, '\n\n');
+    return hadDuplicates ? result.replace(/\n{3,}/g, '\n\n') : result;
   }
 
   const trimmed = body.trimEnd();


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1670

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
When `agents-auto-pilot.yml` creates a PR, it triggers **two parallel paths** that both call `agents_pr_meta_update_body.js`:

1. **Path A**: The PR `opened` event fires `agents-80-pr-event-hub.yml` → `reusable-20-pr-meta.yml` → `agents_pr_meta_update_body.js`
2. **Path B**: Auto-pilot explicitly dispatches `agents-pr-meta.yml` → `reusable-20-pr-meta.yml` → `agents_pr_meta_update_body.js`

Both instances read the PR body before either writes. Since no `<!-- auto-status-summary:start -->` markers exist yet, both append a new block, resulting in **two copies** of the Automated Status Summary in the PR body.

The existing concurrency group on `reusable-20-pr-meta.yml` (`${{ github.workflow }}-${{ github.ref }}`) does not prevent this because the two paths have different caller workflow names and refs, producing different concurrency group keys.

The duplicate causes downstream confusion: the verifier agents (`verify:compare`) may parse inconsistent checkbox states from the two copies, and `upsertBlock()` (which uses `indexOf()`) only ever updates the first pair, leaving the second stale and permanently unchecked.

#### Tasks
- [ ] Update `upsertBlock()` to remove all duplicate marker pairs after replacing the first one
- [ ] Add unit tests for `upsertBlock()` covering: single pair replacement, duplicate pair deduplication, no-marker append, and whitespace cleanup
- [ ] Verify `parseCheckboxStates()` and `mergeCheckboxStates()` still work correctly with the updated `upsertBlock()` (no behavior change for single-pair case)

#### Acceptance criteria
- [ ] When a PR body contains two `<!-- auto-status-summary:start/end -->` pairs, `upsertBlock()` replaces the first and removes the second, producing exactly one block
- [ ] When a PR body contains one pair, behavior is unchanged (replace in place)
- [ ] When a PR body contains no markers, behavior is unchanged (append to end)
- [ ] Checkbox state merging (`mergeCheckboxStates`) continues to preserve agent-reported completion across rebuilds
- [ ] Extra newlines left by removed duplicate blocks are collapsed to at most two consecutive newlines

**Head SHA:** 24ff5ef55039fadb6a1e1725151f52de45b191b2
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Workflows/actions/runs/22531994375) |
| Agents PR meta manager | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/22532188352) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995492) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995472) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995470) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995464) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995479) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995466) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995483) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995477) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995453) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/22531995500) |
<!-- auto-status-summary:end -->