### PR TITLE
chore: register Pension-Data, Inv-Man-Intake, and Ready for consumer sync

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -73,6 +73,9 @@ env:
     stranske/Travel-Plan-Permission
     stranske/Template
     stranske/Counter_Risk
+    stranske/Pension-Data
+    stranske/Inv-Man-Intake
+    stranske/Ready
     stranske/trip-planner
     stranske/Manager-Database
     stranske/Portable-Alpha-Extension-Model


### PR DESCRIPTION
## What
- add `stranske/Pension-Data`, `stranske/Inv-Man-Intake`, and `stranske/Ready` to `REGISTERED_CONSUMER_REPOS` in `.github/workflows/maint-68-sync-consumer-repos.yml`

## Why
- ensure all three new public repos are included in the automatic workflow/template sync roster
- keep `scripts/list_registered_consumer_repos.py` output aligned with active consumers

## Validation
- parsed workflow YAML successfully
- verified `python scripts/list_registered_consumer_repos.py` now returns the three new repos
