### PR TITLE
docs: include keepalive/verify/claude secrets in consumer setup

### DIFF
--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -325,11 +325,10 @@ Claude-run workflows (for example `reusable-claude-run.yml`) require one of:
 Set the preferred token:
 
 ```bash
-# Generates/refreshes a long-lived token
-claude setup-token
-
-# Then paste token into repo secret
-gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo stranske/<your-repo>
+# Generates/refreshes a long-lived token and writes it directly to the repo secret
+gh secret set CLAUDE_CODE_OAUTH_TOKEN \
+  --repo stranske/<your-repo> \
+  --body "$(claude setup-token)"
 ```
 
 Fallback using auth JSON:


### PR DESCRIPTION
## What changed
- expanded consumer setup checklist secret requirements to include keepalive app aliases, verify API keys, and Claude CLI auth secrets
- documented `CLAUDE_CODE_OAUTH_TOKEN` (preferred) and `CLAUDE_AUTH_JSON` (fallback) setup/verification
- clarified that both Workflows and Keepalive GitHub Apps must be installed on each consumer repo

## Why
New repos were missing required secrets for keepalive and verify workflows, and Claude-run workflows were not called out in setup docs.

## Validation
- docs-only change
