### PR TITLE
fix: include setup-api-client action in reusable-pr-context checkout

### DIFF
--- a/.github/workflows/reusable-pr-context.yml
+++ b/.github/workflows/reusable-pr-context.yml
@@ -143,6 +143,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/scripts
+            .github/actions/setup-api-client
           sparse-checkout-cone-mode: false
 
       - name: Setup API client


### PR DESCRIPTION
## What changed
- added `.github/actions/setup-api-client` to the sparse checkout in `reusable-pr-context.yml`

## Why
`reusable-pr-context` invokes a local composite action (`./.github/actions/setup-api-client`) but only checked out `.github/scripts`. That caused runtime failures in consumers using `agents-80-pr-event-hub` because the action directory was missing.

## Validation
- inspected failing consumer run logs showing: `Can't find 'action.yml' ... .github/actions/setup-api-client`
- patched sparse checkout to include the action path
