### PR TITLE
feat: configurable PR health interval via repo variable

### DIFF
--- a/.github/workflows/reusable-agents-pr-health.yml
+++ b/.github/workflows/reusable-agents-pr-health.yml
@@ -62,6 +62,14 @@ on:
           frequency without a code change.
         type: number
         default: 1
+      is_scheduled_trigger:
+        description: >-
+          Whether this run was triggered by a cron schedule.
+          Callers should pass: github.event_name == 'schedule'.
+          Required because github.event_name inside a reusable
+          workflow is always 'workflow_call', not the caller's event.
+        type: boolean
+        default: false
     secrets:
       service_bot_pat:
         required: false
@@ -97,13 +105,22 @@ jobs:
         id: check
         env:
           INTERVAL: ${{ inputs.cron_interval_hours }}
-          EVENT_NAME: ${{ github.event_name }}
+          IS_SCHEDULED: ${{ inputs.is_scheduled_trigger }}
         run: |
           set -euo pipefail
           interval="${INTERVAL:-1}"
 
-          # Manual / non-schedule triggers always proceed
-          if [ "$EVENT_NAME" != "schedule" ]; then
+          # Validate interval — must be a non-negative integer.
+          # Repo variables are free-text; guard against '6h', '6.0', etc.
+          if ! [[ "$interval" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Invalid cron_interval_hours='$interval' — defaulting to 1"
+            interval=1
+          fi
+
+          # Non-scheduled triggers (manual dispatch) always proceed.
+          # Note: github.event_name inside a reusable workflow is always
+          # 'workflow_call', so callers pass is_scheduled_trigger instead.
+          if [ "$IS_SCHEDULED" != "true" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Manual trigger — always proceeding"
             exit 0
@@ -127,9 +144,18 @@ jobs:
           current_hour=$(date -u +%-H)
           remainder=$((current_hour % interval))
           if [ "$remainder" -ne 0 ]; then
-            next_run=$(( (current_hour / interval + 1) * interval % 24 ))
+            # Find the actual next aligned hour on a 24h clock.
+            # Avoids the simple (n/i+1)*i%24 formula which is wrong
+            # for intervals that don't evenly divide 24.
+            next_hour="$current_hour"
+            while :; do
+              next_hour=$(( (next_hour + 1) % 24 ))
+              if [ $((next_hour % interval)) -eq 0 ]; then
+                break
+              fi
+            done
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — UTC hour $current_hour not aligned to ${interval}h interval (next at hour $next_run)"
+            echo "Skipping — UTC hour $current_hour not aligned to ${interval}h interval (next at hour $next_hour)"
           else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Running — UTC hour $current_hour aligned to ${interval}h interval"

--- a/templates/consumer-repo/.github/workflows/agents-pr-health.yml
+++ b/templates/consumer-repo/.github/workflows/agents-pr-health.yml
@@ -57,4 +57,5 @@ jobs:
       dry_run: ${{ inputs.dry_run || false }}
       max_prs: ${{ inputs.max_prs || 10 }}
       cron_interval_hours: ${{ vars.PR_HEALTH_INTERVAL_HOURS || 1 }}
+      is_scheduled_trigger: ${{ github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds a **schedule gate** job to the reusable PR health workflow so consumer repos can control scan frequency via a repository variable — no code changes or PRs required
- Consumer cron runs hourly (`0 * * * *`); the gate checks UTC hour alignment against `PR_HEALTH_INTERVAL_HOURS` and exits early when not aligned (no API calls consumed)
- Manual dispatch (`workflow_dispatch`) always proceeds regardless of interval

### Configuration

Set the repo variable in **Settings → Secrets and variables → Actions → Variables**:

| `PR_HEALTH_INTERVAL_HOURS` | Behavior |
|---|---|
| `1` (default) | Every hour — active development |
| `4` | Every 4 hours |
| `6` | Every 6 hours — moderate activity |
| `12` | Twice daily |
| `0` | Disabled |

### Files changed

| File | Change |
|------|--------|
| `reusable-agents-pr-health.yml` | New `cron_interval_hours` input + gate job; scan and summary gated on it |
| `templates/.../agents-pr-health.yml` | Cron changed to hourly; passes `vars.PR_HEALTH_INTERVAL_HOURS` through |

## Test plan

- [ ] CI passes (actionlint, API wrapper guard, workflow naming)
- [ ] Manual dispatch always runs (gate logs "Manual trigger — always proceeding")
- [ ] Interval=0 skips all work (gate logs "PR Health disabled")
- [ ] Interval=6 only runs at hours 0, 6, 12, 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)