### PR TITLE
Fix PR health check: handle undefined mergeable fields from pulls.list

### DIFF
--- a/.github/workflows/reusable-agents-pr-health.yml
+++ b/.github/workflows/reusable-agents-pr-health.yml
@@ -280,8 +280,10 @@ jobs:
               let mergeableState = pr.mergeable_state;
               let mergeable = pr.mergeable;
 
+              core.info(`PR #${pr.number}: mergeable=${mergeable} (${typeof mergeable}), state=${mergeableState} (${typeof mergeableState})`);
+
               // If unknown, fetch individually to trigger computation
-              if (mergeable === null || mergeableState === 'unknown') {
+              if (mergeable == null || !mergeableState || mergeableState === 'unknown') {
                 await new Promise(r => setTimeout(r, 1000));
                 const { data: fresh } = await withRetry((client) =>
                   client.rest.pulls.get({


### PR DESCRIPTION
## Summary

- **Bug**: The `pulls.list` REST API endpoint does not return `mergeable` or `mergeable_state` fields, so they are `undefined` in JavaScript. The existing strict equality check (`mergeable === null`) fails for `undefined`, meaning the individual PR fetch is never triggered and all PRs are incorrectly classified as healthy.
- **Fix**: Changed `mergeable === null` to `mergeable == null` (loose equality catches both `null` and `undefined`), and added `!mergeableState` to also handle empty strings or other falsy values.
- **Debug logging**: Added a `core.info` line before the check to log the actual `mergeable` and `mergeableState` values and their types, making future troubleshooting easier.

## Details

The `pulls.list` endpoint returns a lighter payload than `pulls.get`. Fields like `mergeable` and `mergeable_state` are only present in the individual PR response. Previously, the code assumed `pulls.list` would return `null` for these fields (triggering the individual fetch), but they are actually `undefined` (absent from the response entirely).

In JavaScript, `undefined === null` is `false`, so the guard clause never fired and `mergeable` stayed `undefined` (truthy in the boolean context used later for conflict detection was not relevant -- the `mergeableState` was also `undefined` and didn't match `'dirty'`).

### Before
```javascript
if (mergeable === null || mergeableState === 'unknown') {
```

### After
```javascript
core.info(`PR #${pr.number}: mergeable=${mergeable} (${typeof mergeable}), state=${mergeableState} (${typeof mergeableState})`);

if (mergeable == null || !mergeableState || mergeableState === 'unknown') {
```

## Test plan

- [ ] Trigger the PR Health workflow on a repo with open PRs that have merge conflicts and verify they are now correctly categorized as unhealthy
- [ ] Check workflow logs for the new debug line showing `mergeable=undefined (undefined)` from the list endpoint, followed by actual values after the individual fetch
- [ ] Verify PRs with clean mergeable state are still categorized as healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)