### PR TITLE
fix: prevent secret masking of PR health scan outputs

### DIFF
--- a/.github/workflows/reusable-agents-pr-health.yml
+++ b/.github/workflows/reusable-agents-pr-health.yml
@@ -298,7 +298,6 @@ jobs:
                 number: pr.number,
                 head_ref: headRef,
                 base_ref: pr.base.ref,
-                head_sha: pr.head.sha,
                 agent_type: agentType,
                 title: pr.title,
               };
@@ -466,7 +465,6 @@ jobs:
                   number: pr.number,
                   head_ref: headRef,
                   base_ref: pr.base.ref,
-                  head_sha: pr.head.sha,
                   agent_type: agentType,
                   title: pr.title,
                   blocking_labels: blockingHits,
@@ -741,7 +739,6 @@ jobs:
           PR_NUM: ${{ matrix.pr.number }}
           HEAD_REF_VAL: ${{ matrix.pr.head_ref }}
           BASE_REF_VAL: ${{ matrix.pr.base_ref }}
-          HEAD_SHA_VAL: ${{ matrix.pr.head_sha }}
           AGENT_TYPE_VAL: ${{ matrix.pr.agent_type }}
           CONFLICT_FILES_VAL: ${{ steps.merge.outputs.conflict_files }}
         with:
@@ -755,6 +752,16 @@ jobs:
             const { withRetry } = await createTokenAwareRetry({
               github, core, task: 'pr-health-dispatch',
             });
+            // Fetch head SHA at runtime to avoid it appearing in job
+            // outputs, which triggers GitHub Actions secret masking.
+            const { data: prData } = await withRetry((client) =>
+              client.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(process.env.PR_NUM, 10),
+              })
+            );
+            const headSha = prData.head.sha;
             // Backup trigger via repository_dispatch — avoids expression
             // interpolation inside JS strings (injection risk).
             await withRetry((client) =>
@@ -766,7 +773,7 @@ jobs:
                   pr_number: parseInt(process.env.PR_NUM, 10),
                   head_ref: process.env.HEAD_REF_VAL,
                   base_ref: process.env.BASE_REF_VAL,
-                  head_sha: process.env.HEAD_SHA_VAL,
+                  head_sha: headSha,
                   agent_type: process.env.AGENT_TYPE_VAL,
                   conflict_files: process.env.CONFLICT_FILES_VAL,
                 },


### PR DESCRIPTION
## Summary
- **Problem**: GitHub Actions suppresses job outputs when they contain substrings matching repository secrets. The `conflict_prs`, `failing_prs`, and `stalled_prs` JSON arrays included `head_sha` fields (40-char hex strings) that occasionally collided with secret substrings, causing errors like `Skip output 'conflict_prs' since it may contain secret`.
- **Fix**: Remove `head_sha` from all `prInfo` objects so SHA strings never appear in job outputs. The only downstream consumer — the "Dispatch conflict event (fallback)" step — now fetches the head SHA at runtime via the `pulls.get` API.
- **Impact**: No functional change. The dispatch payload still contains the correct `head_sha`; it is simply retrieved at execution time rather than passed through the matrix.

## Test plan
- [ ] Trigger the `reusable-agents-pr-health` workflow against a repo with open conflicting PRs
- [ ] Verify the `scan` job outputs are no longer suppressed by secret masking
- [ ] Verify the `resolve-conflicts` matrix jobs run and the dispatch event includes the correct `head_sha`
- [ ] Verify `fix-checks` and `nudge-stalled` matrix jobs still function correctly (they never used `head_sha`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)