### PR TITLE
Fix missing sparse-checkout dep causing 'This isn't working' on PRs

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -630,6 +630,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/scripts/prompt_injection_guard.js
+            .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             .github/scripts/agent_registry.js


### PR DESCRIPTION
## Summary
- `prompt_injection_guard.js` requires `github-rate-limited-wrapper.js` at line 14
- This dependency was missing from the sparse-checkout list in the Gate Followups workflow template
- Every PR triggers "Prepare autofix context" which fails with `Cannot find module './github-rate-limited-wrapper.js'`
- This surfaces as "This isn't working right now. You can try again later." on every PR page

## Fix
Added `github-rate-limited-wrapper.js` to the sparse-checkout list for the security gate checkout step.

## Test plan
- [ ] Apply fix directly to Pension-Data to verify it resolves the error immediately
- [ ] Merge and sync to consumer repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)