### PR TITLE
fix: exclude virtualenv from black check

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -648,8 +648,8 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          # Exclude .workflows-lib since it's synced from source repo with different config
-          black --check --line-length 100 --exclude '(\.workflows-lib|node_modules)' .
+          # Exclude repo-local tooling directories created during CI setup.
+          black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .
 
       - name: Finalize format check
         id: finalize


### PR DESCRIPTION
## Summary
- exclude repo-local virtualenvs from the reusable Black format check
- keep the existing exclusions for `.workflows-lib` and `node_modules`
- prevent consumer CI from formatting third-party packages installed into project-local `.venv`

## Testing
- python3 scripts/validate_template_completeness.py --strict
- python3 - <<'PY2'
from pathlib import Path
import yaml
path = Path('.github/workflows/reusable-10-ci-python.yml')
yaml.safe_load(path.read_text())
print(f'OK {path}')
PY2
