### PR TITLE
sync: fix consumer template guidance and Trend AGENTS skip

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -404,6 +404,11 @@ jobs:
 
           # Repos with custom Gate workflows
           custom_gate_repos = ['stranske/Manager-Database']
+          repo_specific_skip_rules = {
+              ('stranske/Trend_Model_Project', 'AGENTS.md'): (
+                  'Repo keeps historical Agents.md casing to avoid case-only path conflicts'
+              ),
+          }
 
           changes = []
           skipped = []
@@ -429,6 +434,16 @@ jobs:
               """Sync a single file from template to consumer."""
               src = Path(source_path)
               dst = Path(target_path)
+              relative_target = (
+                  str(dst.relative_to(Path('consumer')))
+                  if dst.is_absolute() is False and str(dst).startswith('consumer/')
+                  else str(dst)
+              )
+
+              repo_specific_reason = repo_specific_skip_rules.get((current_repo, relative_target))
+              if repo_specific_reason:
+                  skipped.append(f"{dst.name}: {repo_specific_reason}")
+                  return False
 
               if skip_condition and skip_condition():
                   skipped.append(f"{dst.name}: {skip_condition.__doc__}")

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -23,14 +23,20 @@ the workflow is the source of truth.
 
 Some repos cannot use the template `pr-00-gate.yml` because:
 - **Manager-Database**: Uses `docker compose`, `pre-commit`, custom test setup
+- **Trend_Model_Project**: Keeps the historical `Agents.md` filename, so syncing
+  `AGENTS.md` would create a case-only path collision on case-insensitive
+  filesystems
 
 For these repos:
 - The Gate workflow (`pr-00-gate.yml`) is maintained locally and excluded from sync.
+- `Trend_Model_Project` skips the synced `AGENTS.md` file and keeps its local
+  `Agents.md`.
 - Other files listed in the sync manifest continue to sync normally.
 
 Maint 68 currently implements this by keeping an internal `custom_gate_repos` list in
 its sync script and skipping any manifest entry whose `source` contains
-`pr-00-gate` for those repos.
+`pr-00-gate` for those repos, plus a repo-specific `AGENTS.md` skip for
+`Trend_Model_Project`.
 
 ---
 

--- a/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
+++ b/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
@@ -757,14 +757,14 @@ The Workflows repository includes maintenance workflows that handle sync, update
 ### `maint-73-refresh-reusable-tags.yml` - Legacy Tag Refresh Notice
 **Purpose:** Historical maintenance workflow for floating-tag management
 
-**Trigger:** After new release created
+**Trigger:** Manual dispatch only (deprecated notice workflow)
 
 **What It Does:**
 - Records that first-party consumers now standardize on `@main`
 - Leaves any historical floating-tag maintenance to explicit migration work
 - Does not change the current first-party consumer default
 
-**Use When:** Only when you are auditing historical versioning behavior
+**Use When:** Only when you need a manual reminder of the deprecated floating-tag policy during an audit or migration review
 
 ---
 

--- a/templates/consumer-repo/docs/LABELS.md
+++ b/templates/consumer-repo/docs/LABELS.md
@@ -82,7 +82,7 @@ This document describes all labels that trigger automated workflows or affect CI
 - Issue must have a valid agent assignee (configured in repository settings)
 - Issue should have clear requirements in the description
 
-**Workflow:** `agents-63-issue-intake.yml` (Agents 63 Issue Intake)
+**Workflow:** `agents-issue-intake.yml` (Issue Intake)
 
 ---
 
@@ -102,7 +102,7 @@ This document describes all labels that trigger automated workflows or affect CI
 
 **Note:** Adding this label without `agent:codex` will result in an error.
 
-**Workflow:** `agents-63-issue-intake.yml` (Agents 63 Issue Intake)
+**Workflow:** `agents-issue-intake.yml` (Issue Intake)
 
 ---
 


### PR DESCRIPTION
## Summary
- align the consumer label guide with the canonical agents-issue-intake.yml workflow name
- clarify that maint-73 is a manual deprecated notice, not a post-release automation
- skip syncing AGENTS.md into Trend_Model_Project to avoid the existing case-only collision with Agents.md
- document the Trend-specific sync exception in the consumer maintenance guide

## Validation
- read-back sanity check on the touched files