### PR TITLE
fix: define agentKey in issue bridge create step

### DIFF
--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -975,6 +975,7 @@ jobs:
             const keepaliveMode = process.env.KEEPALIVE_MODE || 'OFF';
             const { buildIssueContext } = require('./.github/scripts/issue_context_utils.js');
             const agent = (process.env.AGENT || '').trim();
+            const agentKey = agent.toLowerCase();
             const fs = require('fs');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
             const retryHelpers = fs.existsSync(retryHelperPath)

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -198,6 +198,16 @@ def test_issue_bridge_keepalive_dispatch_disabled():
     ), "Issue bridge should document that keepalive dispatch is disabled"
 
 
+def test_issue_bridge_create_mode_normalizes_agent_key_for_assignees():
+    text = (WORKFLOWS_DIR / "reusable-agents-issue-bridge.yml").read_text(encoding="utf-8")
+    assert (
+        "const agentKey = agent.toLowerCase();" in text
+    ), "Issue bridge create-mode PR step must define agentKey before agent registry lookups"
+    assert (
+        "const cfg = getAgentConfig(agentKey || 'codex');" in text
+    ), "Issue bridge assignee selection must continue using the normalized agentKey"
+
+
 def test_keepalive_job_present():
     reusable = WORKFLOWS_DIR / "reusable-16-agents.yml"
     text = reusable.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- define \ in the create-mode PR step of \ before assignee selection uses it
- add a regression assertion so the bridge workflow text keeps that normalization in place
- unblock downstream \ runs such as \, which were failing with \

## Testing
- \
no tests ran in 0.10s