### PR TITLE
[codex] Fail Gate when test tool pins are missing

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -533,10 +533,10 @@ jobs:
           isort_spec="isort"
           ruff_spec="ruff"
           mypy_spec="mypy"
-          pytest_spec="pytest"
-          pytest_cov_spec="pytest-cov"
-          coverage_spec="coverage"
-          pytest_xdist_spec="pytest-xdist"
+          pytest_spec=""
+          pytest_cov_spec=""
+          coverage_spec=""
+          pytest_xdist_spec=""
           # Do not install heavyweight "baseline" test deps implicitly.
           # Repos should declare their own runtime/test dependencies.
 
@@ -554,6 +554,14 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
+          require_exact_pin() {
+            local tool=$1
+            local spec=${2:-}
+            if [ -z "$spec" ] || [ "${spec#*==}" = "$spec" ]; then
+              echo "Error: ${tool} must be pinned in ${autofix_env}; refusing to install unpinned tooling." >&2
+              exit 1
+            fi
+          }
           # Always honor tool pins when present. Lock files typically only capture runtime deps.
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
@@ -565,10 +573,18 @@ jobs:
             mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
             pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
             pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
-            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.13.2")
-            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
-          elif [ "$has_lock_file" = "false" ]; then
-            echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "")
+          else
+            echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2
+            exit 1
+          fi
+
+          require_exact_pin "pytest" "$pytest_spec"
+          require_exact_pin "pytest-xdist" "$pytest_xdist_spec"
+          if [ "$coverage_enabled" = "true" ]; then
+            require_exact_pin "pytest-cov" "$pytest_cov_spec"
+            require_exact_pin "coverage" "$coverage_spec"
           fi
 
           # Always install dev tools - lock files only contain runtime deps, not dev tools
@@ -828,10 +844,10 @@ jobs:
           isort_spec="isort"
           ruff_spec="ruff"
           mypy_spec="mypy"
-          pytest_spec="pytest"
-          pytest_cov_spec="pytest-cov"
-          coverage_spec="coverage"
-          pytest_xdist_spec="pytest-xdist"
+          pytest_spec=""
+          pytest_cov_spec=""
+          coverage_spec=""
+          pytest_xdist_spec=""
           # Do not install heavyweight "baseline" test deps implicitly.
           # Repos should declare their own runtime/test dependencies.
 
@@ -849,6 +865,14 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
+          require_exact_pin() {
+            local tool=$1
+            local spec=${2:-}
+            if [ -z "$spec" ] || [ "${spec#*==}" = "$spec" ]; then
+              echo "Error: ${tool} must be pinned in ${autofix_env}; refusing to install unpinned tooling." >&2
+              exit 1
+            fi
+          }
           # Always honor tool pins when present. Lock files typically only capture runtime deps.
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
@@ -860,10 +884,18 @@ jobs:
             mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
             pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
             pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
-            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.13.2")
-            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
-          elif [ "$has_lock_file" = "false" ]; then
-            echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "")
+          else
+            echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2
+            exit 1
+          fi
+
+          require_exact_pin "pytest" "$pytest_spec"
+          require_exact_pin "pytest-xdist" "$pytest_xdist_spec"
+          if [ "$coverage_enabled" = "true" ]; then
+            require_exact_pin "pytest-cov" "$pytest_cov_spec"
+            require_exact_pin "coverage" "$coverage_spec"
           fi
 
           # Always install dev tools - lock files only contain runtime deps, not dev tools
@@ -1132,10 +1164,10 @@ jobs:
           isort_spec="isort"
           ruff_spec="ruff"
           mypy_spec="mypy"
-          pytest_spec="pytest"
-          pytest_cov_spec="pytest-cov"
-          coverage_spec="coverage"
-          pytest_xdist_spec="pytest-xdist"
+          pytest_spec=""
+          pytest_cov_spec=""
+          coverage_spec=""
+          pytest_xdist_spec=""
           # Do not install heavyweight "baseline" test deps implicitly.
           # Repos should declare their own runtime/test dependencies.
 
@@ -1153,6 +1185,14 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
+          require_exact_pin() {
+            local tool=$1
+            local spec=${2:-}
+            if [ -z "$spec" ] || [ "${spec#*==}" = "$spec" ]; then
+              echo "Error: ${tool} must be pinned in ${autofix_env}; refusing to install unpinned tooling." >&2
+              exit 1
+            fi
+          }
           # Always honor tool pins when present. Lock files typically only capture runtime deps.
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
@@ -1164,10 +1204,18 @@ jobs:
             mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
             pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
             pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
-            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.13.2")
-            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
-          elif [ "$has_lock_file" = "false" ]; then
-            echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "")
+          else
+            echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2
+            exit 1
+          fi
+
+          require_exact_pin "pytest" "$pytest_spec"
+          require_exact_pin "pytest-xdist" "$pytest_xdist_spec"
+          if [ "$coverage_enabled" = "true" ]; then
+            require_exact_pin "pytest-cov" "$pytest_cov_spec"
+            require_exact_pin "coverage" "$coverage_spec"
           fi
 
           # Always install dev tools - lock files only contain runtime deps, not dev tools
@@ -1477,10 +1525,10 @@ jobs:
           isort_spec="isort"
           ruff_spec="ruff"
           mypy_spec="mypy"
-          pytest_spec="pytest"
-          pytest_cov_spec="pytest-cov"
-          coverage_spec="coverage"
-          pytest_xdist_spec="pytest-xdist"
+          pytest_spec=""
+          pytest_cov_spec=""
+          coverage_spec=""
+          pytest_xdist_spec=""
           # Do not install heavyweight "baseline" test deps implicitly.
           # Repos should declare their own runtime/test dependencies.
 
@@ -1498,6 +1546,14 @@ jobs:
           }
 
           autofix_env="${GITHUB_WORKSPACE}/.github/workflows/autofix-versions.env"
+          require_exact_pin() {
+            local tool=$1
+            local spec=${2:-}
+            if [ -z "$spec" ] || [ "${spec#*==}" = "$spec" ]; then
+              echo "Error: ${tool} must be pinned in ${autofix_env}; refusing to install unpinned tooling." >&2
+              exit 1
+            fi
+          }
           # Always honor tool pins when present. Lock files typically only capture runtime deps.
           if [ -f "$autofix_env" ]; then
             # shellcheck source=.github/workflows/autofix-versions.env
@@ -1509,10 +1565,18 @@ jobs:
             mypy_spec=$(resolve_spec "mypy" "${MYPY_VERSION:-}" "")
             pytest_spec=$(resolve_spec "pytest" "${PYTEST_VERSION:-}" "")
             pytest_cov_spec=$(resolve_spec "pytest-cov" "${PYTEST_COV_VERSION:-}" "")
-            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "7.13.2")
-            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "3.6.1")
-          elif [ "$has_lock_file" = "false" ]; then
-            echo "Warning: autofix-versions.env not found, installing latest tool versions" >&2
+            coverage_spec=$(resolve_spec "coverage" "${COVERAGE_VERSION:-}" "")
+            pytest_xdist_spec=$(resolve_spec "pytest-xdist" "${PYTEST_XDIST_VERSION:-}" "")
+          else
+            echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2
+            exit 1
+          fi
+
+          require_exact_pin "pytest" "$pytest_spec"
+          require_exact_pin "pytest-xdist" "$pytest_xdist_spec"
+          if [ "$coverage_enabled" = "true" ]; then
+            require_exact_pin "pytest-cov" "$pytest_cov_spec"
+            require_exact_pin "coverage" "$coverage_spec"
           fi
 
           # Always install dev tools - lock files only contain runtime deps, not dev tools

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -511,11 +511,6 @@ jobs:
           tools_installed=()
           tools_skipped=()
 
-          has_lock_file=false
-          if [ -f requirements.lock ]; then
-            has_lock_file=true
-          fi
-
           if [ "$install_project_deps" = "true" ]; then
             if [ -f requirements.lock ]; then
               specs+=('-r' 'requirements.lock')
@@ -821,11 +816,6 @@ jobs:
           specs=()
           tools_installed=()
           tools_skipped=()
-
-          has_lock_file=false
-          if [ -f requirements.lock ]; then
-            has_lock_file=true
-          fi
 
           if [ "$install_project_deps" = "true" ]; then
             if [ -f requirements.lock ]; then

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1137,9 +1137,7 @@ jobs:
           tools_installed=()
           tools_skipped=()
 
-          has_lock_file=false
           if [ -f requirements.lock ]; then
-            has_lock_file=true
             specs+=('-r' 'requirements.lock')
           fi
 
@@ -1498,9 +1496,7 @@ jobs:
           tools_installed=()
           tools_skipped=()
 
-          has_lock_file=false
           if [ -f requirements.lock ]; then
-            has_lock_file=true
             specs+=('-r' 'requirements.lock')
           fi
 

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -120,9 +120,12 @@ def test_workflow_requires_exact_test_tool_pins() -> None:
     assert 'coverage_spec="coverage"' not in run_block
     assert 'pytest_xdist_spec="pytest-xdist"' not in run_block
     assert "installing latest tool versions" not in run_block
-    assert run_block.count(
-        'echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2'
-    ) == 4
+    assert (
+        run_block.count(
+            'echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2'
+        )
+        == 4
+    )
     assert run_block.count('require_exact_pin "pytest" "$pytest_spec"') == 4
     assert run_block.count('require_exact_pin "pytest-xdist" "$pytest_xdist_spec"') == 4
     assert run_block.count('require_exact_pin "pytest-cov" "$pytest_cov_spec"') == 4

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -112,6 +112,23 @@ def test_workflow_uses_shared_mypy_pin_helper() -> None:
     assert 'python "${GITHUB_WORKSPACE}/tools/resolve_mypy_pin.py"' in run_block
 
 
+def test_workflow_requires_exact_test_tool_pins() -> None:
+    run_block = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert 'pytest_spec="pytest"' not in run_block
+    assert 'pytest_cov_spec="pytest-cov"' not in run_block
+    assert 'coverage_spec="coverage"' not in run_block
+    assert 'pytest_xdist_spec="pytest-xdist"' not in run_block
+    assert "installing latest tool versions" not in run_block
+    assert run_block.count(
+        'echo "Error: ${autofix_env} is required; refusing to install unpinned tooling." >&2'
+    ) == 4
+    assert run_block.count('require_exact_pin "pytest" "$pytest_spec"') == 4
+    assert run_block.count('require_exact_pin "pytest-xdist" "$pytest_xdist_spec"') == 4
+    assert run_block.count('require_exact_pin "pytest-cov" "$pytest_cov_spec"') == 4
+    assert run_block.count('require_exact_pin "coverage" "$coverage_spec"') == 4
+
+
 def test_working_directory_propagates_to_steps() -> None:
     workflow = _load_workflow()
     job = workflow["jobs"]["tests"]


### PR DESCRIPTION
## Summary
- make reusable Gate fail closed when `autofix-versions.env` or test tool pins are missing
- remove the fallback that could install unpinned `pytest`, `pytest-cov`, `coverage`, or `pytest-xdist`
- add a regression test that locks in the fail-closed behavior across all duplicated install blocks

## Validation
- `uv run pytest tests/workflows/test_reusable_ci_workflow.py -q`
- `python3 - <<... yaml.safe_load(...)`
