### PR TITLE
Fix synced LangChain scripts for Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,12 @@ ignore = [
     "E501",  # Line too long (handled by black)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# These files are synced into consumer repos that still execute them on
+# Python 3.10/3.11, so they intentionally avoid Python 3.12-only syntax.
+"scripts/langchain/injection_guard.py" = ["UP040"]
+"scripts/langchain/structured_output.py" = ["UP046", "UP047"]
+
 [tool.ruff.lint.isort]
 # Treat scripts.* and tools.* as third-party so import ordering matches consumer
 # repos. Consumer repos have src = ["src", "tests"] which excludes scripts/ and

--- a/scripts/langchain/injection_guard.py
+++ b/scripts/langchain/injection_guard.py
@@ -41,9 +41,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Final, Literal, TypedDict, cast
+from typing import Final, Literal, TypeAlias, TypedDict, cast
 
-type ReasonCode = Literal[
+ReasonCode: TypeAlias = Literal[
     "INSTRUCTION_OVERRIDE",
     "SYSTEM_PROMPT_EXFILTRATION",
     "ROLE_CONFUSION",
@@ -51,7 +51,7 @@ type ReasonCode = Literal[
     "TOOL_INJECTION",
 ]
 
-type GuardResult = tuple[bool, str]
+GuardResult: TypeAlias = tuple[bool, str]
 
 
 class GuardCheckResultAllowed(TypedDict):
@@ -70,7 +70,7 @@ class GuardCheckResultBlocked(TypedDict):
     code: ReasonCode | Literal["GUARD_ERROR"] | None
 
 
-type GuardCheckResult = GuardCheckResultAllowed | GuardCheckResultBlocked
+GuardCheckResult: TypeAlias = GuardCheckResultAllowed | GuardCheckResultBlocked
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -31,7 +31,7 @@ MAX_REPAIR_ATTEMPTS = 1
 
 
 @dataclass(frozen=True)
-class StructuredOutputResult[T: BaseModel]:
+class StructuredOutputResult(Generic[T]):
     payload: T | None
     raw_content: str | None
     error_stage: str | None
@@ -95,7 +95,7 @@ def clamp_repair_attempts(max_repair_attempts: int) -> int:
     )
 
 
-def _invoke_repair_loop[T: BaseModel](
+def _invoke_repair_loop(
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -154,7 +154,7 @@ def _invoke_repair_loop[T: BaseModel](
     )
 
 
-def invoke_repair_loop[T: BaseModel](
+def invoke_repair_loop(
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -171,7 +171,7 @@ def invoke_repair_loop[T: BaseModel](
     )
 
 
-def parse_structured_output[T: BaseModel](
+def parse_structured_output(
     content: str,
     model: type[T],
     *,


### PR DESCRIPTION
## Summary
- revert synced LangChain helper syntax to Python 3.11-compatible TypeAlias/Generic forms
- add Workflows-side Ruff exceptions for the intentional consumer compatibility syntax

## Verification
- `python3 -m py_compile scripts/langchain/injection_guard.py scripts/langchain/structured_output.py`
- `uv run ruff check scripts/langchain/injection_guard.py scripts/langchain/structured_output.py pyproject.toml`
- `uv run black --check --line-length 100 scripts/langchain/injection_guard.py scripts/langchain/structured_output.py`
- `uv run pytest -q tests -k 'structured_output or injection_guard'`\n\nAddresses inline agent review comments on the generated consumer sync PRs that flagged Python 3.12-only PEP 695 syntax in files still executed by Python 3.10/3.11 consumers.