### PR TITLE
Standardize workflow Python runtime on 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows-env",
-  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "onCreateCommand": "sudo apt-get update && sudo apt-get install -y python3-venv curl tar && sudo mkdir -p /usr/local/bin && curl -sSL 'https://github.com/rhysd/actionlint/releases/download/v1.7.3/actionlint_1.7.3_linux_amd64.tar.gz' | sudo tar -xz -C /usr/local/bin actionlint && sudo chmod +x /usr/local/bin/actionlint && sudo rm -f /usr/local/py-utils/bin/black /usr/local/py-utils/bin/ruff /usr/local/py-utils/bin/isort /usr/local/py-utils/bin/mypy",
   "postCreateCommand": "pip install -e '.[dev]' && pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push",
   "postStartCommand": "pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push",

--- a/.github/ISSUE_TEMPLATE/bug_report_codex.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_codex.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Environment
       description: Python version, OS, commit hash
-      placeholder: "Python 3.11, macOS 14.5, commit abc123"
+      placeholder: "Python 3.12, macOS 14.5, commit abc123"
     validations:
       required: true
   - type: textarea

--- a/.github/actions/signature-verify/action.yml
+++ b/.github/actions/signature-verify/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Run signature verification
       shell: bash
       run: |

--- a/.github/signature-fixtures/basic_jobs.json
+++ b/.github/signature-fixtures/basic_jobs.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "core tests (3.11)",
-    "step": "Reusable CI (3.11)",
+    "name": "core tests (3.12)",
+    "step": "Reusable CI (3.12)",
     "stack": "StackToken:ci-311"
   },
   {

--- a/.github/workflow-templates/python-ci.yml
+++ b/.github/workflow-templates/python-ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
-      primary-python-version: '3.11'
+      python-versions: '["3.12", "3.13"]'
+      primary-python-version: '3.12'
       coverage-min: '70'
       enable-soft-gate: true
       # Optional: set this if your project lives in a subdirectory

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,8 +8,8 @@ inventory and naming rules.
 ---
 ## 1. Architecture Snapshot
 Core layers:
-- Gate orchestrator (`pr-00-gate.yml`): single required check that fans out to Python 3.11/3.12 CI and the Docker smoke test using the reusable workflows, then enforces that every leg succeeds.
-- Minimal invariant CI (`pr-11-ci-smoke.yml`): lean push/PR workflow that installs the project once on Python 3.11, sanity-checks imports, and executes the invariant tests from Issue #3651 so regressions surface quickly.
+- Gate orchestrator (`pr-00-gate.yml`): single required check that fans out to Python 3.12/3.13 CI and the Docker smoke test using the reusable workflows, then enforces that every leg succeeds.
+- Minimal invariant CI (`pr-11-ci-smoke.yml`): lean push/PR workflow that installs the project once on Python 3.12, sanity-checks imports, and executes the invariant tests from Issue #3651 so regressions surface quickly.
 - Gate summary (`pr-00-gate.yml` post-CI jobs): integrated post-CI reporting that batches small hygiene fixes, posts Gate summaries, and manages trivial failure remediation using the composite autofix action.
 - Agents orchestration (`agents-70-orchestrator.yml` + `reusable-16-agents.yml`): single entry point for Codex readiness, bootstrap, diagnostics, and watchdog sweeps. Use the [Agent task issue template][agent-task-template] (auto-labels `agents` + `agent:codex`) to raise work for Codex; the issue bridge listens for `agent:codex` and hands issues to the orchestrator. Legacy consumer shims remain removed following Issue #2650.
 - PR metadata management (`agents-pr-meta.yml`): serializes Codex activation commands and PR body decoration through dedicated jobs that share a concurrency group keyed by PR number. This prevents marker thrash while keeping activation dispatch responsive.
@@ -25,7 +25,7 @@ The CI stack now routes every pull request through a single Gate workflow that o
 
 | Lane | Workflow(s) | Purpose | Required Status Today | Future Plan |
 |------|-------------|---------|-----------------------|-------------|
-| Gate orchestrator | `pr-00-gate.yml` job `gate` | Coordinates Python (3.11 + 3.12) and Docker smoke runs, fails fast if any leg fails | Required (`Gate / gate`) | Remains the authoritative CI gate |
+| Gate orchestrator | `pr-00-gate.yml` job `gate` | Coordinates Python (3.12 + 3.13) and Docker smoke runs, fails fast if any leg fails | Required (`Gate / gate`) | Remains the authoritative CI gate |
 | Reusable CI | `reusable-10-ci-python.yml` via `pr-00-gate.yml` | Standard Python toolchain (Black, Ruff, mypy, pytest, coverage upload) used by Gate | Called by Gate | Continue to be the single CI entry point |
 | Reusable Docker smoke | `reusable-12-ci-docker.yml` via `pr-00-gate.yml` | Deterministic Docker build and smoke probe | Called by Gate | Continue to be the single Docker entry point |
 | Gate summary | `pr-00-gate.yml` post-CI jobs | Integrated reporting that posts Gate summaries, commits small hygiene fixes (success runs), and retries trivial CI failures | Not required | Remains optional |
@@ -71,7 +71,7 @@ workflow files.
 
 | Workflow | Trigger(s) | Notes |
 |----------|-----------|-------|
-| `pr-00-gate.yml` | pull_request, workflow_dispatch | Orchestrates reusable Python 3.11/3.12 CI and Docker smoke tests, then enforces all-success before reporting `gate`.
+| `pr-00-gate.yml` | pull_request, workflow_dispatch | Orchestrates reusable Python 3.12/3.13 CI and Docker smoke tests, then enforces all-success before reporting `gate`.
 | `pr-11-ci-smoke.yml` | push (`main`), pull_request (`main`), workflow_dispatch | Minimal invariant sweep that installs the project with dev extras, caches pip dependencies, runs the package import sanity check, and executes `pytest tests/test_invariants.py -q`.
 | `health-41-repo-health.yml` | schedule (weekly), workflow_dispatch | Monday hygiene summary of stale branches and unassigned issues.
 | `maint-47-disable-legacy-workflows.yml` | workflow_run (`Gate`) | Disables legacy workflows as documented for Maint 47.
@@ -237,7 +237,7 @@ Low Coverage Spotlight (follow-up Issue #1386):
 - Customize the threshold with the `low-coverage-threshold` workflow input when calling `reusable-10-ci-python.yml`.
 - Table is separately truncated to the hotspot limit (15) with a truncation notice if more remain.
 Implemented follow-ups (Issue #1352):
-- Normalized artifact naming: `coverage-<python-version>` (e.g. `coverage-3.11`).
+- Normalized artifact naming: `coverage-<python-version>` (e.g. `coverage-3.12`).
 - Consistent file set per matrix job: `coverage.xml`, `coverage.json`, `htmlcov/**`, `pytest-junit.xml`, `pytest-report.xml`.
 - Retention window input `coverage-artifact-retention-days` has a default value of 10.
   This default is chosen to fall within the recommended 7–14 day observation horizon, allowing reviewers to compare multiple consecutive runs without long-term storage bloat.
@@ -269,7 +269,7 @@ Outputs:
   triggers remain disabled after consolidation.
 - **Inputs:**
   - `mode` — `summary`, `comment`, or `dual-runtime`. Summary posts only to the workflow run, comment publishes to a PR, and
-    dual-runtime fans out to both Python 3.11 and 3.12 before surfacing a summary.
+    dual-runtime fans out to both Python 3.12 and 3.13 before surfacing a summary.
   - `post_to` — `none` or `pr-number`. When paired with `mode: comment`, supply `pull_request_number` so the runner knows where
     to post. The workflow validates the number and fails fast on bad input rather than silently skipping the comment.
   - `enable_history` — toggle to download the `selftest-report` artifact emitted by the reusable matrix. Leave disabled for a

--- a/.github/workflows/maint-45-cosmetic-repair.yml
+++ b/.github/workflows/maint-45-cosmetic-repair.yml
@@ -9,7 +9,7 @@ on:
         required: false
       python-version:
         description: Python version to use for pytest
-        default: '3.11'
+        default: '3.12'
         required: false
       dry-run:
         description: Run the repair helper in dry-run mode without creating commits

--- a/.github/workflows/maint-62-integration-consumer.yml
+++ b/.github/workflows/maint-62-integration-consumer.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - name: basic
-            python-versions: '["3.11"]'
+            python-versions: '["3.12"]'
             coverage: false
             format-check: false
             lint: false
@@ -35,7 +35,7 @@ jobs:
             baseline-coverage: '0'
             coverage-alert-drop: '0'
           - name: full
-            python-versions: '["3.11","3.12"]'
+            python-versions: '["3.12","3.13"]'
             coverage: true
             format-check: true
             lint: true
@@ -47,7 +47,7 @@ jobs:
             baseline-coverage: '80'
             coverage-alert-drop: '2'
           - name: monorepo
-            python-versions: '["3.11"]'
+            python-versions: '["3.12"]'
             coverage: true
             format-check: true
             lint: true

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -205,7 +205,7 @@ jobs:
 
           # Check for coverage json
           for candidate in \
-            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.11/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -278,17 +278,17 @@ jobs:
             except json.JSONDecodeError:
               fail(
                 'python-versions must be a valid JSON array of strings '
-                '(example: ["3.11", "3.12"]).'
+                '(example: ["3.12", "3.13"]).'
               )
             if not isinstance(python_versions, list):
-              fail('python-versions must be a JSON array (example: ["3.11", "3.12"]).')
+              fail('python-versions must be a JSON array (example: ["3.12", "3.13"]).')
             if not python_versions:
-              fail('python-versions must include at least one version (example: ["3.11", "3.12"]).')
+              fail('python-versions must include at least one version (example: ["3.12", "3.13"]).')
             for version in python_versions:
               if not isinstance(version, str) or not version.strip():
                 fail(
                   'python-versions entries must be non-empty strings '
-                  '(example: ["3.11", "3.12"]).'
+                  '(example: ["3.12", "3.13"]).'
                 )
 
           validate_number(
@@ -424,7 +424,7 @@ jobs:
             ${{
               inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
 
       - name: Set up Node.js
@@ -448,7 +448,7 @@ jobs:
             ${{ format(
             'uv-{0}-{1}-{2}-{3}',
             runner.os,
-            inputs['primary-python-version'] || inputs['python-version'] || '3.11',
+            inputs['primary-python-version'] || inputs['python-version'] || '3.12',
             hashFiles(format('{0}/requirements.lock', inputs['working-directory'] || '.')),
             hashFiles(format('{0}/pyproject.toml', inputs['working-directory'] || '.'))
             ) }}
@@ -471,7 +471,7 @@ jobs:
             ${{
               inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
         run: |
           set -euo pipefail
@@ -730,7 +730,7 @@ jobs:
             ${{
               inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
 
       - name: Set up Node.js
@@ -754,7 +754,7 @@ jobs:
             ${{ format(
             'uv-{0}-{1}-{2}-{3}',
             runner.os,
-            inputs['primary-python-version'] || inputs['python-version'] || '3.11',
+            inputs['primary-python-version'] || inputs['python-version'] || '3.12',
             hashFiles(format('{0}/requirements.lock', inputs['working-directory'] || '.')),
             hashFiles(format('{0}/pyproject.toml', inputs['working-directory'] || '.'))
             ) }}
@@ -777,7 +777,7 @@ jobs:
             ${{
               inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
         run: |
           set -euo pipefail
@@ -1036,7 +1036,7 @@ jobs:
             ${{
               inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
         run: |
           set -euo pipefail
@@ -1051,7 +1051,7 @@ jobs:
               steps.mypy-pin.outputs.python-version
               || inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
 
       - name: Set up Node.js
@@ -1098,7 +1098,7 @@ jobs:
               steps.mypy-pin.outputs.python-version
               || inputs['primary-python-version']
               || inputs['python-version']
-              || '3.11'
+              || '3.12'
             }}
         run: |
           set -euo pipefail
@@ -1368,7 +1368,7 @@ jobs:
               )
               && format('[{0}]', toJson(inputs['python-version']))
             )
-            || '["3.11"]'
+            || '["3.12"]'
           ) }}
     defaults:
       run:

--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -300,7 +300,7 @@ full_soft_gate"
             const runId = context.runId;
 
             function parsePythonVersions(raw) {
-              const fallback = ['3.11'];
+              const fallback = ['3.12'];
               if (!raw || !raw.trim()) {
                 return fallback;
               }
@@ -515,8 +515,8 @@ full_soft_gate"
             inputs.python_versions) ||
           (github.event_name == 'workflow_dispatch' &&
             inputs.mode == 'dual-runtime' &&
-            '["3.11","3.12"]') ||
-          '["3.11"]'
+            '["3.12","3.13"]') ||
+          '["3.12"]'
         }}
     steps:
       # Mint GitHub App token early to use for API calls (avoids rate limits)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing!
 ### Prerequisites
 
 - Node.js 20+
-- Python 3.11+
+- Python 3.12+
 - Git
 
 ### Local Setup

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -33,7 +33,7 @@ jobs:
   ci:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-version: '3.11'
+      python-version: '3.12'
 ```
 
 2. **Commit and push** - CI will run on your next PR!
@@ -57,12 +57,12 @@ jobs:
   ci-default:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-version: '3.11'
+      python-version: '3.12'
 
   ci-pinned:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@abc123def4567890
     with:
-      python-version: '3.11'
+      python-version: '3.12'
 ```
 
 ---
@@ -78,7 +78,7 @@ jobs:
   python-ci:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-version: '3.11'
+      python-version: '3.12'
     secrets: inherit
 ```
 
@@ -224,7 +224,7 @@ jobs:
   ci:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-version: '3.11'
+      python-version: '3.12'
       run-tests: true
       check-types: true
       coverage-threshold: 80
@@ -426,7 +426,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12', '3.13']
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -794,7 +794,7 @@ The `evaluate` job outputs these new fields:
 **Scenario 1: Tests Failing**
 ```
 Gate Status: failure
-Failed Jobs: [test (3.11), test (3.12)]
+Failed Jobs: [test (3.12), test (3.12)]
 Classification: test failure
 Action: fix
 Reason: fix-test

--- a/docs/WORKFLOW_AUDIT_2025-12-25.md
+++ b/docs/WORKFLOW_AUDIT_2025-12-25.md
@@ -103,7 +103,7 @@ These workflows are designed to be called by other workflows and are not expecte
 
 **Error**: Artifact naming mismatch between expected and actual coverage artifacts
 
-**Root Cause**: The selftest is detecting drift between expected artifact names (`sf-*-coverage-3.11`) and actual (`sf-*-coverage-3.11-1`). This appears to be a test configuration issue.
+**Root Cause**: The selftest is detecting drift between expected artifact names (`sf-*-coverage-3.12`) and actual (`sf-*-coverage-3.12-1`). This appears to be a test configuration issue.
 
 **Recommendation**: Fix the artifact naming expectations or update the reusable workflow to match.
 
@@ -156,7 +156,7 @@ These workflows are designed to be called by other workflows and are not expecte
 ```yaml
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.11'
+    python-version: '3.12'
     cache: pip
     cache-dependency-path: pyproject.toml
 ```

--- a/docs/WORKFLOW_AUDIT_2026-01-09.md
+++ b/docs/WORKFLOW_AUDIT_2026-01-09.md
@@ -72,7 +72,7 @@ ls: cannot access '.github/workflows/agents-capability-check.yml': No such file 
    - Removed self-checkout step (was checking out Workflows into subdirectory)
    - Changed `PYTHONPATH: ${{ github.workspace }}/workflows-repo` → `${{ github.workspace }}`
    - Removed `cd workflows-repo` commands
-   - Changed Python 3.12 → 3.11 (repo standard)
+   - Changed Python 3.12 → 3.12 (repo standard)
 
 **Status:** ✅ Fixed in PR #694
 

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -39,7 +39,7 @@ Tests under `tests/test_workflow_naming.py` enforce the naming policy and invent
 The active roster below mirrors the **Keep** list in the [Workflow System Overview](ci/WORKFLOW_SYSTEM.md). Each entry links back to the filenames under `.github/workflows/` and should be reflected in `docs/ci/WORKFLOWS.md` and the unit tests whenever the inventory changes.
 
 ### PR Checks
-- **`pr-00-gate.yml`** — Required orchestrator that calls the reusable Python (3.11/3.12) and Docker smoke workflows, then fails fast if any leg does not succeed. A lightweight `detect_doc_only` job mirrors the former PR‑14 filters (Markdown, `docs/`, `assets/`) to skip heavy legs and post the friendly notice when a PR is documentation-only, and the ancillary ledger-validation leg now respects that fast-path so readme-only PRs don’t boot Python just to learn there are no `.agents/**` ledgers to scan.
+- **`pr-00-gate.yml`** — Required orchestrator that calls the reusable Python (3.12/3.13) and Docker smoke workflows, then fails fast if any leg does not succeed. A lightweight `detect_doc_only` job mirrors the former PR‑14 filters (Markdown, `docs/`, `assets/`) to skip heavy legs and post the friendly notice when a PR is documentation-only, and the ancillary ledger-validation leg now respects that fast-path so readme-only PRs don’t boot Python just to learn there are no `.agents/**` ledgers to scan.
 - **`pr-11-ci-smoke.yml`** — Minimal invariant CI that runs on push/PR to phase-2-dev and main. Installs the project, validates imports, and runs `pytest tests/test_invariants.py` for fast regression detection; the checkout now relies on the default workflow token since the job never leaves the repository.
 
 _Inline Gate helper_

--- a/docs/archive/plans/DEPENDENCY_MANAGEMENT_SUMMARY.md
+++ b/docs/archive/plans/DEPENDENCY_MANAGEMENT_SUMMARY.md
@@ -35,7 +35,7 @@ The test suite had 30 tests skipping due to missing external dependencies (19 fo
 - Clear distinction between required and optional dependencies
 
 **Test Categories:**
-- `test_python_version()` - Enforces Python 3.11+
+- `test_python_version()` - Enforces Python 3.12+
 - `test_required_packages_importable()` - Validates core packages
 - `test_optional_packages_documented()` - Documents optional package availability
 - `test_node_available()` - Checks Node.js for JavaScript tests
@@ -60,7 +60,7 @@ The test suite had 30 tests skipping due to missing external dependencies (19 fo
 
 **Features:**
 - Color-coded output (green ✓, red ✗, yellow ○)
-- Checks Python version (>=3.11)
+- Checks Python version (>=3.12)
 - Validates all required Python packages
 - Checks optional Python packages
 - Validates external CLI tools (node, npm, uv, coverage)
@@ -72,7 +72,7 @@ The test suite had 30 tests skipping due to missing external dependencies (19 fo
 === Test Dependencies Check ===
 
 Checking Python version...
-✓ Python 3.11.14 (>=3.11 required)
+✓ Python 3.12.14 (>=3.12 required)
 
 Checking required Python packages...
 ✓ pytest
@@ -226,7 +226,7 @@ Created comprehensive 400+ line guide covering:
 ### Required Python Packages
 **Behavior:** Tests fail if missing, CI build fails
 
-- Python 3.11+
+- Python 3.12+
 - pytest >= 8.0
 - coverage >= 7.0
 - hypothesis >= 6.0

--- a/docs/automation-system-implementation.md
+++ b/docs/automation-system-implementation.md
@@ -234,7 +234,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -2,7 +2,7 @@
 
 This repository provides a reusable GitHub Actions workflow that layers three progressive phases on top of a minimal test + coverage gate. All advanced features are opt‑in so existing callers remain unaffected until they enable them.
 
-> **Note (Issue #2656):** The in-repo Gate workflow now calls `reusable-10-ci-python.yml` for Python 3.11/3.12 alongside the Docker smoke reusable. The former matrix wrapper (`reusable-90-ci-python.yml`) was retired during the CI consolidation; downstream consumers should invoke `reusable-10-ci-python.yml` directly or dispatch `selftest-reusable-ci.yml` when they need a matrix verification sweep. Historical notes about the removed wrapper live in [ARCHIVE_WORKFLOWS.md](archive/ARCHIVE_WORKFLOWS.md).
+> **Note (Issue #2656):** The in-repo Gate workflow now calls `reusable-10-ci-python.yml` for Python 3.12/3.13 alongside the Docker smoke reusable. The former matrix wrapper (`reusable-90-ci-python.yml`) was retired during the CI consolidation; downstream consumers should invoke `reusable-10-ci-python.yml` directly or dispatch `selftest-reusable-ci.yml` when they need a matrix verification sweep. Historical notes about the removed wrapper live in [ARCHIVE_WORKFLOWS.md](archive/ARCHIVE_WORKFLOWS.md).
 
 ### Overview
 
@@ -17,7 +17,7 @@ This repository provides a reusable GitHub Actions workflow that layers three pr
 
 Core:
 ```
-python-versions              JSON list of Python versions (default ["3.11"]) 
+python-versions              JSON list of Python versions (default ["3.12"])
 coverage-min                 Minimum coverage percentage to pass (default 70)
 run-mypy                     'true'/'false' toggle to run mypy job (default true)
 ```
@@ -115,7 +115,7 @@ jobs:
   ci:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@v1
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       coverage-min: '72'
       enable-metrics: 'true'
       enable-history: 'true'
@@ -141,7 +141,7 @@ jobs:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@v1
     with:
       working-directory: packages/my-package
-      python-versions: '["3.11"]'
+      python-versions: '["3.12"]'
       coverage-min: '80'
 ```
 

--- a/docs/git-hooks/overview.md
+++ b/docs/git-hooks/overview.md
@@ -173,7 +173,7 @@ Different hooks apply to different file types:
 
 #### Hook Dependencies
 
-- **Python 3.11+** - Required for Black, Ruff
+- **Python 3.12+** - Required for Black, Ruff
 - **Bash** - Required for dev_check.sh, validate_fast.sh
 - **Git** - Obviously required for hooks
 

--- a/docs/integration-test-failure-fix.patch
+++ b/docs/integration-test-failure-fix.patch
@@ -55,7 +55,7 @@ index 4bf74ae..ce5a333 100644
 @@ -32,14 +31,14 @@ def test_main_without_github_output(monkeypatch: pytest.MonkeyPatch) -> None:
      """Test script works locally without GITHUB_OUTPUT."""
      monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-     monkeypatch.setenv("MATRIX_PYTHON_VERSION", "3.11")
+     monkeypatch.setenv("MATRIX_PYTHON_VERSION", "3.12")
 -    
 +
      from tools.resolve_mypy_pin import main
@@ -69,10 +69,10 @@ index 4bf74ae..ce5a333 100644
 -    
 +
      assert result == 0
-     assert "python-version=3.11" in captured_output.getvalue()
+     assert "python-version=3.12" in captured_output.getvalue()
  
 @@ -48,14 +47,14 @@ def test_main_defaults_to_311(monkeypatch: pytest.MonkeyPatch) -> None:
-     """Test script uses 3.11 as default when MATRIX_PYTHON_VERSION not set."""
+     """Test script uses 3.12 as default when MATRIX_PYTHON_VERSION not set."""
      monkeypatch.delenv("MATRIX_PYTHON_VERSION", raising=False)
      monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
 -    
@@ -88,7 +88,7 @@ index 4bf74ae..ce5a333 100644
 -    
 +
      assert result == 0
-     assert "python-version=3.11" in captured_output.getvalue()
+     assert "python-version=3.12" in captured_output.getvalue()
  
 @@ -65,11 +64,11 @@ def test_main_with_custom_version(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
      output_file = tmp_path / "output.txt"
@@ -151,13 +151,13 @@ index 36c8496..cae0dcb 100644
      assert "✅" in result.stdout
  
 @@ -39,6 +40,6 @@ def test_resolve_mypy_pin_as_script() -> None:
-         env={"MATRIX_PYTHON_VERSION": "3.11"},
+         env={"MATRIX_PYTHON_VERSION": "3.12"},
          cwd=Path(__file__).parent.parent,
      )
 -    
 +
      assert result.returncode == 0
-     assert "python-version=3.11" in result.stdout
+     assert "python-version=3.12" in result.stdout
 diff --git a/tests/test_sync_test_dependencies.py b/tests/test_sync_test_dependencies.py
 index c7bd2b6..8272c9f 100644
 --- a/tests/test_sync_test_dependencies.py

--- a/docs/keepalive/SETUP_CHECKLIST.md
+++ b/docs/keepalive/SETUP_CHECKLIST.md
@@ -370,7 +370,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@v1
     with:
-      python-versions: '["3.11", "3.12", "3.13"]'
+      python-versions: '["3.12", "3.13"]'
       primary-python-version: "3.13"
       coverage-min: "80"
     secrets: inherit
@@ -404,7 +404,7 @@ jobs:
   ci:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@v1
     with:
-      python-versions: '["3.11", "3.12", "3.13"]'
+      python-versions: '["3.12", "3.13"]'
       primary-python-version: "3.13"
       coverage-min: "80"
     secrets: inherit
@@ -451,7 +451,7 @@ name = "my-project"
 version = "0.1.0"
 description = "My project description"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.optional-dependencies]
@@ -467,7 +467,7 @@ testpaths = ["tests"]
 addopts = "-v --cov=src --cov-report=term-missing"
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 88
 src = ["src", "tests"]
 
@@ -475,7 +475,7 @@ src = ["src", "tests"]
 select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/docs/plans/black-26-upgrade.md
+++ b/docs/plans/black-26-upgrade.md
@@ -11,7 +11,7 @@ Bring every registered consumer repository up to the same formatter pin that the
 | --- | --- | --- | --- | --- |
 | Travel-Plan-Permission | `../Travel-Plan-Permission` | ✅ `black>=26.1.0` (`pyproject.toml` line 32) & lockfile pin | `rg "black" pyproject.toml requirements.lock` | Already aligned; use as verification baseline after automation runs. |
 | Template | `../Template` | ✅ `black==26.1.0` in dev extras + `[tool.black]` (pyproject lines 26/92) | `rg "black" pyproject.toml requirements-dev.lock` | Added pin + config via Template commit (local changes ready to push). |
-| Counter_Risk | `../Counter_Risk` | ⚠️ `black==24.10.0` across `pyproject.toml`, `requirements.lock`, `requirements-dev.lock` | `rg "black"` | Upgrade blocker; recent rollbacks (see `agents/autofix_pr104_*` notes) need a follow-up fix after verifying Python 3.11 compatibility. |
+| Counter_Risk | `../Counter_Risk` | ⚠️ `black==24.10.0` across `pyproject.toml`, `requirements.lock`, `requirements-dev.lock` | `rg "black"` | Upgrade blocker; recent rollbacks (see `agents/autofix_pr104_*` notes) need a follow-up fix after verifying Python 3.12 compatibility. |
 | trip-planner | `../trip-planner` | 🚫 no formatter dependency or config | `pyproject.toml` only lists ruff/mypy/pytest | Need to add `black==26.1.0` dev extra and wire into CI scripts; also ensure `scripts/check_test_dependencies.sh` installs it. |
 | Manager-Database | `../Manager-Database` | ✅ `black==26.1.0` (`pyproject.toml` line 33, `requirements.lock`) | `rg "black" pyproject.toml requirements.lock` | No change required besides verifying once automation lands. |
 | Portable-Alpha-Extension-Model | `../Portable-Alpha-Extension-Model` | ⚠️ Mixed: `requirements.lock` pin 26.1.0 but `requirements-dev.txt` still 24.4.2 | `rg "black" requirements-dev.txt requirements.lock` | Need to update dev requirements + Makefile bootstrap to 26.1.0 so local workflows stop flipping the version. |
@@ -27,7 +27,7 @@ Bring every registered consumer repository up to the same formatter pin that the
 
 2. **Define repo-specific upgrade steps**
    - **Template:** add `"black==26.1.0"` to `[project.optional-dependencies.dev]` and ensure `.github/workflows/pr-00-gate.yml` calls `black --check .`.
-   - **Counter_Risk:** reproduce the Python 3.11 install error cited in `agents/autofix_pr104_*`, then bump pins + rerun `scripts/sync_dev_dependencies.py --check`. We may need to patch any legacy import incompatibilities before repinning.
+   - **Counter_Risk:** reproduce the Python 3.12 install error cited in `agents/autofix_pr104_*`, then bump pins + rerun `scripts/sync_dev_dependencies.py --check`. We may need to patch any legacy import incompatibilities before repinning.
    - **trip-planner & Collab-Admin:** create `requirements-dev.txt` (if absent) with Black 26, update CI to install it, and add a `[tool.black]` section with the shared settings (line length 100).
    - **Portable-Alpha-Extension-Model:** align `requirements-dev.txt`, Makefile bootstrap, and any docs that still instruct developers to install `black==24.4.2`.
 

--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -21,7 +21,7 @@ Before starting, ensure you have:
 - [ ] A GitHub PAT for the service bot account (for SERVICE_BOT_PAT)
 - [ ] Admin access to create repository secrets and variables
 - [ ] Claude Code login/session available if you want Claude-run workflows
-- [ ] Python 3.11+ installed locally for testing
+- [ ] Python 3.12+ installed locally for testing
 
 ---
 
@@ -694,7 +694,7 @@ For Python projects, ensure:
 - [ ] `pyproject.toml` exists with dependencies
 - [ ] `src/` directory structure follows package conventions
 - [ ] `tests/` directory exists with `conftest.py`
-- [ ] `.python-version` file specifies Python version (e.g., `3.11`)
+- [ ] `.python-version` file specifies Python version (e.g., `3.12`)
 
 ---
 

--- a/docs/templates/WORKFLOW_TEMPLATE.md
+++ b/docs/templates/WORKFLOW_TEMPLATE.md
@@ -162,7 +162,7 @@ jobs:
   ci:
     uses: stranske/Workflows/.github/workflows/WORKFLOW_FILE.yml@v1
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       package-name: my-package
       coverage-min: '80'
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,12 +120,6 @@ ignore = [
     "E501",  # Line too long (handled by black)
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# These files are synced into consumer repos that still execute them on
-# Python 3.10/3.11, so they intentionally avoid Python 3.12-only syntax.
-"scripts/langchain/injection_guard.py" = ["UP040"]
-"scripts/langchain/structured_output.py" = ["UP046", "UP047"]
-
 [tool.ruff.lint.isort]
 # Treat scripts.* and tools.* as third-party so import ordering matches consumer
 # repos. Consumer repos have src = ["src", "tests"] which excludes scripts/ and

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -23,9 +23,9 @@ python_major=$(echo "$python_version" | cut -d. -f1)
 python_minor=$(echo "$python_version" | cut -d. -f2)
 
 if [[ "$python_major" -ge 3 ]] && [[ "$python_minor" -ge 11 ]]; then
-    echo -e "${GREEN}✓${NC} Python $python_version (>=3.11 required)"
+    echo -e "${GREEN}✓${NC} Python $python_version (>=3.12 required)"
 else
-    echo -e "${RED}✗${NC} Python $python_version (>=3.11 required)"
+    echo -e "${RED}✗${NC} Python $python_version (>=3.12 required)"
     all_ok=false
 fi
 echo ""

--- a/scripts/langchain/injection_guard.py
+++ b/scripts/langchain/injection_guard.py
@@ -41,9 +41,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Final, Literal, TypeAlias, TypedDict, cast
+from typing import Final, Literal, TypedDict, cast
 
-ReasonCode: TypeAlias = Literal[
+type ReasonCode = Literal[
     "INSTRUCTION_OVERRIDE",
     "SYSTEM_PROMPT_EXFILTRATION",
     "ROLE_CONFUSION",
@@ -51,7 +51,7 @@ ReasonCode: TypeAlias = Literal[
     "TOOL_INJECTION",
 ]
 
-GuardResult: TypeAlias = tuple[bool, str]
+type GuardResult = tuple[bool, str]
 
 
 class GuardCheckResultAllowed(TypedDict):
@@ -70,7 +70,7 @@ class GuardCheckResultBlocked(TypedDict):
     code: ReasonCode | Literal["GUARD_ERROR"] | None
 
 
-GuardCheckResult: TypeAlias = GuardCheckResultAllowed | GuardCheckResultBlocked
+type GuardCheckResult = GuardCheckResultAllowed | GuardCheckResultBlocked
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -31,7 +31,7 @@ MAX_REPAIR_ATTEMPTS = 1
 
 
 @dataclass(frozen=True)
-class StructuredOutputResult(Generic[T]):
+class StructuredOutputResult[T: BaseModel]:
     payload: T | None
     raw_content: str | None
     error_stage: str | None
@@ -95,7 +95,7 @@ def clamp_repair_attempts(max_repair_attempts: int) -> int:
     )
 
 
-def _invoke_repair_loop(
+def _invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -154,7 +154,7 @@ def _invoke_repair_loop(
     )
 
 
-def invoke_repair_loop(
+def invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -171,7 +171,7 @@ def invoke_repair_loop(
     )
 
 
-def parse_structured_output(
+def parse_structured_output[T: BaseModel](
     content: str,
     model: type[T],
     *,

--- a/templates/ci-full.yml
+++ b/templates/ci-full.yml
@@ -125,7 +125,7 @@ jobs:
             -v
 
       - name: Upload coverage
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           files: coverage.xml

--- a/templates/consumer-repo/.github/scripts/coverage-normalize.js
+++ b/templates/consumer-repo/.github/scripts/coverage-normalize.js
@@ -147,8 +147,8 @@ function sortJobs(jobCoverages) {
     return entries;
   }
   let preferred = null;
-  if (jobCoverages.has('coverage-3.11')) {
-    preferred = 'coverage-3.11';
+  if (jobCoverages.has('coverage-3.12')) {
+    preferred = 'coverage-3.12';
   } else {
     preferred = entries
       .map(([name]) => name)

--- a/templates/consumer-repo/.github/scripts/coverage-normalize.js
+++ b/templates/consumer-repo/.github/scripts/coverage-normalize.js
@@ -147,8 +147,8 @@ function sortJobs(jobCoverages) {
     return entries;
   }
   let preferred = null;
-  if (jobCoverages.has('coverage-3.12')) {
-    preferred = 'coverage-3.12';
+  if (jobCoverages.has('coverage-3.11')) {
+    preferred = 'coverage-3.11';
   } else {
     preferred = entries
       .map(([name]) => name)

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -225,7 +225,7 @@ jobs:
         if: steps.check_enabled.outputs.enabled == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache pip (LLM requirements)
         if: steps.check_enabled.outputs.enabled == 'true'

--- a/templates/consumer-repo/.github/workflows/agents-capability-check.yml
+++ b/templates/consumer-repo/.github/workflows/agents-capability-check.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/templates/consumer-repo/.github/workflows/agents-decompose.yml
+++ b/templates/consumer-repo/.github/workflows/agents-decompose.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/templates/consumer-repo/.github/workflows/agents-dedup.yml
+++ b/templates/consumer-repo/.github/workflows/agents-dedup.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -629,7 +629,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install pydantic langchain-openai langchain-anthropic

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Download metrics artifacts
         env:

--- a/templates/consumer-repo/.github/workflows/ci.yml
+++ b/templates/consumer-repo/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 # - Lint (Ruff)
 # - Format check (Black)
 # - Type checking (mypy)
-# - Tests (pytest) on Python 3.11 and 3.12
+# - Tests (pytest) on Python 3.12 and 3.13
 #
 # NOTE: Do NOT add a top-level 'permissions:' block here. It causes
 # startup_failure when calling reusable workflows. The reusable workflow
@@ -27,7 +27,7 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       typecheck: true
       coverage: true
       coverage-min: '80'

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -227,7 +227,7 @@ jobs:
 
           # Check for coverage json
           for candidate in \
-            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.11/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -132,8 +132,8 @@ jobs:
       contents: read
       actions: read
     with:
-      primary-python-version: '3.11'
-      python-versions: '["3.11", "3.12"]'
+      primary-python-version: '3.12'
+      python-versions: '["3.12", "3.13"]'
       marker: "not quarantine and not slow"
       pytest_markers: ${{ needs.detect.outputs.pytest_markers }}
       lint: ${{ needs.detect.outputs.lint == 'true' }}
@@ -167,7 +167,7 @@ jobs:
       - run: node --test .github/scripts/__tests__/*.test.js
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - run: python -m pip install --upgrade pip pytest requests
       - run: pytest tests/workflows/github_scripts
 
@@ -193,7 +193,7 @@ jobs:
             "refs/heads/${base_ref}:refs/remotes/upstream/${base_ref}"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Check issue number consistency
         run: python scripts/check_issue_consistency.py
         env:
@@ -243,7 +243,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install PyYAML
         run: pip install PyYAML

--- a/templates/consumer-repo/tools/resolve_mypy_pin.py
+++ b/templates/consumer-repo/tools/resolve_mypy_pin.py
@@ -74,7 +74,7 @@ def main() -> int:
         output_version = mypy_version
     else:
         # Default to the primary Python version (first in typical matrices)
-        output_version = matrix_version or "3.11"
+        output_version = matrix_version or "3.12"
 
     # Write to GITHUB_OUTPUT
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/templates/integration-repo/.github/workflows/ci.yml
+++ b/templates/integration-repo/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
 
   # Configuration 2: Full coverage - all features enabled
   full-coverage:
-    name: Full coverage (3.11, 3.12)
+    name: Full coverage (3.12, 3.12)
     uses: __WORKFLOW_REF__
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       coverage: true
       lint: true
       format_check: true
@@ -54,10 +54,10 @@ jobs:
 
   # Configuration 3: Typecheck only - focused mypy validation
   typecheck-only:
-    name: Typecheck only (3.11)
+    name: Typecheck only (3.12)
     uses: __WORKFLOW_REF__
     with:
-      python-versions: '["3.11"]'
+      python-versions: '["3.12"]'
       coverage: false
       lint: false
       format_check: false

--- a/templates/integration-repo/tools/resolve_mypy_pin.py
+++ b/templates/integration-repo/tools/resolve_mypy_pin.py
@@ -13,7 +13,7 @@ import sys
 
 def main() -> int:
     # Get the current matrix Python version from environment
-    matrix_version = os.environ.get("MATRIX_PYTHON_VERSION", "3.11")
+    matrix_version = os.environ.get("MATRIX_PYTHON_VERSION", "3.12")
 
     # Write to GITHUB_OUTPUT
     github_output = os.environ.get("GITHUB_OUTPUT")

--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -10,8 +10,8 @@ def _write_json(path: Path, payload: object) -> None:
 
 def _sample_runs(states: dict[str, str | None] | None = None) -> list[dict[str, object]]:
     job_states = states or {
-        "Core Tests (3.11)": "success",
         "Core Tests (3.12)": "success",
+        "Core Tests (3.13)": "success",
         "Docker Smoke": "success",
         "Gate": "success",
     }
@@ -37,16 +37,16 @@ def test_load_required_groups_derives_from_runs() -> None:
     groups = post_ci_summary._load_required_groups(None, runs)
 
     labels = [group["label"] for group in groups]
-    assert labels == ["Core Tests (3.11)", "Core Tests (3.12)", "Docker Smoke", "Gate"]
-    assert groups[0]["patterns"] == [r"^Core\ Tests\ \(3\.11\)$"]
+    assert labels == ["Core Tests (3.12)", "Core Tests (3.13)", "Docker Smoke", "Gate"]
+    assert groups[0]["patterns"] == [r"^Core\ Tests\ \(3\.12\)$"]
     assert groups[3]["patterns"] == [r"^Gate$"]
 
 
 def test_collect_category_states_marks_docs_only_fast_pass() -> None:
     runs = _sample_runs(
         {
-            "Core Tests (3.11)": "skipped",
             "Core Tests (3.12)": "skipped",
+            "Core Tests (3.13)": "skipped",
             "Docker Smoke": "skipped",
         }
     )
@@ -147,7 +147,7 @@ def test_main_writes_github_output(tmp_path: Path, monkeypatch) -> None:
 
 def test_collect_triage_block_from_artifacts(tmp_path: Path) -> None:
     artifacts_root = tmp_path / "gate_artifacts"
-    runtime_dir = artifacts_root / "downloads" / "coverage" / "runtimes" / "3.11"
+    runtime_dir = artifacts_root / "downloads" / "coverage" / "runtimes" / "3.12"
     runtime_dir.mkdir(parents=True)
 
     summary_payload = {

--- a/tests/workflows/github_scripts/test_gate_summary.py
+++ b/tests/workflows/github_scripts/test_gate_summary.py
@@ -60,7 +60,7 @@ def test_doc_only_summary_state() -> None:
 
 
 def test_active_summary_reads_artifacts(tmp_path: Path) -> None:
-    write_summary(tmp_path, "3.11")
+    write_summary(tmp_path, "3.12")
 
     context = gate_summary.SummaryContext(
         doc_only=False,
@@ -112,7 +112,7 @@ def test_summary_state_reflects_python_outcome(
 
 
 def test_cosmetic_failure_detected(tmp_path: Path) -> None:
-    write_summary(tmp_path, "3.11", format_outcome="failure")
+    write_summary(tmp_path, "3.12", format_outcome="failure")
     context = gate_summary.SummaryContext(
         doc_only=False,
         run_core=True,
@@ -133,7 +133,7 @@ def test_cosmetic_failure_detected(tmp_path: Path) -> None:
 
 
 def test_cosmetic_failure_rejects_other_failures(tmp_path: Path) -> None:
-    write_summary(tmp_path, "3.11", tests="failure")
+    write_summary(tmp_path, "3.12", tests="failure")
     context = gate_summary.SummaryContext(
         doc_only=False,
         run_core=True,
@@ -153,8 +153,8 @@ def test_cosmetic_failure_rejects_other_failures(tmp_path: Path) -> None:
 
 
 def test_cosmetic_failure_reports_all_allowed_checks(tmp_path: Path) -> None:
-    write_summary(tmp_path, "3.11", format_outcome="failure")
-    write_summary(tmp_path, "3.12", lint="failure")
+    write_summary(tmp_path, "3.12", format_outcome="failure")
+    write_summary(tmp_path, "3.13", lint="failure")
 
     context = gate_summary.SummaryContext(
         doc_only=False,
@@ -277,7 +277,7 @@ def test_doc_only_lines_defaults_reason() -> None:
 
 
 def test_summarize_handles_skipped_python_when_core_runs(tmp_path: Path) -> None:
-    write_summary(tmp_path, "3.11")
+    write_summary(tmp_path, "3.12")
     context = gate_summary.SummaryContext(
         doc_only=False,
         run_core=True,

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -34,7 +34,7 @@ def _normalize_expr(value: str) -> str:
 
 
 def test_matrix_expression_supports_arrays_and_singletons() -> None:
-    assert _matrix_candidates('["3.12", "3.13"]', "3.11") == ["3.12", "3.13"]
+    assert _matrix_candidates('["3.12", "3.13"]', "3.12") == ["3.12", "3.13"]
     assert _matrix_candidates("3.13", "3.12") == ["3.13"]
     assert _matrix_candidates("", "3.12") == ["3.12"]
     assert _matrix_candidates("[]", "") == ["3.12"]

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -45,12 +45,12 @@ class RequiredJobGroup(TypedDict):
 
 DEFAULT_REQUIRED_JOB_GROUPS: list[RequiredJobGroup] = [
     {
-        "label": "python ci (3.11)",
-        "patterns": [r"(python\s*ci|core\s*(tests?)?).*(3\.11|py\.?311)"],
-    },
-    {
         "label": "python ci (3.12)",
         "patterns": [r"(python\s*ci|core\s*(tests?)?).*(3\.12|py\.?312)"],
+    },
+    {
+        "label": "python ci (3.13)",
+        "patterns": [r"(python\s*ci|core\s*(tests?)?).*(3\.13|py\.?313)"],
     },
     {"label": "docker smoke", "patterns": [r"docker.*smoke|smoke.*docker"]},
     {"label": "gate", "patterns": [r"gate"]},
@@ -134,26 +134,25 @@ class RequiredJobRule(TypedDict):
 
 REQUIRED_JOB_RULES: list[RequiredJobRule] = [
     {
-        "key": "core311",
-        "label": "core tests (3.11)",
-        "slug_variants": [
-            ["core", "3-11"],
-            ["core", "311"],
-            ["py311"],
-            ["3-11", "tests"],
-        ],
-        "fallback_patterns": [r"core\s*(tests?)?.*(3\.11|py\.?311)"],
-    },
-    {
         "key": "core312",
         "label": "core tests (3.12)",
         "slug_variants": [
             ["core", "3-12"],
-            ["core", "312"],
             ["py312"],
             ["3-12", "tests"],
         ],
         "fallback_patterns": [r"core\s*(tests?)?.*(3\.12|py\.?312)"],
+    },
+    {
+        "key": "core313",
+        "label": "core tests (3.13)",
+        "slug_variants": [
+            ["core", "3-13"],
+            ["core", "313"],
+            ["py313"],
+            ["3-13", "tests"],
+        ],
+        "fallback_patterns": [r"core\s*(tests?)?.*(3\.13|py\.?313)"],
     },
     {
         "key": "docker",
@@ -170,7 +169,7 @@ REQUIRED_JOB_RULES: list[RequiredJobRule] = [
 ]
 
 
-DOC_ONLY_JOB_KEYS: tuple[str, ...] = ("core311", "core312", "docker")
+DOC_ONLY_JOB_KEYS: tuple[str, ...] = ("core312", "core313", "docker")
 
 
 def _matches_slug(slug: str, variants: Sequence[Sequence[str]]) -> bool:

--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -74,7 +74,7 @@ def main() -> int:
         output_version = mypy_version
     else:
         # Default to the primary Python version (first in typical matrices)
-        output_version = matrix_version or "3.11"
+        output_version = matrix_version or "3.12"
 
     # Write to GITHUB_OUTPUT
     github_output = os.environ.get("GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary
- remove remaining active Python 3.11 workflow/runtime defaults from Workflows, reusable CI, actions, templates, and active docs
- shift matrix defaults to Python 3.12/3.13 and single-runtime fallbacks to Python 3.12
- restore synced LangChain helpers to Python 3.12 syntax and remove the previous 3.11 compatibility Ruff exception
- update tests and status-summary grouping for 3.12/3.13

## Audit
- Scanned all 15 owned repos visible to the account: Collab-Admin, Collab-Deliverables, Counter_Risk, Inv-Man-Intake, Manager-Database, Pension-Data, Portable-Alpha-Extension-Model, Ready, stranske, Template, Travel-Plan-Permission, Trend_Model_Project, trip-planner, Workflows, Workflows-Integration-Tests.
- Workflows active runtime/config/test/doc surfaces now have no `3.11` or `py311` hits except dependency package versions such as `idna==3.11` and `orjson==3.11.7`.
- Consumer repos still need follow-up sync and repo-specific PRs for create-only workflows and project-level dependency metadata.

## Verification
- `uv run ruff check .`
- `uv run black --check --line-length 100 .`
- `python scripts/check_api_wrapper_guard.py --base-ref origin/main`
- YAML parse across Workflows, consumer template, and integration template workflows
- targeted Python runtime/status tests: 66 passed
- `uv run pytest -q` (1966 passed, 6 skipped, 3 xfailed)
- `git diff --check`