### PR TITLE
Fix Python 3.12 consumer guard follow-ups

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -207,6 +207,9 @@ scripts:
   - source: tools/coverage_trend.py
     description: "Generates coverage trend summaries - required by reusable CI workflow"
 
+  - source: tools/coverage_guard.py
+    description: "Checks coverage guard artifacts - required by maint-coverage-guard.yml"
+
   # Scripts directory - CI helpers used by reusable-10-ci-python.yml
   - source: scripts/coverage_history_append.py
     description: "Appends coverage data to history file - required by reusable CI workflow"

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -206,6 +206,7 @@ jobs:
           # Check for coverage json
           for candidate in \
             "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.13/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -22,7 +22,7 @@ python_version=$(python --version 2>&1 | awk '{print $2}')
 python_major=$(echo "$python_version" | cut -d. -f1)
 python_minor=$(echo "$python_version" | cut -d. -f2)
 
-if [[ "$python_major" -ge 3 ]] && [[ "$python_minor" -ge 11 ]]; then
+if [[ "$python_major" -gt 3 ]] || { [[ "$python_major" -eq 3 ]] && [[ "$python_minor" -ge 12 ]]; }; then
     echo -e "${GREEN}✓${NC} Python $python_version (>=3.12 required)"
 else
     echo -e "${RED}✗${NC} Python $python_version (>=3.12 required)"

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -228,6 +228,7 @@ jobs:
           # Check for coverage json
           for candidate in \
             "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.13/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then


### PR DESCRIPTION
## Summary
- enforce the 3.12 floor in the shared test dependency shell check
- probe both 3.12 and 3.13 coverage artifact paths in coverage guard workflows
- sync tools/coverage_guard.py because maint-coverage-guard.yml invokes it in consumer repos

## Validation
- bash -n scripts/check_test_dependencies.sh
- uv run ruff check tools/coverage_guard.py
- YAML parse for sync manifest and coverage guard workflows