### PR TITLE
Harden sync review follow-ups

### DIFF
--- a/.github/scripts/__tests__/coverage-normalize.test.js
+++ b/.github/scripts/__tests__/coverage-normalize.test.js
@@ -24,6 +24,7 @@ test('parses coverage xml and json payloads', () => {
 test('computes coverage stats and writes files', async () => {
   const cwd = process.cwd();
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-test-'));
+  const previousReferenceRuntime = process.env.COVERAGE_REFERENCE_RUNTIME;
   process.chdir(tempDir);
   try {
     const summaryDir = path.join(tempDir, 'summary_artifacts', 'coverage-runtimes', 'coverage-3.12');
@@ -42,14 +43,30 @@ test('computes coverage stats and writes files', async () => {
     const deltaPath = path.join(tempDir, 'summary_artifacts', 'coverage-delta.json');
     fs.writeFileSync(deltaPath, JSON.stringify({ delta: 1 }));
 
+    delete process.env.COVERAGE_REFERENCE_RUNTIME;
     const result = await computeCoverageStats({ core: null });
     assert.ok(result.stats.avg_latest >= 0);
     assert.equal(result.stats.job_coverages.length, 2);
-    assert.equal(result.stats.diff_reference, '3.12');
-    assert.equal(result.stats.job_coverages[0].name, 'coverage-3.12');
+    assert.equal(result.stats.diff_reference, '3.13');
+    assert.equal(result.stats.job_coverages[0].name, 'coverage-3.13');
+
+    process.env.COVERAGE_REFERENCE_RUNTIME = '3.12';
+    const primaryRuntime = await computeCoverageStats({ core: null });
+    assert.equal(primaryRuntime.stats.diff_reference, '3.12');
+    assert.equal(primaryRuntime.stats.job_coverages[0].name, 'coverage-3.12');
+
+    process.env.COVERAGE_REFERENCE_RUNTIME = '3.13';
+    const overridden = await computeCoverageStats({ core: null });
+    assert.equal(overridden.stats.diff_reference, '3.13');
+    assert.equal(overridden.stats.job_coverages[0].name, 'coverage-3.13');
     assert.ok(fs.existsSync(path.join(tempDir, 'coverage-stats.json')));
     assert.ok(fs.existsSync(path.join(tempDir, 'coverage-delta-output.json')));
   } finally {
+    if (previousReferenceRuntime === undefined) {
+      delete process.env.COVERAGE_REFERENCE_RUNTIME;
+    } else {
+      process.env.COVERAGE_REFERENCE_RUNTIME = previousReferenceRuntime;
+    }
     process.chdir(cwd);
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/.github/scripts/coverage-normalize.js
+++ b/.github/scripts/coverage-normalize.js
@@ -133,6 +133,14 @@ function runtimeFrom(label) {
   return label.startsWith(prefix) ? label.slice(prefix.length) : label;
 }
 
+function coverageNameForRuntime(runtime) {
+  const value = String(runtime || '').trim();
+  if (!value) {
+    return null;
+  }
+  return value.startsWith('coverage-') ? value : `coverage-${value}`;
+}
+
 function naturalSortKey(name) {
   const runtime = runtimeFrom(name);
   const parts = runtime.split(/(\d+)/);
@@ -141,35 +149,45 @@ function naturalSortKey(name) {
     .map(part => (part.match(/^\d+$/) ? [0, Number.parseInt(part, 10)] : [1, part]));
 }
 
-function sortJobs(jobCoverages) {
+function compareNaturalNames(a, b) {
+  const aKey = naturalSortKey(a);
+  const bKey = naturalSortKey(b);
+  for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
+    const aPart = aKey[i] || [2, ''];
+    const bPart = bKey[i] || [2, ''];
+    if (aPart[0] !== bPart[0]) {
+      return aPart[0] - bPart[0];
+    }
+    if (aPart[1] < bPart[1]) {
+      return -1;
+    }
+    if (aPart[1] > bPart[1]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+function sortJobs(jobCoverages, preferredRuntime = process.env.COVERAGE_REFERENCE_RUNTIME) {
   const entries = Array.from(jobCoverages.entries());
   if (!entries.length) {
     return entries;
   }
   let preferred = null;
-  if (jobCoverages.has('coverage-3.12')) {
-    preferred = 'coverage-3.12';
+  const preferredName = coverageNameForRuntime(preferredRuntime);
+  if (preferredName && jobCoverages.has(preferredName)) {
+    preferred = preferredName;
   } else {
     preferred = entries
       .map(([name]) => name)
-      .sort((a, b) => {
-        const aKey = naturalSortKey(a);
-        const bKey = naturalSortKey(b);
-        for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
-          const aPart = aKey[i] || [2, ''];
-          const bPart = bKey[i] || [2, ''];
-          if (aPart[0] !== bPart[0]) {
-            return aPart[0] - bPart[0];
-          }
-          if (aPart[1] < bPart[1]) {
-            return -1;
-          }
-          if (aPart[1] > bPart[1]) {
-            return 1;
-          }
-        }
-        return 0;
-      })[0];
+      .filter(name => /^coverage-\d+(?:\.\d+)*$/.test(name))
+      .sort(compareNaturalNames)
+      .pop();
+    if (!preferred) {
+      preferred = entries
+        .map(([name]) => name)
+        .sort(compareNaturalNames)[0];
+    }
   }
   return entries.sort((a, b) => {
     if (preferred && a[0] === preferred) {
@@ -178,22 +196,7 @@ function sortJobs(jobCoverages) {
     if (preferred && b[0] === preferred) {
       return 1;
     }
-    const aKey = naturalSortKey(a[0]);
-    const bKey = naturalSortKey(b[0]);
-    for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
-      const aPart = aKey[i] || [2, ''];
-      const bPart = bKey[i] || [2, ''];
-      if (aPart[0] !== bPart[0]) {
-        return aPart[0] - bPart[0];
-      }
-      if (aPart[1] < bPart[1]) {
-        return -1;
-      }
-      if (aPart[1] > bPart[1]) {
-        return 1;
-      }
-    }
-    return 0;
+    return compareNaturalNames(a[0], b[0]);
   });
 }
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -428,6 +428,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           COVERAGE_ROOT: gate_artifacts/downloads
+          COVERAGE_REFERENCE_RUNTIME: '3.12'
         with:
           script: |
             const fs = require('fs');

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -76,6 +76,14 @@ MISSING_CONCERNS_MESSAGE = (
     "Verification output did not include extractable concerns; "
     "re-run verification to capture verifier-context.md and verifier-diff-summary.md."
 )
+MISSING_CONCERNS_VERDICTS = {
+    "unknown",
+    "concerns",
+    "error",
+    "fail",
+    "needs work",
+    "not ready",
+}
 
 LOGGER = logging.getLogger(__name__)
 
@@ -755,7 +763,7 @@ def _should_add_missing_concerns_note(
             verdicts.append(verdict)
     if not verdicts:
         return True
-    return any(not verdict.startswith("pass") for verdict in verdicts)
+    return any(verdict in MISSING_CONCERNS_VERDICTS for verdict in verdicts)
 
 
 def extract_original_issue_data(

--- a/templates/consumer-repo/.github/scripts/coverage-normalize.js
+++ b/templates/consumer-repo/.github/scripts/coverage-normalize.js
@@ -133,6 +133,14 @@ function runtimeFrom(label) {
   return label.startsWith(prefix) ? label.slice(prefix.length) : label;
 }
 
+function coverageNameForRuntime(runtime) {
+  const value = String(runtime || '').trim();
+  if (!value) {
+    return null;
+  }
+  return value.startsWith('coverage-') ? value : `coverage-${value}`;
+}
+
 function naturalSortKey(name) {
   const runtime = runtimeFrom(name);
   const parts = runtime.split(/(\d+)/);
@@ -141,35 +149,45 @@ function naturalSortKey(name) {
     .map(part => (part.match(/^\d+$/) ? [0, Number.parseInt(part, 10)] : [1, part]));
 }
 
-function sortJobs(jobCoverages) {
+function compareNaturalNames(a, b) {
+  const aKey = naturalSortKey(a);
+  const bKey = naturalSortKey(b);
+  for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
+    const aPart = aKey[i] || [2, ''];
+    const bPart = bKey[i] || [2, ''];
+    if (aPart[0] !== bPart[0]) {
+      return aPart[0] - bPart[0];
+    }
+    if (aPart[1] < bPart[1]) {
+      return -1;
+    }
+    if (aPart[1] > bPart[1]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+function sortJobs(jobCoverages, preferredRuntime = process.env.COVERAGE_REFERENCE_RUNTIME) {
   const entries = Array.from(jobCoverages.entries());
   if (!entries.length) {
     return entries;
   }
   let preferred = null;
-  if (jobCoverages.has('coverage-3.12')) {
-    preferred = 'coverage-3.12';
+  const preferredName = coverageNameForRuntime(preferredRuntime);
+  if (preferredName && jobCoverages.has(preferredName)) {
+    preferred = preferredName;
   } else {
     preferred = entries
       .map(([name]) => name)
-      .sort((a, b) => {
-        const aKey = naturalSortKey(a);
-        const bKey = naturalSortKey(b);
-        for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
-          const aPart = aKey[i] || [2, ''];
-          const bPart = bKey[i] || [2, ''];
-          if (aPart[0] !== bPart[0]) {
-            return aPart[0] - bPart[0];
-          }
-          if (aPart[1] < bPart[1]) {
-            return -1;
-          }
-          if (aPart[1] > bPart[1]) {
-            return 1;
-          }
-        }
-        return 0;
-      })[0];
+      .filter(name => /^coverage-\d+(?:\.\d+)*$/.test(name))
+      .sort(compareNaturalNames)
+      .pop();
+    if (!preferred) {
+      preferred = entries
+        .map(([name]) => name)
+        .sort(compareNaturalNames)[0];
+    }
   }
   return entries.sort((a, b) => {
     if (preferred && a[0] === preferred) {
@@ -178,22 +196,7 @@ function sortJobs(jobCoverages) {
     if (preferred && b[0] === preferred) {
       return 1;
     }
-    const aKey = naturalSortKey(a[0]);
-    const bKey = naturalSortKey(b[0]);
-    for (let i = 0; i < Math.max(aKey.length, bKey.length); i += 1) {
-      const aPart = aKey[i] || [2, ''];
-      const bPart = bKey[i] || [2, ''];
-      if (aPart[0] !== bPart[0]) {
-        return aPart[0] - bPart[0];
-      }
-      if (aPart[1] < bPart[1]) {
-        return -1;
-      }
-      if (aPart[1] > bPart[1]) {
-        return 1;
-      }
-    }
-    return 0;
+    return compareNaturalNames(a[0], b[0]);
   });
 }
 

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -427,6 +427,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           COVERAGE_ROOT: gate_artifacts/downloads
+          COVERAGE_REFERENCE_RUNTIME: '3.12'
         with:
           script: |
             const fs = require('fs');

--- a/templates/consumer-repo/tools/langchain_client.py
+++ b/templates/consumer-repo/tools/langchain_client.py
@@ -197,9 +197,9 @@ def build_chat_client(
         return None
 
     try:
-        from langchain_anthropic import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
     except ImportError:
-        ChatAnthropic = None  # noqa: N806
+        ChatAnthropicClass = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -246,11 +246,11 @@ def build_chat_client(
             return None
 
     if selected_provider == PROVIDER_ANTHROPIC:
-        if not anthropic_token or not ChatAnthropic:
+        if not anthropic_token or not ChatAnthropicClass:
             return None
         try:
             client = _build_anthropic_client(
-                ChatAnthropic,
+                ChatAnthropicClass,
                 model=selected_model,
                 token=anthropic_token,
                 timeout=selected_timeout,
@@ -277,10 +277,10 @@ def build_chat_client(
                 )
                 used_override = True
                 return ClientInfo(client=client, provider=PROVIDER_OPENAI, model=slot_model)
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 client = _build_anthropic_client(
-                    ChatAnthropic,
+                    ChatAnthropicClass,
                     model=slot_model,
                     token=anthropic_token,
                     timeout=selected_timeout,
@@ -317,9 +317,9 @@ def build_chat_clients(
         return []
 
     try:
-        from langchain_anthropic import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
     except ImportError:
-        ChatAnthropic = None  # noqa: N806
+        ChatAnthropicClass = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -400,12 +400,12 @@ def build_chat_clients(
                             model=second_model,
                         )
                     )
-        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropic,
+                            ChatAnthropicClass,
                             model=first_model,
                             token=anthropic_token,
                             timeout=selected_timeout,
@@ -420,7 +420,7 @@ def build_chat_clients(
                     clients.append(
                         ClientInfo(
                             client=_build_anthropic_client(
-                                ChatAnthropic,
+                                ChatAnthropicClass,
                                 model=second_model,
                                 token=anthropic_token,
                                 timeout=selected_timeout,
@@ -439,7 +439,7 @@ def build_chat_clients(
         if any(
             (
                 slot.provider == PROVIDER_OPENAI and openai_token,
-                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic,
+                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass,
                 slot.provider == PROVIDER_GITHUB and github_token,
             )
         ):
@@ -468,12 +468,12 @@ def build_chat_clients(
                         model=slot_model,
                     )
                 )
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropic,
+                            ChatAnthropicClass,
                             model=slot_model,
                             token=anthropic_token,
                             timeout=selected_timeout,

--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -34,6 +34,29 @@ def test_find_or_create_issue_updates_existing(monkeypatch: pytest.MonkeyPatch) 
     assert not any(call[0][:3] == ["gh", "issue", "create"] for call in calls)
 
 
+def test_find_or_create_issue_reopens_closed_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 123, "title": "coverage breach", "state": "CLOSED"}])
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    coverage_guard._find_or_create_issue(
+        repo="octo/repo",
+        title="[coverage] baseline breach",
+        body="body",
+        labels=["coverage", "automated"],
+    )
+
+    assert any(call[0][:3] == ["gh", "issue", "reopen"] for call in calls)
+    assert any(call[0][:3] == ["gh", "issue", "edit"] for call in calls)
+
+
 def test_find_or_create_issue_creates_new(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = []
 
@@ -133,6 +156,43 @@ def test_main_skips_issue_management_when_at_or_above_baseline(
     assert close_calls
 
 
+def test_main_leaves_issue_open_until_recovery_window_satisfied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trend_path = tmp_path / "trend.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_json(
+        trend_path,
+        {
+            "current": 72.0,
+            "baseline": 70.0,
+            "history": [{"current": 68.0}, {"current": 72.0}],
+        },
+    )
+    _write_json(baseline_path, {"line": 70.0, "recovery_window": 2})
+
+    close_calls = []
+    monkeypatch.setattr(
+        coverage_guard,
+        "_close_existing_issue",
+        lambda *args: close_calls.append(args),
+    )
+
+    exit_code = coverage_guard.main(
+        [
+            "--repo",
+            "octo/repo",
+            "--trend-path",
+            str(trend_path),
+            "--baseline-path",
+            str(baseline_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert not close_calls
+
+
 def test_main_uses_trend_baseline_when_baseline_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -164,6 +224,37 @@ def test_main_uses_trend_baseline_when_baseline_missing(
 
     assert exit_code == 0
     assert calls
+
+
+def test_main_accepts_legacy_coverage_baseline_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trend_path = tmp_path / "trend.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_json(trend_path, {"current": 72.0, "baseline": 65.0})
+    _write_json(baseline_path, {"coverage": 75.0})
+
+    calls = []
+
+    def fake_issue(repo, title, body, labels):
+        calls.append((repo, title, body, labels))
+
+    monkeypatch.setattr(coverage_guard, "_find_or_create_issue", fake_issue)
+
+    exit_code = coverage_guard.main(
+        [
+            "--repo",
+            "octo/repo",
+            "--trend-path",
+            str(trend_path),
+            "--baseline-path",
+            str(baseline_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls
+    assert "baseline: 75.00%" in calls[0][2]
 
 
 def test_main_dry_run_prints_issue_body(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -203,6 +294,13 @@ def test_load_json_handles_missing_and_invalid(tmp_path: Path) -> None:
     assert coverage_guard._load_json(non_dict) == {}
 
 
+def test_numeric_coercion_rejects_non_finite_values() -> None:
+    assert coverage_guard._to_float("nan", 12.0) == 12.0
+    assert coverage_guard._to_float(float("inf"), 12.0) == 12.0
+    assert coverage_guard._to_int("inf", 7) == 7
+    assert coverage_guard._to_int(float("-inf"), 7) == 7
+
+
 def test_get_hotspots_sorts_and_limits() -> None:
     coverage_data = {
         "files": {
@@ -221,6 +319,12 @@ def test_get_hotspots_sorts_and_limits() -> None:
 def test_get_hotspots_handles_unexpected_payloads() -> None:
     assert coverage_guard._get_hotspots({"files": []}) == []
     assert coverage_guard._get_hotspots({"files": {"bad.py": []}}) == []
+    assert (
+        coverage_guard._get_hotspots(
+            {"files": {"bad.py": {"summary": {"percent_covered": "nan"}}}}
+        )
+        == []
+    )
 
 
 def test_main_skips_when_trend_payload_missing(
@@ -271,3 +375,64 @@ def test_format_issue_body_handles_no_hotspots() -> None:
     )
 
     assert "| _(no files with low coverage)_ | - | - |" in body
+
+
+def test_format_issue_body_handles_missing_run_url() -> None:
+    body = coverage_guard._format_issue_body(
+        current=60.0,
+        baseline=70.0,
+        delta=-10.0,
+        hotspots=[],
+        run_url="",
+    )
+
+    assert "Run URL unavailable." in body
+    assert "Gate Workflow Run]()" not in body
+
+
+def test_main_skips_when_current_is_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trend_path = tmp_path / "trend.json"
+    _write_json(trend_path, {"current": "nan", "baseline": 70.0})
+
+    calls = []
+    monkeypatch.setattr(
+        coverage_guard,
+        "_find_or_create_issue",
+        lambda *args, **kwargs: calls.append(args),
+    )
+    monkeypatch.setattr(
+        coverage_guard,
+        "_close_existing_issue",
+        lambda *args, **kwargs: calls.append(args),
+    )
+
+    exit_code = coverage_guard.main(
+        [
+            "--repo",
+            "octo/repo",
+            "--trend-path",
+            str(trend_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert not calls
+
+
+def test_close_existing_issue_skips_already_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        coverage_guard,
+        "_find_existing_issue",
+        lambda repo, title: {"number": 123, "state": "CLOSED"},
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    coverage_guard._close_existing_issue("octo/repo", "[coverage] baseline breach", "body")
+
+    assert not calls

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -210,6 +210,21 @@ Verdict: **Unknown** @0%
         ]
         assert data.missing_concerns is True
 
+    def test_extract_missing_concerns_for_error_verdict(self):
+        """Add a default concern when verifier crashes report an error verdict."""
+        comment = """
+## PR Verification Report
+
+Verdict: **Error** @0%
+"""
+        data = extract_verification_data(comment)
+
+        assert data.concerns == [
+            "Verification output did not include extractable concerns; "
+            "re-run verification to capture verifier-context.md and verifier-diff-summary.md."
+        ]
+        assert data.missing_concerns is True
+
     def test_extract_low_scores(self):
         """Extract scores below 7/10."""
         comment = """

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -9,9 +9,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+DEFAULT_TREND_PATH = Path("coverage-trend.json")
+DEFAULT_COVERAGE_PATH = Path("coverage.json")
+DEFAULT_BASELINE_PATH = Path("config/coverage-baseline.json")
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -25,16 +31,24 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _to_float(value: Any, default: float = 0.0) -> float:
     """Return a finite float for numeric-ish values."""
+    parsed = _parse_finite_float(value)
+    return parsed if parsed is not None else default
+
+
+def _parse_finite_float(value: Any) -> float | None:
+    """Parse a finite float or return None for missing/invalid values."""
     if isinstance(value, bool):
-        return default
+        return None
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        parsed = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value)
-        except ValueError:
-            return default
-    return default
+            parsed = float(value)
+        except (OverflowError, ValueError):
+            return None
+    else:
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _to_int(value: Any, default: int = 0) -> int:
@@ -44,11 +58,16 @@ def _to_int(value: Any, default: int = 0) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, float):
+        if not math.isfinite(value):
+            return default
         return int(value)
     if isinstance(value, str):
         try:
-            return int(float(value))
-        except ValueError:
+            parsed = float(value)
+            if not math.isfinite(parsed):
+                return default
+            return int(parsed)
+        except (OverflowError, ValueError):
             return default
     return default
 
@@ -66,7 +85,9 @@ def _get_hotspots(coverage_data: dict[str, Any], limit: int = 15) -> list[dict[s
         summary = data.get("summary", {})
         if not isinstance(summary, dict):
             continue
-        percent = _to_float(summary.get("percent_covered"))
+        percent = _parse_finite_float(summary.get("percent_covered"))
+        if percent is None:
+            continue
         missing = _to_int(summary.get("missing_lines"))
         hotspots.append(
             {
@@ -118,16 +139,17 @@ These files have the lowest coverage and are candidates for additional tests:
     if not hotspots:
         body += "| _(no files with low coverage)_ | - | - |\n"
 
+    source_section = (
+        f"\n### Source\n\n[Gate Workflow Run]({run_url})\n" if run_url else "\n### Source\n\nRun URL unavailable.\n"
+    )
+
     body += f"""
 
 ### Actions
 
 - [ ] Review hotspot files and add tests for uncovered code
 - [ ] Update baseline once coverage improves
-
-### Source
-
-[Gate Workflow Run]({run_url})
+{source_section}
 
 ---
 _This issue is automatically updated by the coverage guard workflow._
@@ -135,54 +157,75 @@ _This issue is automatically updated by the coverage guard workflow._
     return body
 
 
+def _format_recovery_body(current: float, baseline: float, delta: float, run_url: str) -> str:
+    """Format a concise recovery comment for closing a breach issue."""
+    source_line = f"\n\n[Gate Workflow Run]({run_url})" if run_url else ""
+    return f"""Coverage has recovered above the configured baseline.
+
+| Metric | Value |
+|--------|-------|
+| Current | {current:.2f}% |
+| Baseline | {baseline:.2f}% |
+| Delta | {delta:+.2f}% |
+
+Closing the coverage baseline breach issue.{source_line}
+"""
+
+
 def _find_existing_issue(repo: str, title: str) -> dict[str, Any] | None:
     """Find an existing issue by title using gh CLI."""
-    import subprocess
+    search_query = f"{title.replace(chr(34), ' ')} in:title"
+    for state in ("open", "all"):
+        search_result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                state,
+                "--search",
+                search_query,
+                "--json",
+                "number,title,state",
+                "--limit",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+        )
 
-    search_result = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "all",
-            "--search",
-            f'"{title}" in:title',
-            "--json",
-            "number,title,state",
-            "--limit",
-            "1",
-        ],
-        capture_output=True,
-        text=True,
-    )
+        if search_result.returncode != 0:
+            error_message = search_result.stderr.strip() or "unknown gh error"
+            print(f"Failed to search for existing issues: {error_message}", file=sys.stderr)
+            raise RuntimeError("gh issue list failed")
 
-    if search_result.returncode != 0:
-        error_message = search_result.stderr.strip() or "unknown gh error"
-        print(f"Failed to search for existing issues: {error_message}", file=sys.stderr)
-        raise RuntimeError("gh issue list failed")
+        try:
+            existing_issues = json.loads(search_result.stdout) if search_result.stdout.strip() else []
+        except json.JSONDecodeError as exc:
+            print("Failed to parse gh issue list output as JSON.", file=sys.stderr)
+            if search_result.stderr.strip():
+                print(search_result.stderr.strip(), file=sys.stderr)
+            raise RuntimeError("gh issue list returned invalid JSON") from exc
 
-    try:
-        existing_issues = json.loads(search_result.stdout) if search_result.stdout.strip() else []
-    except json.JSONDecodeError as exc:
-        print("Failed to parse gh issue list output as JSON.", file=sys.stderr)
-        if search_result.stderr.strip():
-            print(search_result.stderr.strip(), file=sys.stderr)
-        raise RuntimeError("gh issue list returned invalid JSON") from exc
+        if existing_issues:
+            return existing_issues[0]
 
-    return existing_issues[0] if existing_issues else None
+    return None
 
 
 def _find_or_create_issue(repo: str, title: str, body: str, labels: list[str]) -> None:
     """Find existing issue or create a new one using gh CLI."""
-    import subprocess
-
     existing_issue = _find_existing_issue(repo, title)
 
     if existing_issue:
         issue_number = existing_issue["number"]
+        if str(existing_issue.get("state", "")).upper() == "CLOSED":
+            subprocess.run(
+                ["gh", "issue", "reopen", str(issue_number), "--repo", repo],
+                check=True,
+            )
         subprocess.run(
             ["gh", "issue", "edit", str(issue_number), "--repo", repo, "--body", body],
             check=True,
@@ -214,46 +257,85 @@ def _find_or_create_issue(repo: str, title: str, body: str, labels: list[str]) -
 
 def _close_existing_issue(repo: str, title: str, body: str) -> None:
     """Close the existing baseline breach issue after coverage recovers."""
-    import subprocess
-
     existing_issue = _find_existing_issue(repo, title)
     if not existing_issue:
         print("Coverage recovered; no existing breach issue found")
         return
 
     issue_number = existing_issue["number"]
+    if str(existing_issue.get("state", "")).upper() == "CLOSED":
+        print(f"Coverage recovered; issue #{issue_number} is already closed")
+        return
+
     subprocess.run(
         ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body],
         check=True,
     )
-    if str(existing_issue.get("state", "")).upper() != "CLOSED":
-        subprocess.run(
-            [
-                "gh",
-                "issue",
-                "close",
-                str(issue_number),
-                "--repo",
-                repo,
-                "--reason",
-                "completed",
-            ],
-            check=True,
-        )
-        print(f"Closed recovered issue #{issue_number}")
-    else:
-        print(f"Updated already closed issue #{issue_number}")
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "close",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--reason",
+            "completed",
+        ],
+        check=True,
+    )
+    print(f"Closed recovered issue #{issue_number}")
+
+
+def _recovery_window_satisfied(
+    trend_data: dict[str, Any], baseline: float, recovery_window: int
+) -> bool:
+    """Return whether recent coverage samples satisfy the configured recovery window."""
+    if recovery_window <= 1:
+        return True
+    history = trend_data.get("history")
+    if not isinstance(history, list) or len(history) < recovery_window:
+        return False
+    recent = history[-recovery_window:]
+    for record in recent:
+        if not isinstance(record, dict):
+            return False
+        current = _parse_finite_float(record.get("current"))
+        if current is None or current < baseline:
+            return False
+    return True
 
 
 def main(args: list[str] | None = None) -> int:
     """Main entry point for coverage guard."""
     parser = argparse.ArgumentParser(description="Coverage guard - maintain baseline breach issues")
     parser.add_argument("--repo", required=True, help="Repository (owner/repo)")
-    parser.add_argument("--trend-path", type=Path, help="Path to coverage-trend.json")
-    parser.add_argument("--coverage-path", type=Path, help="Path to coverage.json")
-    parser.add_argument("--baseline-path", type=Path, help="Path to coverage-baseline.json")
+    parser.add_argument(
+        "--trend-path",
+        type=Path,
+        default=DEFAULT_TREND_PATH,
+        help="Path to coverage-trend.json",
+    )
+    parser.add_argument(
+        "--coverage-path",
+        type=Path,
+        default=DEFAULT_COVERAGE_PATH,
+        help="Path to coverage.json",
+    )
+    parser.add_argument(
+        "--baseline-path",
+        type=Path,
+        default=DEFAULT_BASELINE_PATH,
+        help="Path to coverage-baseline.json",
+    )
     parser.add_argument("--run-url", default="", help="URL to the workflow run")
     parser.add_argument("--issue-title", default="[coverage] baseline breach", help="Issue title")
+    parser.add_argument(
+        "--recovery-window",
+        type=int,
+        default=None,
+        help="Number of consecutive recovered samples required before closing",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print issue body without creating")
     parsed = parser.parse_args(args)
 
@@ -277,9 +359,21 @@ def main(args: list[str] | None = None) -> int:
         return 0
 
     # Extract values
-    current = _to_float(trend_data.get("current"))
-    baseline = _to_float(baseline_data.get("line"), _to_float(trend_data.get("baseline"), 70.0))
+    current = _parse_finite_float(trend_data.get("current"))
+    if current is None:
+        print("Coverage trend payload has no finite current value; skipping coverage guard update")
+        return 0
+    baseline = _to_float(
+        baseline_data.get("line", baseline_data.get("coverage")),
+        _to_float(trend_data.get("baseline"), 70.0),
+    )
     delta = current - baseline
+    configured_recovery_window = _to_int(
+        parsed.recovery_window
+        if parsed.recovery_window is not None
+        else baseline_data.get("recovery_window", baseline_data.get("recovery_runs")),
+        1,
+    )
 
     # Get hotspots
     hotspots = _get_hotspots(coverage_data)
@@ -296,15 +390,33 @@ def main(args: list[str] | None = None) -> int:
 
     # Create or update issue
     if current < baseline:
-        _find_or_create_issue(
-            repo=parsed.repo,
-            title=parsed.issue_title,
-            body=body,
-            labels=["coverage", "automated"],
-        )
+        try:
+            _find_or_create_issue(
+                repo=parsed.repo,
+                title=parsed.issue_title,
+                body=body,
+                labels=["coverage", "automated"],
+            )
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            print(f"Failed to create or update coverage issue: {exc}", file=sys.stderr)
+            return 1
     else:
         print(f"Coverage {current:.2f}% meets baseline {baseline:.2f}% - no open issue needed")
-        _close_existing_issue(parsed.repo, parsed.issue_title, body)
+        if not _recovery_window_satisfied(trend_data, baseline, configured_recovery_window):
+            print(
+                "Coverage recovered, but configured recovery window is not satisfied; "
+                "leaving any breach issue open"
+            )
+            return 0
+        try:
+            _close_existing_issue(
+                parsed.repo,
+                parsed.issue_title,
+                _format_recovery_body(current, baseline, delta, parsed.run_url),
+            )
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            print(f"Failed to close recovered coverage issue: {exc}", file=sys.stderr)
+            return 1
 
     return 0
 

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -215,9 +215,9 @@ def build_chat_client(
         return None
 
     try:
-        from langchain_anthropic import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
     except ImportError:
-        ChatAnthropic = None  # noqa: N806
+        ChatAnthropicClass = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -264,11 +264,11 @@ def build_chat_client(
             return None
 
     if selected_provider == PROVIDER_ANTHROPIC:
-        if not anthropic_token or not ChatAnthropic:
+        if not anthropic_token or not ChatAnthropicClass:
             return None
         try:
             client = _build_anthropic_client(
-                ChatAnthropic,
+                ChatAnthropicClass,
                 model=selected_model,
                 token=anthropic_token,
                 timeout=selected_timeout,
@@ -295,10 +295,10 @@ def build_chat_client(
                 )
                 used_override = True
                 return ClientInfo(client=client, provider=PROVIDER_OPENAI, model=slot_model)
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 client = _build_anthropic_client(
-                    ChatAnthropic,
+                    ChatAnthropicClass,
                     model=slot_model,
                     token=anthropic_token,
                     timeout=selected_timeout,
@@ -335,9 +335,9 @@ def build_chat_clients(
         return []
 
     try:
-        from langchain_anthropic import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
     except ImportError:
-        ChatAnthropic = None  # noqa: N806
+        ChatAnthropicClass = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -418,12 +418,12 @@ def build_chat_clients(
                             model=second_model,
                         )
                     )
-        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropic,
+                            ChatAnthropicClass,
                             model=first_model,
                             token=anthropic_token,
                             timeout=selected_timeout,
@@ -438,7 +438,7 @@ def build_chat_clients(
                     clients.append(
                         ClientInfo(
                             client=_build_anthropic_client(
-                                ChatAnthropic,
+                                ChatAnthropicClass,
                                 model=second_model,
                                 token=anthropic_token,
                                 timeout=selected_timeout,
@@ -457,7 +457,7 @@ def build_chat_clients(
         if any(
             (
                 slot.provider == PROVIDER_OPENAI and openai_token,
-                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic,
+                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass,
                 slot.provider == PROVIDER_GITHUB and github_token,
             )
         ):
@@ -486,12 +486,12 @@ def build_chat_clients(
                         model=slot_model,
                     )
                 )
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropic:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropic,
+                            ChatAnthropicClass,
                             model=slot_model,
                             token=anthropic_token,
                             timeout=selected_timeout,


### PR DESCRIPTION
## Summary
- address coding-agent review findings from generated sync PRs in the Workflows source of truth
- harden coverage guard numeric parsing, legacy baseline handling, and closed issue reopening
- make coverage normalization reference runtime configurable while preserving Python 3.12 as the default
- tighten follow-up verdict handling and clean up Anthropic client import aliases in source and consumer template

## Tests
- pytest tests/test_coverage_guard.py tests/test_followup_issue_generator.py tests/tools/test_langchain_client.py
- node --test .github/scripts/__tests__/coverage-normalize.test.js
- ruff check tools/coverage_guard.py tests/test_coverage_guard.py scripts/langchain/followup_issue_generator.py tools/langchain_client.py tests/tools/test_langchain_client.py templates/consumer-repo/tools/langchain_client.py
- git diff --check