### PR TITLE
Use coverage history for recovery guard

### DIFF
--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -172,6 +172,16 @@ jobs:
           path: coverage_artifacts/trend
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download coverage trend history artifact
+        if: ${{ steps.discover.outputs.run_id }}
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: gate-coverage-trend-history
+          run-id: ${{ steps.discover.outputs.run_id }}
+          path: coverage_artifacts/history
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download coverage payload artifact
         if: ${{ steps.discover.outputs.run_id }}
         uses: actions/download-artifact@v8
@@ -192,6 +202,7 @@ jobs:
           # Try multiple possible artifact paths (workflow uses different naming)
           TREND_PATH=""
           COVERAGE_PATH=""
+          HISTORY_PATH=""
 
           # Check for trend artifact
           for candidate in \
@@ -199,6 +210,17 @@ jobs:
             "coverage_artifacts/coverage-trend.json"; do
             if [ -f "$candidate" ]; then
               TREND_PATH="$candidate"
+              break
+            fi
+          done
+
+          # Check for trend history artifact
+          for candidate in \
+            "coverage_artifacts/history/coverage-trend-history.ndjson" \
+            "coverage_artifacts/trend/coverage-trend-history.ndjson" \
+            "coverage_artifacts/coverage-trend-history.ndjson"; do
+            if [ -f "$candidate" ]; then
+              HISTORY_PATH="$candidate"
               break
             fi
           done
@@ -227,6 +249,10 @@ jobs:
 
           if [ -n "$COVERAGE_PATH" ]; then
             ARGS+=(--coverage-path "$COVERAGE_PATH")
+          fi
+
+          if [ -n "$HISTORY_PATH" ]; then
+            ARGS+=(--history-path "$HISTORY_PATH")
           fi
 
           if [ -f "config/coverage-baseline.json" ]; then

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -194,6 +194,16 @@ jobs:
           path: coverage_artifacts/trend
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download coverage trend history artifact
+        if: ${{ steps.discover.outputs.run_id }}
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        continue-on-error: true
+        with:
+          name: gate-coverage-trend-history
+          run-id: ${{ steps.discover.outputs.run_id }}
+          path: coverage_artifacts/history
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download coverage payload artifact
         if: ${{ steps.discover.outputs.run_id }}
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
@@ -214,6 +224,7 @@ jobs:
           # Try multiple possible artifact paths (workflow uses different naming)
           TREND_PATH=""
           COVERAGE_PATH=""
+          HISTORY_PATH=""
 
           # Check for trend artifact
           for candidate in \
@@ -221,6 +232,17 @@ jobs:
             "coverage_artifacts/coverage-trend.json"; do
             if [ -f "$candidate" ]; then
               TREND_PATH="$candidate"
+              break
+            fi
+          done
+
+          # Check for trend history artifact
+          for candidate in \
+            "coverage_artifacts/history/coverage-trend-history.ndjson" \
+            "coverage_artifacts/trend/coverage-trend-history.ndjson" \
+            "coverage_artifacts/coverage-trend-history.ndjson"; do
+            if [ -f "$candidate" ]; then
+              HISTORY_PATH="$candidate"
               break
             fi
           done
@@ -249,6 +271,10 @@ jobs:
 
           if [ -n "$COVERAGE_PATH" ]; then
             ARGS+=(--coverage-path "$COVERAGE_PATH")
+          fi
+
+          if [ -n "$HISTORY_PATH" ]; then
+            ARGS+=(--history-path "$HISTORY_PATH")
           fi
 
           if [ -f "config/coverage-baseline.json" ]; then

--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -193,6 +193,48 @@ def test_main_leaves_issue_open_until_recovery_window_satisfied(
     assert not close_calls
 
 
+def test_main_uses_history_file_for_recovery_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trend_path = tmp_path / "trend.json"
+    baseline_path = tmp_path / "baseline.json"
+    history_path = tmp_path / "coverage-trend-history.ndjson"
+    _write_json(trend_path, {"current": 72.0, "baseline": 70.0})
+    _write_json(baseline_path, {"line": 70.0, "recovery_days": 2})
+    history_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"current": 71.0}),
+                json.dumps({"current": 72.0}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    close_calls = []
+    monkeypatch.setattr(
+        coverage_guard,
+        "_close_existing_issue",
+        lambda *args: close_calls.append(args),
+    )
+
+    exit_code = coverage_guard.main(
+        [
+            "--repo",
+            "octo/repo",
+            "--trend-path",
+            str(trend_path),
+            "--baseline-path",
+            str(baseline_path),
+            "--history-path",
+            str(history_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert close_calls
+
+
 def test_main_uses_trend_baseline_when_baseline_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -320,9 +362,7 @@ def test_get_hotspots_handles_unexpected_payloads() -> None:
     assert coverage_guard._get_hotspots({"files": []}) == []
     assert coverage_guard._get_hotspots({"files": {"bad.py": []}}) == []
     assert (
-        coverage_guard._get_hotspots(
-            {"files": {"bad.py": {"summary": {"percent_covered": "nan"}}}}
-        )
+        coverage_guard._get_hotspots({"files": {"bad.py": {"summary": {"percent_covered": "nan"}}}})
         == []
     )
 

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -18,6 +18,7 @@ from typing import Any
 DEFAULT_TREND_PATH = Path("coverage-trend.json")
 DEFAULT_COVERAGE_PATH = Path("coverage.json")
 DEFAULT_BASELINE_PATH = Path("config/coverage-baseline.json")
+DEFAULT_HISTORY_PATH = Path("coverage-trend-history.ndjson")
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -27,6 +28,25 @@ def _load_json(path: Path) -> dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _load_ndjson(path: Path) -> list[dict[str, Any]]:
+    """Load newline-delimited JSON records from a file."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+    records = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
 
 
 def _to_float(value: Any, default: float = 0.0) -> float:
@@ -140,7 +160,9 @@ These files have the lowest coverage and are candidates for additional tests:
         body += "| _(no files with low coverage)_ | - | - |\n"
 
     source_section = (
-        f"\n### Source\n\n[Gate Workflow Run]({run_url})\n" if run_url else "\n### Source\n\nRun URL unavailable.\n"
+        f"\n### Source\n\n[Gate Workflow Run]({run_url})\n"
+        if run_url
+        else "\n### Source\n\nRun URL unavailable.\n"
     )
 
     body += f"""
@@ -202,7 +224,9 @@ def _find_existing_issue(repo: str, title: str) -> dict[str, Any] | None:
             raise RuntimeError("gh issue list failed")
 
         try:
-            existing_issues = json.loads(search_result.stdout) if search_result.stdout.strip() else []
+            existing_issues = (
+                json.loads(search_result.stdout) if search_result.stdout.strip() else []
+            )
         except json.JSONDecodeError as exc:
             print("Failed to parse gh issue list output as JSON.", file=sys.stderr)
             if search_result.stderr.strip():
@@ -288,18 +312,26 @@ def _close_existing_issue(repo: str, title: str, body: str) -> None:
 
 
 def _recovery_window_satisfied(
-    trend_data: dict[str, Any], baseline: float, recovery_window: int
+    trend_data: dict[str, Any],
+    baseline: float,
+    recovery_window: int,
+    history_records: list[dict[str, Any]] | None = None,
 ) -> bool:
     """Return whether recent coverage samples satisfy the configured recovery window."""
     if recovery_window <= 1:
         return True
-    history = trend_data.get("history")
-    if not isinstance(history, list) or len(history) < recovery_window:
+    history = history_records if history_records is not None else trend_data.get("history")
+    if not isinstance(history, list):
+        history = []
+    records = [record for record in history if isinstance(record, dict)]
+    latest_history_current = _parse_finite_float(records[-1].get("current")) if records else None
+    trend_current = _parse_finite_float(trend_data.get("current"))
+    if latest_history_current != trend_current:
+        records.append(trend_data)
+    if len(records) < recovery_window:
         return False
-    recent = history[-recovery_window:]
+    recent = records[-recovery_window:]
     for record in recent:
-        if not isinstance(record, dict):
-            return False
         current = _parse_finite_float(record.get("current"))
         if current is None or current < baseline:
             return False
@@ -328,6 +360,12 @@ def main(args: list[str] | None = None) -> int:
         default=DEFAULT_BASELINE_PATH,
         help="Path to coverage-baseline.json",
     )
+    parser.add_argument(
+        "--history-path",
+        type=Path,
+        default=DEFAULT_HISTORY_PATH,
+        help="Path to coverage-trend-history.ndjson",
+    )
     parser.add_argument("--run-url", default="", help="URL to the workflow run")
     parser.add_argument("--issue-title", default="[coverage] baseline breach", help="Issue title")
     parser.add_argument(
@@ -354,6 +392,10 @@ def main(args: list[str] | None = None) -> int:
     if parsed.baseline_path and parsed.baseline_path.exists():
         baseline_data = _load_json(parsed.baseline_path)
 
+    history_records = []
+    if parsed.history_path and parsed.history_path.exists():
+        history_records = _load_ndjson(parsed.history_path)
+
     if not trend_data:
         print("No coverage trend payload found; skipping coverage guard update")
         return 0
@@ -371,7 +413,10 @@ def main(args: list[str] | None = None) -> int:
     configured_recovery_window = _to_int(
         parsed.recovery_window
         if parsed.recovery_window is not None
-        else baseline_data.get("recovery_window", baseline_data.get("recovery_runs")),
+        else baseline_data.get(
+            "recovery_window",
+            baseline_data.get("recovery_runs", baseline_data.get("recovery_days")),
+        ),
         1,
     )
 
@@ -402,7 +447,12 @@ def main(args: list[str] | None = None) -> int:
             return 1
     else:
         print(f"Coverage {current:.2f}% meets baseline {baseline:.2f}% - no open issue needed")
-        if not _recovery_window_satisfied(trend_data, baseline, configured_recovery_window):
+        if not _recovery_window_satisfied(
+            trend_data,
+            baseline,
+            configured_recovery_window,
+            history_records,
+        ):
             print(
                 "Coverage recovered, but configured recovery window is not satisfied; "
                 "leaving any breach issue open"


### PR DESCRIPTION
## Summary
- download and pass the coverage trend history artifact to the coverage guard workflow
- make coverage recovery windows use actual history records and support existing recovery_days config
- format the touched Python files so synced consumer PRs pass lint-format

## Tests
- pytest tests/test_coverage_guard.py tests/test_followup_issue_generator.py tests/tools/test_langchain_client.py
- node --test .github/scripts/__tests__/coverage-normalize.test.js
- ruff check tools/coverage_guard.py tests/test_coverage_guard.py scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py tools/langchain_client.py tests/tools/test_langchain_client.py templates/consumer-repo/tools/langchain_client.py
- ruff format --check tools/coverage_guard.py tests/test_coverage_guard.py scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py tools/langchain_client.py tests/tools/test_langchain_client.py
- git diff --check