### PR TITLE
Require exact coverage issue matches

### DIFF
--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -16,7 +16,7 @@ def test_find_or_create_issue_updates_existing(monkeypatch: pytest.MonkeyPatch) 
     def fake_run(args, **kwargs):
         calls.append((args, kwargs))
         if args[:3] == ["gh", "issue", "list"]:
-            stdout = json.dumps([{"number": 123, "title": "coverage breach"}])
+            stdout = json.dumps([{"number": 123, "title": "[coverage] baseline breach"}])
             return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -40,7 +40,9 @@ def test_find_or_create_issue_reopens_closed_existing(monkeypatch: pytest.Monkey
     def fake_run(args, **kwargs):
         calls.append((args, kwargs))
         if args[:3] == ["gh", "issue", "list"]:
-            stdout = json.dumps([{"number": 123, "title": "coverage breach", "state": "CLOSED"}])
+            stdout = json.dumps(
+                [{"number": 123, "title": "[coverage] baseline breach", "state": "CLOSED"}]
+            )
             return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -78,6 +80,21 @@ def test_find_or_create_issue_creates_new(monkeypatch: pytest.MonkeyPatch) -> No
     assert any(call[0][:3] == ["gh", "issue", "list"] for call in calls)
     assert any(call[0][:3] == ["gh", "issue", "create"] for call in calls)
     assert not any(call[0][:3] == ["gh", "issue", "edit"] for call in calls)
+
+
+def test_find_existing_issue_requires_exact_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(args, **kwargs):
+        stdout = json.dumps(
+            [
+                {"number": 123, "title": "coverage baseline breach", "state": "OPEN"},
+                {"number": 456, "title": "[coverage] baseline breach details", "state": "OPEN"},
+            ]
+        )
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert coverage_guard._find_existing_issue("octo/repo", "[coverage] baseline breach") is None
 
 
 def test_main_invokes_issue_management_when_below_baseline(

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -196,7 +196,8 @@ Closing the coverage baseline breach issue.{source_line}
 
 def _find_existing_issue(repo: str, title: str) -> dict[str, Any] | None:
     """Find an existing issue by title using gh CLI."""
-    search_query = f"{title.replace(chr(34), ' ')} in:title"
+    escaped_title = title.replace("\\", "\\\\").replace('"', '\\"')
+    search_query = f'"{escaped_title}" in:title'
     for state in ("open", "all"):
         search_result = subprocess.run(
             [
@@ -212,7 +213,7 @@ def _find_existing_issue(repo: str, title: str) -> dict[str, Any] | None:
                 "--json",
                 "number,title,state",
                 "--limit",
-                "1",
+                "20",
             ],
             capture_output=True,
             text=True,
@@ -233,8 +234,9 @@ def _find_existing_issue(repo: str, title: str) -> dict[str, Any] | None:
                 print(search_result.stderr.strip(), file=sys.stderr)
             raise RuntimeError("gh issue list returned invalid JSON") from exc
 
-        if existing_issues:
-            return existing_issues[0]
+        for issue in existing_issues:
+            if issue.get("title") == title:
+                return issue
 
     return None
 


### PR DESCRIPTION
## Summary
- keep the coverage issue search phrase quoted safely
- filter GitHub issue search results to exact title matches before editing, reopening, or closing
- add regression coverage for avoiding unrelated issue matches

## Tests
- pytest tests/test_coverage_guard.py tests/test_followup_issue_generator.py tests/tools/test_langchain_client.py
- node --test .github/scripts/__tests__/coverage-normalize.test.js
- ruff check tools/coverage_guard.py tests/test_coverage_guard.py scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py tools/langchain_client.py tests/tools/test_langchain_client.py templates/consumer-repo/tools/langchain_client.py
- ruff format --check tools/coverage_guard.py tests/test_coverage_guard.py scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py tools/langchain_client.py tests/tools/test_langchain_client.py
- git diff --check