### PR TITLE
Refresh protected consumer action pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ extend-exclude = '''
 profile = "black"
 line_length = 100
 known_first_party = []
+known_third_party = ["scripts", "tools"]
 skip_glob = ["archive/*", ".extraction/*"]
 
 [tool.ruff]

--- a/scripts/validate_workflow_yaml.py
+++ b/scripts/validate_workflow_yaml.py
@@ -17,12 +17,17 @@ except ImportError:
     sys.exit(1)
 
 
+LINE_LENGTH_EXEMPTIONS = ("stranske/Workflows/.github/actions/setup-api-client@",)
+
+
 def check_line_length(file_path: Path, max_length: int = 100) -> list[tuple[int, str]]:
     """Check for lines that exceed maximum length (may cause wrapping issues)."""
     issues = []
     with open(file_path, encoding="utf-8") as f:
         for line_num, line in enumerate(f, 1):
-            if len(line.rstrip()) > max_length:
+            if len(line.rstrip()) > max_length and not any(
+                exemption in line for exemption in LINE_LENGTH_EXEMPTIONS
+            ):
                 issues.append((line_num, f"Line exceeds {max_length} characters"))
     return issues
 

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Resolve Workflows default branch
         id: workflows_ref
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -212,7 +212,7 @@ jobs:
 
       - name: Resolve candidate issue
         id: pick
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_DISPATCH_TOKEN }}
           script: |
@@ -334,7 +334,7 @@ jobs:
 
       - name: Transition issue to in-progress
         if: ${{ steps.pick.outputs.issue != '' && steps.mode.outputs.dry_run != 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_DISPATCH_TOKEN }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}
@@ -192,7 +192,7 @@ jobs:
 
       - name: Determine worker mode
         id: mode
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const coerce = (value) => {
@@ -225,7 +225,7 @@ jobs:
 
       - name: Resolve worker context
         id: ctx
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -303,7 +303,7 @@ jobs:
 
       - name: Resolve Workflows default branch
         id: workflows_ref
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -341,7 +341,7 @@ jobs:
 
       - name: Determine default branch
         id: base
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -366,7 +366,7 @@ jobs:
 
       - name: Check parallel allowance
         id: parallel
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -409,7 +409,7 @@ jobs:
       - name: Evaluate keepalive worker gate
         if: ${{ inputs.keepalive == true }}
         id: keepalive_gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           KEEPALIVE: ${{ inputs.keepalive && 'true' || 'false' }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue }}
@@ -466,7 +466,7 @@ jobs:
       - name: Prune merged step branches
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' }}
         id: prune
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -551,7 +551,7 @@ jobs:
       - name: Re-verify issue labels
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
         id: verify
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -602,7 +602,7 @@ jobs:
 
       - name: Validate branch prefix
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('node:fs');
@@ -774,7 +774,7 @@ jobs:
         id: ledger_issue
         env:
           ISSUE_NUMBER: ${{ steps.ctx.outputs.issue }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -1023,7 +1023,7 @@ jobs:
 
       - name: Ensure issue labels reflect in-progress state
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.verify.outputs.has_in_progress != 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1045,7 +1045,7 @@ jobs:
 
       - name: Remove residual status:ready label
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.verify.outputs.has_ready == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1070,7 +1070,7 @@ jobs:
       - name: Open or refresh agent PR
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' }}
         id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1137,7 +1137,7 @@ jobs:
 
       - name: Configure auto-merge strategy
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.pr.outputs.number }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1177,7 +1177,7 @@ jobs:
 
       - name: Apply automation labels
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.pr.outputs.number }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1201,7 +1201,7 @@ jobs:
 
       - name: Ensure PR assignees include automation
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.pr.outputs.number }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1240,7 +1240,7 @@ jobs:
 
       - name: Post activation comment
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.pr.outputs.number && inputs.keepalive != true }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |
@@ -1316,7 +1316,7 @@ jobs:
 
       - name: Sync issue comment with PR link
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') && steps.mode.outputs.dry_run != 'true' && steps.pr.outputs.number }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_BELT_TOKEN }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Summarise invocation
         id: summary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const summary = core.summary;
@@ -268,7 +268,7 @@ jobs:
 
       - name: Load PR details
         id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -329,7 +329,7 @@ jobs:
 
       - name: Ensure Gate succeeded
         id: gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -358,7 +358,7 @@ jobs:
 
       - name: Detect bootstrap-only placeholder change
         id: bootstrap
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -433,7 +433,7 @@ jobs:
       - name: Merge PR with squash
         if: ${{ steps.mode.outputs.dry_run != 'true' && steps.bootstrap.outputs.bootstrap != 'true' }}
         id: merge
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -458,7 +458,7 @@ jobs:
 
       - name: Delete branch after merge
         if: ${{ steps.mode.outputs.dry_run != 'true' && steps.bootstrap.outputs.bootstrap != 'true' && steps.merge.outputs.merged == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -482,7 +482,7 @@ jobs:
 
       - name: Close source issue
         if: ${{ steps.mode.outputs.dry_run != 'true' && steps.bootstrap.outputs.bootstrap != 'true' && steps.merge.outputs.merged == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -528,7 +528,7 @@ jobs:
 
       - name: Leave merge confirmation on PR
         if: ${{ steps.mode.outputs.dry_run != 'true' && steps.bootstrap.outputs.bootstrap != 'true' && steps.merge.outputs.merged == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |
@@ -560,7 +560,7 @@ jobs:
 
       - name: Re-dispatch dispatcher
         if: ${{ steps.mode.outputs.dry_run != 'true' && steps.bootstrap.outputs.bootstrap != 'true' && steps.merge.outputs.merged == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.GH_CONVEYOR_TOKEN }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Resolve handler inputs
         id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const eventName = context.eventName;
@@ -230,7 +230,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Remove trigger label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -261,7 +261,7 @@ jobs:
     steps:
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -298,7 +298,7 @@ jobs:
       - name: Collect verification and original issue data
         id: collect
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -411,7 +411,7 @@ jobs:
       - name: Fallback to simple extraction
         id: fallback
         if: steps.generate.outcome == 'failure' && steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -442,7 +442,7 @@ jobs:
 
       - name: Create issue
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -475,7 +475,7 @@ jobs:
 
       - name: Remove trigger label
         if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -88,7 +88,7 @@ jobs:
         run: echo "start_ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
       - name: Security gate - prompt injection guard
         id: security_gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -144,7 +144,7 @@ jobs:
 
       - name: Evaluate keepalive state
         id: evaluate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
           INPUT_FORCE_RETRY: ${{ github.event.inputs.force_retry || 'false' }}
@@ -224,10 +224,16 @@ jobs:
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
-          if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+          if [ "$HAS_CODEX_AUTH" = "true" ] || \
+            [ "$HAS_CLAUDE_AUTH" = "true" ] || \
+            [ "$HAS_CLAUDE_OAUTH" = "true" ] || \
+            [ "$HAS_APP_ID" = "true" ]; then
             echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::No agent auth found. Set CLAUDE_CODE_OAUTH_TOKEN (preferred), CODEX_AUTH_JSON, CLAUDE_AUTH_JSON, or KEEPALIVE/WORKFLOWS_APP."
+            message="::error::No agent auth found. Configure one of: CODEX_AUTH_JSON,"
+            message="$message CLAUDE_AUTH_JSON, CLAUDE_CODE_OAUTH_TOKEN, or app credentials"
+            message="$message via KEEPALIVE_APP_ID/PRIVATE_KEY or WORKFLOWS_APP_ID/PRIVATE_KEY."
+            echo "$message"
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -265,7 +271,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Update summary with running status
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -434,7 +440,7 @@ jobs:
           echo "$metrics_json" >> keepalive-metrics.ndjson
 
       - name: Upload keepalive metrics artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: keepalive-metrics
           path: keepalive-metrics.ndjson
@@ -445,7 +451,7 @@ jobs:
         if: |
           needs.run-codex.outputs.changes-made == 'true' ||
           needs.run-claude.outputs.changes-made == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           LLM_COMPLETED_TASKS: >-
             ${{
@@ -522,7 +528,7 @@ jobs:
             core.setOutput('commit_tasks_count', result.sources?.commit || 0);
 
       - name: Update summary comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AGENT_SUMMARY: >-
             ${{
@@ -646,7 +652,7 @@ jobs:
 
       - name: Security gate - prompt injection guard
         id: security_gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -707,7 +713,7 @@ jobs:
 
       - name: Evaluate workflow_run
         id: evaluate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -794,8 +800,14 @@ jobs:
                   .map((label) => (label?.name || '').toLowerCase())
                   .filter(Boolean)
               : [];
-            const nonRoutingAgentLabels = new Set(['agent:rate-limited', 'agent:needs-attention', 'agent:retry']);
-            const hasAgentLabel = labels.some(l => l.startsWith('agent:') && !nonRoutingAgentLabels.has(l));
+            const nonRoutingAgentLabels = new Set([
+              'agent:rate-limited',
+              'agent:needs-attention',
+              'agent:retry',
+            ]);
+            const hasAgentLabel = labels.some(
+              l => l.startsWith('agent:') && !nonRoutingAgentLabels.has(l)
+            );
             const routingLabelObjects = Array.isArray(prData.labels)
               ? prData.labels.filter((label) => {
                   const normalized = (label?.name || '').toLowerCase();
@@ -1035,7 +1047,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Add needs-human label and comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -1106,7 +1118,7 @@ jobs:
 
       - name: Collect metrics
         id: collect
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -1271,7 +1283,7 @@ jobs:
           PY
 
       - name: Upload metrics artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agents-autofix-metrics
           path: autofix-metrics.ndjson

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Get repo labels
         id: get-labels
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -187,7 +187,7 @@ jobs:
         if: |
           steps.match.outputs.has_suggestions == 'true' &&
           steps.match.outputs.auto_apply_labels != '[]'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -234,7 +234,7 @@ jobs:
         if: |
           steps.match.outputs.has_suggestions == 'true' &&
           steps.match.outputs.suggested_labels != '[]'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -102,7 +102,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Check if auto-pilot is enabled
         id: check_enabled
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |
@@ -150,7 +150,7 @@ jobs:
 
       - name: Set up Node
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
@@ -164,7 +164,7 @@ jobs:
       - name: Resolve Workflows default branch
         if: steps.check_enabled.outputs.enabled == 'true'
         id: workflows_ref
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -229,7 +229,7 @@ jobs:
 
       - name: Cache pip (LLM requirements)
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -256,7 +256,7 @@ jobs:
       - name: Determine context
         if: steps.check_enabled.outputs.enabled == 'true'
         id: context
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
@@ -437,7 +437,7 @@ jobs:
       - name: Check step count
         if: steps.context.outputs.should_continue == 'true'
         id: cycles
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
@@ -478,7 +478,7 @@ jobs:
 
       - name: Stop if exceeded
         if: steps.cycles.outputs.exceeded == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
@@ -1171,7 +1171,7 @@ jobs:
 
       - name: Guard - Require optimizer output before apply
         if: steps.next.outputs.next_step == 'apply'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
@@ -1540,7 +1540,7 @@ jobs:
       - name: Complexity pre-check
         if: steps.next.outputs.next_step == 'capability-check'
         id: complexity_check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
@@ -1645,7 +1645,7 @@ jobs:
         if: |
           steps.next.outputs.next_step == 'capability-check' &&
           steps.complexity_check.outputs.too_complex == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           COMPLEXITY_SCORE: ${{ steps.complexity_check.outputs.score }}
@@ -1696,7 +1696,7 @@ jobs:
           steps.next.outputs.next_step == 'capability-check' &&
           steps.complexity_check.outputs.too_complex != 'true'
         id: capability_step
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           STEP_COUNT: ${{ steps.cycles.outputs.count }}
@@ -2017,7 +2017,7 @@ jobs:
       - name: Execute step - Verify
         if: steps.next.outputs.next_step == 'verify'
         id: verify_step
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:
@@ -2154,7 +2154,7 @@ jobs:
       - name: Execute step - Create PR
         if: steps.next.outputs.next_step == 'create-pr'
         id: create_pr_step
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           ISSUE_TITLE: ${{ steps.context.outputs.issue_title }}
@@ -2447,7 +2447,8 @@ jobs:
                   issue_number: issueNumber,
                     body: `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)
 
-                    Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.${redispatchNote}
+                    Branch not created yet.
+                    Attempt ${stallCount + 1}/${maxStallRetries}.${redispatchNote}
                     Waiting before retry...`
                 }));
 
@@ -2861,7 +2862,7 @@ jobs:
       - name: Report - Monitoring PR
         if: steps.next.outputs.next_step == 'monitor-pr'
         id: monitor_pr_step
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           STEP_COUNT: ${{ steps.cycles.outputs.count }}
@@ -3020,7 +3021,7 @@ jobs:
       - name: Execute step - Check Completion & Trigger Merge
         if: steps.next.outputs.next_step == 'check-completion'
         id: completion_step
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           PR_NUMBER: ${{ steps.context.outputs.linked_pr }}
@@ -3154,7 +3155,7 @@ jobs:
       # ── Upload auto-pilot metrics for weekly aggregation ───────────
       - name: Upload auto-pilot metrics
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
           name: autopilot-metrics-${{ github.run_id }}-${{ github.run_attempt }}
@@ -3177,7 +3178,7 @@ jobs:
             fromJSON('["format","optimize","apply","capability-check","create-pr","monitor-pr"]'),
             steps.next.outputs.next_step
           )
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           CURRENT_STEP: ${{ steps.next.outputs.next_step }}
@@ -3284,7 +3285,7 @@ jobs:
 
       - name: Report - Done
         if: steps.next.outputs.next_step == 'done'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
         with:

--- a/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -42,7 +42,7 @@ jobs:
           github_token: ${{ steps.app_token.outputs.token || github.token }}
 
       - name: Dispatch autofix workflow
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |
@@ -71,19 +71,26 @@ jobs:
             const ref = `refs/heads/${defaultBranch}`;
             try {
               await withRetry((client) =>
-                client.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
-                  owner,
-                  repo,
-                  workflow_id: 'agents-autofix-loop.yml',
-                  ref,
-                  inputs: {
-                    gate_run_id: gateRunId,
-                    pr_number: String(prNumber),
-                    head_sha: headSha,
-                  },
-                })
+                client.request(
+                  'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+                  {
+                    owner,
+                    repo,
+                    workflow_id: 'agents-autofix-loop.yml',
+                    ref,
+                    inputs: {
+                      gate_run_id: gateRunId,
+                      pr_number: String(prNumber),
+                      head_sha: headSha,
+                    },
+                  }
+                )
               );
-              core.info(`Triggered agents-autofix-loop for PR #${prNumber} (Gate run ${gateRunId}).`);
+              const shaNote = headSha ? `, headSha=${headSha}` : '';
+              const trace = `gateRunId=${gateRunId}${shaNote}`;
+              core.info(
+                `Triggered agents-autofix-loop for PR #${prNumber} (${trace}).`
+              );
             } catch (error) {
               core.setFailed(`Failed to dispatch autofix workflow: ${error.message}`);
             }

--- a/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
@@ -65,7 +65,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Security gate - prompt injection guard
         id: security_gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: Evaluate gate run
         id: evaluate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -648,7 +648,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -665,7 +665,7 @@ jobs:
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
       - name: Add needs-human label and comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |
@@ -737,7 +737,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -764,7 +764,7 @@ jobs:
 
       - name: Collect metrics
         id: collect
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ env.WRITE_TOKEN }}
           script: |
@@ -930,7 +930,7 @@ jobs:
           PY
 
       - name: Upload metrics artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agents-autofix-metrics
           path: autofix-metrics.ndjson

--- a/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
+++ b/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Resolve PR number and check conditions
         id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -213,7 +213,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Dismiss ignored-path bot reviews
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BOT_AUTHORS: >-
             Copilot,copilot[bot],github-actions[bot],
@@ -389,7 +389,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Remove trigger label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');

--- a/templates/consumer-repo/.github/workflows/agents-capability-check.yml
+++ b/templates/consumer-repo/.github/workflows/agents-capability-check.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Extract issue content
         id: extract
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issue = context.payload.issue;
@@ -112,7 +112,7 @@ jobs:
 
       - name: Add needs-human label if blocked
         if: steps.check.outputs.recommendation == 'BLOCKED'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -154,7 +154,7 @@ jobs:
 
       - name: Post capability report
         if: steps.check.outputs.check_failed != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RESULT_JSON: ${{ steps.check.outputs.result_json }}
           RECOMMENDATION: ${{ steps.check.outputs.recommendation }}

--- a/templates/consumer-repo/.github/workflows/agents-decompose.yml
+++ b/templates/consumer-repo/.github/workflows/agents-decompose.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Extract issue content
         id: extract
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issue = context.payload.issue;
@@ -118,7 +118,7 @@ jobs:
 
       - name: Post decomposition comment
         if: steps.decompose.outputs.decompose_failed != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SUBTASK_COUNT: ${{ steps.decompose.outputs.subtask_count }}
         with:
@@ -191,7 +191,7 @@ jobs:
             }
 
       - name: Remove trigger label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-dedup.yml
+++ b/templates/consumer-repo/.github/workflows/agents-dedup.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get open issues
         id: get-issues
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -195,7 +195,7 @@ jobs:
 
       - name: Post duplicate warning
         if: steps.check.outputs.has_duplicates == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -33,7 +33,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Verify pull_request_target safety invariants
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const path = require('path');
@@ -143,7 +143,7 @@ jobs:
           github_token: ${{ github.token }}
       - name: Evaluate protected file changes
         id: evaluate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -404,7 +404,7 @@ jobs:
 
       - name: Post guard failure comment
         if: steps.evaluate.outputs.blocked == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_BODY_B64: ${{ steps.evaluate.outputs.comment_body_b64 }}
           COMMENT_MARKER: ${{ steps.evaluate.outputs.marker }}
@@ -553,7 +553,7 @@ jobs:
 
       - name: Report agents guard commit status
         if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BLOCKED: ${{ steps.evaluate.outputs.blocked || 'false' }}
           SUMMARY: ${{ steps.evaluate.outputs.summary }}

--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: Check labels and extract info
         id: check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const eventName = context.eventName;

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -93,7 +93,7 @@ jobs:
         id: app_token
         if: steps.check.outputs.should_run == 'true'
         continue-on-error: true
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
@@ -220,7 +220,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 1
 
       - name: Update summary for cancelled/failed runs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -93,7 +93,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.action == 'labeled' &&
           github.event.label.name == 'agent:retry'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -161,7 +161,7 @@ jobs:
         run: echo "start_ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
       - name: Security gate - prompt injection guard
         id: security_gate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -224,7 +224,7 @@ jobs:
 
       - name: Evaluate keepalive state
         id: evaluate
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
           INPUT_FORCE_RETRY: >-
@@ -383,7 +383,7 @@ jobs:
           steps.evaluate.outputs.action == 'run' ||
           steps.evaluate.outputs.action == 'fix' ||
           steps.evaluate.outputs.action == 'conflict'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: keepalive-task-appendix-${{ steps.evaluate.outputs.pr_number }}
           path: /tmp/keepalive-artifacts/task-appendix.txt
@@ -439,7 +439,9 @@ jobs:
               fi
               ;;
             *)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || \
+                [ "$HAS_CLAUDE_AUTH" = "true" ] || \
+                [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -450,13 +452,19 @@ jobs:
           if [ "$agent_auth_ok" != "true" ]; then
             case "$AGENT_TYPE" in
               claude)
-                missing_msg="Missing credentials for agent 'claude'. Set CLAUDE_CODE_OAUTH_TOKEN (preferred), CLAUDE_AUTH_JSON, or configure KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent 'claude'."
+                missing_msg="$missing_msg Set CLAUDE_CODE_OAUTH_TOKEN or CLAUDE_AUTH_JSON,"
+                missing_msg="$missing_msg or configure KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
               codex)
-                missing_msg="Missing credentials for agent 'codex'. Set CODEX_AUTH_JSON, or configure KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent 'codex'."
+                missing_msg="$missing_msg Set CODEX_AUTH_JSON,"
+                missing_msg="$missing_msg or configure KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
               *)
-                missing_msg="Missing credentials for agent '${AGENT_TYPE}'. Configure that agent's credentials or KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent '${AGENT_TYPE}'."
+                missing_msg="$missing_msg Configure that agent's credentials,"
+                missing_msg="$missing_msg or KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
             esac
             echo "::error::$missing_msg"
@@ -492,7 +500,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -505,7 +513,7 @@ jobs:
 
 
       - name: Update summary with running status
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -614,7 +622,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -636,7 +644,7 @@ jobs:
 
       - name: Get recent commits
         id: commits
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -679,7 +687,7 @@ jobs:
 
       - name: Extract acceptance criteria
         id: criteria
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -779,7 +787,7 @@ jobs:
 
       - name: Post review feedback to PR
         if: steps.review_guard.outputs.should_post_review == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REVIEW_FEEDBACK: ${{ steps.review.outputs.feedback }}
         with:
@@ -952,7 +960,7 @@ jobs:
           echo "$metrics_json" >> keepalive-metrics.ndjson
 
       - name: Upload keepalive metrics artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: keepalive-metrics
           path: keepalive-metrics.ndjson
@@ -963,7 +971,7 @@ jobs:
         if: |
           needs.run-codex.outputs.changes-made == 'true' ||
           needs.run-claude.outputs.changes-made == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           LLM_COMPLETED_TASKS: >-
             ${{
@@ -1041,7 +1049,7 @@ jobs:
 
       - name: Update summary comment
         id: update-summary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AGENT_SUMMARY: >-
             ${{
@@ -1132,7 +1140,7 @@ jobs:
           steps.update-summary.outputs.rate_limit_hit == 'true' &&
           env.KEEPALIVE_APP_ID != '' &&
           env.KEEPALIVE_APP_PRIVATE_KEY != ''
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         env:
           KEEPALIVE_APP_ID: ${{ secrets.KEEPALIVE_APP_ID }}
@@ -1149,7 +1157,7 @@ jobs:
           failure() &&
           steps.update-summary.outputs.rate_limit_hit == 'true' &&
           steps.keepalive_app_token.outputs.token != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.keepalive_app_token.outputs.token }}
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-pr-meta.yml
+++ b/templates/consumer-repo/.github/workflows/agents-pr-meta.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Resolve PR context
         id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.issue;
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Resolve PR from workflow_run
         id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const run = context.payload.workflow_run;

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Check trigger conditions
         id: check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -103,7 +103,7 @@ jobs:
       - name: Collect verification and original issue data
         id: collect
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
@@ -230,7 +230,7 @@ jobs:
       - name: Fallback to simple extraction
         id: fallback
         if: steps.generate.outcome == 'failure' && steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
@@ -313,7 +313,7 @@ jobs:
       - name: Create follow-up issue
         id: create-issue
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_TITLE: >-
             ${{ steps.generate.outputs.issue_title ||
@@ -374,7 +374,7 @@ jobs:
 
       - name: Comment on original PR
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -417,7 +417,7 @@ jobs:
 
       - name: Remove trigger label
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
           github-token: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-issue.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-issue.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -43,7 +43,7 @@ jobs:
       - name: Find and extract verification feedback
         id: extract
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -135,7 +135,7 @@ jobs:
       - name: Create follow-up issue
         id: create-issue
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           VERDICT: ${{ steps.extract.outputs.verdict }}
           CONCERNS_SUMMARY: ${{ steps.extract.outputs.concerns_summary }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Comment on original PR
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
         with:
@@ -235,7 +235,7 @@ jobs:
 
       - name: Remove trigger label
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
           script: |

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -106,7 +106,7 @@ jobs:
       - name: Collect verification and original issue data
         id: collect
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
@@ -251,7 +251,7 @@ jobs:
       - name: Check chain depth limit
         id: chain-check
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
           MAX_CHAIN_DEPTH: '2'
@@ -392,7 +392,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           LINKED_ISSUE: ${{ steps.collect.outputs.original_issue_number }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -508,7 +508,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
           EXTRACTED_VERDICT: ${{ steps.extract-verdict.outputs.verdict }}
@@ -680,7 +680,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_TITLE: >-
             ${{ steps.generate.outputs.issue_title ||
@@ -775,7 +775,7 @@ jobs:
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true' &&
           steps.create-issue.outputs.issue_number != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -812,7 +812,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -854,7 +854,7 @@ jobs:
 
       - name: Remove trigger label
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
           github-token: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -19,7 +19,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -160,14 +160,14 @@ jobs:
           python scripts/aggregate_agent_metrics.py
 
       - name: Upload weekly summary
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-weekly-metrics
           path: agent-weekly-metrics.md
           retention-days: 30
 
       - name: Post summary to tracking issue
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.10
+RUFF_VERSION=0.15.11
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.20.1

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Resolve PR context
         id: context
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: >-
             ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT || github.token }}

--- a/templates/consumer-repo/.github/workflows/dependabot-automerge.yml
+++ b/templates/consumer-repo/.github/workflows/dependabot-automerge.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get PR metadata
         id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Wait for checks
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -132,7 +132,7 @@ jobs:
 
       - name: Enable auto-merge
         if: success()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CODESPACES_WORKFLOWS_PAT: ${{ secrets.CODESPACES_WORKFLOWS }}
         with:

--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -42,7 +42,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - id: resolve
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@220272d38887a1caed373da96a9ffdb0919c26cc # v1
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -26,7 +26,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Check API quota
         id: check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           # Higher threshold than orchestrator (1000) so keepalive runs first
           RATE_LIMIT_THRESHOLD: '2000'
@@ -108,7 +108,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Locate latest Gate workflow run
         id: discover
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Download coverage trend artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: gate-coverage-trend
@@ -196,7 +196,7 @@ jobs:
 
       - name: Download coverage trend history artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: gate-coverage-trend-history
@@ -206,7 +206,7 @@ jobs:
 
       - name: Download coverage payload artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: gate-coverage

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -34,7 +34,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -53,7 +53,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Detect changes via API
         id: diff
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { detectChanges } = require('./.github/scripts/detect-changes.js');
@@ -161,7 +161,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
       - run: node --test .github/scripts/__tests__/*.test.js
@@ -225,7 +225,7 @@ jobs:
     steps:
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -288,7 +288,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -317,7 +317,7 @@ jobs:
 
 
       - name: Set up Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
       - name: Install GitHub API dependencies
@@ -325,7 +325,7 @@ jobs:
       - name: Handle docs-only change
         if: needs.detect.outputs.doc_only == 'true'
         id: docs_only
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REASON: ${{ needs.detect.outputs.reason || 'docs_only' }}
         with:
@@ -335,7 +335,7 @@ jobs:
 
       - name: Ensure docs-only fast-pass comment
         if: needs.detect.outputs.doc_only == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_BODY: ${{ steps.docs_only.outputs.comment_body }}
           MARKER: ${{ steps.docs_only.outputs.marker }}
@@ -355,7 +355,7 @@ jobs:
 
       - name: Remove docs-only fast-pass comment when not needed
         if: needs.detect.outputs.doc_only != 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MARKER: ${{ steps.docs_only.outputs.marker }}
           BASE_MESSAGE: ${{ steps.docs_only.outputs.base_message }}
@@ -372,7 +372,7 @@ jobs:
             });
       - name: Discover Gate workflow runs
         id: gather
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { discoverWorkflowRuns } = require('./.github/scripts/maint-post-ci.js');
@@ -381,7 +381,7 @@ jobs:
       - name: Download Gate artifacts
         if: ${{ needs.detect.outputs.doc_only != 'true' && needs.python-ci.result != 'skipped' }}
         continue-on-error: true
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: gate-*
           merge-multiple: true
@@ -424,7 +424,7 @@ jobs:
       - name: Compute coverage stats
         if: needs.detect.outputs.doc_only != 'true' && needs.detect.outputs.coverage == 'true'
         id: coverage_stats
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COVERAGE_ROOT: gate_artifacts/downloads
           COVERAGE_REFERENCE_RUNTIME: '3.12'
@@ -482,7 +482,7 @@ jobs:
           steps.summarize.outputs.state == 'failure' &&
           steps.summarize.outputs.cosmetic_failure == 'true' &&
           !contains(github.event.pull_request.labels.*.name, 'autofix:clean')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ALLOWED_EXTENSIONS: 'py,pyi'
           FORMAT_FAILURE: ${{ steps.summarize.outputs.format_failure || 'false' }}
@@ -630,7 +630,7 @@ jobs:
             ${{ steps.gather.outputs.head_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Append keepalive checklists
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LABEL_APPLIED: ${{ steps.autofix_label.outputs.applied || 'false' }}
@@ -760,7 +760,7 @@ jobs:
 
       - name: Upload Gate summary artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-summary.md
           path: gate-summary.md
@@ -770,7 +770,7 @@ jobs:
 
       - name: Upload coverage stats artifact
         if: ${{ always() && steps.coverage_stats.outputs.stats_json != '' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-coverage.json
           path: gate-coverage.json
@@ -780,7 +780,7 @@ jobs:
 
       - name: Upload coverage delta artifact
         if: ${{ always() && steps.coverage_stats.outputs.delta_json != '' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-coverage-delta.json
           path: gate-coverage-delta.json
@@ -790,7 +790,7 @@ jobs:
 
       - name: Upload coverage summary artifact copy
         if: ${{ always() && steps.coverage_summary.outputs.body != '' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-coverage-summary.md
           path: gate-coverage-summary.md
@@ -800,7 +800,7 @@ jobs:
 
       - name: Ensure consolidated summary comment
         if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -822,7 +822,7 @@ jobs:
 
       - name: Report Gate commit status
         if: ${{ always() }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           STATE: >-
             ${{ steps.summarize.outputs.state || steps.docs_only.outputs.state || 'pending' }}
@@ -881,7 +881,7 @@ jobs:
 
       - name: Dispatch autofix notification
         if: ${{ (steps.summarize.outputs.state || steps.docs_only.outputs.state) == 'failure' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app_token.outputs.token || github.token }}
           script: |

--- a/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
+++ b/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
@@ -145,7 +145,7 @@ jobs:
         id: app_token
         # Use continue-on-error to handle missing secrets gracefully
         continue-on-error: true
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: Fetch PR Context via GraphQL
         id: context
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |

--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -210,6 +210,43 @@ def test_main_leaves_issue_open_until_recovery_window_satisfied(
     assert not close_calls
 
 
+def test_main_uses_embedded_history_when_history_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trend_path = tmp_path / "trend.json"
+    baseline_path = tmp_path / "baseline.json"
+    _write_json(
+        trend_path,
+        {
+            "current": 72.0,
+            "baseline": 70.0,
+            "history": [{"current": 71.0}, {"current": 72.0}],
+        },
+    )
+    _write_json(baseline_path, {"line": 70.0, "recovery_window": 2})
+
+    close_calls = []
+    monkeypatch.setattr(
+        coverage_guard,
+        "_close_existing_issue",
+        lambda *args: close_calls.append(args),
+    )
+
+    exit_code = coverage_guard.main(
+        [
+            "--repo",
+            "octo/repo",
+            "--trend-path",
+            str(trend_path),
+            "--baseline-path",
+            str(baseline_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert close_calls
+
+
 def test_main_uses_history_file_for_recovery_window(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -250,6 +287,18 @@ def test_main_uses_history_file_for_recovery_window(
 
     assert exit_code == 0
     assert close_calls
+
+
+def test_recovery_window_counts_same_coverage_from_distinct_runs() -> None:
+    trend_data = {"current": 72.0, "run_id": "run-2"}
+    history_records = [{"current": 72.0, "run_id": "run-1"}]
+
+    assert coverage_guard._recovery_window_satisfied(
+        trend_data,
+        baseline=70.0,
+        recovery_window=2,
+        history_records=history_records,
+    )
 
 
 def test_main_uses_trend_baseline_when_baseline_missing(

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -326,9 +326,9 @@ def _recovery_window_satisfied(
     if not isinstance(history, list):
         history = []
     records = [record for record in history if isinstance(record, dict)]
-    latest_history_current = _parse_finite_float(records[-1].get("current")) if records else None
-    trend_current = _parse_finite_float(trend_data.get("current"))
-    if latest_history_current != trend_current:
+    latest_key = _coverage_record_key(records[-1]) if records else None
+    trend_key = _coverage_record_key(trend_data)
+    if latest_key != trend_key:
         records.append(trend_data)
     if len(records) < recovery_window:
         return False
@@ -338,6 +338,15 @@ def _recovery_window_satisfied(
         if current is None or current < baseline:
             return False
     return True
+
+
+def _coverage_record_key(record: dict[str, Any]) -> tuple[str, str | float | None]:
+    """Return a stable identity for a coverage sample."""
+    for key in ("run_id", "run_url", "workflow_run_id", "head_sha", "sha", "timestamp", "date"):
+        value = record.get(key)
+        if value not in (None, ""):
+            return (key, str(value))
+    return ("current", _parse_finite_float(record.get("current")))
 
 
 def main(args: list[str] | None = None) -> int:
@@ -394,7 +403,7 @@ def main(args: list[str] | None = None) -> int:
     if parsed.baseline_path and parsed.baseline_path.exists():
         baseline_data = _load_json(parsed.baseline_path)
 
-    history_records = []
+    history_records = None
     if parsed.history_path and parsed.history_path.exists():
         history_records = _load_ndjson(parsed.history_path)
 
@@ -412,14 +421,19 @@ def main(args: list[str] | None = None) -> int:
         _to_float(trend_data.get("baseline"), 70.0),
     )
     delta = current - baseline
-    configured_recovery_window = _to_int(
-        parsed.recovery_window
-        if parsed.recovery_window is not None
-        else baseline_data.get(
-            "recovery_window",
-            baseline_data.get("recovery_runs", baseline_data.get("recovery_days")),
-        ),
+    configured_recovery_window = max(
         1,
+        _to_int(
+            (
+                parsed.recovery_window
+                if parsed.recovery_window is not None
+                else baseline_data.get(
+                    "recovery_window",
+                    baseline_data.get("recovery_runs", baseline_data.get("recovery_days")),
+                )
+            ),
+            1,
+        ),
     )
 
     # Get hotspots


### PR DESCRIPTION
## Summary
- refresh protected consumer workflow template pins for GitHub actions and Dependabot metadata
- update Claude code review action pin to the latest 1.0.102 commit
- keep the workflow YAML validator from rejecting agents-guard's required pinned fallback action line

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/validate_workflow_yaml.py $(git diff --name-only -- 'templates/consumer-repo/.github/workflows/*.yml')
- git diff --check
- pytest tests/scripts/test_validate_template_sync.py tests/test_workflow_validator.py
- actionlint with .github/actionlint-allowlist.txt against changed consumer template workflows