### PR TITLE
Fix synced langchain client ruff violation

### DIFF
--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -215,9 +215,9 @@ def build_chat_client(
         return None
 
     try:
-        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
+        from langchain_anthropic import ChatAnthropic as chat_anthropic_cls
     except ImportError:
-        ChatAnthropicClass = None
+        chat_anthropic_cls = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -264,11 +264,11 @@ def build_chat_client(
             return None
 
     if selected_provider == PROVIDER_ANTHROPIC:
-        if not anthropic_token or not ChatAnthropicClass:
+        if not anthropic_token or not chat_anthropic_cls:
             return None
         try:
             client = _build_anthropic_client(
-                ChatAnthropicClass,
+                chat_anthropic_cls,
                 model=selected_model,
                 token=anthropic_token,
                 timeout=selected_timeout,
@@ -295,10 +295,10 @@ def build_chat_client(
                 )
                 used_override = True
                 return ClientInfo(client=client, provider=PROVIDER_OPENAI, model=slot_model)
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and chat_anthropic_cls:
             with contextlib.suppress(Exception):
                 client = _build_anthropic_client(
-                    ChatAnthropicClass,
+                    chat_anthropic_cls,
                     model=slot_model,
                     token=anthropic_token,
                     timeout=selected_timeout,
@@ -335,9 +335,9 @@ def build_chat_clients(
         return []
 
     try:
-        from langchain_anthropic import ChatAnthropic as ChatAnthropicClass
+        from langchain_anthropic import ChatAnthropic as chat_anthropic_cls
     except ImportError:
-        ChatAnthropicClass = None
+        chat_anthropic_cls = None
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -418,12 +418,12 @@ def build_chat_clients(
                             model=second_model,
                         )
                     )
-        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
+        elif selected_provider == PROVIDER_ANTHROPIC and anthropic_token and chat_anthropic_cls:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropicClass,
+                            chat_anthropic_cls,
                             model=first_model,
                             token=anthropic_token,
                             timeout=selected_timeout,
@@ -438,7 +438,7 @@ def build_chat_clients(
                     clients.append(
                         ClientInfo(
                             client=_build_anthropic_client(
-                                ChatAnthropicClass,
+                                chat_anthropic_cls,
                                 model=second_model,
                                 token=anthropic_token,
                                 timeout=selected_timeout,
@@ -457,7 +457,7 @@ def build_chat_clients(
         if any(
             (
                 slot.provider == PROVIDER_OPENAI and openai_token,
-                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass,
+                slot.provider == PROVIDER_ANTHROPIC and anthropic_token and chat_anthropic_cls,
                 slot.provider == PROVIDER_GITHUB and github_token,
             )
         ):
@@ -486,12 +486,12 @@ def build_chat_clients(
                         model=slot_model,
                     )
                 )
-        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and ChatAnthropicClass:
+        if slot.provider == PROVIDER_ANTHROPIC and anthropic_token and chat_anthropic_cls:
             with contextlib.suppress(Exception):
                 clients.append(
                     ClientInfo(
                         client=_build_anthropic_client(
-                            ChatAnthropicClass,
+                            chat_anthropic_cls,
                             model=slot_model,
                             token=anthropic_token,
                             timeout=selected_timeout,


### PR DESCRIPTION
## Summary
- rename the dynamically imported ChatAnthropic alias to lowercase so consumer ruff N806 checks pass after sync

## Validation
- ruff format --check tools/langchain_client.py
- ruff check tools/langchain_client.py
- python -m py_compile tools/langchain_client.py
- pytest -q tests/tools/test_langchain_client.py

This follows the fresh generated sync PR failures on tools/langchain_client.py in consumer repositories.