### PR TITLE
Fix synced langchain client import style

### DIFF
--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -215,9 +215,11 @@ def build_chat_client(
         return None
 
     try:
-        from langchain_anthropic import ChatAnthropic as chat_anthropic_cls
+        from langchain_anthropic import ChatAnthropic
     except ImportError:
         chat_anthropic_cls = None
+    else:
+        chat_anthropic_cls = ChatAnthropic
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")
@@ -335,9 +337,11 @@ def build_chat_clients(
         return []
 
     try:
-        from langchain_anthropic import ChatAnthropic as chat_anthropic_cls
+        from langchain_anthropic import ChatAnthropic
     except ImportError:
         chat_anthropic_cls = None
+    else:
+        chat_anthropic_cls = ChatAnthropic
 
     github_token = os.environ.get("GITHUB_TOKEN")
     openai_token = os.environ.get("OPENAI_API_KEY")


### PR DESCRIPTION
## Summary
- import ChatAnthropic with its original class name and assign it to the lowercase chat_anthropic_cls local in an else branch
- fixes consumer ruff N813 after the previous N806 fix synced out

## Validation
- ruff format --check tools/langchain_client.py
- ruff check tools/langchain_client.py
- python -m py_compile tools/langchain_client.py
- pytest -q tests/tools/test_langchain_client.py