### PR TITLE
fix: sync followup disposition helpers

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -501,6 +501,8 @@ class VerificationData:
 
     provider_verdicts: dict[str, dict[str, Any]] = field(default_factory=dict)
     concerns: list[str] = field(default_factory=list)
+    non_pass_output: list[str] = field(default_factory=list)
+    non_pass_findings: list[str] = field(default_factory=list)
     low_scores: dict[str, int] = field(default_factory=dict)
     iteration_count: int = 0
     tasks_attempted: int = 0
@@ -746,7 +748,29 @@ def extract_verification_data(comment_body: str) -> VerificationData:
         for match in problem_pattern.finditer(issues_text):
             data.structural_issues.append(match.group(1).strip())
 
+    _refresh_non_pass_evidence(data)
     return data
+
+
+def _refresh_non_pass_evidence(data: VerificationData) -> None:
+    """Rebuild non-PASS evidence from final provider verdicts."""
+
+    data.non_pass_output = []
+    data.non_pass_findings = []
+    for provider, payload in data.provider_verdicts.items():
+        verdict = str(payload.get("verdict", "") or "").strip()
+        if verdict.upper() == "PASS":
+            continue
+        model = str(payload.get("model", "") or "").strip()
+        confidence = int(float(payload.get("confidence", 0) or 0))
+        data.non_pass_output.append(
+            f"Provider={provider}; Model={model}; Verdict={verdict}; Confidence={confidence}%"
+        )
+        summary = str(payload.get("summary", "") or "").strip()
+        if summary:
+            data.non_pass_findings.append(
+                f"Provider={provider}; Verdict={verdict}; Difference={summary}"
+            )
 
 
 def _should_add_missing_concerns_note(
@@ -1139,6 +1163,88 @@ def _append_advisory_notes(body: str, advisory_concerns: list[str]) -> str:
     return body.rstrip() + "\n" + "\n".join(notes_lines) + "\n"
 
 
+def _format_code_change_decision(verification_data: VerificationData) -> str:
+    policy_result = _resolve_verdict_policy(verification_data)
+    blocking_concerns, advisory_concerns = _split_concerns(verification_data.concerns)
+    requires_code_change = policy_result.verdict.lower() in {"fail", "error"} or bool(
+        blocking_concerns
+    )
+    if (
+        policy_result.verdict_kind == "concerns"
+        and policy_result.split_verdict
+        and not policy_result.needs_human
+    ):
+        requires_code_change = False
+    if policy_result.verdict.lower() == "concerns" and advisory_concerns and not blocking_concerns:
+        requires_code_change = False
+
+    rationale = policy_result.needs_human_reason
+    if not rationale:
+        if (
+            policy_result.verdict_kind == "concerns"
+            and policy_result.split_verdict
+            and not policy_result.needs_human
+        ):
+            rationale = (
+                "low-confidence and contradicted by high-confidence PASS provider(s); "
+                "no code follow-up is required."
+            )
+        elif requires_code_change:
+            rationale = (
+                "Difference describes a functional defect or regression signal that should be "
+                "resolved in code."
+            )
+        else:
+            rationale = (
+                "Difference appears advisory or contradicted by higher-confidence PASS "
+                "provider evidence; no code follow-up is required."
+            )
+
+    answer = "yes" if requires_code_change else "no"
+    return f"non-PASS output requires code changes: **{answer}**; technical rationale: {rationale}"
+
+
+def generate_disposition_comment(
+    verification_data: VerificationData,
+    pr_number: int,
+    source_url: str | None = None,
+) -> str:
+    """Generate a durable issue/PR disposition comment for non-PASS verification output."""
+
+    body_parts = [
+        "## verify:compare Disposition",
+        "",
+        f"Source: verify:compare non-PASS output from PR #{pr_number}",
+    ]
+    if source_url:
+        body_parts.append(f"Source link: {source_url}")
+
+    body_parts.extend(["", "### Evidence", ""])
+    if verification_data.non_pass_output:
+        max_non_pass_output = 10
+        for output in verification_data.non_pass_output[:max_non_pass_output]:
+            body_parts.append(f"- `{output}`")
+        remaining_non_pass_output = len(verification_data.non_pass_output) - max_non_pass_output
+        if remaining_non_pass_output > 0:
+            body_parts.append(f"- ... plus {remaining_non_pass_output} more evidence entries")
+    else:
+        body_parts.append("- No structured non-PASS provider output was extracted.")
+
+    if verification_data.non_pass_findings:
+        body_parts.extend(["", "### Findings", ""])
+        for finding in verification_data.non_pass_findings:
+            body_parts.append(f"- {finding}")
+
+    body_parts.extend(["", "### Decision", "", _format_code_change_decision(verification_data)])
+    return "\n".join(body_parts)
+
+
+def generate_issue_disposition_link_comment(disposition_url: str) -> str:
+    """Generate a short issue comment linking to the durable disposition evidence."""
+
+    return f"Disposition documentation for verify:compare is recorded here: {disposition_url}"
+
+
 def generate_followup_issue(
     verification_data: VerificationData,
     original_issue: OriginalIssueData,
@@ -1501,10 +1607,13 @@ def _generate_without_llm(
             f"- Resolved verdict: {verdict}",
         ]
     )
+    for finding in verification_data.non_pass_findings[:10]:
+        body_parts.append(f"- {finding}")
     for concern in blocking_concerns[:10]:
         body_parts.append(f"- Concern: {concern}")
     for concern in advisory_concerns[:10]:
         body_parts.append(f"- Advisory: {concern}")
+    body_parts.append(f"- {_format_code_change_decision(verification_data)}")
 
     body_parts.extend(
         [
@@ -1513,6 +1622,12 @@ def _generate_without_llm(
             "",
         ]
     )
+    max_non_pass_output = 10
+    for output in verification_data.non_pass_output[:max_non_pass_output]:
+        body_parts.append(f"- `{output}`")
+    remaining_non_pass_output = len(verification_data.non_pass_output) - max_non_pass_output
+    if remaining_non_pass_output > 0:
+        body_parts.append(f"- ... plus {remaining_non_pass_output} more evidence entries")
     for provider, data in verification_data.provider_verdicts.items():
         evidence = f"- {provider}: {data.get('verdict', 'Unknown')} @ {data.get('confidence', 0)}%"
         summary = data.get("summary")

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -13,7 +13,9 @@ from scripts.langchain.followup_issue_generator import (
     VerificationData,
     extract_original_issue_data,
     extract_verification_data,
+    generate_disposition_comment,
     generate_followup_issue,
+    generate_issue_disposition_link_comment,
 )
 
 
@@ -57,6 +59,104 @@ class TestExtractVerificationData:
         assert data.provider_verdicts["openai"]["confidence"] == 72
         assert "anthropic" in data.provider_verdicts
         assert data.provider_verdicts["anthropic"]["confidence"] == 92
+        assert data.non_pass_output == [
+            "Provider=openai; Model=gpt-5.2; Verdict=CONCERNS; Confidence=72%"
+        ]
+        assert data.non_pass_findings == [
+            "Provider=openai; Verdict=CONCERNS; Difference=Needs follow-up."
+        ]
+
+    def test_generate_disposition_comment_includes_evidence_decision_and_rationale(self):
+        comment = """
+## Provider Comparison Report
+
+### Provider Summary
+| Provider | Model | Verdict | Confidence | Summary |
+| --- | --- | --- | --- | --- |
+| openai | gpt-5 | FAIL | 60% | Regression in parsing |
+"""
+        verification_data = extract_verification_data(comment)
+
+        disposition = generate_disposition_comment(verification_data, pr_number=49)
+
+        assert "## verify:compare Disposition" in disposition
+        assert "Source: verify:compare non-PASS output from PR #49" in disposition
+        assert "`Provider=openai; Model=gpt-5; Verdict=FAIL; Confidence=60%`" in disposition
+        assert "non-PASS output requires code changes: **yes**" in disposition
+        assert "technical rationale: Difference describes a functional defect" in disposition
+
+    def test_generate_disposition_comment_includes_source_link_when_provided(self):
+        comment = """
+## Provider Comparison Report
+
+### Provider Summary
+| Provider | Model | Verdict | Confidence | Summary |
+| --- | --- | --- | --- | --- |
+| openai | gpt-5 | CONCERNS | 74% | Missing edge case |
+"""
+        verification_data = extract_verification_data(comment)
+
+        disposition = generate_disposition_comment(
+            verification_data,
+            pr_number=49,
+            source_url="https://github.com/stranske/Workflows/pull/49#issuecomment-123",
+        )
+
+        assert "Source: verify:compare non-PASS output from PR #49" in disposition
+        assert (
+            "Source link: https://github.com/stranske/Workflows/pull/49#issuecomment-123"
+            in disposition
+        )
+
+    def test_generate_issue_disposition_link_comment_includes_url(self):
+        body = generate_issue_disposition_link_comment(
+            disposition_url="https://github.com/stranske/Workflows/pull/49#issuecomment-123"
+        )
+
+        assert "Disposition documentation for verify:compare is recorded here" in body
+        assert "https://github.com/stranske/Workflows/pull/49#issuecomment-123" in body
+
+    def test_non_pass_evidence_backfills_from_provider_detail_sections(self):
+        comment = """
+## Provider Comparison Report
+
+#### openai
+- **Verdict:** FAIL
+- **Confidence:** 61%
+"""
+
+        data = extract_verification_data(comment)
+
+        assert data.non_pass_output == ["Provider=openai; Model=; Verdict=FAIL; Confidence=61%"]
+
+    def test_generate_followup_issue_caps_non_pass_output_entries(self):
+        verification_data = VerificationData(
+            provider_verdicts={
+                f"provider-{index}": {
+                    "model": f"model-{index}",
+                    "verdict": "FAIL",
+                    "confidence": 50,
+                    "summary": f"Regression {index}",
+                }
+                for index in range(12)
+            },
+            concerns=["Regression in parser behavior"],
+        )
+        followup_issue_generator._refresh_non_pass_evidence(verification_data)
+        original_issue = OriginalIssueData(title="Issue title", number=92)
+
+        followup = generate_followup_issue(
+            verification_data,
+            original_issue,
+            pr_number=49,
+            use_llm=False,
+        )
+
+        assert "Provider=provider-9; Model=model-9; Verdict=FAIL; Confidence=50%" in followup.body
+        assert "Provider=provider-10; Model=model-10; Verdict=FAIL; Confidence=50%" not in (
+            followup.body
+        )
+        assert "... plus 2 more evidence entries" in followup.body
 
     def test_extract_provider_verdicts_comparison_report_summary(self):
         """Extract verdicts from Provider Comparison Report format."""


### PR DESCRIPTION
## Summary
- restore structured non-PASS verify:compare evidence fields in follow-up generation
- add durable disposition comment helpers expected by consumer tests
- include disposition decisions and evidence in non-LLM follow-up issue output

## Validation
- ruff format scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- ruff check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- pytest -q tests/test_followup_issue_generator.py tests/test_verdict_policy_integration.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- copied patched script into Inv-Man-Intake sync PR checkout and ran /tmp/inv216-venv/bin/pytest -q tests/test_followup_issue_generator.py --no-cov