### PR TITLE
Fix weekly metrics artifact downloads

### DIFF
--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -54,7 +54,8 @@ jobs:
 
           # Get artifact IDs and names
           # shellcheck disable=SC1009,SC1073,SC1039,SC1072
-          node - <<'NODE' |
+          artifact_list="artifacts/metric-artifacts.tsv"
+          node - <<'NODE' > "$artifact_list"
           const { Octokit } = require('@octokit/rest');
           const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
           const core = { info: () => {}, warning: console.warn, debug: () => {} };
@@ -97,6 +98,9 @@ jobs:
             process.exit(1);
           });
           NODE
+          if [ ! -s "$artifact_list" ]; then
+            echo "No metrics artifacts found"
+          fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
             mkdir -p "artifacts/$name"
@@ -105,47 +109,47 @@ jobs:
             export ARTIFACT_DIR="artifacts/$name"
             export ARTIFACT_ZIP="artifacts/$name/$id.zip"
             if ! node - <<'NODE'
-            const fs = require('fs');
-            const { Octokit } = require('@octokit/rest');
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const core = { info: () => {}, warning: console.warn, debug: () => {} };
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const artifactId = Number(process.env.ARTIFACT_ID);
-            const zipPath = process.env.ARTIFACT_ZIP;
-            (async () => {
-              const token = process.env.GH_TOKEN ||
-                process.env.GITHUB_TOKEN;
-              const github = new Octokit({ auth: token });
-              const { withRetry } = await createTokenAwareRetry({
-                github,
-                core,
-                env: process.env,
-                task: 'agents-weekly-metrics-download',
-                capabilities: ['actions:read']
-              });
-              const response = await withRetry((client) => client.rest.actions.downloadArtifact({
-                owner,
-                repo,
-                artifact_id: artifactId,
-                archive_format: 'zip'
-              }));
-              const data = response.data;
-              const buffer = Buffer.isBuffer(data)
-                ? data
-                : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
-              fs.writeFileSync(zipPath, buffer);
-            })().catch((error) => {
-              console.error(error);
-              process.exit(1);
+          const fs = require('fs');
+          const { Octokit } = require('@octokit/rest');
+          const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+          const core = { info: () => {}, warning: console.warn, debug: () => {} };
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+          const artifactId = Number(process.env.ARTIFACT_ID);
+          const zipPath = process.env.ARTIFACT_ZIP;
+          (async () => {
+            const token = process.env.GH_TOKEN ||
+              process.env.GITHUB_TOKEN;
+            const github = new Octokit({ auth: token });
+            const { withRetry } = await createTokenAwareRetry({
+              github,
+              core,
+              env: process.env,
+              task: 'agents-weekly-metrics-download',
+              capabilities: ['actions:read']
             });
-            NODE
+            const response = await withRetry((client) => client.rest.actions.downloadArtifact({
+              owner,
+              repo,
+              artifact_id: artifactId,
+              archive_format: 'zip'
+            }));
+            const data = response.data;
+            const buffer = Buffer.isBuffer(data)
+              ? data
+              : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+            fs.writeFileSync(zipPath, buffer);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
             then
               echo "Warning: Could not download artifact $id ($name)"
               continue
             fi
             unzip -o "artifacts/$name/$id.zip" -d "artifacts/$name" >/dev/null || \
               echo "Warning: Could not unzip artifact $id ($name)"
-          done || true  # Don't fail if no artifacts found
+          done < "$artifact_list"
 
       - name: Aggregate metrics
         env:

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -66,7 +66,8 @@ jobs:
 
           # Get artifact IDs and names
           # shellcheck disable=SC1009,SC1073,SC1039,SC1072
-          node - <<'NODE' |
+          artifact_list="artifacts/metric-artifacts.tsv"
+          node - <<'NODE' > "$artifact_list"
           const { Octokit } = require('@octokit/rest');
           const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
           const core = { info: () => {}, warning: console.warn, debug: () => {} };
@@ -109,6 +110,9 @@ jobs:
             process.exit(1);
           });
           NODE
+          if [ ! -s "$artifact_list" ]; then
+            echo "No metrics artifacts found"
+          fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
             mkdir -p "artifacts/$name"
@@ -117,47 +121,47 @@ jobs:
             export ARTIFACT_DIR="artifacts/$name"
             export ARTIFACT_ZIP="artifacts/$name/$id.zip"
             if ! node - <<'NODE'
-            const fs = require('fs');
-            const { Octokit } = require('@octokit/rest');
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const core = { info: () => {}, warning: console.warn, debug: () => {} };
-            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const artifactId = Number(process.env.ARTIFACT_ID);
-            const zipPath = process.env.ARTIFACT_ZIP;
-            (async () => {
-              const token = process.env.GH_TOKEN ||
-                process.env.GITHUB_TOKEN;
-              const github = new Octokit({ auth: token });
-              const { withRetry } = await createTokenAwareRetry({
-                github,
-                core,
-                env: process.env,
-                task: 'agents-weekly-metrics-download',
-                capabilities: ['actions:read']
-              });
-              const response = await withRetry((client) => client.rest.actions.downloadArtifact({
-                owner,
-                repo,
-                artifact_id: artifactId,
-                archive_format: 'zip'
-              }));
-              const data = response.data;
-              const buffer = Buffer.isBuffer(data)
-                ? data
-                : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
-              fs.writeFileSync(zipPath, buffer);
-            })().catch((error) => {
-              console.error(error);
-              process.exit(1);
+          const fs = require('fs');
+          const { Octokit } = require('@octokit/rest');
+          const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+          const core = { info: () => {}, warning: console.warn, debug: () => {} };
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+          const artifactId = Number(process.env.ARTIFACT_ID);
+          const zipPath = process.env.ARTIFACT_ZIP;
+          (async () => {
+            const token = process.env.GH_TOKEN ||
+              process.env.GITHUB_TOKEN;
+            const github = new Octokit({ auth: token });
+            const { withRetry } = await createTokenAwareRetry({
+              github,
+              core,
+              env: process.env,
+              task: 'agents-weekly-metrics-download',
+              capabilities: ['actions:read']
             });
-            NODE
+            const response = await withRetry((client) => client.rest.actions.downloadArtifact({
+              owner,
+              repo,
+              artifact_id: artifactId,
+              archive_format: 'zip'
+            }));
+            const data = response.data;
+            const buffer = Buffer.isBuffer(data)
+              ? data
+              : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+            fs.writeFileSync(zipPath, buffer);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
             then
               echo "Warning: Could not download artifact $id ($name)"
               continue
             fi
             unzip -o "artifacts/$name/$id.zip" -d "artifacts/$name" >/dev/null || \
               echo "Warning: Could not unzip artifact $id ($name)"
-          done || true  # Don't fail if no artifacts found
+          done < "$artifact_list"
 
       - name: Aggregate metrics
         env:


### PR DESCRIPTION
## Summary\n- repair the weekly metrics artifact-list heredoc so the download loop reads from an explicit TSV file\n- keep empty artifact lists non-fatal\n- mirror the fix into the consumer template workflow\n\n## Verification\n- /opt/homebrew/bin/actionlint .github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml\n- python YAML parse for live/template weekly metrics workflows\n- python -m pytest tests/scripts/test_validate_template_sync.py tests/workflows/test_workflow_agents_consolidation.py -q\n- node --test .github/scripts/__tests__/terminal-disposition-coverage.test.js\n- node --check .github/scripts/terminal_disposition_coverage.js templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js\n- git diff --check