### PR TITLE
Improve weekly telemetry contracts

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -84,7 +84,9 @@ test('reports missing review-thread coverage without failing the contract', () =
   assert.equal(report.schema, 'workflows-terminal-disposition-coverage/v1');
   assert.equal(report.mode, 'warning-only');
   assert.equal(report.status, 'warning');
+  assert.equal(report.scanned_record_count, 3);
   assert.equal(report.terminal_record_count, 3);
+  assert.equal(report.non_terminal_record_count, 0);
   assert.equal(report.expected_source_count, 2);
   assert.equal(report.covered_source_count, 1);
   assert.equal(report.missing_source_count, 1);
@@ -135,6 +137,31 @@ test('reads ndjson files and counts parse errors', () => {
 
   assert.equal(result.records.length, 1);
   assert.equal(result.parse_errors, 2);
+  assert.equal(result.file_count, 1);
+});
+
+test('warns when terminal files contain no terminal disposition records', () => {
+  const report = summarizeTerminalDispositionCoverage(
+    [
+      {
+        schema: 'workflows-keepalive-metrics/v1',
+        source_type: 'review-thread',
+        source_id: '1',
+      },
+    ],
+    {
+      input_file_count: 1,
+      input_files: ['artifacts/review-thread-terminal-disposition-1/review-thread-terminal-disposition.ndjson'],
+    }
+  );
+  const markdown = formatTerminalDispositionCoverageMarkdown(report);
+
+  assert.equal(report.status, 'warning');
+  assert.equal(report.input_file_count, 1);
+  assert.equal(report.terminal_record_count, 0);
+  assert.equal(report.non_terminal_record_count, 1);
+  assert.match(markdown, /Input files: 1/);
+  assert.match(markdown, /did not contain valid terminal disposition records/);
 });
 
 test('collects only terminal disposition ndjson files from metrics artifacts', () => {

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   SELECTION_SCHEMA,
   artifactFamily,
+  buildSelectionErrorReport,
   collectRepoArtifacts,
   formatArtifactTsv,
   formatSelectionMarkdown,
@@ -48,16 +49,43 @@ test('selects only recent matching artifacts with a machine-readable report', ()
   );
 
   assert.equal(report.schema, SELECTION_SCHEMA);
+  assert.equal(report.status, 'pass');
   assert.equal(report.scanned_count, 6);
   assert.equal(report.candidate_count, 3);
   assert.equal(report.selected_count, 3);
   assert.equal(report.ignored_name_count, 1);
   assert.equal(report.ignored_old_count, 1);
   assert.equal(report.ignored_expired_count, 1);
+  assert.deepEqual(report.candidate_family_counts, {
+    'autopilot-metrics': 1,
+    'keepalive-metrics': 1,
+    'review-thread-terminal-disposition': 1,
+  });
+  assert.deepEqual(report.selected_family_counts, {
+    'autopilot-metrics': 1,
+    'keepalive-metrics': 1,
+    'review-thread-terminal-disposition': 1,
+  });
   assert.deepEqual(
     report.selected_artifacts.map((selected) => selected.id),
     [5, 4, 1]
   );
+});
+
+test('builds an error report when artifact selection cannot query GitHub', () => {
+  const report = buildSelectionErrorReport(
+    { now_ms: NOW, max_total: 3 },
+    new Error('API rate limit exceeded')
+  );
+  const markdown = formatSelectionMarkdown(report);
+
+  assert.equal(report.schema, SELECTION_SCHEMA);
+  assert.equal(report.status, 'error');
+  assert.equal(report.error_message, 'API rate limit exceeded');
+  assert.equal(report.selected_count, 0);
+  assert.deepEqual(report.selected_artifacts, []);
+  assert.match(markdown, /Status: error/);
+  assert.match(markdown, /API rate limit exceeded/);
 });
 
 test('bounds selected artifacts by total and per-family limits', () => {
@@ -107,6 +135,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
   assert.match(markdown, /Weekly Metrics Artifact Selection/);
   assert.match(markdown, /Scan cap: 5 pages x 100 artifacts/);
   assert.match(markdown, /Selected artifacts: 2/);
+  assert.match(markdown, /Artifact family \| Candidates \| Selected/);
   assert.match(markdown, /autopilot-metrics/);
   assert.match(markdown, /keepalive-metrics/);
 });

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -64,6 +64,12 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   const terminalRecords = records
     .filter(isTerminalDispositionRecord)
     .map((record) => normalizeTerminalDisposition(record));
+  const scannedRecordCount = records.length;
+  const nonTerminalRecordCount = scannedRecordCount - terminalRecords.length;
+  const inputFiles = Array.isArray(options.input_files) ? options.input_files.map(cleanString).filter(Boolean) : [];
+  const inputFileCount = Number.isFinite(options.input_file_count)
+    ? options.input_file_count
+    : inputFiles.length;
   const observed = new Map();
 
   for (const record of terminalRecords) {
@@ -101,7 +107,7 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
 
   let status = 'pass';
   if (terminalRecords.length === 0) {
-    status = 'no-data';
+    status = parseErrors > 0 || nonTerminalRecordCount > 0 ? 'warning' : 'no-data';
   } else if (missing.length > 0 || parseErrors > 0) {
     status = 'warning';
   }
@@ -110,7 +116,11 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
     schema: COVERAGE_SCHEMA,
     status,
     mode: 'warning-only',
+    input_file_count: inputFileCount,
+    input_files: inputFiles,
+    scanned_record_count: scannedRecordCount,
     terminal_record_count: terminalRecords.length,
+    non_terminal_record_count: nonTerminalRecordCount,
     observed_source_count: observedSources.length,
     expected_source_count: expected.length,
     covered_source_count: covered.length,
@@ -135,7 +145,10 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     '',
     '- Mode: warning-only (does not block merges or automation)',
     `- Status: ${report.status}`,
+    `- Input files: ${report.input_file_count || 0}`,
+    `- Scanned records: ${report.scanned_record_count || 0}`,
     `- Terminal disposition records: ${report.terminal_record_count}`,
+    `- Non-terminal records: ${report.non_terminal_record_count || 0}`,
     `- Observed sources: ${report.observed_source_count}`,
     `- Expected review-thread sources: ${report.expected_source_count}`,
     `- Missing review-thread sources: ${report.missing_source_count}`,
@@ -161,6 +174,8 @@ function formatTerminalDispositionCoverageMarkdown(report) {
 
   if (report.status === 'no-data') {
     lines.push('', '_No terminal disposition records were found in the metrics input._');
+  } else if (report.terminal_record_count === 0 && (report.non_terminal_record_count || 0) > 0) {
+    lines.push('', '_Terminal disposition files were found, but they did not contain valid terminal disposition records._');
   }
 
   return `${lines.join('\n')}\n`;
@@ -194,12 +209,14 @@ function collectNdjsonFiles(root) {
 function readNdjsonFiles(files = []) {
   const records = [];
   let parseErrors = 0;
+  let readErrors = 0;
   for (const file of files) {
     let text = '';
     try {
       text = fs.readFileSync(file, 'utf8');
     } catch (_error) {
       parseErrors += 1;
+      readErrors += 1;
       continue;
     }
     for (const line of text.split(/\r?\n/)) {
@@ -217,7 +234,12 @@ function readNdjsonFiles(files = []) {
       }
     }
   }
-  return { records, parse_errors: parseErrors };
+  return {
+    records,
+    parse_errors: parseErrors,
+    read_errors: readErrors,
+    file_count: files.length,
+  };
 }
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -267,11 +289,17 @@ function main() {
   const inputFiles = options.inputs.length > 0
     ? options.inputs
     : collectNdjsonFiles(options.metrics_dir);
-  const { records, parse_errors: parseErrors } = readNdjsonFiles(inputFiles);
+  const {
+    records,
+    parse_errors: parseErrors,
+    file_count: inputFileCount,
+  } = readNdjsonFiles(inputFiles);
   const expectedSources = parseExpectedSources(options);
   const report = summarizeTerminalDispositionCoverage(records, {
     parse_errors: parseErrors,
     expected_sources: expectedSources,
+    input_file_count: inputFileCount,
+    input_files: inputFiles,
   });
   const markdown = formatTerminalDispositionCoverageMarkdown(report);
   fs.writeFileSync(options.output_json, `${JSON.stringify(report, null, 2)}\n`);

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -100,6 +100,12 @@ function normalizeArtifact(raw = {}) {
   };
 }
 
+function sortedCountObject(counts) {
+  return Object.fromEntries(
+    [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  );
+}
+
 function selectMetricsArtifacts(artifacts = [], options = {}) {
   const config = normalizeSelectionOptions(options);
   const stats = {
@@ -114,6 +120,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   };
 
   const candidates = [];
+  const candidateFamilyCounts = new Map();
   for (const raw of artifacts) {
     const artifact = normalizeArtifact(raw);
     if (!artifact.id || !artifact.name) {
@@ -133,6 +140,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       continue;
     }
     stats.candidate_count += 1;
+    candidateFamilyCounts.set(artifact.family, (candidateFamilyCounts.get(artifact.family) || 0) + 1);
     candidates.push(artifact);
   }
 
@@ -160,6 +168,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   stats.selected_count = selected.length;
   return {
     schema: SELECTION_SCHEMA,
+    status: 'pass',
     config: {
       lookback_days: config.lookback_days,
       max_total: config.max_total,
@@ -169,6 +178,8 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
+    candidate_family_counts: sortedCountObject(candidateFamilyCounts),
+    selected_family_counts: sortedCountObject(familyCounts),
     selected_artifacts: selected.map((artifact) => ({
       id: artifact.id,
       name: artifact.name,
@@ -179,19 +190,50 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   };
 }
 
+function buildSelectionErrorReport(options = {}, error = {}) {
+  const config = normalizeSelectionOptions(options);
+  return {
+    schema: SELECTION_SCHEMA,
+    status: 'error',
+    error_message: cleanString(error?.message || error) || 'Unknown artifact selection error',
+    config: {
+      lookback_days: config.lookback_days,
+      max_total: config.max_total,
+      max_per_family: config.max_per_family,
+      max_scan_pages: config.max_scan_pages,
+      per_page: config.per_page,
+      cutoff_iso: new Date(config.cutoff_ms).toISOString(),
+    },
+    scanned_count: 0,
+    candidate_count: 0,
+    selected_count: 0,
+    ignored_expired_count: 0,
+    ignored_name_count: 0,
+    ignored_old_count: 0,
+    ignored_family_limit_count: 0,
+    ignored_total_limit_count: 0,
+    candidate_family_counts: {},
+    selected_family_counts: {},
+    selected_artifacts: [],
+  };
+}
+
 function formatArtifactTsv(artifacts = []) {
   return artifacts.map((artifact) => `${artifact.id}\t${artifact.name}`).join('\n');
 }
 
 function formatSelectionMarkdown(report) {
-  const familyCounts = new Map();
-  for (const artifact of report.selected_artifacts || []) {
-    familyCounts.set(artifact.family, (familyCounts.get(artifact.family) || 0) + 1);
-  }
+  const candidateFamilyCounts = report.candidate_family_counts || {};
+  const selectedFamilyCounts = report.selected_family_counts || {};
+  const familyNames = [...new Set([
+    ...Object.keys(candidateFamilyCounts),
+    ...Object.keys(selectedFamilyCounts),
+  ])].sort((a, b) => a.localeCompare(b));
   const lines = [
     '## Weekly Metrics Artifact Selection',
     '',
     `- Schema: ${report.schema}`,
+    `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
@@ -203,10 +245,14 @@ function formatSelectionMarkdown(report) {
       `${report.ignored_total_limit_count} over total cap`,
   ];
 
-  if (familyCounts.size > 0) {
-    lines.push('', '| Artifact family | Selected |', '|-----------------|----------|');
-    for (const [family, count] of [...familyCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-      lines.push(`| ${family} | ${count} |`);
+  if (report.status === 'error') {
+    lines.push(`- Error: ${report.error_message || 'Unknown artifact selection error'}`);
+  }
+
+  if (familyNames.length > 0) {
+    lines.push('', '| Artifact family | Candidates | Selected |', '|-----------------|------------|----------|');
+    for (const family of familyNames) {
+      lines.push(`| ${family} | ${candidateFamilyCounts[family] || 0} | ${selectedFamilyCounts[family] || 0} |`);
     }
   }
 
@@ -305,6 +351,23 @@ async function main() {
 
 if (require.main === module) {
   main().catch((error) => {
+    const options = parseArgs();
+    const selection = buildSelectionErrorReport(options, error);
+    try {
+      const path = require('path');
+      fs.mkdirSync(path.dirname(options.output), { recursive: true });
+      fs.mkdirSync(path.dirname(options.report), { recursive: true });
+      if (options.markdown) {
+        fs.mkdirSync(path.dirname(options.markdown), { recursive: true });
+      }
+      fs.writeFileSync(options.output, '');
+      fs.writeFileSync(options.report, `${JSON.stringify(selection, null, 2)}\n`);
+      if (options.markdown) {
+        fs.writeFileSync(options.markdown, formatSelectionMarkdown(selection));
+      }
+    } catch (writeError) {
+      console.error(writeError);
+    }
     console.error(error);
     process.exit(1);
   });
@@ -317,6 +380,7 @@ module.exports = {
   DEFAULT_MAX_TOTAL,
   SELECTION_SCHEMA,
   artifactFamily,
+  buildSelectionErrorReport,
   collectRepoArtifacts,
   formatArtifactTsv,
   formatSelectionMarkdown,

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -153,6 +153,7 @@ jobs:
           fi
 
       - name: Upload weekly summary
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: agent-weekly-metrics
@@ -162,6 +163,7 @@ jobs:
             artifacts/metric-artifacts-selection.md
             terminal-disposition-coverage.json
             terminal-disposition-coverage.md
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Post summary to tracking issue

--- a/.github/workflows/health-68-consumer-sync-drift.yml
+++ b/.github/workflows/health-68-consumer-sync-drift.yml
@@ -58,13 +58,26 @@ jobs:
         env:
           DRIFT_TOKEN: >-
             ${{ secrets.OWNER_PR_PAT || secrets.SERVICE_BOT_PAT || secrets.GITHUB_TOKEN }}
+          CONSUMER_SYNC_DRIFT_REPORT_JSON: artifacts/consumer-sync-drift-report.json
           INPUT_REPOS: ${{ inputs.repos }}
         run: |
+          mkdir -p artifacts
           repos_input="${INPUT_REPOS:-}"
           if [ -z "$repos_input" ]; then
           repos_input=$(python3 scripts/list_registered_consumer_repos.py --separator=,)
           fi
-          python3 scripts/check_consumer_sync_drift.py --repos "$repos_input"
+          python3 scripts/check_consumer_sync_drift.py \
+            --repos "$repos_input" \
+            --report-json "$CONSUMER_SYNC_DRIFT_REPORT_JSON"
+
+      - name: Upload drift report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: consumer-sync-drift-report
+          path: artifacts/consumer-sync-drift-report.json
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Create drift issue
         if: ${{ failure() }}

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import json
 import os
 from pathlib import Path
 
 import requests
 import yaml
+
+REPORT_SCHEMA = "workflows-consumer-sync-drift/v1"
 
 
 def parse_args() -> argparse.Namespace:
@@ -30,6 +33,11 @@ def parse_args() -> argparse.Namespace:
         "--summary",
         default=os.environ.get("GITHUB_STEP_SUMMARY", ""),
         help="Optional path to write a summary markdown.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default=os.environ.get("CONSUMER_SYNC_DRIFT_REPORT_JSON", ""),
+        help="Optional path to write a machine-readable drift report.",
     )
     return parser.parse_args()
 
@@ -56,21 +64,91 @@ def file_hash(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def sorted_items(values: set[str]) -> list[str]:
+    return sorted(values)
+
+
+def build_report(
+    *,
+    repos: list[str],
+    drift: set[str],
+    missing: set[str],
+    errors: set[str],
+    obsolete: set[str],
+) -> dict[str, object]:
+    counts = {
+        "drift": len(drift),
+        "missing": len(missing),
+        "errors": len(errors),
+        "obsolete": len(obsolete),
+    }
+    status = "pass" if all(value == 0 for value in counts.values()) else "drift"
+    return {
+        "schema": REPORT_SCHEMA,
+        "status": status,
+        "repo_count": len(repos),
+        "repos": repos,
+        "counts": counts,
+        "drift": sorted_items(drift),
+        "missing": sorted_items(missing),
+        "errors": sorted_items(errors),
+        "obsolete": sorted_items(obsolete),
+    }
+
+
+def write_report_json(path: str, report: dict[str, object]) -> None:
+    if not path:
+        return
+    report_path = Path(path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def main() -> int:
     args = parse_args()
     repos = resolve_repos(args.repos)
     if not repos:
         print("::error::No repos provided or found in REGISTERED_CONSUMER_REPOS")
+        write_report_json(
+            args.report_json,
+            build_report(
+                repos=[],
+                drift=set(),
+                missing=set(),
+                errors={"No repos provided or found in REGISTERED_CONSUMER_REPOS"},
+                obsolete=set(),
+            ),
+        )
         return 1
 
     manifest_path = Path(args.manifest)
     if not manifest_path.exists():
         print("::error::sync-manifest.yml not found")
+        write_report_json(
+            args.report_json,
+            build_report(
+                repos=repos,
+                drift=set(),
+                missing=set(),
+                errors={"sync-manifest.yml not found"},
+                obsolete=set(),
+            ),
+        )
         return 1
 
     token = os.environ.get("DRIFT_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
     if not token:
         print("::error::No GitHub token available for cross-repo reads")
+        write_report_json(
+            args.report_json,
+            build_report(
+                repos=repos,
+                drift=set(),
+                missing=set(),
+                errors={"No GitHub token available for cross-repo reads"},
+                obsolete=set(),
+            ),
+        )
         return 1
 
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
@@ -160,6 +238,15 @@ def main() -> int:
                 continue
             obsolete.add(f"{repo}: {target}")
 
+    report = build_report(
+        repos=repos,
+        drift=drift,
+        missing=missing,
+        errors=errors,
+        obsolete=obsolete,
+    )
+    write_report_json(args.report_json, report)
+
     if args.summary:
         summary_path = Path(args.summary)
         summary_path.parent.mkdir(parents=True, exist_ok=True)
@@ -185,7 +272,7 @@ def main() -> int:
                 handle.write("\n".join(f"- {item}" for item in sorted(obsolete)))
                 handle.write("\n\n")
 
-    if drift or missing or errors or obsolete:
+    if report["status"] != "pass":
         print("::warning::Consumer repo drift detected")
         return 1
 

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -64,6 +64,12 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   const terminalRecords = records
     .filter(isTerminalDispositionRecord)
     .map((record) => normalizeTerminalDisposition(record));
+  const scannedRecordCount = records.length;
+  const nonTerminalRecordCount = scannedRecordCount - terminalRecords.length;
+  const inputFiles = Array.isArray(options.input_files) ? options.input_files.map(cleanString).filter(Boolean) : [];
+  const inputFileCount = Number.isFinite(options.input_file_count)
+    ? options.input_file_count
+    : inputFiles.length;
   const observed = new Map();
 
   for (const record of terminalRecords) {
@@ -101,7 +107,7 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
 
   let status = 'pass';
   if (terminalRecords.length === 0) {
-    status = 'no-data';
+    status = parseErrors > 0 || nonTerminalRecordCount > 0 ? 'warning' : 'no-data';
   } else if (missing.length > 0 || parseErrors > 0) {
     status = 'warning';
   }
@@ -110,7 +116,11 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
     schema: COVERAGE_SCHEMA,
     status,
     mode: 'warning-only',
+    input_file_count: inputFileCount,
+    input_files: inputFiles,
+    scanned_record_count: scannedRecordCount,
     terminal_record_count: terminalRecords.length,
+    non_terminal_record_count: nonTerminalRecordCount,
     observed_source_count: observedSources.length,
     expected_source_count: expected.length,
     covered_source_count: covered.length,
@@ -135,7 +145,10 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     '',
     '- Mode: warning-only (does not block merges or automation)',
     `- Status: ${report.status}`,
+    `- Input files: ${report.input_file_count || 0}`,
+    `- Scanned records: ${report.scanned_record_count || 0}`,
     `- Terminal disposition records: ${report.terminal_record_count}`,
+    `- Non-terminal records: ${report.non_terminal_record_count || 0}`,
     `- Observed sources: ${report.observed_source_count}`,
     `- Expected review-thread sources: ${report.expected_source_count}`,
     `- Missing review-thread sources: ${report.missing_source_count}`,
@@ -161,6 +174,8 @@ function formatTerminalDispositionCoverageMarkdown(report) {
 
   if (report.status === 'no-data') {
     lines.push('', '_No terminal disposition records were found in the metrics input._');
+  } else if (report.terminal_record_count === 0 && (report.non_terminal_record_count || 0) > 0) {
+    lines.push('', '_Terminal disposition files were found, but they did not contain valid terminal disposition records._');
   }
 
   return `${lines.join('\n')}\n`;
@@ -194,12 +209,14 @@ function collectNdjsonFiles(root) {
 function readNdjsonFiles(files = []) {
   const records = [];
   let parseErrors = 0;
+  let readErrors = 0;
   for (const file of files) {
     let text = '';
     try {
       text = fs.readFileSync(file, 'utf8');
     } catch (_error) {
       parseErrors += 1;
+      readErrors += 1;
       continue;
     }
     for (const line of text.split(/\r?\n/)) {
@@ -217,7 +234,12 @@ function readNdjsonFiles(files = []) {
       }
     }
   }
-  return { records, parse_errors: parseErrors };
+  return {
+    records,
+    parse_errors: parseErrors,
+    read_errors: readErrors,
+    file_count: files.length,
+  };
 }
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -267,11 +289,17 @@ function main() {
   const inputFiles = options.inputs.length > 0
     ? options.inputs
     : collectNdjsonFiles(options.metrics_dir);
-  const { records, parse_errors: parseErrors } = readNdjsonFiles(inputFiles);
+  const {
+    records,
+    parse_errors: parseErrors,
+    file_count: inputFileCount,
+  } = readNdjsonFiles(inputFiles);
   const expectedSources = parseExpectedSources(options);
   const report = summarizeTerminalDispositionCoverage(records, {
     parse_errors: parseErrors,
     expected_sources: expectedSources,
+    input_file_count: inputFileCount,
+    input_files: inputFiles,
   });
   const markdown = formatTerminalDispositionCoverageMarkdown(report);
   fs.writeFileSync(options.output_json, `${JSON.stringify(report, null, 2)}\n`);

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -100,6 +100,12 @@ function normalizeArtifact(raw = {}) {
   };
 }
 
+function sortedCountObject(counts) {
+  return Object.fromEntries(
+    [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  );
+}
+
 function selectMetricsArtifacts(artifacts = [], options = {}) {
   const config = normalizeSelectionOptions(options);
   const stats = {
@@ -114,6 +120,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   };
 
   const candidates = [];
+  const candidateFamilyCounts = new Map();
   for (const raw of artifacts) {
     const artifact = normalizeArtifact(raw);
     if (!artifact.id || !artifact.name) {
@@ -133,6 +140,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       continue;
     }
     stats.candidate_count += 1;
+    candidateFamilyCounts.set(artifact.family, (candidateFamilyCounts.get(artifact.family) || 0) + 1);
     candidates.push(artifact);
   }
 
@@ -160,6 +168,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   stats.selected_count = selected.length;
   return {
     schema: SELECTION_SCHEMA,
+    status: 'pass',
     config: {
       lookback_days: config.lookback_days,
       max_total: config.max_total,
@@ -169,6 +178,8 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
+    candidate_family_counts: sortedCountObject(candidateFamilyCounts),
+    selected_family_counts: sortedCountObject(familyCounts),
     selected_artifacts: selected.map((artifact) => ({
       id: artifact.id,
       name: artifact.name,
@@ -179,19 +190,50 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
   };
 }
 
+function buildSelectionErrorReport(options = {}, error = {}) {
+  const config = normalizeSelectionOptions(options);
+  return {
+    schema: SELECTION_SCHEMA,
+    status: 'error',
+    error_message: cleanString(error?.message || error) || 'Unknown artifact selection error',
+    config: {
+      lookback_days: config.lookback_days,
+      max_total: config.max_total,
+      max_per_family: config.max_per_family,
+      max_scan_pages: config.max_scan_pages,
+      per_page: config.per_page,
+      cutoff_iso: new Date(config.cutoff_ms).toISOString(),
+    },
+    scanned_count: 0,
+    candidate_count: 0,
+    selected_count: 0,
+    ignored_expired_count: 0,
+    ignored_name_count: 0,
+    ignored_old_count: 0,
+    ignored_family_limit_count: 0,
+    ignored_total_limit_count: 0,
+    candidate_family_counts: {},
+    selected_family_counts: {},
+    selected_artifacts: [],
+  };
+}
+
 function formatArtifactTsv(artifacts = []) {
   return artifacts.map((artifact) => `${artifact.id}\t${artifact.name}`).join('\n');
 }
 
 function formatSelectionMarkdown(report) {
-  const familyCounts = new Map();
-  for (const artifact of report.selected_artifacts || []) {
-    familyCounts.set(artifact.family, (familyCounts.get(artifact.family) || 0) + 1);
-  }
+  const candidateFamilyCounts = report.candidate_family_counts || {};
+  const selectedFamilyCounts = report.selected_family_counts || {};
+  const familyNames = [...new Set([
+    ...Object.keys(candidateFamilyCounts),
+    ...Object.keys(selectedFamilyCounts),
+  ])].sort((a, b) => a.localeCompare(b));
   const lines = [
     '## Weekly Metrics Artifact Selection',
     '',
     `- Schema: ${report.schema}`,
+    `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
@@ -203,10 +245,14 @@ function formatSelectionMarkdown(report) {
       `${report.ignored_total_limit_count} over total cap`,
   ];
 
-  if (familyCounts.size > 0) {
-    lines.push('', '| Artifact family | Selected |', '|-----------------|----------|');
-    for (const [family, count] of [...familyCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-      lines.push(`| ${family} | ${count} |`);
+  if (report.status === 'error') {
+    lines.push(`- Error: ${report.error_message || 'Unknown artifact selection error'}`);
+  }
+
+  if (familyNames.length > 0) {
+    lines.push('', '| Artifact family | Candidates | Selected |', '|-----------------|------------|----------|');
+    for (const family of familyNames) {
+      lines.push(`| ${family} | ${candidateFamilyCounts[family] || 0} | ${selectedFamilyCounts[family] || 0} |`);
     }
   }
 
@@ -305,6 +351,23 @@ async function main() {
 
 if (require.main === module) {
   main().catch((error) => {
+    const options = parseArgs();
+    const selection = buildSelectionErrorReport(options, error);
+    try {
+      const path = require('path');
+      fs.mkdirSync(path.dirname(options.output), { recursive: true });
+      fs.mkdirSync(path.dirname(options.report), { recursive: true });
+      if (options.markdown) {
+        fs.mkdirSync(path.dirname(options.markdown), { recursive: true });
+      }
+      fs.writeFileSync(options.output, '');
+      fs.writeFileSync(options.report, `${JSON.stringify(selection, null, 2)}\n`);
+      if (options.markdown) {
+        fs.writeFileSync(options.markdown, formatSelectionMarkdown(selection));
+      }
+    } catch (writeError) {
+      console.error(writeError);
+    }
     console.error(error);
     process.exit(1);
   });
@@ -317,6 +380,7 @@ module.exports = {
   DEFAULT_MAX_TOTAL,
   SELECTION_SCHEMA,
   artifactFamily,
+  buildSelectionErrorReport,
   collectRepoArtifacts,
   formatArtifactTsv,
   formatSelectionMarkdown,

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -165,6 +165,7 @@ jobs:
           fi
 
       - name: Upload weekly summary
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent-weekly-metrics
@@ -174,6 +175,7 @@ jobs:
             artifacts/metric-artifacts-selection.md
             terminal-disposition-coverage.json
             terminal-disposition-coverage.md
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Post summary to tracking issue

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -1,0 +1,41 @@
+import json
+
+from scripts import check_consumer_sync_drift
+
+
+def test_build_report_returns_machine_readable_counts() -> None:
+    report = check_consumer_sync_drift.build_report(
+        repos=["owner/b", "owner/a"],
+        drift={"owner/b: .github/workflows/a.yml"},
+        missing={"owner/a: .github/scripts/a.js"},
+        errors=set(),
+        obsolete={"owner/a: old.yml"},
+    )
+
+    assert report["schema"] == "workflows-consumer-sync-drift/v1"
+    assert report["status"] == "drift"
+    assert report["repo_count"] == 2
+    assert report["counts"] == {
+        "drift": 1,
+        "missing": 1,
+        "errors": 0,
+        "obsolete": 1,
+    }
+    assert report["drift"] == ["owner/b: .github/workflows/a.yml"]
+
+
+def test_write_report_json_creates_parent_directory(tmp_path) -> None:
+    output = tmp_path / "artifacts" / "consumer-sync-drift-report.json"
+    report = check_consumer_sync_drift.build_report(
+        repos=["owner/repo"],
+        drift=set(),
+        missing=set(),
+        errors=set(),
+        obsolete=set(),
+    )
+
+    check_consumer_sync_drift.write_report_json(str(output), report)
+
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema"] == "workflows-consumer-sync-drift/v1"
+    assert loaded["status"] == "pass"

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -142,6 +142,36 @@ def test_agent_watchdog_workflow_absent():
     assert not legacy_watchdog.exists(), "Standalone agent-watchdog workflow must remain deleted"
 
 
+def test_consumer_sync_drift_uploads_machine_readable_report():
+    text = (WORKFLOWS_DIR / "health-68-consumer-sync-drift.yml").read_text(encoding="utf-8")
+    assert (
+        "CONSUMER_SYNC_DRIFT_REPORT_JSON" in text
+    ), "Health 68 must configure a JSON drift report path"
+    assert (
+        '--report-json "$CONSUMER_SYNC_DRIFT_REPORT_JSON"' in text
+    ), "Health 68 must pass the drift report path into the checker"
+    assert (
+        "consumer-sync-drift-report" in text
+    ), "Health 68 must upload the drift report as a GitHub-visible artifact"
+
+
+def test_weekly_metrics_uploads_selector_report_on_failure():
+    workflow_text = (WORKFLOWS_DIR / "agents-weekly-metrics.yml").read_text(encoding="utf-8")
+    template_text = Path(
+        "templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml"
+    ).read_text(encoding="utf-8")
+    for text in (workflow_text, template_text):
+        assert (
+            "artifacts/metric-artifacts-selection.json" in text
+        ), "Weekly metrics must include selector JSON in uploaded artifacts"
+        assert (
+            "if: ${{ always() }}" in text
+        ), "Weekly metrics artifact upload must run after selector failures"
+        assert (
+            "if-no-files-found: warn" in text
+        ), "Weekly metrics upload must not mask the original failure when files are absent"
+
+
 def test_issue_intake_handles_codex_events():
     intake = WORKFLOWS_DIR / "agents-63-issue-intake.yml"
     assert intake.exists(), "agents-63-issue-intake.yml must exist"


### PR DESCRIPTION
## Summary
- add candidate/selected family counts and error-shaped reports to weekly metrics artifact selection
- add input/scanned/non-terminal counts to terminal-disposition coverage reports while keeping warning-only policy
- add a machine-readable Health 68 consumer sync drift report artifact

## Verification
- node --test .github/scripts/__tests__/weekly-metrics-artifacts.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js
- node --check .github/scripts/weekly_metrics_artifacts.js .github/scripts/terminal_disposition_coverage.js templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/scripts/test_validate_template_sync.py tests/workflows/test_workflow_agents_consolidation.py -q
- /opt/homebrew/bin/actionlint .github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml .github/workflows/health-68-consumer-sync-drift.yml
- ruff check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- git diff --check