### PR TITLE
Reduce workflow health check waste

### DIFF
--- a/.github/workflows/health-40-sweep.yml
+++ b/.github/workflows/health-40-sweep.yml
@@ -94,6 +94,8 @@ jobs:
   branch-protection-verify:
     name: branch protection sweep
     needs: detect
-    if: github.event_name != 'pull_request' && needs.detect.outputs.run_branch_protection != 'false'
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.detect.outputs.run_branch_protection != 'false'
     uses: ./.github/workflows/health-44-gate-branch-protection.yml
     secrets: inherit

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -104,6 +104,15 @@ def write_report_json(path: str, report: dict[str, object]) -> None:
     report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def repo_access_error(session: requests.Session, repo: str) -> str | None:
+    """Return a concise access error for an unreadable repo, or None when readable."""
+    url = f"https://api.github.com/repos/{repo}"
+    response = session.get(url)
+    if response.status_code < 400:
+        return None
+    return f"{repo}: repository access preflight failed (HTTP {response.status_code})"
+
+
 def main() -> int:
     args = parse_args()
     repos = resolve_repos(args.repos)
@@ -180,6 +189,14 @@ def main() -> int:
     errors: set[str] = set()
     obsolete: set[str] = set()
 
+    accessible_repos: list[str] = []
+    for repo in repos:
+        access_error = repo_access_error(session, repo)
+        if access_error:
+            errors.add(access_error)
+        else:
+            accessible_repos.append(repo)
+
     def _check_file(local_file: Path, remote_target: str, repo: str) -> None:
         """Compare a single local file against its remote counterpart."""
         local_digest = file_hash(local_file.read_bytes())
@@ -213,7 +230,7 @@ def main() -> int:
                 errors.add(f"{section}: missing local file for {source}")
                 continue
 
-            for repo in repos:
+            for repo in accessible_repos:
                 if is_directory or local_path.is_dir():
                     # Recursively compare all files within the directory
                     for child in sorted(local_path.rglob("*")):
@@ -228,7 +245,7 @@ def main() -> int:
         target = entry.get("target")
         if not target:
             continue
-        for repo in repos:
+        for repo in accessible_repos:
             url = f"https://api.github.com/repos/{repo}/contents/{target}"
             response = session.get(url)
             if response.status_code == 404:

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -39,3 +39,33 @@ def test_write_report_json_creates_parent_directory(tmp_path) -> None:
     loaded = json.loads(output.read_text(encoding="utf-8"))
     assert loaded["schema"] == "workflows-consumer-sync-drift/v1"
     assert loaded["status"] == "pass"
+
+
+def test_repo_access_error_reports_single_preflight_failure() -> None:
+    class Response:
+        status_code = 403
+
+    class Session:
+        requested_urls: list[str] = []
+
+        def get(self, url: str) -> Response:
+            self.requested_urls.append(url)
+            return Response()
+
+    session = Session()
+
+    error = check_consumer_sync_drift.repo_access_error(session, "owner/private-repo")
+
+    assert error == "owner/private-repo: repository access preflight failed (HTTP 403)"
+    assert session.requested_urls == ["https://api.github.com/repos/owner/private-repo"]
+
+
+def test_repo_access_error_allows_readable_repo() -> None:
+    class Response:
+        status_code = 200
+
+    class Session:
+        def get(self, url: str) -> Response:
+            return Response()
+
+    assert check_consumer_sync_drift.repo_access_error(Session(), "owner/repo") is None

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -155,6 +155,16 @@ def test_consumer_sync_drift_uploads_machine_readable_report():
     ), "Health 68 must upload the drift report as a GitHub-visible artifact"
 
 
+def test_health_40_branch_protection_sweep_skips_push_runs():
+    text = (WORKFLOWS_DIR / "health-40-sweep.yml").read_text(encoding="utf-8")
+    assert (
+        "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'" in text
+    ), "Health 40 should reserve branch-protection verification for scheduled/manual sweeps"
+    assert (
+        "needs.detect.outputs.run_branch_protection != 'false'" in text
+    ), "Manual Health 40 sweeps must keep the branch-protection opt-out"
+
+
 def test_weekly_metrics_uploads_selector_report_on_failure():
     workflow_text = (WORKFLOWS_DIR / "agents-weekly-metrics.yml").read_text(encoding="utf-8")
     template_text = Path(


### PR DESCRIPTION
## Summary
- add repo-level access preflight to Health 68 consumer drift checks so inaccessible repos emit one concise error instead of thousands of per-file 403s
- keep Health 40 branch-protection verification on scheduled/manual sweeps and skip that reusable on push-triggered workflow lint sweeps
- add targeted regression coverage for both contracts

## Verification
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m py_compile scripts/check_consumer_sync_drift.py
- /opt/homebrew/bin/actionlint .github/workflows/health-40-sweep.yml .github/workflows/health-68-consumer-sync-drift.yml
- ruff check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- black --check --line-length 100 scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- git diff --check
- local Health 68 preflight replay against an unreadable repo produced one repo-level error

## Notes
- Local automation remains optional; the durable state is still GitHub-visible via workflow artifacts and checks.
- No review-thread hard blocking is enabled.