### PR TITLE
Stop autofix workflow-job noise

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -4,8 +4,6 @@ on:
   workflow_run:
     workflows: ["Gate", "CI", "Python CI"]
     types: [completed]
-  workflow_job:
-    types: [completed]
   pull_request_target:
     types:
       - labeled
@@ -287,120 +285,6 @@ jobs:
                 pr,
                 sameRepo,
                 callerActor: run.actor?.login || context.actor,
-              });
-              return;
-            }
-
-            // --- workflow_job trigger (early lint failure) ---
-            if (context.eventName === 'workflow_job') {
-              const workflowJob = context.payload.workflow_job;
-              if (!workflowJob) {
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const workflowName = String(workflowJob.workflow_name || '').trim();
-              const jobName = String(workflowJob.name || '').toLowerCase();
-              const conclusion = String(workflowJob.conclusion || '').toLowerCase();
-
-              // Only respond to failing lint jobs in the workflows we care about.
-              const relevantJob =
-                jobName.includes('lint-format') || jobName.includes('lint-ruff');
-              if (!relevantJob) {
-                core.info(
-                  `workflow_job '${workflowJob.name}' is not a lint-format/lint-ruff job.`
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const allowedWorkflows = new Set(['Gate', 'CI', 'Python CI']);
-              if (workflowName && !allowedWorkflows.has(workflowName)) {
-                core.info(
-                  `workflow_job is from workflow '${workflowName}', not Gate/CI/Python CI; ` +
-                    'skipping.'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (conclusion !== 'failure') {
-                core.info(
-                  `workflow_job '${workflowJob.name}' concluded '${workflowJob.conclusion}' — ` +
-                    'no autofix needed'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const prs = workflowJob.pull_requests || [];
-              if (!prs.length) {
-                core.info('workflow_job event has no associated PR; skipping.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const prNumber = prs[0].number;
-              const triggerHeadSha = String(workflowJob.head_sha || '');
-              const { owner, repo } = context.repo;
-              const { data: pr } = await withRetry((client) =>
-                client.rest.pulls.get({ owner, repo, pull_number: prNumber })
-              );
-
-              if (pr.state !== 'open') {
-                core.info(`PR #${prNumber} is ${pr.state}`);
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (pr.draft) {
-                core.info('PR is draft.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const sameRepo =
-                pr.head.repo !== null &&
-                pr.head.repo.full_name === pr.base.repo?.full_name;
-              if (!sameRepo) {
-                core.info('Fork PR — not supported.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const headSha = pr.head?.sha;
-              if (!headSha) {
-                core.info('PR head SHA missing; skipping autofix.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (triggerHeadSha && triggerHeadSha !== headSha) {
-                core.info(
-                  `workflow_job head_sha ${triggerHeadSha} does not match PR head ${headSha}; ` +
-                    'skipping stale event.'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const files = await listFilesOrNullOnRateLimit({ owner, repo, prNumber });
-              const hasPython =
-                files === null
-                  ? true
-                  : files.some(
-                      (file) => file.filename.endsWith('.py') || file.filename.endsWith('.pyi')
-                    );
-              if (!hasPython) {
-                core.info('No Python files changed.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              setOutputs({
-                pr,
-                sameRepo,
-                callerActor: context.payload.sender?.login || context.actor,
               });
               return;
             }

--- a/tests/workflows/test_workflow_autofix_guard.py
+++ b/tests/workflows/test_workflow_autofix_guard.py
@@ -45,6 +45,16 @@ def test_gate_summary_uses_post_ci_helper() -> None:
     assert "./.github/scripts/maint-post-ci.js" in contents
 
 
+def test_autofix_loop_does_not_subscribe_to_workflow_job_events() -> None:
+    data = _load_yaml("autofix.yml")
+    triggers = data.get("on") or data.get(True) or {}
+    assert "workflow_run" in triggers
+    assert "pull_request_target" in triggers
+    assert (
+        "workflow_job" not in triggers
+    ), "workflow_job events create noisy push-associated autofix runs with no correctness gain"
+
+
 def test_reusable_autofix_guard_applies_to_all_steps() -> None:
     data = _load_yaml("reusable-18-autofix.yml")
     steps = data["jobs"]["autofix"]["steps"]


### PR DESCRIPTION
## Summary
- remove the broad workflow_job trigger from CI Autofix Loop
- keep workflow_run failure handling and manual autofix/autofix:clean label handling
- delete the now-unreachable workflow_job resolver branch and add a guard test

## Verification
- python -m pytest tests/workflows/test_workflow_autofix_guard.py -q
- python -m pytest tests/workflows/test_workflow_autofix_guard.py tests/workflows/test_workflow_naming.py tests/scripts/test_workflow_concurrency_audit.py -q
- /opt/homebrew/bin/actionlint .github/workflows/autofix.yml
- parsed autofix.yml triggers: pull_request_target, workflow_run
- git diff --check

## Notes
- Autofix remains optional; Gate summary and manual labels still provide the correctness path.
- This targets the recurring push-associated .github/workflows/autofix.yml failure that listed only a successful maint-36 actionlint job.