### PR TITLE
Quiet autofix false failures and summarize drift

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -165,8 +165,8 @@ jobs:
 
             let run;
             try {
-              const response = await withRetry((client) =>
-                client.rest.actions.getWorkflowRun({
+              const response = await withRetry(() =>
+                github.rest.actions.getWorkflowRun({
                   owner,
                   repo,
                   run_id: runIdNumber,
@@ -200,8 +200,8 @@ jobs:
               return;
             }
 
-            const { data: pr } = await withRetry((client) =>
-              client.rest.pulls.get({
+            const { data: pr } = await withRetry(() =>
+              github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
@@ -260,8 +260,8 @@ jobs:
 
             let run;
             try {
-              const response = await withRetry((client) =>
-                client.rest.actions.getWorkflowRun({
+              const response = await withRetry(() =>
+                github.rest.actions.getWorkflowRun({
                   owner,
                   repo,
                   run_id: runIdNumber,
@@ -324,8 +324,8 @@ jobs:
 
             const prNumber = Number(manualInputs.prNumber || prInfo.number);
             outputs.pr_number = String(prNumber);
-            const pr = await withRetry((client) =>
-              client.rest.pulls.get({ owner, repo, pull_number: prNumber })
+            const pr = await withRetry(() =>
+              github.rest.pulls.get({ owner, repo, pull_number: prNumber })
             );
             const prData = pr.data;
 
@@ -451,8 +451,8 @@ jobs:
                   : 'No basic autofix (non-Python PR?) and Gate failing';
                 core.info(`🔄 Auto-escalation: ${reason}. Escalating to Codex CLI...`);
                 try {
-                  await withRetry((client) =>
-                    client.rest.issues.addLabels({
+                  await withRetry(() =>
+                    github.rest.issues.addLabels({
                       owner,
                       repo,
                       issue_number: prNumber,
@@ -717,8 +717,8 @@ jobs:
 
             const { owner, repo } = context.repo;
 
-            await withRetry((client) =>
-              client.rest.issues.addLabels({
+            await withRetry(() =>
+              github.rest.issues.addLabels({
                 owner,
                 repo,
                 issue_number: prNumber,
@@ -740,8 +740,8 @@ jobs:
               'Please investigate manually.',
             ].join('\n');
 
-            await withRetry((client) =>
-              client.rest.issues.createComment({
+            await withRetry(() =>
+              github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: prNumber,
@@ -833,8 +833,8 @@ jobs:
 
             if (prNumber) {
               try {
-                const { data: pr } = await withRetry((client) =>
-                  client.rest.pulls.get({
+                const { data: pr } = await withRetry(() =>
+                  github.rest.pulls.get({
                     owner,
                     repo,
                     pull_number: prNumber,
@@ -851,8 +851,8 @@ jobs:
                   const prLabels = pr.labels?.map((label) => label.name) || [];
                   if (prLabels.includes('autofix:escalated')) {
                     try {
-                      await withRetry((client) =>
-                        client.rest.issues.removeLabel({
+                      await withRetry(() =>
+                        github.rest.issues.removeLabel({
                           owner,
                           repo,
                           issue_number: prNumber,

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -14,6 +14,7 @@ import requests
 import yaml
 
 REPORT_SCHEMA = "workflows-consumer-sync-drift/v1"
+SUMMARY_ITEM_LIMIT = 50
 
 
 def parse_args() -> argparse.Namespace:
@@ -68,6 +69,60 @@ def sorted_items(values: set[str]) -> list[str]:
     return sorted(values)
 
 
+def split_report_item(item: str) -> tuple[str, str]:
+    repo, separator, detail = item.partition(": ")
+    if not separator:
+        return "", item
+    return repo, detail
+
+
+def path_prefix(detail: str) -> str:
+    path = detail.split(" (", 1)[0].strip()
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return "unknown"
+    if parts[0] == ".github" and len(parts) > 1:
+        return "/".join(parts[:2])
+    if len(parts) > 1 and parts[0] in {"scripts", "tools", "docs", "templates"}:
+        return "/".join(parts[:2])
+    return parts[0]
+
+
+def build_repo_summaries(
+    *,
+    repos: list[str],
+    drift: set[str],
+    missing: set[str],
+    errors: set[str],
+    obsolete: set[str],
+) -> dict[str, dict[str, int]]:
+    summaries = {
+        repo: {"drift": 0, "missing": 0, "errors": 0, "obsolete": 0} for repo in sorted(repos)
+    }
+    for category, items in (
+        ("drift", drift),
+        ("missing", missing),
+        ("errors", errors),
+        ("obsolete", obsolete),
+    ):
+        for item in items:
+            repo, _detail = split_report_item(item)
+            if not repo:
+                continue
+            summaries.setdefault(repo, {"drift": 0, "missing": 0, "errors": 0, "obsolete": 0})
+            summaries[repo][category] += 1
+    return summaries
+
+
+def build_prefix_counts(items: set[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        _repo, detail = split_report_item(item)
+        prefix = path_prefix(detail)
+        counts[prefix] = counts.get(prefix, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
 def build_report(
     *,
     repos: list[str],
@@ -89,11 +144,85 @@ def build_report(
         "repo_count": len(repos),
         "repos": repos,
         "counts": counts,
+        "repo_summaries": build_repo_summaries(
+            repos=repos,
+            drift=drift,
+            missing=missing,
+            errors=errors,
+            obsolete=obsolete,
+        ),
+        "path_prefix_counts": {
+            "drift": build_prefix_counts(drift),
+            "missing": build_prefix_counts(missing),
+            "errors": build_prefix_counts(errors),
+            "obsolete": build_prefix_counts(obsolete),
+        },
+        "summary_limits": {"max_items_per_section": SUMMARY_ITEM_LIMIT},
         "drift": sorted_items(drift),
         "missing": sorted_items(missing),
         "errors": sorted_items(errors),
         "obsolete": sorted_items(obsolete),
     }
+
+
+def write_summary_markdown(path: str, report: dict[str, object]) -> None:
+    if not path:
+        return
+    summary_path = Path(path)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    counts = report.get("counts", {})
+    repos = report.get("repos", [])
+    with summary_path.open("a", encoding="utf-8") as handle:
+        handle.write("## Consumer Sync Drift Check\n")
+        handle.write(f"Checked repos: {', '.join(str(repo) for repo in repos)}\n\n")
+        handle.write("### Counts\n")
+        for category in ("drift", "missing", "errors", "obsolete"):
+            handle.write(f"- {category}: {counts.get(category, 0)}\n")
+        handle.write("\n")
+
+        repo_summaries = report.get("repo_summaries", {})
+        if isinstance(repo_summaries, dict) and repo_summaries:
+            handle.write("### Repo summary\n")
+            for repo, repo_counts in repo_summaries.items():
+                if not isinstance(repo_counts, dict):
+                    continue
+                total = sum(int(repo_counts.get(category, 0)) for category in counts)
+                if total <= 0:
+                    continue
+                details = ", ".join(
+                    f"{category}={repo_counts.get(category, 0)}" for category in counts
+                )
+                handle.write(f"- {repo}: {details}\n")
+            handle.write("\n")
+
+        path_prefix_counts = report.get("path_prefix_counts", {})
+        if isinstance(path_prefix_counts, dict) and path_prefix_counts:
+            handle.write("### Path prefixes\n")
+            for category, prefixes in path_prefix_counts.items():
+                if not isinstance(prefixes, dict) or not prefixes:
+                    continue
+                rendered = ", ".join(f"{prefix}={count}" for prefix, count in prefixes.items())
+                handle.write(f"- {category}: {rendered}\n")
+            handle.write("\n")
+
+        for title, key in (
+            ("Drift detected for", "drift"),
+            ("Missing files", "missing"),
+            ("Errors", "errors"),
+            ("Obsolete files present (should be removed)", "obsolete"),
+        ):
+            items = report.get(key, [])
+            if not isinstance(items, list) or not items:
+                if key == "drift":
+                    handle.write("✅ No drift detected.\n\n")
+                continue
+            handle.write(f"### {title}\n")
+            for item in items[:SUMMARY_ITEM_LIMIT]:
+                handle.write(f"- {item}\n")
+            remaining = len(items) - SUMMARY_ITEM_LIMIT
+            if remaining > 0:
+                handle.write(f"- ... {remaining} more in consumer-sync-drift-report.json\n")
+            handle.write("\n")
 
 
 def write_report_json(path: str, report: dict[str, object]) -> None:
@@ -263,31 +392,7 @@ def main() -> int:
         obsolete=obsolete,
     )
     write_report_json(args.report_json, report)
-
-    if args.summary:
-        summary_path = Path(args.summary)
-        summary_path.parent.mkdir(parents=True, exist_ok=True)
-        with summary_path.open("a", encoding="utf-8") as handle:
-            handle.write("## Consumer Sync Drift Check\n")
-            handle.write(f"Checked repos: {', '.join(repos)}\n\n")
-            if drift:
-                handle.write("❌ Drift detected for:\n")
-                handle.write("\n".join(f"- {item}" for item in sorted(drift)))
-                handle.write("\n\n")
-            else:
-                handle.write("✅ No drift detected.\n\n")
-            if missing:
-                handle.write("⚠️ Missing files:\n")
-                handle.write("\n".join(f"- {item}" for item in sorted(missing)))
-                handle.write("\n\n")
-            if errors:
-                handle.write("⚠️ Errors:\n")
-                handle.write("\n".join(f"- {item}" for item in sorted(errors)))
-                handle.write("\n\n")
-            if obsolete:
-                handle.write("⚠️ Obsolete files present (should be removed):\n")
-                handle.write("\n".join(f"- {item}" for item in sorted(obsolete)))
-                handle.write("\n\n")
+    write_summary_markdown(args.summary, report)
 
     if report["status"] != "pass":
         print("::warning::Consumer repo drift detected")

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -21,6 +21,16 @@ def test_build_report_returns_machine_readable_counts() -> None:
         "errors": 0,
         "obsolete": 1,
     }
+    assert report["repo_summaries"] == {
+        "owner/a": {"drift": 0, "missing": 1, "errors": 0, "obsolete": 1},
+        "owner/b": {"drift": 1, "missing": 0, "errors": 0, "obsolete": 0},
+    }
+    assert report["path_prefix_counts"] == {
+        "drift": {".github/workflows": 1},
+        "missing": {".github/scripts": 1},
+        "errors": {},
+        "obsolete": {"old.yml": 1},
+    }
     assert report["drift"] == ["owner/b: .github/workflows/a.yml"]
 
 
@@ -39,6 +49,27 @@ def test_write_report_json_creates_parent_directory(tmp_path) -> None:
     loaded = json.loads(output.read_text(encoding="utf-8"))
     assert loaded["schema"] == "workflows-consumer-sync-drift/v1"
     assert loaded["status"] == "pass"
+
+
+def test_write_summary_markdown_groups_and_bounds_items(tmp_path) -> None:
+    output = tmp_path / "summary.md"
+    drift = {f"owner/repo: .github/workflows/{index}.yml" for index in range(55)}
+    report = check_consumer_sync_drift.build_report(
+        repos=["owner/repo"],
+        drift=drift,
+        missing={"owner/repo: scripts/langchain/formatter.py"},
+        errors=set(),
+        obsolete=set(),
+    )
+
+    check_consumer_sync_drift.write_summary_markdown(str(output), report)
+
+    contents = output.read_text(encoding="utf-8")
+    assert "### Counts" in contents
+    assert "- drift: 55" in contents
+    assert "- owner/repo: drift=55, missing=1, errors=0, obsolete=0" in contents
+    assert "- drift: .github/workflows=55" in contents
+    assert "... 5 more in consumer-sync-drift-report.json" in contents
 
 
 def test_repo_access_error_reports_single_preflight_failure() -> None:

--- a/tests/workflows/test_workflow_autofix_guard.py
+++ b/tests/workflows/test_workflow_autofix_guard.py
@@ -55,6 +55,13 @@ def test_autofix_loop_does_not_subscribe_to_workflow_job_events() -> None:
     ), "workflow_job events create noisy push-associated autofix runs with no correctness gain"
 
 
+def test_agents_autofix_loop_uses_direct_retry_helper_contract() -> None:
+    """Direct retry helper calls must close over ``github`` in github-script."""
+    contents = (WORKFLOWS / "agents-autofix-loop.yml").read_text(encoding="utf-8")
+    assert "withRetry((client)" not in contents
+    assert "github.rest.actions.getWorkflowRun" in contents
+
+
 def test_reusable_autofix_guard_applies_to_all_steps() -> None:
     data = _load_yaml("reusable-18-autofix.yml")
     steps = data["jobs"]["autofix"]["steps"]


### PR DESCRIPTION
## Summary
- fix Agents Autofix Loop retry-helper calls so optional autofix no longer fails while loading successful Gate runs
- extend Health 68 drift reports with repo summaries, path-prefix counts, and bounded step summaries
- add regression coverage for both contracts

## Verification
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_autofix_guard.py -q
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_workflow_naming.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_autofix_guard.py -q
- python -m py_compile scripts/check_consumer_sync_drift.py
- ruff check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_autofix_guard.py
- black --check --line-length 100 scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_autofix_guard.py
- /opt/homebrew/bin/actionlint .github/workflows/agents-autofix-loop.yml .github/workflows/health-68-consumer-sync-drift.yml
- git diff --check

## Durable evidence
- Health 68 run 24922263173 report validated schema workflows-consumer-sync-drift/v1 with 11 repos and 0 errors after preflight
- replayed the live-sized report through the new summary writer: 11 repo summaries, bounded 132-line markdown summary