### PR TITLE
Skip autofix on rate-limited Gate lookup

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -146,6 +146,15 @@ jobs:
 
             const { evaluatePromptInjectionGuard } = require(guardPath);
             const { owner, repo } = context.repo;
+            const isRateLimitError = (error) => {
+              const status = Number(error?.status || error?.response?.status || 0);
+              const message = String(error?.message || '').toLowerCase();
+              return (
+                status === 429 ||
+                (status === 403 &&
+                  (message.includes('rate limit') || message.includes('secondary rate')))
+              );
+            };
             const manualInputs = {
               runId: (process.env.MANUAL_GATE_RUN_ID || '').trim(),
               prNumber: (process.env.MANUAL_PR_NUMBER || '').trim(),
@@ -174,6 +183,14 @@ jobs:
               );
               run = response.data;
             } catch (error) {
+              if (isRateLimitError(error)) {
+                core.warning(
+                  `Skipping prompt-injection gate: workflow_run ${manualInputs.runId} lookup was rate-limited.`
+                );
+                core.setOutput('blocked', 'false');
+                core.setOutput('reason', 'workflow-run-lookup-rate-limited');
+                return;
+              }
               core.setFailed(`Failed to load workflow_run ${manualInputs.runId}: ${error.message}`);
               return;
             }
@@ -241,6 +258,15 @@ jobs:
                 };
             const { withRetry, paginateWithRetry } = retryHelpers;
             const { owner, repo } = context.repo;
+            const isRateLimitError = (error) => {
+              const status = Number(error?.status || error?.response?.status || 0);
+              const message = String(error?.message || '').toLowerCase();
+              return (
+                status === 429 ||
+                (status === 403 &&
+                  (message.includes('rate limit') || message.includes('secondary rate')))
+              );
+            };
             const manualInputs = {
               runId: (process.env.MANUAL_GATE_RUN_ID || '').trim(),
               prNumber: (process.env.MANUAL_PR_NUMBER || '').trim(),
@@ -258,22 +284,6 @@ jobs:
               return;
             }
 
-            let run;
-            try {
-              const response = await withRetry(() =>
-                github.rest.actions.getWorkflowRun({
-                  owner,
-                  repo,
-                  run_id: runIdNumber,
-                })
-              );
-              run = response.data;
-            } catch (error) {
-              core.setFailed(
-                `Failed to load Gate run ${manualInputs.runId}: ${error.message}`
-              );
-              return;
-            }
             const outputs = {
               should_run: 'false',
               pr_number: '',
@@ -287,8 +297,8 @@ jobs:
               trigger_reason: 'unknown',
               trigger_job: '',
               trigger_step: '',
-              gate_conclusion: String(run?.conclusion || run?.status || ''),
-              gate_run_id: String(run?.id || ''),
+              gate_conclusion: '',
+              gate_run_id: String(manualInputs.runId || ''),
               has_high_privilege: 'false',
             };
 
@@ -300,7 +310,28 @@ jobs:
               }
             };
 
-            outputs.gate_run_id = String(manualInputs.runId || run?.id || '');
+            let run;
+            try {
+              const response = await withRetry(() =>
+                github.rest.actions.getWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: runIdNumber,
+                })
+              );
+              run = response.data;
+            } catch (error) {
+              if (isRateLimitError(error)) {
+                return stop('gate run lookup rate-limited', 'rate_limited');
+              }
+              core.setFailed(
+                `Failed to load Gate run ${manualInputs.runId}: ${error.message}`
+              );
+              return;
+            }
+
+            outputs.gate_conclusion = String(run?.conclusion || run?.status || '');
+            outputs.gate_run_id = String(run?.id || manualInputs.runId || '');
 
             if ((run.conclusion || '').toLowerCase() === 'success') {
               return stop('upstream Gate succeeded');

--- a/tests/workflows/test_workflow_autofix_guard.py
+++ b/tests/workflows/test_workflow_autofix_guard.py
@@ -62,6 +62,13 @@ def test_agents_autofix_loop_uses_direct_retry_helper_contract() -> None:
     assert "github.rest.actions.getWorkflowRun" in contents
 
 
+def test_agents_autofix_loop_skips_rate_limited_gate_lookup() -> None:
+    contents = (WORKFLOWS / "agents-autofix-loop.yml").read_text(encoding="utf-8")
+    assert "workflow-run-lookup-rate-limited" in contents
+    assert "gate run lookup rate-limited" in contents
+    assert "isRateLimitError(error)" in contents
+
+
 def test_reusable_autofix_guard_applies_to_all_steps() -> None:
     data = _load_yaml("reusable-18-autofix.yml")
     steps = data["jobs"]["autofix"]["steps"]


### PR DESCRIPTION
## Summary
- make Agents Autofix Loop skip, not fail, when Gate workflow_run lookup is rate-limited in the security gate
- make the evaluate step publish a machine-readable stop reason instead of failing on the same rate-limit shape
- add regression coverage for the skip contract

## Note
- Health 68 content-error bounding was merged separately on main as 28ea5e51 while this PR was running; this PR is now narrowed to the remaining Autofix failure path.

## Verification
- python -m pytest tests/workflows/test_workflow_autofix_guard.py tests/scripts/test_check_consumer_sync_drift.py -q
- /opt/homebrew/bin/actionlint .github/workflows/agents-autofix-loop.yml .github/workflows/health-68-consumer-sync-drift.yml
- ruff check tests/workflows/test_workflow_autofix_guard.py tests/scripts/test_check_consumer_sync_drift.py scripts/check_consumer_sync_drift.py
- black --check --line-length 100 tests/workflows/test_workflow_autofix_guard.py tests/scripts/test_check_consumer_sync_drift.py scripts/check_consumer_sync_drift.py
- python scripts/validate_template_sync.py
- git diff --check --cached