### PR TITLE
fix(health): make consumer drift reports actionable

### DIFF
--- a/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
+++ b/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  countsLine,
+  formatIssueBody,
+  formatIssueComment,
+} = require('../consumer_sync_drift_issue_body');
+
+const report = {
+  counts: { drift: 27, missing: 73, errors: 0, obsolete: 0 },
+  top_repo_gaps: [
+    { repo: 'owner/a', total: 100, drift: 27, missing: 73, errors: 0, obsolete: 0 },
+    { repo: 'owner/b', total: 4, drift: 4, missing: 0, errors: 0, obsolete: 0 },
+  ],
+  path_prefix_counts: {
+    drift: { '.github/workflows': 11, 'scripts/langchain': 16 },
+    missing: { '.github/scripts': 60, '.github/actions': 13 },
+  },
+  follow_up: {
+    all_repos_command: 'gh workflow run maint-68-sync-consumer-repos.yml --repo stranske/Workflows --ref main',
+    targeted_repos_command: 'gh workflow run maint-68-sync-consumer-repos.yml --repo stranske/Workflows --ref main -f repos=owner/a,owner/b',
+  },
+};
+
+test('countsLine renders stable drift counts', () => {
+  assert.equal(countsLine(report), 'drift=27, missing=73, errors=0, obsolete=0');
+});
+
+test('formatIssueBody includes actionable repo, prefix, and command details', () => {
+  const body = formatIssueBody(report, {
+    runUrl: 'https://github.com/owner/repo/actions/runs/1',
+    runNumber: '123',
+  });
+
+  assert.match(body, /Run #123/);
+  assert.match(body, /owner\/a: total=100, drift=27, missing=73/);
+  assert.match(body, /\.github\/scripts=60/);
+  assert.match(body, /Top repos first: `gh workflow run maint-68-sync-consumer-repos.yml/);
+  assert.match(body, /consumer-sync-drift-report/);
+});
+
+test('formatIssueComment stays compact for existing issue updates', () => {
+  const body = formatIssueComment(report, {
+    runUrl: 'https://github.com/owner/repo/actions/runs/1',
+    runNumber: '124',
+  });
+
+  assert.match(body, /Drift still detected in \[run #124\]/);
+  assert.match(body, /Counts: drift=27, missing=73, errors=0, obsolete=0/);
+  assert.match(body, /Highest-impact repos:/);
+});

--- a/.github/scripts/consumer_sync_drift_issue_body.js
+++ b/.github/scripts/consumer_sync_drift_issue_body.js
@@ -1,0 +1,99 @@
+function countsLine(report) {
+  const counts = report && report.counts ? report.counts : {};
+  return `drift=${counts.drift || 0}, missing=${counts.missing || 0}, errors=${counts.errors || 0}, obsolete=${counts.obsolete || 0}`;
+}
+
+function formatRepoGaps(report, limit = 10) {
+  const gaps = Array.isArray(report && report.top_repo_gaps) ? report.top_repo_gaps : [];
+  if (gaps.length === 0) {
+    return ['- No per-repo gaps were reported.'];
+  }
+  return gaps.slice(0, limit).map((item) => {
+    return `- ${item.repo}: total=${item.total || 0}, drift=${item.drift || 0}, ` +
+      `missing=${item.missing || 0}, errors=${item.errors || 0}, obsolete=${item.obsolete || 0}`;
+  });
+}
+
+function formatPrefixCounts(report, limit = 8) {
+  const groups = report && report.path_prefix_counts ? report.path_prefix_counts : {};
+  const lines = [];
+  for (const category of ['drift', 'missing', 'errors', 'obsolete']) {
+    const prefixes = groups[category] || {};
+    const rendered = Object.entries(prefixes)
+      .slice(0, limit)
+      .map(([prefix, count]) => `${prefix}=${count}`)
+      .join(', ');
+    if (rendered) {
+      lines.push(`- ${category}: ${rendered}`);
+    }
+  }
+  return lines.length ? lines : ['- No path-prefix details were reported.'];
+}
+
+function followUpLines(report) {
+  const followUp = report && report.follow_up ? report.follow_up : {};
+  const lines = [];
+  if (followUp.all_repos_command) {
+    lines.push(`- All repos: \`${followUp.all_repos_command}\``);
+  }
+  if (followUp.targeted_repos_command) {
+    lines.push(`- Top repos first: \`${followUp.targeted_repos_command}\``);
+  }
+  return lines.length ? lines : ['- Run Maint 68 Sync Consumer Repos from the Workflows repo.'];
+}
+
+function formatIssueBody(report, options = {}) {
+  const runUrl = options.runUrl || '';
+  const runNumber = options.runNumber || '';
+  const runLink = runUrl && runNumber ? `[Run #${runNumber}](${runUrl})` : runUrl || 'current run';
+
+  return [
+    '## Consumer Repo Drift Detected',
+    '',
+    'One or more consumer repos have drifted from the Workflows templates or manifest entries.',
+    '',
+    `**Check Details:** ${runLink}`,
+    `**Counts:** ${countsLine(report)}`,
+    '',
+    '### Highest-impact repos',
+    ...formatRepoGaps(report),
+    '',
+    '### Path prefixes',
+    ...formatPrefixCounts(report),
+    '',
+    '### Required Actions',
+    ...followUpLines(report),
+    '- Review `consumer-sync-drift-report` for exact file paths.',
+    '- Close this issue when Health 68 passes.',
+    '',
+    '### Notes',
+    '- Files marked with `sync_mode: create_only` are excluded from this check.',
+    '- Workflows-Integration-Tests is validated separately by Health 67.',
+  ].join('\n');
+}
+
+function formatIssueComment(report, options = {}) {
+  const runUrl = options.runUrl || '';
+  const runNumber = options.runNumber || '';
+  const runLink = runUrl && runNumber ? `[run #${runNumber}](${runUrl})` : runUrl || 'latest run';
+
+  return [
+    `Drift still detected in ${runLink}.`,
+    '',
+    `Counts: ${countsLine(report)}`,
+    '',
+    'Highest-impact repos:',
+    ...formatRepoGaps(report, 5),
+    '',
+    'Follow-up:',
+    ...followUpLines(report),
+  ].join('\n');
+}
+
+module.exports = {
+  countsLine,
+  formatIssueBody,
+  formatIssueComment,
+  formatPrefixCounts,
+  formatRepoGaps,
+};

--- a/.github/workflows/health-68-consumer-sync-drift.yml
+++ b/.github/workflows/health-68-consumer-sync-drift.yml
@@ -68,6 +68,7 @@ jobs:
           fi
           python3 scripts/check_consumer_sync_drift.py \
             --repos "$repos_input" \
+            --summary "$GITHUB_STEP_SUMMARY" \
             --report-json "$CONSUMER_SYNC_DRIFT_REPORT_JSON"
 
       - name: Upload drift report
@@ -85,6 +86,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const {
+              formatIssueBody,
+              formatIssueComment,
+            } = require('./.github/scripts/consumer_sync_drift_issue_body.js');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
             const retryHelpers = fs.existsSync(retryHelperPath)
               ? require(retryHelperPath)
@@ -98,24 +103,18 @@ jobs:
             const label = 'consumer-sync';
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}` +
               `/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const reportPath = 'artifacts/consumer-sync-drift-report.json';
+            let report = {};
+            if (fs.existsSync(reportPath)) {
+              report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+            } else {
+              console.log(`Drift report missing at ${reportPath}; creating generic issue body.`);
+            }
 
-            const body = [
-              '## Consumer Repo Drift Detected',
-              '',
-              'One or more consumer repos have drifted from the Workflows templates',
-              'or manifest entries.',
-              '',
-              `**Check Details:** [Run #${process.env.GITHUB_RUN_NUMBER}](${runUrl})`,
-              '',
-              '### Required Actions',
-              '1. Review the drift in the workflow run summary',
-              '2. Run Maint 68 Sync Consumer Repos to restore parity',
-              '3. Close this issue when resolved',
-              '',
-              '### Notes',
-              '- Files marked with sync_mode: create_only are excluded from this check.',
-              '- Workflows-Integration-Tests is validated separately by Health 67.',
-            ].join('\n');
+            const body = formatIssueBody(report, {
+              runUrl,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+            });
 
             const { data: issues } = await withRetry(() => github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -130,7 +129,10 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issues[0].number,
-                body: `Drift still detected. See [run #${process.env.GITHUB_RUN_NUMBER}](${runUrl})`
+                body: formatIssueComment(report, {
+                  runUrl,
+                  runNumber: process.env.GITHUB_RUN_NUMBER,
+                })
               }));
               console.log(`Added comment to existing issue #${issues[0].number}`);
             } else {

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -18,6 +18,13 @@ SUMMARY_ITEM_LIMIT = 50
 CONTENT_ERROR_THRESHOLD = 5
 
 
+def join_remote_path(base: str, *parts: object) -> str:
+    """Join manifest target fragments without creating API paths with doubled slashes."""
+    fragments = [str(base).strip("/")]
+    fragments.extend(str(part).strip("/") for part in parts if str(part))
+    return "/".join(fragment for fragment in fragments if fragment)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Check consumer repos for drift against Workflows templates and manifest entries."
@@ -124,6 +131,20 @@ def build_prefix_counts(items: set[str]) -> dict[str, int]:
     return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
 
 
+def build_top_repo_gaps(
+    repo_summaries: dict[str, dict[str, int]], limit: int = 10
+) -> list[dict[str, object]]:
+    gaps: list[dict[str, object]] = []
+    for repo, counts in repo_summaries.items():
+        total = sum(
+            int(counts.get(category, 0)) for category in ("drift", "missing", "errors", "obsolete")
+        )
+        if total <= 0:
+            continue
+        gaps.append({"repo": repo, "total": total, **counts})
+    return sorted(gaps, key=lambda item: (-int(item["total"]), str(item["repo"])))[:limit]
+
+
 def record_content_error(
     *,
     errors: set[str],
@@ -162,24 +183,42 @@ def build_report(
         "obsolete": len(obsolete),
     }
     status = "pass" if all(value == 0 for value in counts.values()) else "drift"
+    repo_summaries = build_repo_summaries(
+        repos=repos,
+        drift=drift,
+        missing=missing,
+        errors=errors,
+        obsolete=obsolete,
+    )
+    top_repo_gaps = build_top_repo_gaps(repo_summaries)
+    targeted_repos = [str(item["repo"]) for item in top_repo_gaps]
     return {
         "schema": REPORT_SCHEMA,
         "status": status,
         "repo_count": len(repos),
         "repos": repos,
         "counts": counts,
-        "repo_summaries": build_repo_summaries(
-            repos=repos,
-            drift=drift,
-            missing=missing,
-            errors=errors,
-            obsolete=obsolete,
-        ),
+        "repo_summaries": repo_summaries,
+        "repo_summary_count": len(repo_summaries),
+        "top_repo_gaps": top_repo_gaps,
         "path_prefix_counts": {
             "drift": build_prefix_counts(drift),
             "missing": build_prefix_counts(missing),
             "errors": build_prefix_counts(errors),
             "obsolete": build_prefix_counts(obsolete),
+        },
+        "follow_up": {
+            "workflow": "maint-68-sync-consumer-repos.yml",
+            "all_repos_command": (
+                "gh workflow run maint-68-sync-consumer-repos.yml "
+                "--repo stranske/Workflows --ref main"
+            ),
+            "targeted_repos_command": (
+                "gh workflow run maint-68-sync-consumer-repos.yml "
+                f"--repo stranske/Workflows --ref main -f repos={','.join(targeted_repos)}"
+                if targeted_repos
+                else ""
+            ),
         },
         "summary_limits": {
             "content_error_threshold_per_repo": CONTENT_ERROR_THRESHOLD,
@@ -222,6 +261,25 @@ def write_summary_markdown(path: str, report: dict[str, object]) -> None:
                 handle.write(f"- {repo}: {details}\n")
             handle.write("\n")
 
+        top_repo_gaps = report.get("top_repo_gaps", [])
+        if isinstance(top_repo_gaps, list) and top_repo_gaps:
+            handle.write("### Highest-impact repos\n")
+            for item in top_repo_gaps[:10]:
+                if not isinstance(item, dict):
+                    continue
+                handle.write(
+                    "- {repo}: total={total}, drift={drift}, missing={missing}, "
+                    "errors={errors}, obsolete={obsolete}\n".format(
+                        repo=item.get("repo", "unknown"),
+                        total=item.get("total", 0),
+                        drift=item.get("drift", 0),
+                        missing=item.get("missing", 0),
+                        errors=item.get("errors", 0),
+                        obsolete=item.get("obsolete", 0),
+                    )
+                )
+            handle.write("\n")
+
         path_prefix_counts = report.get("path_prefix_counts", {})
         if isinstance(path_prefix_counts, dict) and path_prefix_counts:
             handle.write("### Path prefixes\n")
@@ -231,6 +289,18 @@ def write_summary_markdown(path: str, report: dict[str, object]) -> None:
                 rendered = ", ".join(f"{prefix}={count}" for prefix, count in prefixes.items())
                 handle.write(f"- {category}: {rendered}\n")
             handle.write("\n")
+
+        follow_up = report.get("follow_up", {})
+        if isinstance(follow_up, dict):
+            all_repos_command = str(follow_up.get("all_repos_command", "")).strip()
+            targeted_repos_command = str(follow_up.get("targeted_repos_command", "")).strip()
+            if all_repos_command or targeted_repos_command:
+                handle.write("### Follow-up commands\n")
+                if all_repos_command:
+                    handle.write(f"- All repos: `{all_repos_command}`\n")
+                if targeted_repos_command:
+                    handle.write(f"- Top repos: `{targeted_repos_command}`\n")
+                handle.write("\n")
 
         for title, key in (
             ("Drift detected for", "drift"),
@@ -406,7 +476,7 @@ def main() -> int:
                     for child in sorted(local_path.rglob("*")):
                         if child.is_file():
                             rel = child.relative_to(local_path)
-                            remote_target = f"{target}/{rel}"
+                            remote_target = join_remote_path(target, rel)
                             _check_file(child, remote_target, repo)
                 else:
                     _check_file(local_path, target, repo)

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -25,11 +25,27 @@ def test_build_report_returns_machine_readable_counts() -> None:
         "owner/a": {"drift": 0, "missing": 1, "errors": 0, "obsolete": 1},
         "owner/b": {"drift": 1, "missing": 0, "errors": 0, "obsolete": 0},
     }
+    assert report["repo_summary_count"] == 2
+    assert report["top_repo_gaps"] == [
+        {"repo": "owner/a", "total": 2, "drift": 0, "missing": 1, "errors": 0, "obsolete": 1},
+        {"repo": "owner/b", "total": 1, "drift": 1, "missing": 0, "errors": 0, "obsolete": 0},
+    ]
     assert report["path_prefix_counts"] == {
         "drift": {".github/workflows": 1},
         "missing": {".github/scripts": 1},
         "errors": {},
         "obsolete": {"old.yml": 1},
+    }
+    assert report["follow_up"] == {
+        "workflow": "maint-68-sync-consumer-repos.yml",
+        "all_repos_command": (
+            "gh workflow run maint-68-sync-consumer-repos.yml "
+            "--repo stranske/Workflows --ref main"
+        ),
+        "targeted_repos_command": (
+            "gh workflow run maint-68-sync-consumer-repos.yml "
+            "--repo stranske/Workflows --ref main -f repos=owner/a,owner/b"
+        ),
     }
     assert report["summary_limits"]["content_error_threshold_per_repo"] == 5
     assert report["drift"] == ["owner/b: .github/workflows/a.yml"]
@@ -69,8 +85,27 @@ def test_write_summary_markdown_groups_and_bounds_items(tmp_path) -> None:
     assert "### Counts" in contents
     assert "- drift: 55" in contents
     assert "- owner/repo: drift=55, missing=1, errors=0, obsolete=0" in contents
+    assert "- owner/repo: total=56, drift=55, missing=1, errors=0, obsolete=0" in contents
     assert "- drift: .github/workflows=55" in contents
+    assert "gh workflow run maint-68-sync-consumer-repos.yml" in contents
     assert "... 5 more in consumer-sync-drift-report.json" in contents
+
+
+def test_join_remote_path_normalizes_manifest_directory_targets() -> None:
+    assert (
+        check_consumer_sync_drift.join_remote_path(
+            ".github/scripts/node_modules/minimatch/",
+            "dist/commonjs/index.js",
+        )
+        == ".github/scripts/node_modules/minimatch/dist/commonjs/index.js"
+    )
+    assert (
+        check_consumer_sync_drift.join_remote_path(
+            ".github/actions/setup-api-client/",
+            "/action.yml",
+        )
+        == ".github/actions/setup-api-client/action.yml"
+    )
 
 
 def test_record_content_error_skips_after_threshold() -> None:

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -151,6 +151,12 @@ def test_consumer_sync_drift_uploads_machine_readable_report():
         '--report-json "$CONSUMER_SYNC_DRIFT_REPORT_JSON"' in text
     ), "Health 68 must pass the drift report path into the checker"
     assert (
+        '--summary "$GITHUB_STEP_SUMMARY"' in text
+    ), "Health 68 must publish the report summary into the workflow run"
+    assert (
+        "consumer_sync_drift_issue_body.js" in text
+    ), "Health 68 issue payload must use the structured drift report"
+    assert (
         "consumer-sync-drift-report" in text
     ), "Health 68 must upload the drift report as a GitHub-visible artifact"
 


### PR DESCRIPTION
## Summary
- normalize Health 68 directory target comparisons so manifest entries with trailing slashes do not create doubled-slash API paths
- add top repo gaps, repo summary count, and Maint 68 follow-up commands to the drift JSON and run summary
- create structured consumer-sync issue/comment bodies from the machine-readable drift report

## Verification
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py -q
- node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
- ruff check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- black --check --line-length 100 scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- /opt/homebrew/bin/actionlint .github/workflows/health-68-consumer-sync-drift.yml
- python -m py_compile scripts/check_consumer_sync_drift.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check