### PR TITLE
[codex] Add Maint 71 sync merge report contract

### DIFF
--- a/.github/scripts/__tests__/sync-pr-merge-contract.test.js
+++ b/.github/scripts/__tests__/sync-pr-merge-contract.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildMarkdownSummary,
+  buildMergeReport,
+  normalizeSyncHash,
+  parseBooleanInput,
+  selectActiveSyncPr,
+  summarizeResults,
+  syncBranchForHash,
+} = require('../sync_pr_merge_contract');
+
+const pr = (number, ref, created_at) => ({
+  number,
+  title: `sync ${number}`,
+  created_at,
+  head: { ref },
+});
+
+test('normalizeSyncHash accepts raw hashes and branch names', () => {
+  assert.equal(normalizeSyncHash('5108b94a2435'), '5108b94a2435');
+  assert.equal(normalizeSyncHash('sync/workflows-5108b94a2435'), '5108b94a2435');
+  assert.equal(syncBranchForHash('5108b94a2435'), 'sync/workflows-5108b94a2435');
+});
+
+test('parseBooleanInput preserves explicit false values', () => {
+  assert.equal(parseBooleanInput('false', true), false);
+  assert.equal(parseBooleanInput(false, true), false);
+  assert.equal(parseBooleanInput('0', true), false);
+  assert.equal(parseBooleanInput('', true), true);
+  assert.equal(parseBooleanInput(undefined, false), false);
+});
+
+test('selectActiveSyncPr falls back to newest sync PR without a target hash', () => {
+  const selection = selectActiveSyncPr([
+    pr(1, 'sync/workflows-old', '2026-04-25T01:00:00Z'),
+    pr(2, 'sync/workflows-new', '2026-04-25T02:00:00Z'),
+  ]);
+
+  assert.equal(selection.active.number, 2);
+  assert.deepEqual(selection.stale.map((item) => item.number), [1]);
+  assert.equal(selection.missingExpected, false);
+});
+
+test('selectActiveSyncPr honors target hash instead of newest PR', () => {
+  const selection = selectActiveSyncPr(
+    [
+      pr(1, 'sync/workflows-5108b94a2435', '2026-04-25T01:00:00Z'),
+      pr(2, 'sync/workflows-later', '2026-04-25T02:00:00Z'),
+    ],
+    '5108b94a2435',
+  );
+
+  assert.equal(selection.active.number, 1);
+  assert.equal(selection.expectedBranch, 'sync/workflows-5108b94a2435');
+  assert.deepEqual(selection.stale.map((item) => item.number), [2]);
+});
+
+test('selectActiveSyncPr reports missing target without marking stale PRs', () => {
+  const selection = selectActiveSyncPr(
+    [pr(1, 'sync/workflows-other', '2026-04-25T01:00:00Z')],
+    '5108b94a2435',
+  );
+
+  assert.equal(selection.active, null);
+  assert.deepEqual(selection.stale, []);
+  assert.equal(selection.missingExpected, true);
+});
+
+test('buildMergeReport provides machine-readable summary counts', () => {
+  const report = buildMergeReport({
+    generatedAt: '2026-04-25T06:00:00Z',
+    syncHash: 'sync/workflows-5108b94a2435',
+    registeredRepos: ['stranske/Ready'],
+    targetRepos: ['stranske/Ready'],
+    autoMerge: false,
+    dryRun: true,
+    results: [
+      { repo: 'stranske/Ready', status: 'stale_closed' },
+      { repo: 'stranske/Ready', status: 'dry_run_merge' },
+    ],
+  });
+
+  assert.equal(report.schema, 'workflows-sync-pr-merge/v1');
+  assert.equal(report.inputs.expected_branch, 'sync/workflows-5108b94a2435');
+  assert.deepEqual(report.summary, {
+    no_prs: 0,
+    target_missing: 0,
+    stale_closed: 1,
+    stale_close_failed: 0,
+    checks_failed: 0,
+    checks_pending: 0,
+    ready: 0,
+    dry_run_merge: 1,
+    merged: 0,
+    merge_failed: 0,
+    error: 0,
+  });
+});
+
+test('buildMarkdownSummary includes non-zero statuses and artifact name', () => {
+  const markdown = buildMarkdownSummary({
+    schema: 'workflows-sync-pr-merge/v1',
+    inputs: {
+      repos: ['stranske/Ready'],
+      auto_merge: true,
+      dry_run: false,
+      expected_branch: 'sync/workflows-5108b94a2435',
+    },
+    summary: summarizeResults([
+      { status: 'merged' },
+      { status: 'checks_pending' },
+    ]),
+  });
+
+  assert.match(markdown, /Expected branch: `sync\/workflows-5108b94a2435`/);
+  assert.match(markdown, /\| merged \| 1 \|/);
+  assert.match(markdown, /sync-pr-merge-report/);
+});

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const REPORT_SCHEMA = 'workflows-sync-pr-merge/v1';
+const SYNC_BRANCH_PREFIX = 'sync/workflows-';
+
+function normalizeSyncHash(value) {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return '';
+  }
+  return raw.startsWith(SYNC_BRANCH_PREFIX) ? raw.slice(SYNC_BRANCH_PREFIX.length) : raw;
+}
+
+function syncBranchForHash(syncHash) {
+  const normalized = normalizeSyncHash(syncHash);
+  return normalized ? `${SYNC_BRANCH_PREFIX}${normalized}` : '';
+}
+
+function parseBooleanInput(value, defaultValue = false) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return Boolean(defaultValue);
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n'].includes(normalized)) {
+    return false;
+  }
+  return Boolean(defaultValue);
+}
+
+function sortSyncPrs(prs) {
+  return [...(prs || [])].sort((a, b) => {
+    const aTime = new Date(a.created_at || a.createdAt || 0).getTime();
+    const bTime = new Date(b.created_at || b.createdAt || 0).getTime();
+    return aTime - bTime;
+  });
+}
+
+function selectActiveSyncPr(prs, syncHash = '') {
+  const ordered = sortSyncPrs(prs);
+  const expectedBranch = syncBranchForHash(syncHash);
+  if (!expectedBranch) {
+    const active = ordered[ordered.length - 1] || null;
+    return {
+      active,
+      stale: active ? ordered.filter((pr) => pr.number !== active.number) : [],
+      expectedBranch: '',
+      missingExpected: false,
+    };
+  }
+
+  const active = ordered.find((pr) => pr.head && pr.head.ref === expectedBranch) || null;
+  return {
+    active,
+    stale: active ? ordered.filter((pr) => pr.number !== active.number) : [],
+    expectedBranch,
+    missingExpected: !active,
+  };
+}
+
+function summarizeResults(results) {
+  const counts = {
+    no_prs: 0,
+    target_missing: 0,
+    stale_closed: 0,
+    stale_close_failed: 0,
+    checks_failed: 0,
+    checks_pending: 0,
+    ready: 0,
+    dry_run_merge: 0,
+    merged: 0,
+    merge_failed: 0,
+    error: 0,
+  };
+  for (const result of results || []) {
+    if (Object.prototype.hasOwnProperty.call(counts, result.status)) {
+      counts[result.status] += 1;
+    }
+  }
+  return counts;
+}
+
+function buildMergeReport({
+  results = [],
+  registeredRepos = [],
+  targetRepos = [],
+  autoMerge = true,
+  dryRun = false,
+  syncHash = '',
+  run = {},
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const normalizedSyncHash = normalizeSyncHash(syncHash);
+  return {
+    schema: REPORT_SCHEMA,
+    generated_at: generatedAt,
+    run,
+    inputs: {
+      repos: targetRepos,
+      registered_repos: registeredRepos,
+      auto_merge: Boolean(autoMerge),
+      dry_run: Boolean(dryRun),
+      sync_hash: normalizedSyncHash,
+      expected_branch: syncBranchForHash(normalizedSyncHash),
+    },
+    summary: summarizeResults(results),
+    results,
+  };
+}
+
+function buildMarkdownSummary(report) {
+  const summary = report.summary || {};
+  const inputs = report.inputs || {};
+  const lines = [
+    '### Sync PR Merge Summary',
+    '',
+    `Schema: \`${report.schema || REPORT_SCHEMA}\``,
+    `Processed repos: ${Array.isArray(inputs.repos) ? inputs.repos.length : 0}`,
+    `Auto-merge: ${inputs.auto_merge ? 'true' : 'false'}`,
+    `Dry run: ${inputs.dry_run ? 'true' : 'false'}`,
+  ];
+  if (inputs.expected_branch) {
+    lines.push(`Expected branch: \`${inputs.expected_branch}\``);
+  }
+  lines.push(
+    '',
+    '| Status | Count |',
+    '| --- | ---: |',
+  );
+  for (const [status, count] of Object.entries(summary)) {
+    if (count) {
+      lines.push(`| ${status} | ${count} |`);
+    }
+  }
+  lines.push('', 'Artifact: `sync-pr-merge-report`');
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  REPORT_SCHEMA,
+  SYNC_BRANCH_PREFIX,
+  normalizeSyncHash,
+  syncBranchForHash,
+  parseBooleanInput,
+  sortSyncPrs,
+  selectActiveSyncPr,
+  summarizeResults,
+  buildMergeReport,
+  buildMarkdownSummary,
+};

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      sync_hash:
+        description: "Optional sync hash to keep active (accepts hash or sync/workflows-* branch)"
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       repos:
@@ -54,6 +59,11 @@ on:
         required: false
         type: boolean
         default: false
+      sync_hash:
+        description: "Optional sync hash to keep active (accepts hash or sync/workflows-* branch)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -86,17 +96,41 @@ jobs:
 
       - name: Check and merge sync PRs
         uses: actions/github-script@v9
+        env:
+          REPOS_INPUT: ${{ inputs.repos || 'all' }}
+          AUTO_MERGE_INPUT: ${{ inputs.auto_merge }}
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+          SYNC_HASH_INPUT: ${{ inputs.sync_hash || '' }}
+          SYNC_PR_MERGE_REPORT_JSON: artifacts/sync-pr-merge-report.json
         with:
           github-token: ${{ secrets.SERVICE_BOT_PAT || secrets.CODESPACES_WORKFLOWS || github.token }}
           script: |
             const defaultOwner = context.repo.owner;
-            // Support repository_dispatch (no inputs) with sensible defaults
-            const inputRepos = '${{ inputs.repos }}' || 'all';
-            const autoMerge =
-              '${{ inputs.auto_merge }}' === '' ? true : ${{ inputs.auto_merge || true }};
-            const dryRun = '${{ inputs.dry_run }}' === '' ? false : ${{ inputs.dry_run || false }};
             const fs = require('fs');
+            const path = require('path');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
+            const {
+              buildMarkdownSummary,
+              buildMergeReport,
+              normalizeSyncHash,
+              parseBooleanInput,
+              selectActiveSyncPr,
+            } = require('./.github/scripts/sync_pr_merge_contract.js');
+            // Support repository_dispatch (no inputs) with sensible defaults
+            const inputRepos =
+              process.env.REPOS_INPUT ||
+              (context.payload.client_payload && context.payload.client_payload.repos) ||
+              'all';
+            const autoMerge = parseBooleanInput(
+              process.env.AUTO_MERGE_INPUT ||
+                (context.payload.client_payload && context.payload.client_payload.auto_merge),
+              true,
+            );
+            const dryRun = parseBooleanInput(
+              process.env.DRY_RUN_INPUT ||
+                (context.payload.client_payload && context.payload.client_payload.dry_run),
+              false,
+            );
             const retryHelpers = fs.existsSync(retryHelperPath)
               ? require(retryHelperPath)
               : {
@@ -130,10 +164,18 @@ jobs:
             const targetRepos = inputRepos === 'all'
               ? registeredRepos
               : inputRepos.split(',').map(r => r.trim());
+            const requestedSyncHash = normalizeSyncHash(
+              process.env.SYNC_HASH_INPUT ||
+                (context.payload.client_payload && context.payload.client_payload.sync_hash) ||
+                '',
+            );
 
             console.log(`Registered consumer repos: ${registeredRepos.join(', ')}`);
             console.log(`Processing repos: ${targetRepos.join(', ')}`);
             console.log(`Auto-merge: ${autoMerge}, Dry run: ${dryRun}\n`);
+            if (requestedSyncHash) {
+              console.log(`Target sync hash: ${requestedSyncHash}`);
+            }
 
             const results = [];
 
@@ -159,54 +201,97 @@ jobs:
 
                 if (syncPRs.length === 0) {
                   console.log('No sync PRs found');
-                  results.push({ repo, status: 'no_prs' });
+                  results.push({ owner, repo, status: 'no_prs' });
                   continue;
                 }
 
-                // Sort by created date, oldest first (for stale cleanup)
-                syncPRs.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+                const selection = selectActiveSyncPr(syncPRs, requestedSyncHash);
+                if (selection.missingExpected) {
+                  console.log(
+                    `Expected sync PR branch ${selection.expectedBranch} was not found; leaving ` +
+                      `${syncPRs.length} sync PRs untouched`,
+                  );
+                  results.push({
+                    owner,
+                    repo,
+                    status: 'target_missing',
+                    expected_branch: selection.expectedBranch,
+                    open_sync_prs: syncPRs.map((item) => ({
+                      number: item.number,
+                      branch: item.head.ref,
+                      url: item.html_url,
+                    })),
+                  });
+                  continue;
+                }
 
                 // If multiple sync PRs exist, close older ones as stale
-                if (syncPRs.length > 1) {
+                if (selection.stale.length > 0) {
                   console.log(
-                    `Found ${syncPRs.length} sync PRs - closing ${syncPRs.length - 1} stale PRs`,
+                    `Found ${syncPRs.length} sync PRs - closing ${selection.stale.length} stale PRs`,
                   );
 
-                  for (let i = 0; i < syncPRs.length - 1; i++) {
-                    const stalePR = syncPRs[i];
+                  for (const stalePR of selection.stale) {
                     console.log(`\nClosing stale PR #${stalePR.number}: ${stalePR.title}`);
                     console.log(`Branch: ${stalePR.head.ref}, Created: ${stalePR.created_at}`);
 
                     if (!dryRun) {
-                      // Close PR
-                      await withRetry((client) => client.rest.pulls.update({
-                        owner,
-                        repo,
-                        pull_number: stalePR.number,
-                        state: 'closed'
-                      }));
-                      console.log('✓ Closed');
-
-                      // Delete branch
                       try {
-                        await withRetry((client) => client.rest.git.deleteRef({
+                        // Close PR
+                        await withRetry((client) => client.rest.pulls.update({
                           owner,
                           repo,
-                          ref: `heads/${stalePR.head.ref}`
+                          pull_number: stalePR.number,
+                          state: 'closed'
                         }));
-                        console.log('✓ Branch deleted');
-                      } catch (delErr) {
-                        console.log(`⚠ Branch delete failed: ${delErr.message}`);
+                        console.log('✓ Closed');
+
+                        // Delete branch
+                        try {
+                          await withRetry((client) => client.rest.git.deleteRef({
+                            owner,
+                            repo,
+                            ref: `heads/${stalePR.head.ref}`
+                          }));
+                          console.log('✓ Branch deleted');
+                        } catch (delErr) {
+                          console.log(`⚠ Branch delete failed: ${delErr.message}`);
+                        }
+                        results.push({
+                          owner,
+                          repo,
+                          pr: stalePR.number,
+                          branch: stalePR.head.ref,
+                          status: 'stale_closed',
+                        });
+                      } catch (staleErr) {
+                        console.log(`✗ Stale close failed: ${staleErr.message}`);
+                        results.push({
+                          owner,
+                          repo,
+                          pr: stalePR.number,
+                          branch: stalePR.head.ref,
+                          status: 'stale_close_failed',
+                          error: staleErr.message,
+                        });
                       }
                     } else {
                       console.log('[DRY RUN] Would close and delete branch');
+                      results.push({
+                        owner,
+                        repo,
+                        pr: stalePR.number,
+                        branch: stalePR.head.ref,
+                        status: 'stale_closed',
+                        dry_run: true,
+                      });
                     }
                   }
                 }
 
-                // Process the most recent PR
-                const pr = syncPRs[syncPRs.length - 1];
-                console.log(`\nProcessing most recent PR #${pr.number}: ${pr.title}`);
+                // Process the selected active PR
+                const pr = selection.active;
+                console.log(`\nProcessing active PR #${pr.number}: ${pr.title}`);
                 console.log(`Branch: ${pr.head.ref}`);
                 console.log(`Created: ${pr.created_at}`);
 
@@ -268,26 +353,54 @@ jobs:
                 if (failedChecks.length > 0) {
                   console.log('Failed checks:');
                   failedChecks.forEach(c => console.log(`  - ${c.name}: ${c.conclusion}`));
-                  results.push({ repo, pr: pr.number, status: 'checks_failed' });
+                  results.push({
+                    owner,
+                    repo,
+                    pr: pr.number,
+                    branch: pr.head.ref,
+                    status: 'checks_failed',
+                    failed_checks: failedChecks.map((check) => ({
+                      name: check.name,
+                      conclusion: check.conclusion,
+                      status: check.status,
+                    })),
+                  });
                   continue;
                 }
 
                 if (pendingChecks.length > 0) {
                   console.log('Waiting for checks to complete');
-                  results.push({ repo, pr: pr.number, status: 'checks_pending' });
+                  results.push({
+                    owner,
+                    repo,
+                    pr: pr.number,
+                    branch: pr.head.ref,
+                    status: 'checks_pending',
+                    pending_checks: pendingChecks.map((check) => ({
+                      name: check.name,
+                      conclusion: check.conclusion,
+                      status: check.status,
+                    })),
+                  });
                   continue;
                 }
 
                 // All checks passed
                 if (!autoMerge) {
                   console.log('✓ Ready to merge (auto-merge disabled)');
-                  results.push({ repo, pr: pr.number, status: 'ready' });
+                  results.push({ owner, repo, pr: pr.number, branch: pr.head.ref, status: 'ready' });
                   continue;
                 }
 
                 if (dryRun) {
                   console.log('✓ Would merge (dry run)');
-                  results.push({ repo, pr: pr.number, status: 'dry_run_merge' });
+                  results.push({
+                    owner,
+                    repo,
+                    pr: pr.number,
+                    branch: pr.head.ref,
+                    status: 'dry_run_merge',
+                  });
                   continue;
                 }
 
@@ -338,44 +451,80 @@ jobs:
                     console.log(`⚠ Could not delete branch: ${e.message}`);
                   }
 
-                  results.push({ repo, pr: pr.number, status: 'merged' });
+                  results.push({ owner, repo, pr: pr.number, branch: pr.head.ref, status: 'merged' });
                 } catch (e) {
                   console.log(`✗ Merge failed: ${e.message}`);
-                  results.push({ repo, pr: pr.number, status: 'merge_failed', error: e.message });
+                  results.push({
+                    owner,
+                    repo,
+                    pr: pr.number,
+                    branch: pr.head.ref,
+                    status: 'merge_failed',
+                    error: e.message,
+                  });
                 }
               } catch (e) {
                 console.log(`✗ Error processing ${repo}: ${e.message}`);
-                results.push({ repo, status: 'error', error: e.message });
+                results.push({ owner, repo, status: 'error', error: e.message });
               }
             }
 
             // Summary
             console.log('\n=== Summary ===');
             console.log(JSON.stringify(results, null, 2));
+            const report = buildMergeReport({
+              results,
+              registeredRepos,
+              targetRepos,
+              autoMerge,
+              dryRun,
+              syncHash: requestedSyncHash,
+              run: {
+                repository: `${context.repo.owner}/${context.repo.repo}`,
+                run_id: context.runId,
+                run_number: context.runNumber,
+                workflow: context.workflow,
+                ref: context.ref,
+                sha: context.sha,
+              },
+            });
+            const reportPath = process.env.SYNC_PR_MERGE_REPORT_JSON;
+            fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+            fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+            await core.summary.addRaw(buildMarkdownSummary(report)).write();
 
-            const merged = results.filter(r => r.status === 'merged').length;
-            const stale = results.filter(r => r.status === 'stale_closed').length;
-            const failed = results.filter(
-              (r) => r.status === 'checks_failed' || r.status === 'merge_failed',
-            ).length;
-            const pending = results.filter(r => r.status === 'checks_pending').length;
-            const ready = results.filter(r => r.status === 'ready').length;
+            const merged = report.summary.merged;
+            const stale = report.summary.stale_closed;
+            const blockingFailures = results.filter(
+              (r) =>
+                r.status === 'checks_failed' ||
+                r.status === 'merge_failed' ||
+                r.status === 'stale_close_failed' ||
+                r.status === 'target_missing',
+            );
+            const failed = dryRun ? 0 : blockingFailures.length;
+            const pending = report.summary.checks_pending;
+            const ready = report.summary.ready;
 
             console.log(`\nMerged: ${merged}`);
             console.log(`Stale closed: ${stale}`);
             console.log(`Failed: ${failed}`);
             console.log(`Pending: ${pending}`);
             console.log(`Ready (not auto-merged): ${ready}`);
+            if (dryRun && blockingFailures.length > 0) {
+              core.notice(
+                `Dry run observed ${blockingFailures.length} blocking result(s); report-only mode remains successful.`,
+              );
+            }
 
             if (failed > 0) {
               core.setFailed(`${failed} PRs failed to merge`);
             }
 
-      - name: Post summary
+      - name: Upload sync PR merge report
         if: always()
-        run: |
-          echo "### Sync PR Merge Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Processed repos: ${{ inputs.repos || 'all' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Auto-merge: ${{ inputs.auto_merge }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Dry run: ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+        uses: actions/upload-artifact@v5
+        with:
+          name: sync-pr-merge-report
+          path: artifacts/sync-pr-merge-report.json
+          if-no-files-found: warn

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -161,6 +161,27 @@ def test_consumer_sync_drift_uploads_machine_readable_report():
     ), "Health 68 must upload the drift report as a GitHub-visible artifact"
 
 
+def test_merge_sync_prs_uploads_machine_readable_report_and_hash_input():
+    text = (WORKFLOWS_DIR / "maint-71-merge-sync-prs.yml").read_text(encoding="utf-8")
+    assert "sync_hash:" in text, "Maint 71 must expose a target sync hash input"
+    assert (
+        "sync_pr_merge_contract.js" in text
+    ), "Maint 71 must use the structured sync PR merge contract helper"
+    assert (
+        "selectActiveSyncPr" in text
+    ), "Maint 71 must select the active PR with the hash-aware contract"
+    assert (
+        "parseBooleanInput" in text and "AUTO_MERGE_INPUT" in text
+    ), "Maint 71 must preserve explicit false boolean inputs"
+    assert "SYNC_PR_MERGE_REPORT_JSON" in text, "Maint 71 must configure a JSON merge report path"
+    assert (
+        "report-only mode remains successful" in text
+    ), "Maint 71 dry-run mode must report blocking statuses without failing the workflow"
+    assert (
+        "sync-pr-merge-report" in text
+    ), "Maint 71 must upload the merge report as a GitHub-visible artifact"
+
+
 def test_health_40_branch_protection_sweep_skips_push_runs():
     text = (WORKFLOWS_DIR / "health-40-sweep.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
## Summary
- Adds a hash-aware Maint 71 sync PR selection contract so cleanup can target the intended sync branch instead of relying only on newest PR ordering.
- Emits a machine-readable `sync-pr-merge-report` artifact and run-summary table for stale cleanup, readiness, pending, failed, and merged statuses.
- Records stale close attempts in results and keeps target-missing runs fail-closed without closing unrelated sync PRs.

## Verification
- `node --test .github/scripts/__tests__/sync-pr-merge-contract.test.js`
- `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q`
- `python -m pytest tests/workflows/test_workflow_naming.py tests/workflows/test_workflow_agents_consolidation.py -q`
- `/opt/homebrew/bin/actionlint .github/workflows/maint-71-merge-sync-prs.yml`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `git diff --check`