### PR TITLE
[codex] Publish coverage guard sync contract

### DIFF
--- a/tests/test_coverage_guard.py
+++ b/tests/test_coverage_guard.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 import subprocess
 from pathlib import Path
@@ -9,6 +10,174 @@ from tools import coverage_guard
 
 def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_baseline_applies_defaults(tmp_path: Path) -> None:
+    config_path = tmp_path / "baseline.json"
+    _write_json(
+        config_path,
+        {
+            "line": 86.5,
+            "warn_drop": 0.75,
+            "recovery_days": "7",
+        },
+    )
+
+    baseline = coverage_guard.load_baseline(config_path)
+
+    assert baseline.baseline == pytest.approx(86.5)
+    assert baseline.warn_drop == pytest.approx(0.75)
+    assert baseline.recovery_days == 7
+
+
+def test_load_baseline_enforces_minimum_recovery_days(tmp_path: Path) -> None:
+    config_path = tmp_path / "baseline.json"
+    _write_json(
+        config_path,
+        {
+            "line": 85.0,
+            "warn_drop": 1.0,
+            "recovery_days": 0,
+        },
+    )
+
+    baseline = coverage_guard.load_baseline(config_path)
+
+    assert baseline.recovery_days == 3
+
+
+def test_compute_top_files_prioritises_missing_lines() -> None:
+    coverage = {
+        "files": {
+            "src/a.py": {
+                "summary": {
+                    "percent_covered": 50.0,
+                    "covered_lines": 5,
+                    "missing_lines": 5,
+                    "num_statements": 10,
+                }
+            },
+            "src/b.py": {
+                "summary": {
+                    "percent_covered": 70.0,
+                    "covered_lines": 7,
+                    "missing_lines": 3,
+                    "num_statements": 10,
+                }
+            },
+            "src/c.py": {
+                "summary": {
+                    "percent_covered": 100.0,
+                    "covered_lines": 10,
+                    "missing_lines": 0,
+                    "num_statements": 10,
+                }
+            },
+        }
+    }
+
+    top = coverage_guard.compute_top_files(coverage, limit=2)
+
+    assert [item.path for item in top] == ["src/a.py", "src/b.py"]
+    assert all(item.missing > 0 for item in top)
+
+
+def test_compute_top_files_falls_back_to_total_lines() -> None:
+    coverage = {
+        "files": {
+            "src/a.py": {
+                "summary": {
+                    "percent_covered": 100.0,
+                    "covered_lines": 40,
+                    "missing_lines": 0,
+                    "num_statements": 40,
+                }
+            },
+            "src/b.py": {
+                "summary": {
+                    "percent_covered": 100.0,
+                    "covered_lines": 10,
+                    "missing_lines": 0,
+                    "num_statements": 10,
+                }
+            },
+        }
+    }
+
+    top = coverage_guard.compute_top_files(coverage, limit=2)
+
+    assert [item.path for item in top] == ["src/a.py", "src/b.py"]
+
+
+def test_build_update_comment_formats_metrics() -> None:
+    snapshot = coverage_guard.CoverageSnapshot(current=82.3, baseline=85.0, delta=-2.7)
+    config = coverage_guard.BaselineConfig(baseline=85.0, warn_drop=1.0, recovery_days=3)
+    today = dt.date(2024, 12, 31)
+    files = [
+        coverage_guard.FileCoverage(
+            path="src/a.py",
+            percent=60.0,
+            covered=6,
+            total=10,
+            missing=4,
+        ),
+        coverage_guard.FileCoverage(
+            path="src/b.py",
+            percent=75.0,
+            covered=15,
+            total=20,
+            missing=5,
+        ),
+    ]
+
+    comment = coverage_guard.build_update_comment(
+        snapshot,
+        config,
+        below_baseline=True,
+        date=today,
+        run_url="https://example.invalid/run/1",
+        recovery_progress=None,
+        top_files=files,
+    )
+
+    assert "2024-12-31" in comment
+    assert "Current coverage: 82.30%" in comment
+    assert "Baseline coverage: 85.00%" in comment
+    assert "Delta vs baseline: -2.70 pts" in comment
+    assert "Top changed files" in comment
+    assert "src/a.py" in comment
+
+
+def test_build_update_comment_handles_missing_files() -> None:
+    snapshot = coverage_guard.CoverageSnapshot(current=86.0, baseline=85.0, delta=1.0)
+    config = coverage_guard.BaselineConfig(baseline=85.0, warn_drop=1.0, recovery_days=3)
+    today = dt.date(2025, 1, 1)
+
+    comment = coverage_guard.build_update_comment(
+        snapshot,
+        config,
+        below_baseline=False,
+        date=today,
+        run_url="",
+        recovery_progress="1/3 days above baseline",
+        top_files=[],
+    )
+
+    assert "2025-01-01" in comment
+    assert "Status: At or above baseline" in comment
+    assert "Top changed files unavailable" in comment
+
+
+def test_build_recovered_comment_announces_closure() -> None:
+    snapshot = coverage_guard.CoverageSnapshot(current=86.0, baseline=85.0, delta=1.0)
+    config = coverage_guard.BaselineConfig(baseline=85.0, warn_drop=1.0, recovery_days=4)
+    today = dt.date(2025, 1, 4)
+
+    message = coverage_guard.build_recovered_comment(snapshot, config, today)
+
+    assert "Coverage recovered above baseline" in message
+    assert "4 consecutive days" in message
+    assert "Closing this issue" in message
 
 
 def test_find_or_create_issue_updates_existing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -8,10 +8,12 @@ a tracking issue when coverage falls below the threshold.
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import math
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +21,38 @@ DEFAULT_TREND_PATH = Path("coverage-trend.json")
 DEFAULT_COVERAGE_PATH = Path("coverage.json")
 DEFAULT_BASELINE_PATH = Path("config/coverage-baseline.json")
 DEFAULT_HISTORY_PATH = Path("coverage-trend-history.ndjson")
+DEFAULT_BASELINE = 80.0
+DEFAULT_WARN_DROP = 1.0
+DEFAULT_RECOVERY_DAYS = 3
+
+
+@dataclass(frozen=True)
+class BaselineConfig:
+    """Coverage baseline settings used by guard comments and issue policy."""
+
+    baseline: float
+    warn_drop: float
+    recovery_days: int
+
+
+@dataclass(frozen=True)
+class CoverageSnapshot:
+    """Current coverage state relative to the configured baseline."""
+
+    current: float
+    baseline: float
+    delta: float
+
+
+@dataclass(frozen=True)
+class FileCoverage:
+    """Coverage details for a file that needs attention."""
+
+    path: str
+    percent: float
+    covered: int
+    total: int
+    missing: int
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -90,6 +124,136 @@ def _to_int(value: Any, default: int = 0) -> int:
         except (OverflowError, ValueError):
             return default
     return default
+
+
+def load_baseline(path: Path) -> BaselineConfig:
+    """Load baseline configuration with conservative defaults."""
+    payload = _load_json(path)
+    baseline = _to_float(payload.get("line", payload.get("coverage")), DEFAULT_BASELINE)
+    warn_drop = _to_float(payload.get("warn_drop"), DEFAULT_WARN_DROP)
+    recovery_days = max(
+        DEFAULT_RECOVERY_DAYS,
+        _to_int(
+            payload.get(
+                "recovery_days",
+                payload.get("recovery_window", payload.get("recovery_runs")),
+            ),
+            DEFAULT_RECOVERY_DAYS,
+        ),
+    )
+    return BaselineConfig(
+        baseline=baseline,
+        warn_drop=warn_drop,
+        recovery_days=recovery_days,
+    )
+
+
+def compute_top_files(coverage_data: dict[str, Any], limit: int = 15) -> list[FileCoverage]:
+    """Return the most useful file-level coverage rows for issue comments."""
+    files = coverage_data.get("files", {})
+    if not isinstance(files, dict) or limit <= 0:
+        return []
+
+    rows: list[FileCoverage] = []
+    for filepath, data in files.items():
+        if not isinstance(filepath, str) or not isinstance(data, dict):
+            continue
+        summary = data.get("summary", {})
+        if not isinstance(summary, dict):
+            continue
+        percent = _parse_finite_float(summary.get("percent_covered"))
+        if percent is None:
+            continue
+        covered = _to_int(summary.get("covered_lines"))
+        missing = _to_int(summary.get("missing_lines"))
+        total = _to_int(summary.get("num_statements"), covered + missing)
+        if total <= 0:
+            total = covered + missing
+        rows.append(
+            FileCoverage(
+                path=filepath,
+                percent=percent,
+                covered=covered,
+                total=total,
+                missing=missing,
+            )
+        )
+
+    if any(row.missing > 0 for row in rows):
+        rows = [row for row in rows if row.missing > 0]
+        rows.sort(key=lambda row: (-row.missing, row.percent, row.path))
+    else:
+        rows.sort(key=lambda row: (-row.total, row.percent, row.path))
+    return rows[:limit]
+
+
+def build_update_comment(
+    snapshot: CoverageSnapshot,
+    config: BaselineConfig,
+    *,
+    below_baseline: bool,
+    date: dt.date,
+    run_url: str,
+    recovery_progress: str | None,
+    top_files: list[FileCoverage],
+) -> str:
+    """Build the durable coverage issue update comment."""
+    status = "Below baseline" if below_baseline else "At or above baseline"
+    lines = [
+        "## Coverage guard update",
+        "",
+        f"Date: {date.isoformat()}",
+        f"Status: {status}",
+        f"Current coverage: {snapshot.current:.2f}%",
+        f"Baseline coverage: {snapshot.baseline:.2f}%",
+        f"Delta vs baseline: {snapshot.delta:+.2f} pts",
+        f"Warning threshold: {config.warn_drop:.2f} pts",
+        f"Recovery window: {config.recovery_days} days",
+    ]
+    if recovery_progress:
+        lines.append(f"Recovery progress: {recovery_progress}")
+    if run_url:
+        lines.append(f"Run: {run_url}")
+
+    lines.extend(["", "### Top changed files"])
+    if top_files:
+        lines.extend(
+            [
+                "",
+                "| File | Coverage | Covered | Missing | Total |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for item in top_files:
+            lines.append(
+                f"| `{item.path}` | {item.percent:.2f}% | {item.covered} | "
+                f"{item.missing} | {item.total} |"
+            )
+    else:
+        lines.append("")
+        lines.append("Top changed files unavailable.")
+    return "\n".join(lines)
+
+
+def build_recovered_comment(
+    snapshot: CoverageSnapshot,
+    config: BaselineConfig,
+    date: dt.date,
+) -> str:
+    """Build the comment used when closing a recovered coverage issue."""
+    return "\n".join(
+        [
+            "Coverage recovered above baseline.",
+            "",
+            f"Date: {date.isoformat()}",
+            f"Current coverage: {snapshot.current:.2f}%",
+            f"Baseline coverage: {snapshot.baseline:.2f}%",
+            f"Delta vs baseline: {snapshot.delta:+.2f} pts",
+            f"Recovered for {config.recovery_days} consecutive days.",
+            "",
+            "Closing this issue.",
+        ]
+    )
 
 
 def _get_hotspots(coverage_data: dict[str, Any], limit: int = 15) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- publishes the coverage guard public helper contract from the Workflows source tree
- adds focused tests for baseline loading, top-file selection, and update/recovered comment builders
- prevents consumer syncs from deleting the contract restored in Trend_Model_Project PR 5087

## Validation
- `/opt/anaconda3/bin/python3.12 -m pytest tests/test_coverage_guard.py -q`
- `/opt/anaconda3/bin/python3.12 -m black --check --target-version py312 --line-length 100 tools/coverage_guard.py tests/test_coverage_guard.py`
- `/opt/anaconda3/bin/python3.12 -m ruff check tools/coverage_guard.py tests/test_coverage_guard.py`
- `git diff --check`

## Automation context
This fixes the source-side contract gap found after Maint 71 merged Ready PR 67 and Trend_Model_Project PR 5087. Without this source update, the next consumer sync PR for Trend_Model_Project (PR 5089) would remove the newly restored coverage guard API.