### PR TITLE
[codex] Add Maint 68 sync run report contract

### DIFF
--- a/.github/scripts/__tests__/sync-run-contract.test.js
+++ b/.github/scripts/__tests__/sync-run-contract.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildMarkdownSummary,
+  buildSyncRunReport,
+  summarizeResults,
+} = require('../sync_run_contract');
+
+test('summarizeResults counts known statuses and buckets unknown as error', () => {
+  assert.deepEqual(
+    summarizeResults([
+      { status: 'created_pr' },
+      { status: 'existing_pr' },
+      { status: 'created_pr' },
+      { status: 'unexpected_status' },
+    ]),
+    {
+      no_changes: 0,
+      dry_run_changes: 0,
+      existing_pr: 1,
+      created_pr: 2,
+      no_committed_changes: 0,
+      create_pr_failed: 0,
+      sync_failed: 0,
+      label_failed: 0,
+      error: 1,
+    },
+  );
+});
+
+test('buildSyncRunReport publishes the sync branch contract', () => {
+  const report = buildSyncRunReport({
+    generatedAt: '2026-04-25T08:00:00Z',
+    targetRepos: ['stranske/Ready'],
+    registeredRepos: ['stranske/Ready', 'stranske/Template'],
+    templateHash: '91c0e7663c12',
+    dryRun: true,
+    force: false,
+    run: {
+      repository: 'stranske/Workflows',
+      run_id: 123,
+    },
+    results: [
+      {
+        repo: 'stranske/Ready',
+        status: 'dry_run_changes',
+        changes_count: 7,
+      },
+    ],
+  });
+
+  assert.equal(report.schema, 'workflows-consumer-sync-run/v1');
+  assert.equal(report.inputs.expected_branch, 'sync/workflows-91c0e7663c12');
+  assert.equal(report.inputs.dry_run, true);
+  assert.deepEqual(report.summary, {
+    no_changes: 0,
+    dry_run_changes: 1,
+    existing_pr: 0,
+    created_pr: 0,
+    no_committed_changes: 0,
+    create_pr_failed: 0,
+    sync_failed: 0,
+    label_failed: 0,
+    error: 0,
+  });
+});
+
+test('buildMarkdownSummary names the report artifact and non-zero statuses', () => {
+  const markdown = buildMarkdownSummary(
+    buildSyncRunReport({
+      targetRepos: ['stranske/Ready'],
+      templateHash: '91c0e7663c12',
+      results: [{ status: 'created_pr' }, { status: 'no_changes' }],
+    }),
+  );
+
+  assert.match(markdown, /workflows-consumer-sync-run\/v1/);
+  assert.match(markdown, /sync\/workflows-91c0e7663c12/);
+  assert.match(markdown, /\| created_pr \| 1 \|/);
+  assert.match(markdown, /consumer-sync-run-report/);
+});

--- a/.github/scripts/sync_run_contract.js
+++ b/.github/scripts/sync_run_contract.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const REPORT_SCHEMA = 'workflows-consumer-sync-run/v1';
+
+function summarizeResults(results) {
+  const counts = {
+    no_changes: 0,
+    dry_run_changes: 0,
+    existing_pr: 0,
+    created_pr: 0,
+    no_committed_changes: 0,
+    create_pr_failed: 0,
+    sync_failed: 0,
+    label_failed: 0,
+    error: 0,
+  };
+  for (const result of results || []) {
+    const status = result.status || 'error';
+    if (Object.prototype.hasOwnProperty.call(counts, status)) {
+      counts[status] += 1;
+    } else {
+      counts.error += 1;
+    }
+  }
+  return counts;
+}
+
+function buildSyncRunReport({
+  results = [],
+  targetRepos = [],
+  registeredRepos = [],
+  templateHash = '',
+  dryRun = false,
+  force = false,
+  run = {},
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  return {
+    schema: REPORT_SCHEMA,
+    generated_at: generatedAt,
+    run,
+    inputs: {
+      repos: targetRepos,
+      registered_repos: registeredRepos,
+      template_hash: templateHash,
+      expected_branch: templateHash ? `sync/workflows-${templateHash}` : '',
+      dry_run: Boolean(dryRun),
+      force: Boolean(force),
+    },
+    summary: summarizeResults(results),
+    results,
+  };
+}
+
+function buildMarkdownSummary(report) {
+  const inputs = report.inputs || {};
+  const summary = report.summary || {};
+  const lines = [
+    '## Consumer Repo Sync Summary',
+    '',
+    `Schema: \`${report.schema || REPORT_SCHEMA}\``,
+    `Template hash: \`${inputs.template_hash || ''}\``,
+    `Expected branch: \`${inputs.expected_branch || ''}\``,
+    `Processed repos: ${Array.isArray(inputs.repos) ? inputs.repos.length : 0}`,
+    `Dry run: ${inputs.dry_run ? 'true' : 'false'}`,
+    `Force: ${inputs.force ? 'true' : 'false'}`,
+    '',
+    '| Status | Count |',
+    '| --- | ---: |',
+  ];
+  for (const [status, count] of Object.entries(summary)) {
+    if (count) {
+      lines.push(`| ${status} | ${count} |`);
+    }
+  }
+  lines.push('', 'Artifact: `consumer-sync-run-report`');
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  REPORT_SCHEMA,
+  summarizeResults,
+  buildSyncRunReport,
+  buildMarkdownSummary,
+};

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -299,6 +299,12 @@ jobs:
       # Job-level alias for repo token (uses OWNER_PR_PAT or SERVICE_BOT_PAT)
       REPO_TOKEN: ${{ secrets.OWNER_PR_PAT || secrets.SERVICE_BOT_PAT }}
     steps:
+      - name: Compute result artifact name
+        id: repo_meta
+        run: |
+          safe_name=$(printf '%s' '${{ matrix.repo }}' | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^-+|-+$//g')
+          echo "artifact_name=${safe_name:-unknown-repo}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout Workflows
         uses: actions/checkout@v6
         with:
@@ -707,6 +713,7 @@ jobs:
           SYNC_SCRIPT
 
       - name: Check for required labels
+        id: labels
         if: steps.sync.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
@@ -746,6 +753,7 @@ jobs:
             --color "0E8A16" --force || true
 
       - name: Create sync PR
+        id: create_pr
         if: steps.sync.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
@@ -759,6 +767,11 @@ jobs:
           if [ -n "$existing_pr" ]; then
             echo "PR #$existing_pr already exists for this sync"
             echo "::notice::Existing PR: #$existing_pr"
+            {
+              echo "status=existing_pr"
+              echo "pr_number=$existing_pr"
+              echo "pr_url=https://github.com/${{ matrix.repo }}/pull/$existing_pr"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -816,6 +829,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No changes to commit after sync; skipping PR creation."
+            echo "status=no_committed_changes" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -841,11 +855,17 @@ jobs:
           **Source:** stranske/Workflows
           **Manifest:** \`.github/sync-manifest.yml\`"
 
-          gh pr create \
+          pr_url=$(gh pr create \
             --head "$branch_name" \
             --title "chore: sync workflow templates" \
             --body "$pr_body" \
-            --label "sync,automated"
+            --label "sync,automated")
+          pr_number=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
+          {
+            echo "status=created_pr"
+            echo "pr_number=$pr_number"
+            echo "pr_url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Dry run summary
         if: inputs.dry_run == true
@@ -859,6 +879,92 @@ jobs:
             cat sync_summary.md
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Write sync result artifact
+        if: always()
+        env:
+          REPO: ${{ matrix.repo }}
+          TEMPLATE_HASH: ${{ needs.prepare.outputs.template_hash }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
+          SYNC_OUTCOME: ${{ steps.sync.outcome || 'skipped' }}
+          LABELS_OUTCOME: ${{ steps.labels.outcome || 'skipped' }}
+          CREATE_PR_OUTCOME: ${{ steps.create_pr.outcome || 'skipped' }}
+          CREATE_PR_STATUS: ${{ steps.create_pr.outputs.status || '' }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pr_number || '' }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url || '' }}
+          HAS_CHANGES: ${{ steps.sync.outputs.has_changes || 'false' }}
+          CHANGES_COUNT: ${{ steps.sync.outputs.changes_count || '0' }}
+        run: |
+          mkdir -p artifacts/consumer-sync-results
+          python3 << 'RESULT_SCRIPT'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          repo = os.environ["REPO"]
+          safe_repo = re.sub(r"[^A-Za-z0-9_.-]+", "-", repo).strip("-") or "unknown-repo"
+          dry_run = os.environ.get("DRY_RUN", "false") == "true"
+          has_changes = os.environ.get("HAS_CHANGES", "false") == "true"
+          changes_count = int(os.environ.get("CHANGES_COUNT") or "0")
+          sync_outcome = os.environ.get("SYNC_OUTCOME", "skipped")
+          labels_outcome = os.environ.get("LABELS_OUTCOME", "skipped")
+          create_outcome = os.environ.get("CREATE_PR_OUTCOME", "skipped")
+          create_status = os.environ.get("CREATE_PR_STATUS", "")
+
+          if sync_outcome == "failure":
+              status = "sync_failed"
+          elif labels_outcome == "failure":
+              status = "label_failed"
+          elif not has_changes:
+              status = "no_changes"
+          elif dry_run:
+              status = "dry_run_changes"
+          elif create_outcome == "failure":
+              status = "create_pr_failed"
+          else:
+              status = create_status or "error"
+
+          result = {
+              "repo": repo,
+              "status": status,
+              "template_hash": os.environ.get("TEMPLATE_HASH", ""),
+              "expected_branch": (
+                  f"sync/workflows-{os.environ.get('TEMPLATE_HASH', '')}"
+                  if os.environ.get("TEMPLATE_HASH", "")
+                  else ""
+              ),
+              "dry_run": dry_run,
+              "force": os.environ.get("FORCE", "false") == "true",
+              "has_changes": has_changes,
+              "changes_count": changes_count,
+              "outcomes": {
+                  "sync": sync_outcome,
+                  "labels": labels_outcome,
+                  "create_pr": create_outcome,
+              },
+          }
+          pr_number = os.environ.get("PR_NUMBER", "")
+          if pr_number:
+              result["pr"] = int(pr_number)
+          pr_url = os.environ.get("PR_URL", "")
+          if pr_url:
+              result["pr_url"] = pr_url
+
+          Path(f"artifacts/consumer-sync-results/{safe_repo}.json").write_text(
+              json.dumps(result, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          RESULT_SCRIPT
+
+      - name: Upload sync result artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: consumer-sync-result-${{ steps.repo_meta.outputs.artifact_name || 'unknown-repo' }}
+          path: artifacts/consumer-sync-results/*.json
+          retention-days: 14
+
   # ============================================================================
   # SUMMARY: Generate overall sync report
   # ============================================================================
@@ -867,11 +973,90 @@ jobs:
     needs: [prepare, validate, sync]
     runs-on: ubuntu-latest
     if: always()
+    env:
+      CONSUMER_SYNC_RUN_REPORT_JSON: artifacts/consumer-sync-run-report.json
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/scripts/sync_run_contract.js
+          sparse-checkout-cone-mode: false
+
+      - name: Download sync result artifacts
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: consumer-sync-result-*
+          path: artifacts/consumer-sync-results
+          merge-multiple: true
+
+      - name: Build sync run report
+        run: |
+          mkdir -p artifacts
+          node << 'REPORT_SCRIPT'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const {
+            buildMarkdownSummary,
+            buildSyncRunReport,
+          } = require('./.github/scripts/sync_run_contract');
+
+          function parseRepos(value) {
+            if (!value) return [];
+            const parsed = JSON.parse(value);
+            return Array.isArray(parsed.repo) ? parsed.repo : [];
+          }
+
+          const resultsDir = 'artifacts/consumer-sync-results';
+          const results = fs.existsSync(resultsDir)
+            ? fs.readdirSync(resultsDir)
+                .filter((name) => name.endsWith('.json'))
+                .sort()
+                .map((name) => JSON.parse(
+                  fs.readFileSync(path.join(resultsDir, name), 'utf8'),
+                ))
+            : [];
+
+          const registeredRepos = (process.env.REGISTERED_CONSUMER_REPOS || '')
+            .split(/\r?\n/)
+            .map((repo) => repo.trim())
+            .filter(Boolean);
+
+          const report = buildSyncRunReport({
+            results,
+            targetRepos: parseRepos(process.env.TARGET_REPOS_JSON || ''),
+            registeredRepos,
+            templateHash: process.env.TEMPLATE_HASH || '',
+            dryRun: process.env.DRY_RUN === 'true',
+            force: process.env.FORCE === 'true',
+            run: {
+              repository: process.env.GITHUB_REPOSITORY,
+              run_id: Number(process.env.GITHUB_RUN_ID || 0),
+              run_number: Number(process.env.GITHUB_RUN_NUMBER || 0),
+              workflow: process.env.GITHUB_WORKFLOW,
+              ref: process.env.GITHUB_REF,
+              sha: process.env.GITHUB_SHA,
+            },
+          });
+
+          fs.writeFileSync(
+            process.env.CONSUMER_SYNC_RUN_REPORT_JSON,
+            `${JSON.stringify(report, null, 2)}\n`,
+            'utf8',
+          );
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, buildMarkdownSummary(report), 'utf8');
+          REPORT_SCRIPT
+        env:
+          TARGET_REPOS_JSON: ${{ needs.prepare.outputs.repos || '{"repo":[]}' }}
+          TEMPLATE_HASH: ${{ needs.prepare.outputs.template_hash || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
+
       - name: Generate summary
         run: |
           {
-            echo "## Consumer Repo Sync Summary"
+            echo "## Consumer Repo Sync Details"
             echo ""
             echo "**Template Hash:** ${{ needs.prepare.outputs.template_hash }}"
             echo "**Dry Run:** ${{ inputs.dry_run || 'false' }}"
@@ -886,6 +1071,15 @@ jobs:
             echo "---"
             echo "*Sync driven by .github/sync-manifest.yml*"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sync run report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: consumer-sync-run-report
+          path: ${{ env.CONSUMER_SYNC_RUN_REPORT_JSON }}
+          retention-days: 14
+          if-no-files-found: warn
 
   # ============================================================================
   # FAILURE NOTIFICATION: Create issue when sync fails

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -182,6 +182,25 @@ def test_merge_sync_prs_uploads_machine_readable_report_and_hash_input():
     ), "Maint 71 must upload the merge report as a GitHub-visible artifact"
 
 
+def test_consumer_sync_run_uploads_machine_readable_report():
+    text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
+    assert (
+        "sync_run_contract.js" in text
+    ), "Maint 68 summary must use the structured sync run contract helper"
+    assert (
+        "CONSUMER_SYNC_RUN_REPORT_JSON" in text
+    ), "Maint 68 must configure a JSON sync run report path"
+    assert (
+        "consumer-sync-result-" in text
+    ), "Maint 68 matrix jobs must upload per-repo result artifacts"
+    assert (
+        "consumer-sync-run-report" in text
+    ), "Maint 68 must upload the aggregate sync run report as a GitHub-visible artifact"
+    assert (
+        "sync_failed" in text and "create_pr_failed" in text
+    ), "Maint 68 report must distinguish sync failures from PR creation failures"
+
+
 def test_health_40_branch_protection_sweep_skips_push_runs():
     text = (WORKFLOWS_DIR / "health-40-sweep.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
## Summary
- add a workflows-consumer-sync-run/v1 JSON contract for Maint 68 sync-creation runs
- upload per-repo sync result artifacts and an aggregate consumer-sync-run-report artifact
- record PR creation, existing PR, no-change, dry-run, label, sync, and PR creation failure states separately

## Validation
- node --test .github/scripts/__tests__/sync-run-contract.test.js .github/scripts/__tests__/sync-pr-merge-contract.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- /opt/homebrew/bin/actionlint .github/workflows/maint-68-sync-consumer-repos.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- black --check --line-length 100 tests/workflows/test_workflow_agents_consolidation.py
- git diff --check

## Automation context
This continues the Workflows system review implementation program by making Maint 68 sync creation GitHub-visible and machine-readable, matching the existing Health 68 drift and Maint 71 merge contracts.