### PR TITLE
Fix Maint 68 header-aware sync diff

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -419,22 +419,26 @@ jobs:
           changes = []
           skipped = []
 
+          def comparable_lines(path):
+              """Return file lines after leading comment/blank header lines."""
+              lines = path.read_text().splitlines()
+              index = 0
+              while index < len(lines):
+                  stripped = lines[index].strip()
+                  if stripped == '' or stripped.startswith('#'):
+                      index += 1
+                      continue
+                  break
+              return lines[index:]
+
           def files_differ(src, dst):
-              """Compare files, ignoring header comments (first 10 lines)."""
+              """Compare files, ignoring only leading comment headers."""
               if not dst.exists():
                   return True
               if not src.exists():
                   return False
 
-              src_lines = src.read_text().splitlines()
-              dst_lines = dst.read_text().splitlines()
-
-              # For short files, compare everything
-              if len(src_lines) < 15 or len(dst_lines) < 15:
-                  return src_lines != dst_lines
-
-              # Skip header (first 10 lines) for comparison
-              return src_lines[10:] != dst_lines[10:]
+              return comparable_lines(src) != comparable_lines(dst)
 
           def sync_file(source_path, target_path, description, skip_condition=None):
               """Sync a single file from template to consumer."""

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -204,6 +204,19 @@ def test_consumer_sync_run_uploads_machine_readable_report():
     ), "Maint 68 report must distinguish sync failures from PR creation failures"
 
 
+def test_consumer_sync_diff_keeps_functional_lines_in_comparison():
+    text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
+    assert (
+        "def comparable_lines(path):" in text
+    ), "Maint 68 must normalize only leading file headers before comparing sync targets"
+    assert (
+        "return comparable_lines(src) != comparable_lines(dst)" in text
+    ), "Maint 68 must compare functional lines after any leading comment header"
+    assert (
+        "src_lines[10:] != dst_lines[10:]" not in text
+    ), "Maint 68 must not ignore fixed line ranges that can contain version pins"
+
+
 def test_health_40_branch_protection_sweep_skips_push_runs():
     text = (WORKFLOWS_DIR / "health-40-sweep.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
## Summary
- compare Maint 68 sync targets after only leading comment/blank headers
- stop ignoring fixed first-10-line ranges that can contain functional version pins
- add workflow contract coverage for the comparison behavior

## Verification
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/scripts/test_check_consumer_sync_drift.py
- python -m ruff check tests/workflows/test_workflow_agents_consolidation.py
- python -m black --check tests/workflows/test_workflow_agents_consolidation.py
- yaml.safe_load(.github/workflows/maint-68-sync-consumer-repos.yml)
- git diff --check