### PR TITLE
Fix consumer sync manifest skip contract

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -20,6 +20,8 @@
 #   - source: Path relative to templates/consumer-repo/ (or .github/ for reusable-only)
 #   - target: Path in consumer repo (defaults to same as source)
 #   - description: What this file does (required for documentation)
+#   - skip_repos: Optional list of repo-specific exclusions with a reason.
+#       Use only when a consumer has an intentional incompatible path or policy.
 
 version: 1
 
@@ -580,6 +582,9 @@ docs:
   - source: AGENTS.md
     target: AGENTS.md
     description: "Context file for agents and coding assistants"
+    skip_repos:
+      - repo: stranske/Trend_Model_Project
+        reason: "Repo keeps historical Agents.md casing to avoid case-only path conflicts"
 
   - source: CLAUDE.md
     target: CLAUDE.md

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -410,14 +410,22 @@ jobs:
 
           # Repos with custom Gate workflows
           custom_gate_repos = ['stranske/Manager-Database']
-          repo_specific_skip_rules = {
-              ('stranske/Trend_Model_Project', 'AGENTS.md'): (
-                  'Repo keeps historical Agents.md casing to avoid case-only path conflicts'
-              ),
-          }
-
           changes = []
           skipped = []
+
+          def manifest_skip_reason(item, repo):
+              """Return the manifest-declared skip reason for this repo, if any."""
+              for rule in item.get('skip_repos', []) or []:
+                  if isinstance(rule, str):
+                      if rule == repo:
+                          return 'Manifest skip for repo'
+                      continue
+                  if not isinstance(rule, dict):
+                      continue
+                  if str(rule.get('repo', '')).strip() != repo:
+                      continue
+                  return str(rule.get('reason', '')).strip() or 'Manifest skip for repo'
+              return ''
 
           def comparable_lines(path):
               """Return file lines after leading comment/blank header lines."""
@@ -440,7 +448,7 @@ jobs:
 
               return comparable_lines(src) != comparable_lines(dst)
 
-          def sync_file(source_path, target_path, description, skip_condition=None):
+          def sync_file(source_path, target_path, description, skip_condition=None, item=None):
               """Sync a single file from template to consumer."""
               src = Path(source_path)
               dst = Path(target_path)
@@ -450,9 +458,9 @@ jobs:
                   else str(dst)
               )
 
-              repo_specific_reason = repo_specific_skip_rules.get((current_repo, relative_target))
-              if repo_specific_reason:
-                  skipped.append(f"{dst.name}: {repo_specific_reason}")
+              skip_reason = manifest_skip_reason(item or {}, current_repo)
+              if skip_reason:
+                  skipped.append(f"{relative_target}: {skip_reason}")
                   return False
 
               if skip_condition and skip_condition():
@@ -471,10 +479,20 @@ jobs:
                   return True
               return False
 
-          def sync_directory(source_path, target_path, description):
+          def sync_directory(source_path, target_path, description, item=None):
               """Sync an entire directory from template to consumer."""
               src = Path(source_path)
               dst = Path(target_path)
+              relative_target = (
+                  str(dst.relative_to(Path('consumer')))
+                  if dst.is_absolute() is False and str(dst).startswith('consumer/')
+                  else str(dst)
+              )
+
+              skip_reason = manifest_skip_reason(item or {}, current_repo)
+              if skip_reason:
+                  skipped.append(f"{relative_target}: {skip_reason}")
+                  return False
 
               if not src.exists() or not src.is_dir():
                   print(f"  ⚠ Source directory missing: {src}")
@@ -536,7 +554,7 @@ jobs:
               elif 'pr-00-gate' in source and current_repo in custom_gate_repos:
                   skip_fn = skip_custom_gate
 
-              sync_file(template_src, consumer_dst, description, skip_fn)
+              sync_file(template_src, consumer_dst, description, skip_fn, item)
 
           # Process prompts
           print("Processing prompts...")
@@ -545,7 +563,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / source
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process scripts
           print("Processing scripts...")
@@ -557,9 +575,9 @@ jobs:
               template_src = Path('workflows') / source
               consumer_dst = Path('consumer') / source
               if is_directory:
-                  sync_directory(template_src, consumer_dst, description)
+                  sync_directory(template_src, consumer_dst, description, item)
               else:
-                  sync_file(template_src, consumer_dst, description)
+                  sync_file(template_src, consumer_dst, description, item=item)
 
           # Process codex_config
           print("Processing codex config...")
@@ -568,7 +586,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / source
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process copilot_config
           print("Processing copilot config...")
@@ -580,9 +598,9 @@ jobs:
               consumer_dst = Path('consumer') / source
 
               if is_directory:
-                  sync_directory(template_src, consumer_dst, description)
+                  sync_directory(template_src, consumer_dst, description, item)
               else:
-                  sync_file(template_src, consumer_dst, description)
+                  sync_file(template_src, consumer_dst, description, item=item)
 
           # Process templates (markdown templates, instructions, etc.)
           print("Processing templates...")
@@ -592,7 +610,7 @@ jobs:
               # Templates come from .github/templates/, same as scripts pattern
               template_src = Path('workflows') / source
               consumer_dst = Path('consumer') / source
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process actions
           print("Processing actions...")
@@ -604,9 +622,9 @@ jobs:
               consumer_dst = Path('consumer') / source
 
               if is_directory:
-                  sync_directory(template_src, consumer_dst, description)
+                  sync_directory(template_src, consumer_dst, description, item)
               else:
-                  sync_file(template_src, consumer_dst, description)
+                  sync_file(template_src, consumer_dst, description, item=item)
 
           # Process docs
           print("Processing docs...")
@@ -616,7 +634,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / target
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process llm_config
           print("Processing llm config...")
@@ -629,7 +647,7 @@ jobs:
               skip_fn = None
               if sync_mode == 'create_only':
                   skip_fn = lambda: consumer_dst.exists()
-              sync_file(template_src, consumer_dst, description, skip_fn)
+              sync_file(template_src, consumer_dst, description, skip_fn, item)
 
           # Process git_config
           print("Processing git config...")
@@ -638,7 +656,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / source
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process issue_templates
           print("Processing issue templates...")
@@ -647,7 +665,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / source
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process user_docs
           print("Processing user docs...")
@@ -657,7 +675,7 @@ jobs:
               description = item.get('description', 'No description')
               template_src = Path('workflows/templates/consumer-repo') / source
               consumer_dst = Path('consumer') / target
-              sync_file(template_src, consumer_dst, description)
+              sync_file(template_src, consumer_dst, description, item=item)
 
           # Process removals
           print("Processing removals...")

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -111,6 +111,25 @@ def sorted_items(values: set[str]) -> list[str]:
     return sorted(values)
 
 
+def manifest_skip_reason(entry: dict[str, object], repo: str) -> str:
+    """Return the manifest-declared skip reason for a repo, if any."""
+    rules = entry.get("skip_repos", [])
+    if not isinstance(rules, list):
+        return ""
+    for rule in rules:
+        if isinstance(rule, str):
+            if rule == repo:
+                return "Manifest skip for repo"
+            continue
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("repo", "")).strip() != repo:
+            continue
+        reason = str(rule.get("reason", "")).strip()
+        return reason or "Manifest skip for repo"
+    return ""
+
+
 def token_candidates(env: dict[str, str] | None = None) -> list[dict[str, str]]:
     """Return deduplicated token candidates without exposing token values."""
     values = env if env is not None else os.environ
@@ -353,8 +372,10 @@ def build_report(
     missing: set[str],
     errors: set[str],
     obsolete: set[str],
+    skipped: set[str] | None = None,
     token_diagnostics: dict[str, object] | None = None,
 ) -> dict[str, object]:
+    skipped = skipped or set()
     counts = {
         "drift": len(drift),
         "missing": len(missing),
@@ -403,6 +424,8 @@ def build_report(
             "content_error_threshold_per_repo": CONTENT_ERROR_THRESHOLD,
             "max_items_per_section": SUMMARY_ITEM_LIMIT,
         },
+        "skip_count": len(skipped),
+        "skipped": sorted_items(skipped),
         "drift": sorted_items(drift),
         "missing": sorted_items(missing),
         "errors": sorted_items(errors),
@@ -489,6 +512,7 @@ def write_summary_markdown(path: str, report: dict[str, object]) -> None:
             ("Missing files", "missing"),
             ("Errors", "errors"),
             ("Obsolete files present (should be removed)", "obsolete"),
+            ("Skipped by manifest policy", "skipped"),
         ):
             items = report.get(key, [])
             if not isinstance(items, list) or not items:
@@ -648,6 +672,7 @@ def main() -> int:
     missing: set[str] = set()
     errors: set[str] = set()
     obsolete: set[str] = set()
+    skipped: set[str] = set()
 
     remote_trees: dict[str, dict[str, dict[str, object]]] = {}
     for repo in repos:
@@ -684,6 +709,10 @@ def main() -> int:
                 continue
 
             for repo in remote_trees:
+                skip_reason = manifest_skip_reason(entry, repo)
+                if skip_reason:
+                    skipped.add(f"{repo}: {target} ({skip_reason})")
+                    continue
                 if is_directory or local_path.is_dir():
                     # Recursively compare all files within the directory
                     for child in sorted(local_path.rglob("*")):
@@ -708,6 +737,7 @@ def main() -> int:
         missing=missing,
         errors=errors,
         obsolete=obsolete,
+        skipped=skipped,
         token_diagnostics=token_diagnostics,
     )
     write_report_json(args.report_json, report)

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -74,6 +74,40 @@ def test_token_candidates_deduplicates_without_exposing_values() -> None:
     ]
 
 
+def test_manifest_skip_reason_supports_repo_specific_policy() -> None:
+    entry = {
+        "source": "AGENTS.md",
+        "skip_repos": [
+            {
+                "repo": "owner/custom",
+                "reason": "Uses historical Agents.md casing",
+            }
+        ],
+    }
+
+    assert (
+        check_consumer_sync_drift.manifest_skip_reason(entry, "owner/custom")
+        == "Uses historical Agents.md casing"
+    )
+    assert check_consumer_sync_drift.manifest_skip_reason(entry, "owner/standard") == ""
+
+
+def test_build_report_surfaces_manifest_skips_without_failing() -> None:
+    report = check_consumer_sync_drift.build_report(
+        repos=["owner/custom"],
+        drift=set(),
+        missing=set(),
+        errors=set(),
+        obsolete=set(),
+        skipped={"owner/custom: AGENTS.md (Uses historical Agents.md casing)"},
+    )
+
+    assert report["status"] == "pass"
+    assert report["counts"] == {"drift": 0, "missing": 0, "errors": 0, "obsolete": 0}
+    assert report["skip_count"] == 1
+    assert report["skipped"] == ["owner/custom: AGENTS.md (Uses historical Agents.md casing)"]
+
+
 def test_select_read_token_rejects_rate_limited_candidate() -> None:
     class Response:
         def __init__(self, status_code: int, message: str = "", remaining: str = "42") -> None:

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -217,6 +217,18 @@ def test_consumer_sync_diff_keeps_functional_lines_in_comparison():
     ), "Maint 68 must not ignore fixed line ranges that can contain version pins"
 
 
+def test_consumer_sync_repo_exclusions_live_in_manifest():
+    workflow_text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
+    manifest_text = Path(".github/sync-manifest.yml").read_text(encoding="utf-8")
+    checker_text = Path("scripts/check_consumer_sync_drift.py").read_text(encoding="utf-8")
+
+    assert "skip_repos:" in manifest_text
+    assert "stranske/Trend_Model_Project" in manifest_text
+    assert "manifest_skip_reason" in workflow_text
+    assert "manifest_skip_reason" in checker_text
+    assert "repo_specific_skip_rules" not in workflow_text
+
+
 def test_health_40_branch_protection_sweep_skips_push_runs():
     text = (WORKFLOWS_DIR / "health-40-sweep.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
## Summary
- Move the Trend_Model_Project AGENTS.md casing exception into .github/sync-manifest.yml as a manifest-level skip_repos contract.
- Teach Maint 68 and Health 68 to read the same manifest skip reason, removing the hidden hardcoded Maint 68 exception.
- Surface skipped manifest entries in the Health 68 JSON report without counting them as drift.

## Verification
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m ruff check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- python -m black --check scripts/check_consumer_sync_drift.py tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py
- python -m py_compile scripts/check_consumer_sync_drift.py
- YAML parse: .github/sync-manifest.yml and .github/workflows/maint-68-sync-consumer-repos.yml
- git diff --check