### PR TITLE
[codex] Harden terminal metrics contracts

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -86,6 +86,11 @@ test('reports missing review-thread coverage without failing the contract', () =
   assert.equal(report.schema, 'workflows-terminal-disposition-coverage/v1');
   assert.equal(report.mode, 'warning-only');
   assert.equal(report.status, 'warning');
+  assert.deepEqual(report.enforcement, {
+    mode: 'warning-only',
+    hard_block_eligible: false,
+    blockers: ['missing-review-thread-sources'],
+  });
   assert.equal(report.scanned_record_count, 3);
   assert.equal(report.terminal_record_count, 3);
   assert.equal(report.non_terminal_record_count, 0);
@@ -188,7 +193,7 @@ test('summarizes terminal artifact selector inputs in coverage report', () => {
   });
   const markdown = formatTerminalDispositionCoverageMarkdown(report);
 
-  assert.equal(report.status, 'no-data');
+  assert.equal(report.status, 'warning');
   assert.deepEqual(report.artifact_selection, {
     schema: 'workflows-weekly-metrics-artifact-selection/v1',
     status: 'pass',
@@ -202,6 +207,34 @@ test('summarizes terminal artifact selector inputs in coverage report', () => {
   assert.match(markdown, /Artifact selector status: pass/);
   assert.match(markdown, /Terminal artifacts selected: 2/);
   assert.match(markdown, /Terminal artifacts candidates: 4/);
+});
+
+test('warns when selected terminal artifacts do not produce input files', () => {
+  const report = summarizeTerminalDispositionCoverage([], {
+    artifact_selection_report: {
+      schema: 'workflows-weekly-metrics-artifact-selection/v1',
+      status: 'pass',
+      candidate_family_counts: {
+        'verifier-terminal-disposition': 1,
+      },
+      selected_family_counts: {
+        'verifier-terminal-disposition': 1,
+      },
+      selected_artifacts: [
+        { id: 10, name: 'verifier-terminal-disposition-123', family: 'verifier-terminal-disposition' },
+      ],
+    },
+    input_file_count: 0,
+  });
+  const markdown = formatTerminalDispositionCoverageMarkdown(report);
+
+  assert.equal(report.status, 'warning');
+  assert.equal(report.terminal_artifact_input_mismatch, true);
+  assert.deepEqual(report.enforcement.blockers, [
+    'no-terminal-disposition-records',
+    'selected-terminal-artifacts-without-input-files',
+  ]);
+  assert.match(markdown, /Terminal artifact input mismatch/);
 });
 
 test('warns when configured artifact selection report is missing', () => {

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -112,6 +112,36 @@ test('bounds selected artifacts by total and per-family limits', () => {
   assert.equal(report.ignored_total_limit_count, 1);
 });
 
+test('reserves scarce terminal artifacts before filling the total cap', () => {
+  const report = selectMetricsArtifacts(
+    [
+      artifact(1, 'keepalive-metrics', '2026-04-25T11:59:00Z'),
+      artifact(2, 'agents-autofix-metrics', '2026-04-25T11:58:00Z'),
+      artifact(3, 'verifier-terminal-disposition-77', '2026-04-25T09:00:00Z'),
+      artifact(4, 'review-thread-terminal-disposition-77', '2026-04-25T08:00:00Z'),
+    ],
+    {
+      now_ms: NOW,
+      max_total: 3,
+    }
+  );
+
+  assert.deepEqual(
+    report.selected_artifacts.map((selected) => selected.name),
+    [
+      'verifier-terminal-disposition-77',
+      'review-thread-terminal-disposition-77',
+      'keepalive-metrics',
+    ]
+  );
+  assert.equal(report.ignored_total_limit_count, 1);
+  assert.deepEqual(report.selected_family_counts, {
+    'keepalive-metrics': 1,
+    'review-thread-terminal-disposition': 1,
+    'verifier-terminal-disposition': 1,
+  });
+});
+
 test('formats selected artifacts for the workflow download loop', () => {
   const tsv = formatArtifactTsv([
     { id: 42, name: 'keepalive-metrics' },

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -115,20 +115,39 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   const artifactSelectionWarning = artifactSelection &&
     artifactSelection.status !== 'pass' &&
     artifactSelection.status !== 'not-configured';
+  const selectedTerminalArtifactCount = artifactSelection?.selected_terminal_artifact_count || 0;
+  const terminalArtifactInputMismatch = selectedTerminalArtifactCount > 0 && inputFileCount === 0;
 
   let status = 'pass';
   if (terminalRecords.length === 0) {
-    status = parseErrors > 0 || nonTerminalRecordCount > 0 || artifactSelectionWarning
+    status = parseErrors > 0 ||
+      nonTerminalRecordCount > 0 ||
+      artifactSelectionWarning ||
+      terminalArtifactInputMismatch
       ? 'warning'
       : 'no-data';
   } else if (missing.length > 0 || parseErrors > 0 || artifactSelectionWarning) {
     status = 'warning';
   }
 
+  const enforcementBlockers = [];
+  if (terminalRecords.length === 0) enforcementBlockers.push('no-terminal-disposition-records');
+  if (terminalArtifactInputMismatch) {
+    enforcementBlockers.push('selected-terminal-artifacts-without-input-files');
+  }
+  if (missing.length > 0) enforcementBlockers.push('missing-review-thread-sources');
+  if (parseErrors > 0) enforcementBlockers.push('parse-errors');
+  if (artifactSelectionWarning) enforcementBlockers.push('artifact-selection-warning');
+
   return {
     schema: COVERAGE_SCHEMA,
     status,
     mode: 'warning-only',
+    enforcement: {
+      mode: 'warning-only',
+      hard_block_eligible: enforcementBlockers.length === 0,
+      blockers: enforcementBlockers,
+    },
     input_file_count: inputFileCount,
     input_files: inputFiles,
     scanned_record_count: scannedRecordCount,
@@ -139,6 +158,7 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
     covered_source_count: covered.length,
     missing_source_count: missing.length,
     parse_errors: parseErrors,
+    terminal_artifact_input_mismatch: terminalArtifactInputMismatch,
     artifact_selection: artifactSelection,
     observed_sources: observedSources,
     expected_sources: expected,
@@ -242,6 +262,12 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     if (selection.error_message) {
       lines.push(`- Artifact selector error: ${selection.error_message}`);
     }
+  }
+
+  if (report.terminal_artifact_input_mismatch) {
+    lines.push(
+      '- Terminal artifact input mismatch: selected terminal artifacts did not yield terminal NDJSON input files'
+    );
   }
 
   if (report.missing_sources.length > 0) {

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -22,6 +22,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
   'review-thread-terminal-disposition-',
 ];
 
+const PRIORITY_METRICS_FAMILIES = [
+  'verifier-terminal-disposition',
+  'review-thread-terminal-disposition',
+];
+
 function cleanString(value) {
   if (value === null || value === undefined) return '';
   return String(value).trim();
@@ -151,7 +156,29 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
 
   const familyCounts = new Map();
   const selected = [];
+  const selectedIds = new Set();
+
+  function selectArtifact(artifact) {
+    if (selected.length >= config.max_total) {
+      return false;
+    }
+    const familyCount = familyCounts.get(artifact.family) || 0;
+    if (familyCount >= config.max_per_family) {
+      return false;
+    }
+    selected.push(artifact);
+    selectedIds.add(String(artifact.id));
+    familyCounts.set(artifact.family, familyCount + 1);
+    return true;
+  }
+
+  for (const family of PRIORITY_METRICS_FAMILIES) {
+    const artifact = candidates.find((candidate) => candidate.family === family);
+    if (artifact) selectArtifact(artifact);
+  }
+
   for (const artifact of candidates) {
+    if (selectedIds.has(String(artifact.id))) continue;
     if (selected.length >= config.max_total) {
       stats.ignored_total_limit_count += 1;
       continue;
@@ -161,8 +188,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       stats.ignored_family_limit_count += 1;
       continue;
     }
-    selected.push(artifact);
-    familyCounts.set(artifact.family, familyCount + 1);
+    selectArtifact(artifact);
   }
 
   stats.selected_count = selected.length;
@@ -378,6 +404,7 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  PRIORITY_METRICS_FAMILIES,
   SELECTION_SCHEMA,
   artifactFamily,
   buildSelectionErrorReport,

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -523,7 +523,7 @@ jobs:
 
       - name: Upload sync PR merge report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: sync-pr-merge-report
           path: artifacts/sync-pr-merge-report.json

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -115,20 +115,39 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   const artifactSelectionWarning = artifactSelection &&
     artifactSelection.status !== 'pass' &&
     artifactSelection.status !== 'not-configured';
+  const selectedTerminalArtifactCount = artifactSelection?.selected_terminal_artifact_count || 0;
+  const terminalArtifactInputMismatch = selectedTerminalArtifactCount > 0 && inputFileCount === 0;
 
   let status = 'pass';
   if (terminalRecords.length === 0) {
-    status = parseErrors > 0 || nonTerminalRecordCount > 0 || artifactSelectionWarning
+    status = parseErrors > 0 ||
+      nonTerminalRecordCount > 0 ||
+      artifactSelectionWarning ||
+      terminalArtifactInputMismatch
       ? 'warning'
       : 'no-data';
   } else if (missing.length > 0 || parseErrors > 0 || artifactSelectionWarning) {
     status = 'warning';
   }
 
+  const enforcementBlockers = [];
+  if (terminalRecords.length === 0) enforcementBlockers.push('no-terminal-disposition-records');
+  if (terminalArtifactInputMismatch) {
+    enforcementBlockers.push('selected-terminal-artifacts-without-input-files');
+  }
+  if (missing.length > 0) enforcementBlockers.push('missing-review-thread-sources');
+  if (parseErrors > 0) enforcementBlockers.push('parse-errors');
+  if (artifactSelectionWarning) enforcementBlockers.push('artifact-selection-warning');
+
   return {
     schema: COVERAGE_SCHEMA,
     status,
     mode: 'warning-only',
+    enforcement: {
+      mode: 'warning-only',
+      hard_block_eligible: enforcementBlockers.length === 0,
+      blockers: enforcementBlockers,
+    },
     input_file_count: inputFileCount,
     input_files: inputFiles,
     scanned_record_count: scannedRecordCount,
@@ -139,6 +158,7 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
     covered_source_count: covered.length,
     missing_source_count: missing.length,
     parse_errors: parseErrors,
+    terminal_artifact_input_mismatch: terminalArtifactInputMismatch,
     artifact_selection: artifactSelection,
     observed_sources: observedSources,
     expected_sources: expected,
@@ -242,6 +262,12 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     if (selection.error_message) {
       lines.push(`- Artifact selector error: ${selection.error_message}`);
     }
+  }
+
+  if (report.terminal_artifact_input_mismatch) {
+    lines.push(
+      '- Terminal artifact input mismatch: selected terminal artifacts did not yield terminal NDJSON input files'
+    );
   }
 
   if (report.missing_sources.length > 0) {

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -22,6 +22,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
   'review-thread-terminal-disposition-',
 ];
 
+const PRIORITY_METRICS_FAMILIES = [
+  'verifier-terminal-disposition',
+  'review-thread-terminal-disposition',
+];
+
 function cleanString(value) {
   if (value === null || value === undefined) return '';
   return String(value).trim();
@@ -151,7 +156,29 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
 
   const familyCounts = new Map();
   const selected = [];
+  const selectedIds = new Set();
+
+  function selectArtifact(artifact) {
+    if (selected.length >= config.max_total) {
+      return false;
+    }
+    const familyCount = familyCounts.get(artifact.family) || 0;
+    if (familyCount >= config.max_per_family) {
+      return false;
+    }
+    selected.push(artifact);
+    selectedIds.add(String(artifact.id));
+    familyCounts.set(artifact.family, familyCount + 1);
+    return true;
+  }
+
+  for (const family of PRIORITY_METRICS_FAMILIES) {
+    const artifact = candidates.find((candidate) => candidate.family === family);
+    if (artifact) selectArtifact(artifact);
+  }
+
   for (const artifact of candidates) {
+    if (selectedIds.has(String(artifact.id))) continue;
     if (selected.length >= config.max_total) {
       stats.ignored_total_limit_count += 1;
       continue;
@@ -161,8 +188,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       stats.ignored_family_limit_count += 1;
       continue;
     }
-    selected.push(artifact);
-    familyCounts.set(artifact.family, familyCount + 1);
+    selectArtifact(artifact);
   }
 
   stats.selected_count = selected.length;
@@ -378,6 +404,7 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  PRIORITY_METRICS_FAMILIES,
   SELECTION_SCHEMA,
   artifactFamily,
   buildSelectionErrorReport,


### PR DESCRIPTION
## Summary
- reserve scarce terminal-disposition artifact families before weekly metrics fills the total artifact download cap
- add warning-only enforcement readiness details to terminal-disposition coverage reports
- warn when selected terminal artifacts do not produce terminal NDJSON input files
- update Maint 71 sync report upload to actions/upload-artifact@v7

## Validation
- node --test .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- node --test .github/scripts/__tests__/terminal-disposition-coverage.test.js
- node --test .github/scripts/__tests__/weekly-metrics-artifacts.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js .github/scripts/__tests__/sync-pr-merge-contract.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- YAML parse for agents-weekly-metrics.yml and maint-71-merge-sync-prs.yml
- node --check weekly_metrics_artifacts.js and terminal_disposition_coverage.js
- git diff --check