### PR TITLE
[codex] Fix token load balancer dependency resolution

### DIFF
--- a/.github/scripts/__tests__/github-api-with-retry.test.js
+++ b/.github/scripts/__tests__/github-api-with-retry.test.js
@@ -173,7 +173,7 @@ test('createTokenAwareRetry falls back when registry initialization fails', asyn
   const client = await createTokenAwareRetry({
     github,
     core,
-    env: {},
+    env: { GITHUB_TOKEN: 'github-token' },
     tokenRegistry,
   });
 
@@ -185,6 +185,38 @@ test('createTokenAwareRetry falls back when registry initialization fails', asyn
 
   const result = await client.withRetry(async () => ({ headers: {}, data: { ok: true } }));
   assert.equal(result.data.ok, true);
+});
+
+test('createTokenAwareRetry skips registry initialization when no token inputs exist', async () => {
+  const calls = [];
+  const tokenRegistry = {
+    async initializeTokenRegistry() {
+      calls.push('initialize');
+      throw new Error('should not initialize without tokens');
+    },
+    async getOptimalToken() {
+      calls.push('select');
+      throw new Error('should not select without tokens');
+    },
+    isInitialized() {
+      return false;
+    },
+  };
+
+  const github = { token: 'github-script-client' };
+  const warnings = [];
+  const client = await createTokenAwareRetry({
+    github,
+    core: { warning: (message) => warnings.push(String(message)) },
+    env: {},
+    tokenRegistry,
+  });
+
+  assert.equal(client.github, github);
+  assert.equal(client.tokenRegistry, null);
+  assert.equal(client.getTokenSource(), null);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(warnings, []);
 });
 
 test('createTokenAwareRetry falls back when token selection fails', async () => {

--- a/.github/scripts/__tests__/token-load-balancer-resolution.test.js
+++ b/.github/scripts/__tests__/token-load-balancer-resolution.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+test('refreshAllRateLimits resolves Octokit from NODE_PATH-installed action deps', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-load-balancer-node-path-'));
+  const nodePath = path.join(tempDir, 'node_modules');
+  const restDir = path.join(nodePath, '@octokit', 'rest');
+  fs.mkdirSync(restDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(restDir, 'package.json'),
+    JSON.stringify({ name: '@octokit/rest', main: 'index.js' }) + '\n'
+  );
+  fs.writeFileSync(
+    path.join(restDir, 'index.js'),
+    `
+class Octokit {
+  constructor(options) {
+    this.auth = options.auth;
+    this.rateLimit = {
+      get: async () => ({
+        data: {
+          resources: {
+            core: {
+              limit: 5000,
+              remaining: 4999,
+              used: 1,
+              reset: 2000000000
+            }
+          }
+        }
+      })
+    };
+  }
+}
+module.exports = { Octokit };
+`
+  );
+
+  const scriptPath = path.resolve(__dirname, '..', 'token_load_balancer.js');
+  const child = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `
+(async () => {
+  const balancer = require(process.argv[1]);
+  const errors = [];
+  balancer.tokenRegistry.tokens.clear();
+  balancer.tokenRegistry.lastRefresh = 0;
+  balancer.registerToken({
+    id: 'TEST_TOKEN',
+    token: 'token',
+    type: 'PAT',
+    source: 'TEST_TOKEN',
+    capabilities: ['read-repo'],
+    priority: 5
+  });
+  await balancer.refreshAllRateLimits({
+    core: {
+      error: (message) => errors.push(message),
+      warning: (message) => errors.push(message),
+      debug: () => {}
+    }
+  });
+  const rateLimit = balancer.tokenRegistry.tokens.get('TEST_TOKEN').rateLimit;
+  process.stdout.write(JSON.stringify({ errors, rateLimit }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`,
+      scriptPath,
+    ],
+    {
+      env: {
+        ...process.env,
+        NODE_PATH: nodePath,
+      },
+      encoding: 'utf8',
+    }
+  );
+
+  assert.equal(child.status, 0, child.stderr);
+  const result = JSON.parse(child.stdout);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.rateLimit.remaining, 4999);
+  assert.equal(result.rateLimit.importFailed, undefined);
+});

--- a/.github/scripts/github-api-with-retry.js
+++ b/.github/scripts/github-api-with-retry.js
@@ -516,13 +516,21 @@ async function createTokenAwareRetry(options = {}) {
   const registry = tokenRegistry || require('./token_load_balancer');
   const secrets = collectTokenSecrets(env || {});
   const resolvedGithubToken = githubToken || env?.GITHUB_TOKEN || env?.GH_TOKEN || '';
+  const hasTokenInputs =
+    Boolean(resolvedGithubToken) ||
+    Object.values(secrets).some((value) => Boolean(value));
 
   let registryInitialized = false;
   if (registry && typeof registry.isInitialized === 'function' && registry.isInitialized()) {
     registryInitialized = true;
   }
 
-  if (!registryInitialized && registry && typeof registry.initializeTokenRegistry === 'function') {
+  if (
+    hasTokenInputs &&
+    !registryInitialized &&
+    registry &&
+    typeof registry.initializeTokenRegistry === 'function'
+  ) {
     try {
       await registry.initializeTokenRegistry({
         secrets,

--- a/.github/scripts/token_load_balancer.js
+++ b/.github/scripts/token_load_balancer.js
@@ -20,6 +20,22 @@
  *   const token = await getOptimalToken({ github, core, capabilities: ['cross-repo'] });
  */
 
+function requireOrImport(moduleName) {
+  try {
+    return Promise.resolve(require(moduleName));
+  } catch (requireError) {
+    return import(moduleName).catch((importError) => {
+      const error = new Error(
+        `Unable to load ${moduleName}; require failed: ${requireError.message}; ` +
+        `import failed: ${importError.message}`
+      );
+      error.requireError = requireError;
+      error.importError = importError;
+      throw error;
+    });
+  }
+}
+
 // Token registry - tracks all available tokens and their metadata
 const tokenRegistry = {
   // Each entry: { token, type, source, capabilities, rateLimit: { limit, remaining, reset, checked } }
@@ -369,6 +385,11 @@ async function initializeTokenRegistry({ secrets, github, core, githubToken }) {
   }
   
   core?.info?.(`Token registry initialized with ${tokenRegistry.tokens.size} tokens`);
+
+  if (tokenRegistry.tokens.size === 0) {
+    core?.debug?.('Token registry has no token inputs; using provided GitHub client.');
+    return getRegistrySummary();
+  }
   
   // Initial rate limit check for all tokens
   await refreshAllRateLimits({ github, core });
@@ -410,16 +431,14 @@ async function refreshAllRateLimits({ github, core }) {
   // not token-specific.
   let Octokit = null;
   try {
-    ({ Octokit } = await import('@octokit/rest'));
+    ({ Octokit } = await requireOrImport('@octokit/rest'));
   } catch (importErr) {
-    // ESM import() resolves relative to file location — if node_modules
-    // is not co-located (e.g., workflows-lib checkout without symlink),
-    // the import fails.  All tokens get a conservative synthetic budget.
+    // All tokens get a conservative synthetic budget when Octokit is not
+    // resolvable from the action dependency layout.
     core?.error?.(
       `@octokit/rest import failed: ${importErr.message}. ` +
       `Token rotation is degraded — rate limit checks are skipped. ` +
-      `Ensure node_modules is symlinked to the scripts directory ` +
-      `(see setup-api-client install_dir or link step).`
+      `Ensure setup-api-client installs dependencies and exports NODE_PATH.`
     );
   }
   
@@ -531,8 +550,8 @@ async function checkTokenRateLimit({ tokenInfo, github, core, Octokit }) {
  */
 async function mintAppToken({ tokenInfo, core }) {
   try {
-    const { createAppAuth } = await import('@octokit/auth-app');
-    const { Octokit } = await import('@octokit/rest');
+    const { createAppAuth } = await requireOrImport('@octokit/auth-app');
+    const { Octokit } = await requireOrImport('@octokit/rest');
     
     const auth = createAppAuth({
       appId: tokenInfo.appId,
@@ -904,6 +923,7 @@ module.exports = {
   getBestAvailableToken,
   getTimeUntilReset,
   shouldDefer,
+  requireOrImport,
   TOKEN_CAPABILITIES,
   TOKEN_SPECIALIZATIONS,
   tokenRegistry, // Export for testing/debugging

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -207,10 +207,9 @@ jobs:
       - name: Link node_modules for Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'
         run: |
-          # ESM import() resolves relative to file location, not NODE_PATH.
-          # token_load_balancer.js uses 'await import("@octokit/rest")' which
-          # fails when scripts run from workflows-lib/ because node_modules
-          # was installed at $GITHUB_WORKSPACE/.github/scripts/ by setup-api-client.
+          # Keep a compatibility link for scripts loaded from workflows-lib/.
+          # token_load_balancer.js now honors NODE_PATH first, but this keeps
+          # older dynamic-import fallback paths resolvable.
           SRC="${GITHUB_WORKSPACE}/.github/scripts/node_modules"
           DST="${GITHUB_WORKSPACE}/workflows-lib/.github/scripts/node_modules"
           if [ -d "$SRC" ] && [ ! -d "$DST" ]; then

--- a/templates/consumer-repo/.github/scripts/github-api-with-retry.js
+++ b/templates/consumer-repo/.github/scripts/github-api-with-retry.js
@@ -516,13 +516,21 @@ async function createTokenAwareRetry(options = {}) {
   const registry = tokenRegistry || require('./token_load_balancer');
   const secrets = collectTokenSecrets(env || {});
   const resolvedGithubToken = githubToken || env?.GITHUB_TOKEN || env?.GH_TOKEN || '';
+  const hasTokenInputs =
+    Boolean(resolvedGithubToken) ||
+    Object.values(secrets).some((value) => Boolean(value));
 
   let registryInitialized = false;
   if (registry && typeof registry.isInitialized === 'function' && registry.isInitialized()) {
     registryInitialized = true;
   }
 
-  if (!registryInitialized && registry && typeof registry.initializeTokenRegistry === 'function') {
+  if (
+    hasTokenInputs &&
+    !registryInitialized &&
+    registry &&
+    typeof registry.initializeTokenRegistry === 'function'
+  ) {
     try {
       await registry.initializeTokenRegistry({
         secrets,

--- a/templates/consumer-repo/.github/scripts/token_load_balancer.js
+++ b/templates/consumer-repo/.github/scripts/token_load_balancer.js
@@ -20,6 +20,22 @@
  *   const token = await getOptimalToken({ github, core, capabilities: ['cross-repo'] });
  */
 
+function requireOrImport(moduleName) {
+  try {
+    return Promise.resolve(require(moduleName));
+  } catch (requireError) {
+    return import(moduleName).catch((importError) => {
+      const error = new Error(
+        `Unable to load ${moduleName}; require failed: ${requireError.message}; ` +
+        `import failed: ${importError.message}`
+      );
+      error.requireError = requireError;
+      error.importError = importError;
+      throw error;
+    });
+  }
+}
+
 // Token registry - tracks all available tokens and their metadata
 const tokenRegistry = {
   // Each entry: { token, type, source, capabilities, rateLimit: { limit, remaining, reset, checked } }
@@ -369,6 +385,11 @@ async function initializeTokenRegistry({ secrets, github, core, githubToken }) {
   }
   
   core?.info?.(`Token registry initialized with ${tokenRegistry.tokens.size} tokens`);
+
+  if (tokenRegistry.tokens.size === 0) {
+    core?.debug?.('Token registry has no token inputs; using provided GitHub client.');
+    return getRegistrySummary();
+  }
   
   // Initial rate limit check for all tokens
   await refreshAllRateLimits({ github, core });
@@ -410,16 +431,14 @@ async function refreshAllRateLimits({ github, core }) {
   // not token-specific.
   let Octokit = null;
   try {
-    ({ Octokit } = await import('@octokit/rest'));
+    ({ Octokit } = await requireOrImport('@octokit/rest'));
   } catch (importErr) {
-    // ESM import() resolves relative to file location — if node_modules
-    // is not co-located (e.g., workflows-lib checkout without symlink),
-    // the import fails.  All tokens get a conservative synthetic budget.
+    // All tokens get a conservative synthetic budget when Octokit is not
+    // resolvable from the action dependency layout.
     core?.error?.(
       `@octokit/rest import failed: ${importErr.message}. ` +
       `Token rotation is degraded — rate limit checks are skipped. ` +
-      `Ensure node_modules is symlinked to the scripts directory ` +
-      `(see setup-api-client install_dir or link step).`
+      `Ensure setup-api-client installs dependencies and exports NODE_PATH.`
     );
   }
   
@@ -531,8 +550,8 @@ async function checkTokenRateLimit({ tokenInfo, github, core, Octokit }) {
  */
 async function mintAppToken({ tokenInfo, core }) {
   try {
-    const { createAppAuth } = await import('@octokit/auth-app');
-    const { Octokit } = await import('@octokit/rest');
+    const { createAppAuth } = await requireOrImport('@octokit/auth-app');
+    const { Octokit } = await requireOrImport('@octokit/rest');
     
     const auth = createAppAuth({
       appId: tokenInfo.appId,
@@ -904,6 +923,7 @@ module.exports = {
   getBestAvailableToken,
   getTimeUntilReset,
   shouldDefer,
+  requireOrImport,
   TOKEN_CAPABILITIES,
   TOKEN_SPECIALIZATIONS,
   tokenRegistry, // Export for testing/debugging

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -207,10 +207,9 @@ jobs:
       - name: Link node_modules for Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'
         run: |
-          # ESM import() resolves relative to file location, not NODE_PATH.
-          # token_load_balancer.js uses 'await import("@octokit/rest")' which
-          # fails when scripts run from workflows-lib/ because node_modules
-          # was installed at $GITHUB_WORKSPACE/.github/scripts/ by setup-api-client.
+          # Keep a compatibility link for scripts loaded from workflows-lib/.
+          # token_load_balancer.js now honors NODE_PATH first, but this keeps
+          # older dynamic-import fallback paths resolvable.
           SRC="${GITHUB_WORKSPACE}/.github/scripts/node_modules"
           DST="${GITHUB_WORKSPACE}/workflows-lib/.github/scripts/node_modules"
           if [ -d "$SRC" ] && [ ! -d "$DST" ]; then


### PR DESCRIPTION
## Summary
- resolve Octokit dependencies through CommonJS require first so setup-api-client NODE_PATH installs are honored
- keep dynamic import as fallback and update the consumer template copy
- add a regression test that simulates NODE_PATH-installed action dependencies

## Verification
- node --test .github/scripts/__tests__/*.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- node --check .github/scripts/token_load_balancer.js
- node --check templates/consumer-repo/.github/scripts/token_load_balancer.js
- YAML parse for .github/workflows/agents-auto-pilot.yml and template copy
- git diff --check