### PR TITLE
[codex] Fix bot comment manual probe follow-through

### DIFF
--- a/.github/scripts/__tests__/bot-comment-dismiss.test.js
+++ b/.github/scripts/__tests__/bot-comment-dismiss.test.js
@@ -2,6 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const Module = require('node:module');
 
 const {
   autoDismissReviewComments,
@@ -12,6 +13,38 @@ const {
 } = require('../bot-comment-dismiss');
 
 describe('bot-comment-dismiss', () => {
+  it('falls back when minimatch is unavailable in sparse workflow checkouts', () => {
+    const scriptPath = require.resolve('../bot-comment-dismiss');
+    const cached = require.cache[scriptPath];
+    const originalLoad = Module._load;
+    delete require.cache[scriptPath];
+    Module._load = function patchedLoad(request, parent, isMain) {
+      if (request === 'minimatch') {
+        throw new Error('Cannot find module minimatch');
+      }
+      return originalLoad.call(this, request, parent, isMain);
+    };
+    try {
+      const isolated = require('../bot-comment-dismiss');
+      assert.deepStrictEqual(
+        isolated.collectDismissable(
+          [{ id: 1, path: '.agents/issue-1-ledger.yml', user: { login: 'copilot[bot]' } }],
+          {
+            ignoredPaths: ['.agents/'],
+            botAuthors: ['copilot[bot]'],
+          }
+        ),
+        [{ id: 1, path: '.agents/issue-1-ledger.yml', author: 'copilot[bot]' }]
+      );
+    } finally {
+      Module._load = originalLoad;
+      delete require.cache[scriptPath];
+      if (cached) {
+        require.cache[scriptPath] = cached;
+      }
+    }
+  });
+
   it('collects bot comments in ignored paths', () => {
     const comments = [
       { id: 1, path: '.agents/issue-1-ledger.yml', user: { login: 'copilot[bot]' } },

--- a/.github/scripts/bot-comment-dismiss.js
+++ b/.github/scripts/bot-comment-dismiss.js
@@ -15,10 +15,46 @@
  *   await autoDismissReviewComments({ github, withRetry, ... });
  */
 
-const { minimatch } = require('minimatch');
+let minimatch;
+try {
+  ({ minimatch } = require('minimatch'));
+} catch (_) {
+  minimatch = fallbackMinimatch;
+}
 
 const DEFAULT_IGNORED_PATTERNS = ['.agents/**'];
 const DEFAULT_MAX_AGE_SECONDS = 30;
+
+function escapeRegExp(value) {
+  return String(value).replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function fallbackGlobToRegExp(pattern) {
+  let expression = '^';
+  const text = String(pattern || '');
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (char === '*') {
+      if (next === '*') {
+        expression += '.*';
+        index += 1;
+      } else {
+        expression += '[^/]*';
+      }
+    } else if (char === '?') {
+      expression += '[^/]';
+    } else {
+      expression += escapeRegExp(char);
+    }
+  }
+  expression += '$';
+  return new RegExp(expression);
+}
+
+function fallbackMinimatch(filename, pattern) {
+  return fallbackGlobToRegExp(pattern).test(filename);
+}
 
 function parseCsv(value) {
   if (!value) {

--- a/.github/workflows/reusable-bot-comment-handler.yml
+++ b/.github/workflows/reusable-bot-comment-handler.yml
@@ -93,8 +93,11 @@ on:
       service_bot_pat:
         description: 'PAT for service bot (comments, labels)'
         required: false
+      gh_app_client_id:
+        description: 'GitHub App client ID for authentication'
+        required: false
       gh_app_id:
-        description: 'GitHub App ID for authentication'
+        description: 'Legacy GitHub App ID for authentication'
         required: false
       gh_app_private_key:
         description: 'GitHub App private key'
@@ -121,10 +124,37 @@ jobs:
       agent: ${{ steps.agent.outputs.agent }}
       agent_workflow: ${{ steps.agent.outputs.workflow }}
     steps:
-      - name: Generate token (if App configured)
-        id: token
-        uses: actions/create-github-app-token@v3
+      - name: Detect App credentials
+        id: app-creds
+        env:
+          GH_APP_CLIENT_ID: ${{ secrets.gh_app_client_id }}
+          GH_APP_ID: ${{ secrets.gh_app_id }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.gh_app_private_key }}
+        run: |
+          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=true" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+          fi
 
+      - name: Generate token (if App client ID configured)
+        id: token-client
+        if: steps.app-creds.outputs.use_client == 'true'
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          client-id: ${{ secrets.gh_app_client_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+
+      - name: Generate token (if legacy App ID configured)
+        id: token-legacy
+        if: steps.app-creds.outputs.use_legacy == 'true'
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.gh_app_id }}
@@ -133,7 +163,7 @@ jobs:
       - name: Resolve token
         id: auth
         env:
-          TOKEN_OUTPUT: ${{ steps.token.outputs.token }}
+          TOKEN_OUTPUT: ${{ steps.token-client.outputs.token || steps.token-legacy.outputs.token }}
           SERVICE_PAT: ${{ secrets.service_bot_pat }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -557,8 +587,36 @@ jobs:
     outputs:
       triggered: ${{ steps.dispatch.outputs.triggered }}
     steps:
-      - name: Generate token (if App configured)
-        id: token
+      - name: Detect App credentials
+        id: app-creds
+        env:
+          GH_APP_CLIENT_ID: ${{ secrets.gh_app_client_id }}
+          GH_APP_ID: ${{ secrets.gh_app_id }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.gh_app_private_key }}
+        run: |
+          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=true" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate token (if App client ID configured)
+        id: token-client
+        if: steps.app-creds.outputs.use_client == 'true'
+        uses: actions/create-github-app-token@v3
+        continue-on-error: true
+        with:
+          client-id: ${{ secrets.gh_app_client_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+
+      - name: Generate token (if legacy App ID configured)
+        id: token-legacy
+        if: steps.app-creds.outputs.use_legacy == 'true'
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
@@ -568,7 +626,7 @@ jobs:
       - name: Resolve token
         id: auth
         env:
-          TOKEN_OUTPUT: ${{ steps.token.outputs.token }}
+          TOKEN_OUTPUT: ${{ steps.token-client.outputs.token || steps.token-legacy.outputs.token }}
           SERVICE_PAT: ${{ secrets.service_bot_pat }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/templates/consumer-repo/.github/scripts/bot-comment-dismiss.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-dismiss.js
@@ -15,10 +15,46 @@
  *   await autoDismissReviewComments({ github, withRetry, ... });
  */
 
-const { minimatch } = require('minimatch');
+let minimatch;
+try {
+  ({ minimatch } = require('minimatch'));
+} catch (_) {
+  minimatch = fallbackMinimatch;
+}
 
 const DEFAULT_IGNORED_PATTERNS = ['.agents/**'];
 const DEFAULT_MAX_AGE_SECONDS = 30;
+
+function escapeRegExp(value) {
+  return String(value).replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function fallbackGlobToRegExp(pattern) {
+  let expression = '^';
+  const text = String(pattern || '');
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (char === '*') {
+      if (next === '*') {
+        expression += '.*';
+        index += 1;
+      } else {
+        expression += '[^/]*';
+      }
+    } else if (char === '?') {
+      expression += '[^/]';
+    } else {
+      expression += escapeRegExp(char);
+    }
+  }
+  expression += '$';
+  return new RegExp(expression);
+}
+
+function fallbackMinimatch(filename, pattern) {
+  return fallbackGlobToRegExp(pattern).test(filename);
+}
 
 function parseCsv(value) {
   if (!value) {

--- a/tests/workflows/test_bot_comment_handler.py
+++ b/tests/workflows/test_bot_comment_handler.py
@@ -63,6 +63,39 @@ def test_reusable_bot_comment_handler_uploads_terminal_disposition_artifact() ->
     assert upload_with.get("retention-days") == 14
 
 
+def test_reusable_bot_comment_handler_prefers_app_client_id() -> None:
+    workflow = _load_yaml(ROOT / ".github/workflows/reusable-bot-comment-handler.yml")
+    workflow_call_secrets = (workflow.get("on") or workflow.get(True))["workflow_call"]["secrets"]
+    collect_steps = workflow["jobs"]["collect"]["steps"]
+    detect_step = next(
+        step for step in collect_steps if step.get("name") == "Detect App credentials"
+    )
+    client_step = next(
+        step
+        for step in collect_steps
+        if step.get("name") == "Generate token (if App client ID configured)"
+    )
+    legacy_step = next(
+        step
+        for step in collect_steps
+        if step.get("name") == "Generate token (if legacy App ID configured)"
+    )
+    resolve_step = next(step for step in collect_steps if step.get("name") == "Resolve token")
+
+    assert "gh_app_client_id" in workflow_call_secrets
+    assert detect_step["env"]["GH_APP_CLIENT_ID"] == "${{ secrets.gh_app_client_id }}"
+    assert detect_step["env"]["GH_APP_PRIVATE_KEY"] == "${{ secrets.gh_app_private_key }}"
+    assert client_step.get("if") == "steps.app-creds.outputs.use_client == 'true'"
+    assert "client-id" in client_step.get("with", {})
+    assert "app-id" not in client_step.get("with", {})
+    assert legacy_step.get("if") == "steps.app-creds.outputs.use_legacy == 'true'"
+    assert "app-id" in legacy_step.get("with", {})
+    assert (
+        "steps.token-client.outputs.token || steps.token-legacy.outputs.token"
+        in resolve_step["env"]["TOKEN_OUTPUT"]
+    )
+
+
 def test_template_bot_comment_handler_passes_agents_ignore() -> None:
     workflow = _load_yaml(
         ROOT / "templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml"


### PR DESCRIPTION
## Summary
- make bot-comment-dismiss work in sparse workflow checkouts without minimatch installed
- skip empty GitHub App token generation for manual probes, prefer client-id when configured, and keep legacy app-id as fallback
- add tests for the fallback loader and token selection contract

## Verification
- node --test .github/scripts/__tests__/bot-comment-dismiss.test.js .github/scripts/__tests__/terminal-disposition.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- python -m pytest tests/workflows/test_bot_comment_handler.py tests/workflows/test_workflow_agents_consolidation.py -q
- black --check --line-length 100 tests/workflows/test_bot_comment_handler.py
- YAML parse for .github/workflows/reusable-bot-comment-handler.yml
- git diff --check