### PR TITLE
Gate terminal coverage hard-block policy

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -9,6 +9,7 @@ const {
   expectedReviewThreadSources,
   formatTerminalDispositionCoverageMarkdown,
   isTerminalDispositionNdjsonFile,
+  normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
   normalizeExpectedSource,
   readArtifactSelectionReport,
@@ -88,8 +89,13 @@ test('reports missing review-thread coverage without failing the contract', () =
   assert.equal(report.status, 'warning');
   assert.deepEqual(report.enforcement, {
     mode: 'warning-only',
+    requested_mode: 'warning-only',
+    hard_block_approved: false,
     hard_block_eligible: false,
+    hard_block_active: false,
+    should_fail: false,
     blockers: ['missing-review-thread-sources'],
+    policy_blockers: [],
   });
   assert.equal(report.scanned_record_count, 3);
   assert.equal(report.terminal_record_count, 3);
@@ -101,6 +107,79 @@ test('reports missing review-thread coverage without failing the contract', () =
     report.missing_sources.map((source) => source.source_key),
     ['review-thread:102']
   );
+});
+
+test('keeps hard blocking disabled without explicit approval', () => {
+  const report = summarizeTerminalDispositionCoverage([], {
+    enforcement_mode: 'hard-block',
+  });
+
+  assert.equal(report.status, 'no-data');
+  assert.equal(report.mode, 'warning-only');
+  assert.equal(report.requested_mode, 'hard-block');
+  assert.equal(report.enforcement.hard_block_active, false);
+  assert.equal(report.enforcement.should_fail, false);
+  assert.deepEqual(report.enforcement.policy_blockers, ['hard-block-approval-required']);
+});
+
+test('fails only when hard blocking is requested and approved', () => {
+  const report = summarizeTerminalDispositionCoverage([], {
+    enforcement_mode: 'hard-block',
+    hard_block_approved: 'approved',
+  });
+  const markdown = formatTerminalDispositionCoverageMarkdown(report);
+
+  assert.equal(report.status, 'fail');
+  assert.equal(report.coverage_status, 'no-data');
+  assert.equal(report.mode, 'hard-block');
+  assert.equal(report.enforcement.hard_block_active, true);
+  assert.equal(report.enforcement.should_fail, true);
+  assert.match(markdown, /Mode: hard-block/);
+  assert.match(markdown, /Hard block active: true/);
+});
+
+test('passes approved hard blocking when coverage has no blockers', () => {
+  const report = summarizeTerminalDispositionCoverage(
+    [
+      {
+        schema: 'workflows-terminal-disposition/v1',
+        source_type: 'source-issue',
+        source_id: '7',
+        pr_number: 101,
+        disposition: 'follow-up-created',
+      },
+      {
+        schema: 'workflows-terminal-disposition/v1',
+        source_type: 'review-thread',
+        source_id: '101',
+        pr_number: 101,
+        disposition: 'no-unresolved-bot-comments',
+      },
+    ],
+    {
+      enforcement_mode: 'hard-block',
+      hard_block_approved: true,
+    }
+  );
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.mode, 'hard-block');
+  assert.equal(report.enforcement.hard_block_eligible, true);
+  assert.equal(report.enforcement.should_fail, false);
+});
+
+test('normalizes the terminal coverage enforcement policy', () => {
+  assert.deepEqual(normalizeEnforcementPolicy({ mode: 'enforce', hard_block_approved: 'yes' }), {
+    schema: 'workflows-terminal-disposition-enforcement-policy/v1',
+    requested_mode: 'hard-block',
+    effective_mode: 'hard-block',
+    default_mode: 'warning-only',
+    hard_block_approved: true,
+    policy_blockers: [],
+  });
+  assert.deepEqual(normalizeEnforcementPolicy({ mode: 'hard-block' }).policy_blockers, [
+    'hard-block-approval-required',
+  ]);
 });
 
 test('formats markdown for observed and missing sources', () => {

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -12,6 +12,8 @@ const TERMINAL_ARTIFACT_FAMILIES = new Set([
   'verifier-terminal-disposition',
   'review-thread-terminal-disposition',
 ]);
+const DEFAULT_ENFORCEMENT_MODE = 'warning-only';
+const HARD_BLOCK_MODE = 'hard-block';
 
 function cleanString(value) {
   if (value === null || value === undefined) return '';
@@ -23,6 +25,49 @@ function cleanInt(value) {
   if (!text) return null;
   const parsed = Number.parseInt(text, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeBoolean(value) {
+  const text = cleanString(value).toLowerCase();
+  return ['1', 'true', 'yes', 'y', 'approved', 'approve', 'on'].includes(text);
+}
+
+function normalizeEnforcementMode(value) {
+  const text = cleanString(value).toLowerCase();
+  if (['hard-block', 'hard_block', 'hard', 'block', 'blocking', 'enforce'].includes(text)) {
+    return HARD_BLOCK_MODE;
+  }
+  return DEFAULT_ENFORCEMENT_MODE;
+}
+
+function normalizeEnforcementPolicy(options = {}) {
+  const requestedMode = normalizeEnforcementMode(
+    options.mode ??
+      options.enforcement_mode ??
+      options.enforcementMode ??
+      process.env.TERMINAL_DISPOSITION_COVERAGE_MODE
+  );
+  const hardBlockApproved = normalizeBoolean(
+    options.hard_block_approved ??
+      options.hardBlockApproved ??
+      process.env.TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED
+  );
+  const policyBlockers = [];
+  let effectiveMode = requestedMode;
+
+  if (requestedMode === HARD_BLOCK_MODE && !hardBlockApproved) {
+    effectiveMode = DEFAULT_ENFORCEMENT_MODE;
+    policyBlockers.push('hard-block-approval-required');
+  }
+
+  return {
+    schema: 'workflows-terminal-disposition-enforcement-policy/v1',
+    requested_mode: requestedMode,
+    effective_mode: effectiveMode,
+    default_mode: DEFAULT_ENFORCEMENT_MODE,
+    hard_block_approved: hardBlockApproved,
+    policy_blockers: policyBlockers,
+  };
 }
 
 function normalizeExpectedSource(input = {}) {
@@ -64,6 +109,9 @@ function expectedReviewThreadSources(records = []) {
 }
 
 function summarizeTerminalDispositionCoverage(records = [], options = {}) {
+  const policy = normalizeEnforcementPolicy(
+    options.enforcement_policy ?? options.enforcementPolicy ?? options
+  );
   const parseErrors = Number(options.parse_errors || options.parseErrors || 0);
   const artifactSelection = normalizeArtifactSelectionSummary(
     options.artifact_selection_report ?? options.artifactSelectionReport
@@ -139,14 +187,27 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   if (parseErrors > 0) enforcementBlockers.push('parse-errors');
   if (artifactSelectionWarning) enforcementBlockers.push('artifact-selection-warning');
 
+  const hardBlockEligible = enforcementBlockers.length === 0;
+  const hardBlockActive = policy.effective_mode === HARD_BLOCK_MODE;
+  const shouldFail = hardBlockActive && status !== 'pass';
+  const finalStatus = shouldFail ? 'fail' : status;
+
   return {
     schema: COVERAGE_SCHEMA,
-    status,
-    mode: 'warning-only',
+    status: finalStatus,
+    coverage_status: status,
+    mode: policy.effective_mode,
+    requested_mode: policy.requested_mode,
+    policy,
     enforcement: {
-      mode: 'warning-only',
-      hard_block_eligible: enforcementBlockers.length === 0,
+      mode: policy.effective_mode,
+      requested_mode: policy.requested_mode,
+      hard_block_approved: policy.hard_block_approved,
+      hard_block_eligible: hardBlockEligible,
+      hard_block_active: hardBlockActive,
+      should_fail: shouldFail,
       blockers: enforcementBlockers,
+      policy_blockers: policy.policy_blockers,
     },
     input_file_count: inputFileCount,
     input_files: inputFiles,
@@ -240,8 +301,14 @@ function formatTerminalDispositionCoverageMarkdown(report) {
   const lines = [
     '## Terminal Disposition Coverage Preflight',
     '',
-    '- Mode: warning-only (does not block merges or automation)',
+    report.enforcement?.hard_block_active
+      ? '- Mode: hard-block (approved terminal coverage enforcement)'
+      : '- Mode: warning-only (does not block merges or automation)',
+    `- Requested mode: ${report.requested_mode || report.enforcement?.requested_mode || report.mode || DEFAULT_ENFORCEMENT_MODE}`,
     `- Status: ${report.status}`,
+    `- Coverage status: ${report.coverage_status || report.status}`,
+    `- Hard block eligible: ${report.enforcement?.hard_block_eligible ? 'true' : 'false'}`,
+    `- Hard block active: ${report.enforcement?.hard_block_active ? 'true' : 'false'}`,
     `- Input files: ${report.input_file_count || 0}`,
     `- Scanned records: ${report.scanned_record_count || 0}`,
     `- Terminal disposition records: ${report.terminal_record_count}`,
@@ -268,6 +335,11 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     lines.push(
       '- Terminal artifact input mismatch: selected terminal artifacts did not yield terminal NDJSON input files'
     );
+  }
+
+  const policyBlockers = report.enforcement?.policy_blockers || [];
+  if (policyBlockers.length > 0) {
+    lines.push(`- Policy blockers: ${policyBlockers.join(', ')}`);
   }
 
   if (report.missing_sources.length > 0) {
@@ -387,6 +459,12 @@ function parseArgs(argv = process.argv.slice(2)) {
     } else if (arg === '--artifact-selection-json') {
       options.artifact_selection_json = next;
       index += 1;
+    } else if (arg === '--mode') {
+      options.enforcement_mode = next;
+      index += 1;
+    } else if (arg === '--hard-block-approved') {
+      options.hard_block_approved = next;
+      index += 1;
     }
   }
 
@@ -440,11 +518,16 @@ function main() {
     artifact_selection_report: artifactSelectionReport,
     input_file_count: inputFileCount,
     input_files: inputFiles,
+    enforcement_mode: options.enforcement_mode,
+    hard_block_approved: options.hard_block_approved,
   });
   const markdown = formatTerminalDispositionCoverageMarkdown(report);
   fs.writeFileSync(options.output_json, `${JSON.stringify(report, null, 2)}\n`);
   fs.writeFileSync(options.output_md, markdown);
   process.stdout.write(markdown);
+  if (report.enforcement.should_fail) {
+    process.exitCode = 1;
+  }
 }
 
 if (require.main === module) {
@@ -458,6 +541,8 @@ module.exports = {
   formatTerminalDispositionCoverageMarkdown,
   isTerminalDispositionNdjsonFile,
   normalizeExpectedSource,
+  normalizeEnforcementMode,
+  normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
   readNdjsonFiles,
   readArtifactSelectionReport,

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -157,7 +157,7 @@ jobs:
               } >> agent-weekly-metrics.md
             fi
           fi
-          exit "$terminal_coverage_status"
+          echo "TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS=${terminal_coverage_status}" >> "$GITHUB_ENV"
 
       - name: Upload weekly summary
         if: ${{ always() }}
@@ -221,3 +221,7 @@ jobs:
             }
 
             core.setOutput('issue_number', target.number);
+
+      - name: Honor terminal coverage hard-block
+        if: ${{ always() }}
+        run: exit "${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -141,8 +141,13 @@ jobs:
           TERMINAL_DISPOSITION_ARTIFACT_SELECTION_JSON: artifacts/metric-artifacts-selection.json
           TERMINAL_DISPOSITION_COVERAGE_JSON: terminal-disposition-coverage.json
           TERMINAL_DISPOSITION_COVERAGE_MD: terminal-disposition-coverage.md
+          TERMINAL_DISPOSITION_COVERAGE_MODE: ${{ vars.TERMINAL_DISPOSITION_COVERAGE_MODE || 'warning-only' }}
+          TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED: ${{ vars.TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED || 'false' }}
         run: |
+          set +e
           node .github/scripts/terminal_disposition_coverage.js
+          terminal_coverage_status=$?
+          set -e
           if [ -f terminal-disposition-coverage.md ]; then
             cat terminal-disposition-coverage.md >> "$GITHUB_STEP_SUMMARY"
             if [ -f agent-weekly-metrics.md ]; then
@@ -152,6 +157,7 @@ jobs:
               } >> agent-weekly-metrics.md
             fi
           fi
+          exit "$terminal_coverage_status"
 
       - name: Upload weekly summary
         if: ${{ always() }}

--- a/docs/keepalive/Observability_Contract.md
+++ b/docs/keepalive/Observability_Contract.md
@@ -95,17 +95,19 @@ SYNC: action=<update-branch|create-pr|escalate|skip> head_changed=<true|false> t
 
 ## 6A) Terminal Disposition Coverage Preflight
 
-Weekly metrics MUST run a warning-only `workflows-terminal-disposition-coverage/v1`
-preflight after downloading agent metrics artifacts. The preflight consumes
+Weekly metrics MUST run a `workflows-terminal-disposition-coverage/v1` preflight
+after downloading agent metrics artifacts. The preflight consumes
 `workflows-terminal-disposition/v1` records from verifier and review-thread
 handlers and writes both JSON and Markdown reports into the weekly metrics
 artifact.
 
-The preflight is deliberately non-blocking. Missing `review-thread:<PR>` source
-coverage is reported as `status=warning`, not as a failed check, because local
-automation remains optional and direct remote/manual work must stay valid. This
-gives operators enough data to decide whether a future review-thread hard block
-would be reliable before any blocking policy is enabled.
+The preflight defaults to `mode=warning-only` and is deliberately non-blocking.
+Missing `review-thread:<PR>` source coverage is reported as `status=warning`,
+not as a failed check, because local automation remains optional and direct
+remote/manual work must stay valid. Hard blocking is only valid when the
+machine-readable enforcement policy records `requested_mode=hard-block`,
+`hard_block_approved=true`, and no policy blocker such as
+`hard-block-approval-required`.
 
 Weekly metrics SHOULD pass the machine-readable
 `workflows-weekly-metrics-artifact-selection/v1` selector report into the
@@ -116,7 +118,15 @@ failure, download failure, or a real absence of terminal artifacts.
 Required report fields:
 
 - `schema=workflows-terminal-disposition-coverage/v1`
-- `mode=warning-only`
+- `mode` / `enforcement.mode`: `warning-only` by default; `hard-block` only
+  when explicitly approved
+- `coverage_status`: the observed terminal coverage result before enforcement
+- `enforcement.requested_mode`
+- `enforcement.hard_block_approved`
+- `enforcement.hard_block_active`
+- `enforcement.should_fail`
+- `enforcement.policy_blockers[]`
+- `policy.schema=workflows-terminal-disposition-enforcement-policy/v1`
 - `terminal_record_count`
 - `expected_source_count`
 - `covered_source_count`

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -12,6 +12,8 @@ const TERMINAL_ARTIFACT_FAMILIES = new Set([
   'verifier-terminal-disposition',
   'review-thread-terminal-disposition',
 ]);
+const DEFAULT_ENFORCEMENT_MODE = 'warning-only';
+const HARD_BLOCK_MODE = 'hard-block';
 
 function cleanString(value) {
   if (value === null || value === undefined) return '';
@@ -23,6 +25,49 @@ function cleanInt(value) {
   if (!text) return null;
   const parsed = Number.parseInt(text, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeBoolean(value) {
+  const text = cleanString(value).toLowerCase();
+  return ['1', 'true', 'yes', 'y', 'approved', 'approve', 'on'].includes(text);
+}
+
+function normalizeEnforcementMode(value) {
+  const text = cleanString(value).toLowerCase();
+  if (['hard-block', 'hard_block', 'hard', 'block', 'blocking', 'enforce'].includes(text)) {
+    return HARD_BLOCK_MODE;
+  }
+  return DEFAULT_ENFORCEMENT_MODE;
+}
+
+function normalizeEnforcementPolicy(options = {}) {
+  const requestedMode = normalizeEnforcementMode(
+    options.mode ??
+      options.enforcement_mode ??
+      options.enforcementMode ??
+      process.env.TERMINAL_DISPOSITION_COVERAGE_MODE
+  );
+  const hardBlockApproved = normalizeBoolean(
+    options.hard_block_approved ??
+      options.hardBlockApproved ??
+      process.env.TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED
+  );
+  const policyBlockers = [];
+  let effectiveMode = requestedMode;
+
+  if (requestedMode === HARD_BLOCK_MODE && !hardBlockApproved) {
+    effectiveMode = DEFAULT_ENFORCEMENT_MODE;
+    policyBlockers.push('hard-block-approval-required');
+  }
+
+  return {
+    schema: 'workflows-terminal-disposition-enforcement-policy/v1',
+    requested_mode: requestedMode,
+    effective_mode: effectiveMode,
+    default_mode: DEFAULT_ENFORCEMENT_MODE,
+    hard_block_approved: hardBlockApproved,
+    policy_blockers: policyBlockers,
+  };
 }
 
 function normalizeExpectedSource(input = {}) {
@@ -64,6 +109,9 @@ function expectedReviewThreadSources(records = []) {
 }
 
 function summarizeTerminalDispositionCoverage(records = [], options = {}) {
+  const policy = normalizeEnforcementPolicy(
+    options.enforcement_policy ?? options.enforcementPolicy ?? options
+  );
   const parseErrors = Number(options.parse_errors || options.parseErrors || 0);
   const artifactSelection = normalizeArtifactSelectionSummary(
     options.artifact_selection_report ?? options.artifactSelectionReport
@@ -139,14 +187,27 @@ function summarizeTerminalDispositionCoverage(records = [], options = {}) {
   if (parseErrors > 0) enforcementBlockers.push('parse-errors');
   if (artifactSelectionWarning) enforcementBlockers.push('artifact-selection-warning');
 
+  const hardBlockEligible = enforcementBlockers.length === 0;
+  const hardBlockActive = policy.effective_mode === HARD_BLOCK_MODE;
+  const shouldFail = hardBlockActive && status !== 'pass';
+  const finalStatus = shouldFail ? 'fail' : status;
+
   return {
     schema: COVERAGE_SCHEMA,
-    status,
-    mode: 'warning-only',
+    status: finalStatus,
+    coverage_status: status,
+    mode: policy.effective_mode,
+    requested_mode: policy.requested_mode,
+    policy,
     enforcement: {
-      mode: 'warning-only',
-      hard_block_eligible: enforcementBlockers.length === 0,
+      mode: policy.effective_mode,
+      requested_mode: policy.requested_mode,
+      hard_block_approved: policy.hard_block_approved,
+      hard_block_eligible: hardBlockEligible,
+      hard_block_active: hardBlockActive,
+      should_fail: shouldFail,
       blockers: enforcementBlockers,
+      policy_blockers: policy.policy_blockers,
     },
     input_file_count: inputFileCount,
     input_files: inputFiles,
@@ -240,8 +301,14 @@ function formatTerminalDispositionCoverageMarkdown(report) {
   const lines = [
     '## Terminal Disposition Coverage Preflight',
     '',
-    '- Mode: warning-only (does not block merges or automation)',
+    report.enforcement?.hard_block_active
+      ? '- Mode: hard-block (approved terminal coverage enforcement)'
+      : '- Mode: warning-only (does not block merges or automation)',
+    `- Requested mode: ${report.requested_mode || report.enforcement?.requested_mode || report.mode || DEFAULT_ENFORCEMENT_MODE}`,
     `- Status: ${report.status}`,
+    `- Coverage status: ${report.coverage_status || report.status}`,
+    `- Hard block eligible: ${report.enforcement?.hard_block_eligible ? 'true' : 'false'}`,
+    `- Hard block active: ${report.enforcement?.hard_block_active ? 'true' : 'false'}`,
     `- Input files: ${report.input_file_count || 0}`,
     `- Scanned records: ${report.scanned_record_count || 0}`,
     `- Terminal disposition records: ${report.terminal_record_count}`,
@@ -268,6 +335,11 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     lines.push(
       '- Terminal artifact input mismatch: selected terminal artifacts did not yield terminal NDJSON input files'
     );
+  }
+
+  const policyBlockers = report.enforcement?.policy_blockers || [];
+  if (policyBlockers.length > 0) {
+    lines.push(`- Policy blockers: ${policyBlockers.join(', ')}`);
   }
 
   if (report.missing_sources.length > 0) {
@@ -387,6 +459,12 @@ function parseArgs(argv = process.argv.slice(2)) {
     } else if (arg === '--artifact-selection-json') {
       options.artifact_selection_json = next;
       index += 1;
+    } else if (arg === '--mode') {
+      options.enforcement_mode = next;
+      index += 1;
+    } else if (arg === '--hard-block-approved') {
+      options.hard_block_approved = next;
+      index += 1;
     }
   }
 
@@ -440,11 +518,16 @@ function main() {
     artifact_selection_report: artifactSelectionReport,
     input_file_count: inputFileCount,
     input_files: inputFiles,
+    enforcement_mode: options.enforcement_mode,
+    hard_block_approved: options.hard_block_approved,
   });
   const markdown = formatTerminalDispositionCoverageMarkdown(report);
   fs.writeFileSync(options.output_json, `${JSON.stringify(report, null, 2)}\n`);
   fs.writeFileSync(options.output_md, markdown);
   process.stdout.write(markdown);
+  if (report.enforcement.should_fail) {
+    process.exitCode = 1;
+  }
 }
 
 if (require.main === module) {
@@ -458,6 +541,8 @@ module.exports = {
   formatTerminalDispositionCoverageMarkdown,
   isTerminalDispositionNdjsonFile,
   normalizeExpectedSource,
+  normalizeEnforcementMode,
+  normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
   readNdjsonFiles,
   readArtifactSelectionReport,

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -169,7 +169,7 @@ jobs:
               } >> agent-weekly-metrics.md
             fi
           fi
-          exit "$terminal_coverage_status"
+          echo "TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS=${terminal_coverage_status}" >> "$GITHUB_ENV"
 
       - name: Upload weekly summary
         if: ${{ always() }}
@@ -233,3 +233,7 @@ jobs:
             }
 
             core.setOutput('issue_number', target.number);
+
+      - name: Honor terminal coverage hard-block
+        if: ${{ always() }}
+        run: exit "${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -153,8 +153,13 @@ jobs:
           TERMINAL_DISPOSITION_ARTIFACT_SELECTION_JSON: artifacts/metric-artifacts-selection.json
           TERMINAL_DISPOSITION_COVERAGE_JSON: terminal-disposition-coverage.json
           TERMINAL_DISPOSITION_COVERAGE_MD: terminal-disposition-coverage.md
+          TERMINAL_DISPOSITION_COVERAGE_MODE: ${{ vars.TERMINAL_DISPOSITION_COVERAGE_MODE || 'warning-only' }}
+          TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED: ${{ vars.TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED || 'false' }}
         run: |
+          set +e
           node .github/scripts/terminal_disposition_coverage.js
+          terminal_coverage_status=$?
+          set -e
           if [ -f terminal-disposition-coverage.md ]; then
             cat terminal-disposition-coverage.md >> "$GITHUB_STEP_SUMMARY"
             if [ -f agent-weekly-metrics.md ]; then
@@ -164,6 +169,7 @@ jobs:
               } >> agent-weekly-metrics.md
             fi
           fi
+          exit "$terminal_coverage_status"
 
       - name: Upload weekly summary
         if: ${{ always() }}

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -264,8 +264,16 @@ def test_weekly_metrics_uploads_selector_report_on_failure():
             "TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED" in text
         ), "Terminal coverage hard blocking must require an explicit approval flag"
         assert (
-            "terminal_coverage_status=$?" in text and 'exit "$terminal_coverage_status"' in text
-        ), "Terminal coverage must append/upload reports before honoring hard-block failure"
+            "terminal_coverage_status=$?" in text
+            and "TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS=${terminal_coverage_status}" in text
+            and "Honor terminal coverage hard-block" in text
+        ), "Terminal coverage must post/upload reports before honoring hard-block failure"
+        assert text.index("Upload weekly summary") < text.index(
+            "Honor terminal coverage hard-block"
+        ), "Terminal coverage hard-block failure must wait for artifact upload"
+        assert text.index("Post summary to tracking issue") < text.index(
+            "Honor terminal coverage hard-block"
+        ), "Terminal coverage hard-block failure must wait for tracking issue posting"
 
 
 def test_terminal_disposition_records_include_artifact_identity():

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -257,6 +257,15 @@ def test_weekly_metrics_uploads_selector_report_on_failure():
         assert (
             "TERMINAL_DISPOSITION_ARTIFACT_SELECTION_JSON" in text
         ), "Terminal coverage must receive the selector report for no-data traceability"
+        assert (
+            "TERMINAL_DISPOSITION_COVERAGE_MODE" in text
+        ), "Terminal coverage must expose an explicit enforcement mode"
+        assert (
+            "TERMINAL_DISPOSITION_HARD_BLOCK_APPROVED" in text
+        ), "Terminal coverage hard blocking must require an explicit approval flag"
+        assert (
+            "terminal_coverage_status=$?" in text and 'exit "$terminal_coverage_status"' in text
+        ), "Terminal coverage must append/upload reports before honoring hard-block failure"
 
 
 def test_terminal_disposition_records_include_artifact_identity():


### PR DESCRIPTION
## Summary
- add a machine-readable terminal coverage enforcement policy contract
- keep warning-only as the default and require explicit approval before hard-block mode can fail a run
- wire weekly metrics and consumer template workflows to preserve/upload reports before honoring hard-block exit status

## Verification
- node --test .github/scripts/__tests__/terminal-disposition-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js .github/scripts/__tests__/terminal-disposition.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_bot_comment_handler.py -q
- python -m black --check --line-length 100 --target-version py312 tests/workflows/test_workflow_agents_consolidation.py
- python YAML parse for weekly metrics workflow and consumer template
- git diff --check
- CLI smoke: approved hard-block exits 1 on no-data; unapproved hard-block stays warning-only and exits 0