### PR TITLE
Reduce invalid token warning noise

### DIFF
--- a/.github/scripts/__tests__/token-load-balancer-resolution.test.js
+++ b/.github/scripts/__tests__/token-load-balancer-resolution.test.js
@@ -90,3 +90,114 @@ module.exports = { Octokit };
   assert.equal(result.rateLimit.remaining, 4999);
   assert.equal(result.rateLimit.importFailed, undefined);
 });
+
+test('invalid credential warning cache defaults outside the repository workspace', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-invalid-auth-runner-temp-'));
+  const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-invalid-auth-workspace-'));
+  const scriptPath = path.resolve(__dirname, '..', 'token_load_balancer.js');
+  const balancer = require(scriptPath);
+
+  const previousRunnerTemp = process.env.RUNNER_TEMP;
+  const previousWorkspace = process.env.GITHUB_WORKSPACE;
+  process.env.RUNNER_TEMP = tempDir;
+  process.env.GITHUB_WORKSPACE = workspaceDir;
+
+  try {
+    assert.equal(
+      balancer.getInvalidAuthWarningCachePath(),
+      path.join(tempDir, 'github-token-invalid-auth-warnings.json')
+    );
+  } finally {
+    if (previousRunnerTemp === undefined) {
+      delete process.env.RUNNER_TEMP;
+    } else {
+      process.env.RUNNER_TEMP = previousRunnerTemp;
+    }
+    if (previousWorkspace === undefined) {
+      delete process.env.GITHUB_WORKSPACE;
+    } else {
+      process.env.GITHUB_WORKSPACE = previousWorkspace;
+    }
+  }
+});
+
+test('invalid credential warnings are cached across node processes', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-invalid-auth-cache-'));
+  const cachePath = path.join(tempDir, 'invalid-auth-warnings.json');
+  const scriptPath = path.resolve(__dirname, '..', 'token_load_balancer.js');
+
+  const runProbe = () => spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `
+(async () => {
+  const fs = require('node:fs');
+  const balancer = require(process.argv[1]);
+  const cachePath = process.argv[2];
+  const warnings = [];
+  const debug = [];
+  class Octokit {
+    constructor() {
+      this.rateLimit = {
+        get: async () => {
+          const error = new Error('Bad credentials');
+          error.status = 401;
+          throw error;
+        }
+      };
+    }
+  }
+  const rateLimit = await balancer.checkTokenRateLimit({
+    tokenInfo: {
+      id: 'BAD_TOKEN',
+      token: 'bad-token',
+      type: 'PAT',
+    },
+    Octokit,
+    core: {
+      warning: (message) => warnings.push(message),
+      debug: (message) => debug.push(message),
+    },
+  });
+  const cache = fs.existsSync(cachePath)
+    ? JSON.parse(fs.readFileSync(cachePath, 'utf8'))
+    : null;
+  process.stdout.write(JSON.stringify({ warnings, debug, cache, rateLimit }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`,
+      scriptPath,
+      cachePath,
+    ],
+    {
+      env: {
+        ...process.env,
+        TOKEN_INVALID_AUTH_WARNING_CACHE: cachePath,
+      },
+      encoding: 'utf8',
+    }
+  );
+
+  const first = runProbe();
+  assert.equal(first.status, 0, first.stderr);
+  const firstResult = JSON.parse(first.stdout);
+  assert.equal(firstResult.warnings.length, 1);
+  assert.match(firstResult.warnings[0], /BAD_TOKEN has invalid credentials/);
+  assert.deepEqual(firstResult.cache.tokens, ['BAD_TOKEN']);
+  assert.equal(firstResult.rateLimit.invalidAuth, true);
+
+  const second = runProbe();
+  assert.equal(second.status, 0, second.stderr);
+  const secondResult = JSON.parse(second.stdout);
+  assert.deepEqual(secondResult.warnings, []);
+  assert.ok(
+    secondResult.debug.some((message) =>
+      message.includes('BAD_TOKEN still has invalid credentials')
+    )
+  );
+  assert.deepEqual(secondResult.cache.tokens, ['BAD_TOKEN']);
+  assert.equal(secondResult.rateLimit.invalidAuth, true);
+});

--- a/.github/scripts/token_load_balancer.js
+++ b/.github/scripts/token_load_balancer.js
@@ -20,6 +20,10 @@
  *   const token = await getOptimalToken({ github, core, capabilities: ['cross-repo'] });
  */
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
 function requireOrImport(moduleName) {
   try {
     return Promise.resolve(require(moduleName));
@@ -53,6 +57,8 @@ const tokenRegistry = {
   // Threshold below which we consider a token "critical" (5%)
   criticalThreshold: 0.05,
 };
+
+const invalidAuthWarningMemory = new Set();
 
 /**
  * Token capabilities - what each token type can do
@@ -463,6 +469,122 @@ async function refreshAllRateLimits({ github, core }) {
   return results;
 }
 
+function getInvalidAuthWarningCachePath() {
+  const configured =
+    process.env.TOKEN_INVALID_AUTH_WARNING_CACHE ||
+    process.env.GITHUB_TOKEN_INVALID_AUTH_WARNING_CACHE ||
+    '';
+  if (configured.trim()) {
+    return path.resolve(configured.trim());
+  }
+
+  const tempRoot = process.env.RUNNER_TEMP || os.tmpdir();
+  return path.join(tempRoot, 'github-token-invalid-auth-warnings.json');
+}
+
+function readInvalidAuthWarningCache(cachePath, core) {
+  if (!cachePath || !fs.existsSync(cachePath)) {
+    return new Set();
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter(Boolean));
+    }
+    if (Array.isArray(parsed?.tokens)) {
+      return new Set(parsed.tokens.filter(Boolean));
+    }
+  } catch (error) {
+    core?.debug?.(`Ignoring invalid token warning cache ${cachePath}: ${error.message}`);
+  }
+
+  return new Set();
+}
+
+function sleepSync(ms) {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+function withInvalidAuthWarningCacheLock(cachePath, core, fn) {
+  if (!cachePath) {
+    return fn();
+  }
+
+  const lockPath = `${cachePath}.lock`;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    let lockFd = null;
+    try {
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      lockFd = fs.openSync(lockPath, 'wx');
+      try {
+        return fn();
+      } finally {
+        fs.closeSync(lockFd);
+        fs.rmSync(lockPath, { force: true });
+      }
+    } catch (error) {
+      if (lockFd !== null) {
+        try {
+          fs.closeSync(lockFd);
+        } catch {
+          // Ignore cleanup failures; the warning cache is best effort.
+        }
+      }
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+      sleepSync(25);
+    }
+  }
+
+  core?.debug?.(`Invalid token warning cache lock timed out for ${cachePath}; writing best effort.`);
+  return fn();
+}
+
+function writeInvalidAuthWarningCache(cachePath, warnedTokens, core) {
+  if (!cachePath) {
+    return;
+  }
+
+  try {
+    withInvalidAuthWarningCacheLock(cachePath, core, () => {
+      const mergedTokens = new Set([
+        ...readInvalidAuthWarningCache(cachePath, core),
+        ...warnedTokens,
+      ]);
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      const tempPath = `${cachePath}.${process.pid}.tmp`;
+      fs.writeFileSync(
+        tempPath,
+        `${JSON.stringify({ tokens: Array.from(mergedTokens).sort() }, null, 2)}\n`
+      );
+      fs.renameSync(tempPath, cachePath);
+    });
+  } catch (error) {
+    core?.debug?.(`Unable to update invalid token warning cache ${cachePath}: ${error.message}`);
+  }
+}
+
+function shouldWarnInvalidAuth(tokenId, core) {
+  if (invalidAuthWarningMemory.has(tokenId)) {
+    return false;
+  }
+
+  const cachePath = getInvalidAuthWarningCachePath();
+  const warnedTokens = readInvalidAuthWarningCache(cachePath, core);
+  if (warnedTokens.has(tokenId)) {
+    invalidAuthWarningMemory.add(tokenId);
+    return false;
+  }
+
+  warnedTokens.add(tokenId);
+  invalidAuthWarningMemory.add(tokenId);
+  writeInvalidAuthWarningCache(cachePath, warnedTokens, core);
+  return true;
+}
+
 /**
  * Check rate limit for a specific token.
  * @param {object} params
@@ -526,10 +648,16 @@ async function checkTokenRateLimit({ tokenInfo, github, core, Octokit }) {
       throw error;
     }
 
-    core?.warning?.(
-      `Token ${tokenInfo.id} has invalid credentials (HTTP 401). ` +
-      `It will be skipped until the backing secret is corrected.`
-    );
+    if (shouldWarnInvalidAuth(tokenInfo.id, core)) {
+      core?.warning?.(
+        `Token ${tokenInfo.id} has invalid credentials (HTTP 401). ` +
+        `It will be skipped until the backing secret is corrected.`
+      );
+    } else {
+      core?.debug?.(
+        `Token ${tokenInfo.id} still has invalid credentials; repeated warning suppressed.`
+      );
+    }
 
     return {
       limit: 5000,
@@ -924,6 +1052,8 @@ module.exports = {
   getTimeUntilReset,
   shouldDefer,
   requireOrImport,
+  shouldWarnInvalidAuth,
+  getInvalidAuthWarningCachePath,
   TOKEN_CAPABILITIES,
   TOKEN_SPECIALIZATIONS,
   tokenRegistry, // Export for testing/debugging

--- a/templates/consumer-repo/.github/scripts/token_load_balancer.js
+++ b/templates/consumer-repo/.github/scripts/token_load_balancer.js
@@ -20,6 +20,10 @@
  *   const token = await getOptimalToken({ github, core, capabilities: ['cross-repo'] });
  */
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
 function requireOrImport(moduleName) {
   try {
     return Promise.resolve(require(moduleName));
@@ -53,6 +57,8 @@ const tokenRegistry = {
   // Threshold below which we consider a token "critical" (5%)
   criticalThreshold: 0.05,
 };
+
+const invalidAuthWarningMemory = new Set();
 
 /**
  * Token capabilities - what each token type can do
@@ -463,6 +469,122 @@ async function refreshAllRateLimits({ github, core }) {
   return results;
 }
 
+function getInvalidAuthWarningCachePath() {
+  const configured =
+    process.env.TOKEN_INVALID_AUTH_WARNING_CACHE ||
+    process.env.GITHUB_TOKEN_INVALID_AUTH_WARNING_CACHE ||
+    '';
+  if (configured.trim()) {
+    return path.resolve(configured.trim());
+  }
+
+  const tempRoot = process.env.RUNNER_TEMP || os.tmpdir();
+  return path.join(tempRoot, 'github-token-invalid-auth-warnings.json');
+}
+
+function readInvalidAuthWarningCache(cachePath, core) {
+  if (!cachePath || !fs.existsSync(cachePath)) {
+    return new Set();
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter(Boolean));
+    }
+    if (Array.isArray(parsed?.tokens)) {
+      return new Set(parsed.tokens.filter(Boolean));
+    }
+  } catch (error) {
+    core?.debug?.(`Ignoring invalid token warning cache ${cachePath}: ${error.message}`);
+  }
+
+  return new Set();
+}
+
+function sleepSync(ms) {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+function withInvalidAuthWarningCacheLock(cachePath, core, fn) {
+  if (!cachePath) {
+    return fn();
+  }
+
+  const lockPath = `${cachePath}.lock`;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    let lockFd = null;
+    try {
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      lockFd = fs.openSync(lockPath, 'wx');
+      try {
+        return fn();
+      } finally {
+        fs.closeSync(lockFd);
+        fs.rmSync(lockPath, { force: true });
+      }
+    } catch (error) {
+      if (lockFd !== null) {
+        try {
+          fs.closeSync(lockFd);
+        } catch {
+          // Ignore cleanup failures; the warning cache is best effort.
+        }
+      }
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+      sleepSync(25);
+    }
+  }
+
+  core?.debug?.(`Invalid token warning cache lock timed out for ${cachePath}; writing best effort.`);
+  return fn();
+}
+
+function writeInvalidAuthWarningCache(cachePath, warnedTokens, core) {
+  if (!cachePath) {
+    return;
+  }
+
+  try {
+    withInvalidAuthWarningCacheLock(cachePath, core, () => {
+      const mergedTokens = new Set([
+        ...readInvalidAuthWarningCache(cachePath, core),
+        ...warnedTokens,
+      ]);
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      const tempPath = `${cachePath}.${process.pid}.tmp`;
+      fs.writeFileSync(
+        tempPath,
+        `${JSON.stringify({ tokens: Array.from(mergedTokens).sort() }, null, 2)}\n`
+      );
+      fs.renameSync(tempPath, cachePath);
+    });
+  } catch (error) {
+    core?.debug?.(`Unable to update invalid token warning cache ${cachePath}: ${error.message}`);
+  }
+}
+
+function shouldWarnInvalidAuth(tokenId, core) {
+  if (invalidAuthWarningMemory.has(tokenId)) {
+    return false;
+  }
+
+  const cachePath = getInvalidAuthWarningCachePath();
+  const warnedTokens = readInvalidAuthWarningCache(cachePath, core);
+  if (warnedTokens.has(tokenId)) {
+    invalidAuthWarningMemory.add(tokenId);
+    return false;
+  }
+
+  warnedTokens.add(tokenId);
+  invalidAuthWarningMemory.add(tokenId);
+  writeInvalidAuthWarningCache(cachePath, warnedTokens, core);
+  return true;
+}
+
 /**
  * Check rate limit for a specific token.
  * @param {object} params
@@ -526,10 +648,16 @@ async function checkTokenRateLimit({ tokenInfo, github, core, Octokit }) {
       throw error;
     }
 
-    core?.warning?.(
-      `Token ${tokenInfo.id} has invalid credentials (HTTP 401). ` +
-      `It will be skipped until the backing secret is corrected.`
-    );
+    if (shouldWarnInvalidAuth(tokenInfo.id, core)) {
+      core?.warning?.(
+        `Token ${tokenInfo.id} has invalid credentials (HTTP 401). ` +
+        `It will be skipped until the backing secret is corrected.`
+      );
+    } else {
+      core?.debug?.(
+        `Token ${tokenInfo.id} still has invalid credentials; repeated warning suppressed.`
+      );
+    }
 
     return {
       limit: 5000,
@@ -924,6 +1052,8 @@ module.exports = {
   getTimeUntilReset,
   shouldDefer,
   requireOrImport,
+  shouldWarnInvalidAuth,
+  getInvalidAuthWarningCachePath,
   TOKEN_CAPABILITIES,
   TOKEN_SPECIALIZATIONS,
   tokenRegistry, // Export for testing/debugging


### PR DESCRIPTION
## Summary
- cache invalid-token warning state across Node invocations in the same GitHub workspace
- keep invalid credentials skipped for selection while suppressing repeated HTTP 401 warnings after the first report
- mirror the token balancer update to the consumer template

## Verification
- node --test .github/scripts/__tests__/token-load-balancer-resolution.test.js .github/scripts/__tests__/github-api-with-retry.test.js
- node --check .github/scripts/token_load_balancer.js && node --check templates/consumer-repo/.github/scripts/token_load_balancer.js
- git diff --check