### PR TITLE
[codex] Restore standalone CODESPACES token references

### DIFF
--- a/docs/fixes/RATE_LIMIT_REMEDIATION_PLAN.md
+++ b/docs/fixes/RATE_LIMIT_REMEDIATION_PLAN.md
@@ -478,7 +478,7 @@ With when rate-limited:
 | WORKFLOWS_APP | 0 | 13:30 UTC |
 | KEEPALIVE_APP | 23 | 13:45 UTC |
 | SERVICE_BOT_PAT | 0 | 13:30 UTC |
-| OWNER_PR_PAT | 1,247 | 14:00 UTC |
+| CODESPACES | 1,247 | 14:00 UTC |
 
 **Action:** Waiting for rate limits to reset. Next attempt at 13:30 UTC.
 ```
@@ -573,11 +573,11 @@ Apply setup action to less frequent workflows:
 2. **Check the "Implementation Plan" section** for current phase
 3. **Run diagnostics:**
    ```bash
-   GH_TOKEN=$OWNER_PR_PAT gh workflow run "Health 75 API Rate Diagnostic" --repo stranske/Workflows
+   GH_TOKEN=$CODESPACES gh workflow run "Health 75 API Rate Diagnostic" --repo stranske/Workflows
    ```
 4. **Check recent keepalive failures:**
    ```bash
-   GH_TOKEN=$OWNER_PR_PAT gh run list --repo stranske/Trend_Model_Project --workflow "Agents Keepalive Loop" --status failure --limit 5
+   GH_TOKEN=$CODESPACES gh run list --repo stranske/Trend_Model_Project --workflow "Agents Keepalive Loop" --status failure --limit 5
    ```
 
 ### Key Files to Know
@@ -591,7 +591,7 @@ Apply setup action to less frequent workflows:
 
 ### Don't Forget
 
-- **Use `OWNER_PR_PAT` or `SERVICE_BOT_PAT`** for cross-repo operations
+- **Use `CODESPACES` PAT** for cross-repo operations
 - **Test in BOTH** Workflows repo AND consumer repo
 - **Verify actual switching** not just "tokens available"
 

--- a/docs/keepalive/Agents.md
+++ b/docs/keepalive/Agents.md
@@ -81,7 +81,7 @@ unset GH_TOKEN GITHUB_TOKEN
 gh auth status
 ```
 
-If there is no stored auth session, run commands with an explicit token (for example `GH_TOKEN="$OWNER_PR_PAT" ...`) and document scope limitations instead of assuming repository misconfiguration.
+If there is no stored auth session, run commands with an explicit token (for example `GH_TOKEN="$CODESPACES" ...`) and document scope limitations instead of assuming repository misconfiguration.
 
 ## Keepalive Implementations
 

--- a/manage_sync_prs.sh
+++ b/manage_sync_prs.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-# Manage sync PRs in consumer repos using an owner or service bot PAT
+# Manage sync PRs in consumer repos using CODESPACES secret
 # This script:
 # 1. Closes stale sync PRs (keeps only the latest)
 # 2. Checks status of remaining PRs
 # 3. Reports which PRs are ready to merge
 
-SYNC_MANAGEMENT_TOKEN="${OWNER_PR_PAT:-${SERVICE_BOT_PAT:-}}"
-
-if [ -z "${SYNC_MANAGEMENT_TOKEN}" ]; then
-  echo "Error: OWNER_PR_PAT or SERVICE_BOT_PAT is required" >&2
+if [ -z "${CODESPACES:-}" ]; then
+  echo "Error: CODESPACES secret not found" >&2
   exit 1
 fi
 
-# Use the selected management token for gh CLI (overrides GITHUB_TOKEN)
-export GH_TOKEN="$SYNC_MANAGEMENT_TOKEN"
+# Use CODESPACES token for gh CLI (overrides GITHUB_TOKEN)
+export GH_TOKEN="$CODESPACES"
 
 REPOS=(
   "Travel-Plan-Permission"

--- a/templates/consumer-repo/.github/copilot-instructions.md
+++ b/templates/consumer-repo/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ These files are internal task trackers and should never receive Copilot review c
 ## Skill: GitHub Operations
 
 ### Authentication & PAT Usage
-- **Elevated PAT**: When performing GitHub operations that require elevated permissions (pushing to protected branches, creating releases, etc.), always check if an `OWNER_PR_PAT`, `SERVICE_BOT_PAT`, or `GH_TOKEN` environment variable is available
+- **Codespaces PAT**: When performing GitHub operations that require elevated permissions (pushing to protected branches, creating releases, etc.), always check if a `CODESPACES_PAT` or `GH_TOKEN` environment variable is available
 - Use `gh auth status` to verify current authentication before operations
 - If authentication fails, remind the user they may need to set up a PAT with appropriate scopes
 - If GITHUB_TOKEN is set and blocking PAT usage: `unset GITHUB_TOKEN` first


### PR DESCRIPTION
## Summary
- restore the standalone CODESPACES token usage in sync PR management docs and script
- preserve the removal of the separate CODESPACES_WORKFLOWS secret/wiring
- restore the generic consumer template CODESPACES_PAT guidance that is not tied to CODESPACES_WORKFLOWS

## Verification
- git diff --check
- bash -n manage_sync_prs.sh
- BASE_REMOTE=origin BASE_REF=main PR_TITLE="[codex] Restore standalone CODESPACES token references" python scripts/check_issue_consistency.py
- rg --hidden -n "CODESPACES_WORKFLOWS|codespaces_workflows|CODESPACES_WORKFLOWS_PAT" .github templates scripts docs archives SOLUTION_SUMMARY.md manage_sync_prs.sh (no matches)
- rg --hidden -n "\bCODESPACES\b|CODESPACES_PAT|Codespaces PAT" manage_sync_prs.sh docs/keepalive/Agents.md docs/fixes/RATE_LIMIT_REMEDIATION_PLAN.md templates/consumer-repo/.github/copilot-instructions.md