### PR TITLE
Prefer client ID in bot comment wrapper

### DIFF
--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -59,21 +59,53 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       should_run: ${{ steps.resolve.outputs.should_run }}
     steps:
-      # Mint GitHub App token early to use for API calls (avoids rate limits)
-      - name: Mint GitHub App Token
-        id: app_token
+      - name: Detect workflow App credentials
+        id: workflow-app-creds
+        env:
+          WORKFLOWS_APP_CLIENT_ID: ${{ secrets.WORKFLOWS_APP_CLIENT_ID }}
+          WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+          WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=true" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
+          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
+          else
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint GitHub App Token (client ID)
+        id: app_token_client
         uses: actions/create-github-app-token@v3
+        if: steps.workflow-app-creds.outputs.use_client == 'true'
         continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
+          client-id: ${{ secrets.WORKFLOWS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Mint GitHub App Token (legacy App ID)
+        id: app_token_legacy
+        uses: actions/create-github-app-token@v3
+        if: steps.workflow-app-creds.outputs.use_legacy == 'true'
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout retry helpers
         uses: actions/checkout@v6
         with:
 
-          token: ${{ steps.app_token.outputs.token || github.token }}
+          token: ${{ steps.app_token_client.outputs.token || steps.app_token_legacy.outputs.token || github.token }}
           repository: ${{ github.repository }}
           ref: >-
             ${{
@@ -246,22 +278,54 @@ jobs:
       github.event.label.name == 'autofix:bot-comments'
     runs-on: ubuntu-latest
     steps:
-      # Mint GitHub App token early to use for API calls (avoids rate limits)
-      - name: Mint GitHub App Token
-        id: app_token
+      - name: Detect workflow App credentials
+        id: workflow-app-creds
+        env:
+          WORKFLOWS_APP_CLIENT_ID: ${{ secrets.WORKFLOWS_APP_CLIENT_ID }}
+          WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+          WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=true" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
+          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
+          else
+            echo "use_client=false" >> "$GITHUB_OUTPUT"
+            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
+            echo "workflow_app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint GitHub App Token (client ID)
+        id: app_token_client
         uses: actions/create-github-app-token@v3
+        if: steps.workflow-app-creds.outputs.use_client == 'true'
         continue-on-error: true
         with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
+          client-id: ${{ secrets.WORKFLOWS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      # Mint GitHub App token early to use for API calls (avoids rate limits)
+      - name: Mint GitHub App Token (legacy App ID)
+        id: app_token_legacy
+        uses: actions/create-github-app-token@v3
+        if: steps.workflow-app-creds.outputs.use_legacy == 'true'
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Checkout retry helpers with the best token available.
       - name: Checkout retry helpers
         uses: actions/checkout@v6
         with:
 
-          token: ${{ steps.app_token.outputs.token || github.token }}
+          token: ${{ steps.app_token_client.outputs.token || steps.app_token_legacy.outputs.token || github.token }}
           repository: ${{ github.repository }}
           ref: >-
             ${{
@@ -287,7 +351,7 @@ jobs:
         uses: actions/github-script@v9
         with:
 
-          github-token: ${{ steps.app_token.outputs.token || github.token }}
+          github-token: ${{ steps.app_token_client.outputs.token || steps.app_token_legacy.outputs.token || github.token }}
           script: |
             const fs = require('fs');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';

--- a/docs/bot-comment-handler.md
+++ b/docs/bot-comment-handler.md
@@ -144,6 +144,11 @@ gh workflow run agents-bot-comment-handler.yml -f pr_number=123
 | `GH_APP_ID` | No | Legacy GitHub App ID fallback |
 | `GH_APP_PRIVATE_KEY` | No | GitHub App private key |
 
+The canonical Workflows repo wrapper also accepts `WORKFLOWS_APP_CLIENT_ID` for its
+internal resolve/cleanup API calls. If that secret is missing, it falls back to
+`WORKFLOWS_APP_ID` with a warning so the reusable bot-comment path remains
+observable without breaking existing installs.
+
 ## Troubleshooting
 
 ### No comments found

--- a/tests/workflows/test_bot_comment_handler.py
+++ b/tests/workflows/test_bot_comment_handler.py
@@ -132,6 +132,43 @@ def test_bot_comment_handler_callers_pass_app_client_id() -> None:
             assert secrets.get("gh_app_private_key") == "${{ secrets.GH_APP_PRIVATE_KEY }}"
 
 
+def test_canonical_bot_comment_handler_direct_app_tokens_prefer_client_id() -> None:
+    workflow = _load_yaml(ROOT / ".github/workflows/agents-bot-comment-handler.yml")
+
+    for job_name in ("resolve", "cleanup"):
+        steps = workflow["jobs"][job_name]["steps"]
+        detect_step = next(
+            step for step in steps if step.get("name") == "Detect workflow App credentials"
+        )
+        client_step = next(
+            step for step in steps if step.get("name") == "Mint GitHub App Token (client ID)"
+        )
+        legacy_step = next(
+            step for step in steps if step.get("name") == "Mint GitHub App Token (legacy App ID)"
+        )
+        checkout_step = next(step for step in steps if step.get("uses") == "actions/checkout@v6")
+
+        assert detect_step["env"]["WORKFLOWS_APP_CLIENT_ID"] == (
+            "${{ secrets.WORKFLOWS_APP_CLIENT_ID }}"
+        )
+        assert "workflow_app_auth_mode=client-id" in detect_step["run"]
+        assert "workflow_app_auth_mode=legacy-app-id" in detect_step["run"]
+        assert "workflow_app_auth_mode=none" in detect_step["run"]
+        assert "Legacy Workflows App ID fallback" in detect_step["run"]
+        assert client_step.get("if") == "steps.workflow-app-creds.outputs.use_client == 'true'"
+        assert "client-id" in client_step.get("with", {})
+        assert "app-id" not in client_step.get("with", {})
+        assert legacy_step.get("if") == "steps.workflow-app-creds.outputs.use_legacy == 'true'"
+        assert "app-id" in legacy_step.get("with", {})
+        assert (
+            "steps.app_token_client.outputs.token || steps.app_token_legacy.outputs.token"
+            in checkout_step["with"]["token"]
+        )
+
+    serialized_workflow = yaml.safe_dump(workflow)
+    assert "steps.app_token.outputs.token" not in serialized_workflow
+
+
 def test_template_bot_comment_handler_passes_agents_ignore() -> None:
     workflow = _load_yaml(
         ROOT / "templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml"


### PR DESCRIPTION
## Summary
- make the canonical bot-comment wrapper prefer WORKFLOWS_APP_CLIENT_ID for its direct resolve/cleanup token minting
- keep WORKFLOWS_APP_ID as a warning-only legacy fallback with workflow_app_auth_mode outputs
- add regression coverage for the direct wrapper path and document the wrapper secret

## Verification
- python -m pytest tests/workflows/test_bot_comment_handler.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m black --check --line-length 100 --target-version py312 tests/workflows/test_bot_comment_handler.py
- YAML parse for bot-comment reusable/callers
- python scripts/validate_template_sync.py
- python -m pytest tests/scripts/test_validate_template_sync.py -q
- git diff --check
- rg -n 'CODESPACES_WORKFLOWS|codespaces_workflows|CODESPACES_WORKFLOWS_PAT' . || true