### PR TITLE
Add bot comment auth coverage artifacts

### DIFF
--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       should_run: ${{ steps.resolve.outputs.should_run }}
+      workflow_app_auth_mode: ${{ steps.workflow-app-creds.outputs.workflow_app_auth_mode }}
     steps:
       - name: Detect workflow App credentials
         id: workflow-app-creds
@@ -66,20 +67,79 @@ jobs:
           WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
           WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=true" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
-          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
-          else
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          client_id_configured=false
+          legacy_app_id_configured=false
+          private_key_configured=false
+          use_client=false
+          use_legacy=false
+          workflow_app_auth_mode=none
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ]; then
+            client_id_configured=true
           fi
+          if [ -n "${WORKFLOWS_APP_ID}" ]; then
+            legacy_app_id_configured=true
+          fi
+          if [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            private_key_configured=true
+          fi
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            use_client=true
+            workflow_app_auth_mode=client-id
+          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            use_legacy=true
+            workflow_app_auth_mode=legacy-app-id
+            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
+          fi
+          {
+            echo "client_id_configured=${client_id_configured}"
+            echo "legacy_app_id_configured=${legacy_app_id_configured}"
+            echo "private_key_configured=${private_key_configured}"
+            echo "use_client=${use_client}"
+            echo "use_legacy=${use_legacy}"
+            echo "workflow_app_auth_mode=${workflow_app_auth_mode}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write wrapper App auth coverage
+        if: always()
+        env:
+          WORKFLOW_APP_AUTH_MODE: ${{ steps.workflow-app-creds.outputs.workflow_app_auth_mode }}
+          WORKFLOW_APP_CLIENT_ID_CONFIGURED: ${{ steps.workflow-app-creds.outputs.client_id_configured }}
+          WORKFLOW_APP_LEGACY_APP_ID_CONFIGURED: ${{ steps.workflow-app-creds.outputs.legacy_app_id_configured }}
+          WORKFLOW_APP_PRIVATE_KEY_CONFIGURED: ${{ steps.workflow-app-creds.outputs.private_key_configured }}
+        run: |
+          mkdir -p bot-comment-auth-coverage
+          node <<'NODE'
+          const fs = require('fs');
+          const truthy = (value) => String(value || '').toLowerCase() === 'true';
+          const record = {
+            schema: 'workflows-bot-comment-auth-coverage/v1',
+            component: 'agents-bot-comment-handler-wrapper',
+            repository: process.env.GITHUB_REPOSITORY || '',
+            workflow: process.env.GITHUB_WORKFLOW || '',
+            run_id: process.env.GITHUB_RUN_ID || '',
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || '',
+            event_name: process.env.GITHUB_EVENT_NAME || '',
+            auth_mode: process.env.WORKFLOW_APP_AUTH_MODE || 'none',
+            client_id_configured: truthy(process.env.WORKFLOW_APP_CLIENT_ID_CONFIGURED),
+            legacy_app_id_configured: truthy(process.env.WORKFLOW_APP_LEGACY_APP_ID_CONFIGURED),
+            private_key_configured: truthy(process.env.WORKFLOW_APP_PRIVATE_KEY_CONFIGURED),
+            fallback_warning_active: process.env.WORKFLOW_APP_AUTH_MODE === 'legacy-app-id',
+            direct_jobs_covered: ['resolve', 'cleanup'],
+          };
+          fs.writeFileSync(
+            'bot-comment-auth-coverage/wrapper.json',
+            `${JSON.stringify(record, null, 2)}\n`
+          );
+          NODE
+
+      - name: Upload wrapper App auth coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bot-comment-auth-coverage-wrapper-${{ github.run_id }}
+          path: bot-comment-auth-coverage/wrapper.json
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Mint GitHub App Token (client ID)
         id: app_token_client
@@ -285,20 +345,37 @@ jobs:
           WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
           WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=true" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
-          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
-          else
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "workflow_app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          client_id_configured=false
+          legacy_app_id_configured=false
+          private_key_configured=false
+          use_client=false
+          use_legacy=false
+          workflow_app_auth_mode=none
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ]; then
+            client_id_configured=true
           fi
+          if [ -n "${WORKFLOWS_APP_ID}" ]; then
+            legacy_app_id_configured=true
+          fi
+          if [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            private_key_configured=true
+          fi
+          if [ -n "${WORKFLOWS_APP_CLIENT_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            use_client=true
+            workflow_app_auth_mode=client-id
+          elif [ -n "${WORKFLOWS_APP_ID}" ] && [ -n "${WORKFLOWS_APP_PRIVATE_KEY}" ]; then
+            use_legacy=true
+            workflow_app_auth_mode=legacy-app-id
+            echo "::warning title=Legacy Workflows App ID fallback::Configure WORKFLOWS_APP_CLIENT_ID to avoid the deprecated app-id path."
+          fi
+          {
+            echo "client_id_configured=${client_id_configured}"
+            echo "legacy_app_id_configured=${legacy_app_id_configured}"
+            echo "private_key_configured=${private_key_configured}"
+            echo "use_client=${use_client}"
+            echo "use_legacy=${use_legacy}"
+            echo "workflow_app_auth_mode=${workflow_app_auth_mode}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Mint GitHub App Token (client ID)
         id: app_token_client

--- a/.github/workflows/reusable-bot-comment-handler.yml
+++ b/.github/workflows/reusable-bot-comment-handler.yml
@@ -15,6 +15,7 @@
 # - comments_found: 'true' if unresolved bot comments were found
 # - comments_count: Number of unresolved bot comments found
 # - agent_triggered: 'true' if the agent was triggered to address comments
+# - app_auth_mode: 'client-id', 'legacy-app-id', or 'none' for App auth selection
 
 name: Reusable Bot Comment Handler
 
@@ -89,6 +90,9 @@ on:
       agent_triggered:
         description: 'Whether the agent was triggered to address comments'
         value: ${{ jobs.dispatch.outputs.triggered }}
+      app_auth_mode:
+        description: 'Selected App auth mode: client-id, legacy-app-id, or none'
+        value: ${{ jobs.collect.outputs.app_auth_mode }}
     secrets:
       service_bot_pat:
         description: 'PAT for service bot (comments, labels)'
@@ -123,6 +127,7 @@ jobs:
       comments_json: ${{ steps.collect.outputs.comments }}
       agent: ${{ steps.agent.outputs.agent }}
       agent_workflow: ${{ steps.agent.outputs.workflow }}
+      app_auth_mode: ${{ steps.app-creds.outputs.app_auth_mode }}
     steps:
       - name: Detect App credentials
         id: app-creds
@@ -131,20 +136,37 @@ jobs:
           GH_APP_ID: ${{ secrets.gh_app_id }}
           GH_APP_PRIVATE_KEY: ${{ secrets.gh_app_private_key }}
         run: |
-          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=true" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
-          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
-          else
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          client_id_configured=false
+          legacy_app_id_configured=false
+          private_key_configured=false
+          use_client=false
+          use_legacy=false
+          app_auth_mode=none
+          if [ -n "${GH_APP_CLIENT_ID}" ]; then
+            client_id_configured=true
           fi
+          if [ -n "${GH_APP_ID}" ]; then
+            legacy_app_id_configured=true
+          fi
+          if [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            private_key_configured=true
+          fi
+          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            use_client=true
+            app_auth_mode=client-id
+          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            use_legacy=true
+            app_auth_mode=legacy-app-id
+            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
+          fi
+          {
+            echo "client_id_configured=${client_id_configured}"
+            echo "legacy_app_id_configured=${legacy_app_id_configured}"
+            echo "private_key_configured=${private_key_configured}"
+            echo "use_client=${use_client}"
+            echo "use_legacy=${use_legacy}"
+            echo "app_auth_mode=${app_auth_mode}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate token (if App client ID configured)
         id: token-client
@@ -178,6 +200,47 @@ jobs:
           else
             echo "token=${GITHUB_TOKEN}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Write App auth coverage
+        if: always()
+        env:
+          APP_AUTH_MODE: ${{ steps.app-creds.outputs.app_auth_mode }}
+          APP_CLIENT_ID_CONFIGURED: ${{ steps.app-creds.outputs.client_id_configured }}
+          APP_LEGACY_APP_ID_CONFIGURED: ${{ steps.app-creds.outputs.legacy_app_id_configured }}
+          APP_PRIVATE_KEY_CONFIGURED: ${{ steps.app-creds.outputs.private_key_configured }}
+        run: |
+          mkdir -p bot-comment-auth-coverage
+          node <<'NODE'
+          const fs = require('fs');
+          const truthy = (value) => String(value || '').toLowerCase() === 'true';
+          const record = {
+            schema: 'workflows-bot-comment-auth-coverage/v1',
+            component: 'reusable-bot-comment-handler',
+            repository: process.env.GITHUB_REPOSITORY || '',
+            workflow: process.env.GITHUB_WORKFLOW || '',
+            run_id: process.env.GITHUB_RUN_ID || '',
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || '',
+            event_name: process.env.GITHUB_EVENT_NAME || '',
+            auth_mode: process.env.APP_AUTH_MODE || 'none',
+            client_id_configured: truthy(process.env.APP_CLIENT_ID_CONFIGURED),
+            legacy_app_id_configured: truthy(process.env.APP_LEGACY_APP_ID_CONFIGURED),
+            private_key_configured: truthy(process.env.APP_PRIVATE_KEY_CONFIGURED),
+            fallback_warning_active: process.env.APP_AUTH_MODE === 'legacy-app-id',
+          };
+          fs.writeFileSync(
+            'bot-comment-auth-coverage/reusable.json',
+            `${JSON.stringify(record, null, 2)}\n`
+          );
+          NODE
+
+      - name: Upload App auth coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bot-comment-auth-coverage-reusable-${{ github.run_id }}
+          path: bot-comment-auth-coverage/reusable.json
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Checkout retry helpers
         uses: actions/checkout@v6
@@ -598,20 +661,37 @@ jobs:
           GH_APP_ID: ${{ secrets.gh_app_id }}
           GH_APP_PRIVATE_KEY: ${{ secrets.gh_app_private_key }}
         run: |
-          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=true" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=client-id" >> "$GITHUB_OUTPUT"
-          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=true" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=legacy-app-id" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
-          else
-            echo "use_client=false" >> "$GITHUB_OUTPUT"
-            echo "use_legacy=false" >> "$GITHUB_OUTPUT"
-            echo "app_auth_mode=none" >> "$GITHUB_OUTPUT"
+          client_id_configured=false
+          legacy_app_id_configured=false
+          private_key_configured=false
+          use_client=false
+          use_legacy=false
+          app_auth_mode=none
+          if [ -n "${GH_APP_CLIENT_ID}" ]; then
+            client_id_configured=true
           fi
+          if [ -n "${GH_APP_ID}" ]; then
+            legacy_app_id_configured=true
+          fi
+          if [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            private_key_configured=true
+          fi
+          if [ -n "${GH_APP_CLIENT_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            use_client=true
+            app_auth_mode=client-id
+          elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
+            use_legacy=true
+            app_auth_mode=legacy-app-id
+            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
+          fi
+          {
+            echo "client_id_configured=${client_id_configured}"
+            echo "legacy_app_id_configured=${legacy_app_id_configured}"
+            echo "private_key_configured=${private_key_configured}"
+            echo "use_client=${use_client}"
+            echo "use_legacy=${use_legacy}"
+            echo "app_auth_mode=${app_auth_mode}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate token (if App client ID configured)
         id: token-client

--- a/docs/bot-comment-handler.md
+++ b/docs/bot-comment-handler.md
@@ -149,6 +149,20 @@ internal resolve/cleanup API calls. If that secret is missing, it falls back to
 `WORKFLOWS_APP_ID` with a warning so the reusable bot-comment path remains
 observable without breaking existing installs.
 
+Each run uploads warning-only App auth coverage artifacts:
+
+- `bot-comment-auth-coverage-wrapper-<run_id>` records the canonical wrapper
+  `auth_mode` (`client-id`, `legacy-app-id`, or `none`) plus boolean secret
+  coverage for `WORKFLOWS_APP_CLIENT_ID`, `WORKFLOWS_APP_ID`, and
+  `WORKFLOWS_APP_PRIVATE_KEY`.
+- `bot-comment-auth-coverage-reusable-<run_id>` records the reusable handler
+  `auth_mode` plus boolean secret coverage for `GH_APP_CLIENT_ID`, `GH_APP_ID`,
+  and `GH_APP_PRIVATE_KEY`.
+
+Both artifacts use schema `workflows-bot-comment-auth-coverage/v1` and do not
+include secret values. A `legacy-app-id` mode means migration is still incomplete;
+do not remove the legacy fallback until active runs report `client-id` or `none`.
+
 ## Troubleshooting
 
 ### No comments found

--- a/docs/ci/WORKFLOW_OUTPUTS.md
+++ b/docs/ci/WORKFLOW_OUTPUTS.md
@@ -47,6 +47,7 @@ that only emit artifacts, see the "Workflows without workflow_call outputs" sect
 | `reusable-bot-comment-handler.yml` | `comments_found` | string (boolean-like) | Whether unresolved bot comments were found | `needs.bot_comments.outputs.comments_found` |
 | `reusable-bot-comment-handler.yml` | `comments_count` | string (number-like) | Number of unresolved bot comments found | `needs.bot_comments.outputs.comments_count` |
 | `reusable-bot-comment-handler.yml` | `agent_triggered` | string (boolean-like) | Whether the agent was triggered to address comments | `needs.bot_comments.outputs.agent_triggered` |
+| `reusable-bot-comment-handler.yml` | `app_auth_mode` | string enum | Selected App auth mode: client-id, legacy-app-id, or none | `needs.bot_comments.outputs.app_auth_mode` |
 | `reusable-pr-context.yml` | `pr_number` | string (number-like) | PR number | `needs.context.outputs.pr_number` |
 | `reusable-pr-context.yml` | `pr_title` | string | PR title | `needs.context.outputs.pr_title` |
 | `reusable-pr-context.yml` | `pr_body` | string | PR body (may be truncated for very long bodies) | `needs.context.outputs.pr_body` |

--- a/docs/keepalive/SETUP_CHECKLIST.md
+++ b/docs/keepalive/SETUP_CHECKLIST.md
@@ -94,11 +94,14 @@ The Workflows GitHub App provides secure, scoped authentication without personal
 
 Navigate to **Settings** → **Secrets and variables** → **Actions** → **Secrets** tab
 
-1. [ ] Get **App ID** from App settings page (numeric ID)
-2. [ ] **Generate Private Key** from App settings (downloads `.pem` file)
-3. [ ] Add secrets:
+1. [ ] Get **Client ID** from App settings page (preferred token input)
+2. [ ] Get **App ID** from App settings page (legacy fallback token input)
+3. [ ] **Generate Private Key** from App settings (downloads `.pem` file)
+4. [ ] Add secrets:
+   - Name: `WORKFLOWS_APP_CLIENT_ID`
+   - Value: The App client ID
    - Name: `WORKFLOWS_APP_ID`
-   - Value: The numeric App ID
+   - Value: The numeric App ID (legacy fallback)
    - Name: `WORKFLOWS_APP_PRIVATE_KEY`  
    - Value: Contents of the `.pem` file (entire file, including `-----BEGIN/END-----` lines)
 

--- a/docs/ops/api-rate-limit-management.md
+++ b/docs/ops/api-rate-limit-management.md
@@ -141,8 +141,10 @@ This allows mid-execution switching rather than waiting for failure.
 |--------|----------|---------|
 | `KEEPALIVE_APP_ID` | Yes | Keepalive-loop dedicated app |
 | `KEEPALIVE_APP_PRIVATE_KEY` | Yes | Keepalive-loop dedicated app |
+| `WORKFLOWS_APP_CLIENT_ID` | Recommended | Preferred App auth for Workflows wrapper jobs |
 | `WORKFLOWS_APP_ID` | Yes | Autofix workflows |
 | `WORKFLOWS_APP_PRIVATE_KEY` | Yes | Autofix workflows |
+| `GH_APP_CLIENT_ID` | Recommended | Preferred issue/comment handling App auth |
 | `GH_APP_ID` | Recommended | Issue/comment handling |
 | `GH_APP_PRIVATE_KEY` | Recommended | Issue/comment handling |
 | `SERVICE_BOT_PAT` | **Critical** | Bot-identity comments (reserve capacity!) |

--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -250,8 +250,12 @@ Navigate to: **Settings** → **Secrets and variables** → **Actions** → **Se
 | `AGENTS_AUTOMATION_PAT` | PAT used by autofix/retry flows when available | Contact admin for token |
 | `OWNER_PR_PAT` | PAT for PR creation | Repository owner's PAT |
 | `CODEX_AUTH_JSON` | Codex CLI authentication | Export from `~/.codex/auth.json` |
+| `WORKFLOWS_APP_CLIENT_ID` | GitHub App client ID for preferred token minting | Contact admin for App client ID |
 | `WORKFLOWS_APP_ID` | GitHub App ID for token minting | Contact admin for App ID |
 | `WORKFLOWS_APP_PRIVATE_KEY` | GitHub App private key | Contact admin for private key |
+| `GH_APP_CLIENT_ID` | Bot-comment GitHub App client ID | Contact admin for App client ID |
+| `GH_APP_ID` | Bot-comment legacy GitHub App ID fallback | Contact admin for App ID |
+| `GH_APP_PRIVATE_KEY` | Bot-comment GitHub App private key | Contact admin for private key |
 | `KEEPALIVE_APP_ID` | Keepalive App ID (preferred for keepalive loop auth) | Contact admin for App ID |
 | `KEEPALIVE_APP_PRIVATE_KEY` | Keepalive App private key | Contact admin for private key |
 | `OPENAI_API_KEY` | OpenAI API key for verify/optimizer/decompose flows | Contact admin for token |
@@ -265,8 +269,12 @@ Add each secret:
 - [ ] `AGENTS_AUTOMATION_PAT` — Recommended for autofix/retry dispatches
 - [ ] `OWNER_PR_PAT` — Required for creating PRs from agent bridge
 - [ ] `CODEX_AUTH_JSON` — Required for Codex CLI to authenticate with ChatGPT
+- [ ] `WORKFLOWS_APP_CLIENT_ID` — Preferred GitHub App token minting path
 - [ ] `WORKFLOWS_APP_ID` — **Required for keepalive** - Used for GitHub App token minting
 - [ ] `WORKFLOWS_APP_PRIVATE_KEY` — **Required for keepalive** - GitHub App authentication
+- [ ] `GH_APP_CLIENT_ID` — Preferred bot-comment App auth path
+- [ ] `GH_APP_ID` — Legacy bot-comment App ID fallback
+- [ ] `GH_APP_PRIVATE_KEY` — Bot-comment App private key
 - [ ] `KEEPALIVE_APP_ID` — **Required for keepalive parity** - Explicit keepalive app alias
 - [ ] `KEEPALIVE_APP_PRIVATE_KEY` — **Required for keepalive parity** - Explicit keepalive app key
 - [ ] `OPENAI_API_KEY` — Required for verify/decompose/optimizer workflows

--- a/templates/consumer-repo/README.md
+++ b/templates/consumer-repo/README.md
@@ -161,10 +161,14 @@ Use an exact commit SHA when you need stricter reproducibility or a controlled r
 | Secret | Purpose | Alternative |
 |--------|---------|-------------|
 | `CODEX_AUTH_JSON` | ChatGPT auth for Codex CLI | Recommended for Codex |
+| `WORKFLOWS_APP_CLIENT_ID` | GitHub App client ID | Preferred with private key |
 | `WORKFLOWS_APP_ID` | GitHub App ID | Use instead of CODEX_AUTH_JSON |
 | `WORKFLOWS_APP_PRIVATE_KEY` | GitHub App private key | Required with APP_ID |
+| `GH_APP_CLIENT_ID` | Bot-comment App client ID | Preferred bot-comment auth |
+| `GH_APP_ID` | Bot-comment legacy App ID | Fallback bot-comment auth |
+| `GH_APP_PRIVATE_KEY` | Bot-comment App private key | Required with GH App IDs |
 
-**Note:** Choose either `CODEX_AUTH_JSON` (ChatGPT auth) OR the GitHub App credentials (`WORKFLOWS_APP_ID` + `WORKFLOWS_APP_PRIVATE_KEY`), not both.
+**Note:** Choose either `CODEX_AUTH_JSON` (ChatGPT auth) OR the GitHub App credentials (`WORKFLOWS_APP_CLIENT_ID` or `WORKFLOWS_APP_ID` + `WORKFLOWS_APP_PRIVATE_KEY`), not both. Prefer client ID secrets where available; legacy App ID fallbacks remain supported for existing installs.
 
 ### Legacy Secrets (for agents-orchestrator.yml)
 

--- a/tests/workflows/test_bot_comment_handler.py
+++ b/tests/workflows/test_bot_comment_handler.py
@@ -65,7 +65,8 @@ def test_reusable_bot_comment_handler_uploads_terminal_disposition_artifact() ->
 
 def test_reusable_bot_comment_handler_prefers_app_client_id() -> None:
     workflow = _load_yaml(ROOT / ".github/workflows/reusable-bot-comment-handler.yml")
-    workflow_call_secrets = (workflow.get("on") or workflow.get(True))["workflow_call"]["secrets"]
+    workflow_call = (workflow.get("on") or workflow.get(True))["workflow_call"]
+    workflow_call_secrets = workflow_call["secrets"]
     collect_steps = workflow["jobs"]["collect"]["steps"]
     dispatch_steps = workflow["jobs"]["dispatch"]["steps"]
     detect_steps = [
@@ -87,12 +88,21 @@ def test_reusable_bot_comment_handler_prefers_app_client_id() -> None:
 
     assert "gh_app_client_id" in workflow_call_secrets
     assert "prefer gh_app_client_id" in workflow_call_secrets["gh_app_id"]["description"]
+    assert workflow_call["outputs"]["app_auth_mode"]["value"] == (
+        "${{ jobs.collect.outputs.app_auth_mode }}"
+    )
+    assert workflow["jobs"]["collect"]["outputs"]["app_auth_mode"] == (
+        "${{ steps.app-creds.outputs.app_auth_mode }}"
+    )
     assert detect_step["env"]["GH_APP_CLIENT_ID"] == "${{ secrets.gh_app_client_id }}"
     assert detect_step["env"]["GH_APP_PRIVATE_KEY"] == "${{ secrets.gh_app_private_key }}"
     for detect_step in detect_steps:
         detect_script = detect_step["run"]
         assert detect_step["env"]["GH_APP_CLIENT_ID"] == "${{ secrets.gh_app_client_id }}"
         assert detect_step["env"]["GH_APP_PRIVATE_KEY"] == "${{ secrets.gh_app_private_key }}"
+        assert "client_id_configured=true" in detect_script
+        assert "legacy_app_id_configured=true" in detect_script
+        assert "private_key_configured=true" in detect_script
         assert "app_auth_mode=client-id" in detect_script
         assert "app_auth_mode=legacy-app-id" in detect_script
         assert "app_auth_mode=none" in detect_script
@@ -106,6 +116,28 @@ def test_reusable_bot_comment_handler_prefers_app_client_id() -> None:
         "steps.token-client.outputs.token || steps.token-legacy.outputs.token"
         in resolve_step["env"]["TOKEN_OUTPUT"]
     )
+
+
+def test_reusable_bot_comment_handler_uploads_auth_coverage_artifact() -> None:
+    workflow = _load_yaml(ROOT / ".github/workflows/reusable-bot-comment-handler.yml")
+    collect_steps = workflow["jobs"]["collect"]["steps"]
+    write_step = next(
+        step for step in collect_steps if step.get("name") == "Write App auth coverage"
+    )
+    upload_step = next(
+        step for step in collect_steps if step.get("name") == "Upload App auth coverage"
+    )
+
+    assert write_step.get("if") == "always()"
+    assert write_step["env"]["APP_AUTH_MODE"] == "${{ steps.app-creds.outputs.app_auth_mode }}"
+    assert "workflows-bot-comment-auth-coverage/v1" in write_step["run"]
+    assert "client_id_configured" in write_step["run"]
+    assert "fallback_warning_active" in write_step["run"]
+    assert upload_step.get("if") == "always()"
+    assert upload_step.get("uses") == "actions/upload-artifact@v7"
+    assert upload_step["with"]["name"] == "bot-comment-auth-coverage-reusable-${{ github.run_id }}"
+    assert upload_step["with"]["path"] == "bot-comment-auth-coverage/reusable.json"
+    assert upload_step["with"]["if-no-files-found"] == "error"
 
 
 def test_bot_comment_handler_callers_pass_app_client_id() -> None:
@@ -134,6 +166,11 @@ def test_bot_comment_handler_callers_pass_app_client_id() -> None:
 
 def test_canonical_bot_comment_handler_direct_app_tokens_prefer_client_id() -> None:
     workflow = _load_yaml(ROOT / ".github/workflows/agents-bot-comment-handler.yml")
+    resolve_job = workflow["jobs"]["resolve"]
+
+    assert resolve_job["outputs"]["workflow_app_auth_mode"] == (
+        "${{ steps.workflow-app-creds.outputs.workflow_app_auth_mode }}"
+    )
 
     for job_name in ("resolve", "cleanup"):
         steps = workflow["jobs"][job_name]["steps"]
@@ -151,6 +188,9 @@ def test_canonical_bot_comment_handler_direct_app_tokens_prefer_client_id() -> N
         assert detect_step["env"]["WORKFLOWS_APP_CLIENT_ID"] == (
             "${{ secrets.WORKFLOWS_APP_CLIENT_ID }}"
         )
+        assert "client_id_configured=true" in detect_step["run"]
+        assert "legacy_app_id_configured=true" in detect_step["run"]
+        assert "private_key_configured=true" in detect_step["run"]
         assert "workflow_app_auth_mode=client-id" in detect_step["run"]
         assert "workflow_app_auth_mode=legacy-app-id" in detect_step["run"]
         assert "workflow_app_auth_mode=none" in detect_step["run"]
@@ -167,6 +207,30 @@ def test_canonical_bot_comment_handler_direct_app_tokens_prefer_client_id() -> N
 
     serialized_workflow = yaml.safe_dump(workflow)
     assert "steps.app_token.outputs.token" not in serialized_workflow
+
+
+def test_canonical_bot_comment_handler_uploads_wrapper_auth_coverage_artifact() -> None:
+    workflow = _load_yaml(ROOT / ".github/workflows/agents-bot-comment-handler.yml")
+    resolve_steps = workflow["jobs"]["resolve"]["steps"]
+    write_step = next(
+        step for step in resolve_steps if step.get("name") == "Write wrapper App auth coverage"
+    )
+    upload_step = next(
+        step for step in resolve_steps if step.get("name") == "Upload wrapper App auth coverage"
+    )
+
+    assert write_step.get("if") == "always()"
+    assert write_step["env"]["WORKFLOW_APP_AUTH_MODE"] == (
+        "${{ steps.workflow-app-creds.outputs.workflow_app_auth_mode }}"
+    )
+    assert "workflows-bot-comment-auth-coverage/v1" in write_step["run"]
+    assert "agents-bot-comment-handler-wrapper" in write_step["run"]
+    assert "direct_jobs_covered" in write_step["run"]
+    assert upload_step.get("if") == "always()"
+    assert upload_step.get("uses") == "actions/upload-artifact@v7"
+    assert upload_step["with"]["name"] == "bot-comment-auth-coverage-wrapper-${{ github.run_id }}"
+    assert upload_step["with"]["path"] == "bot-comment-auth-coverage/wrapper.json"
+    assert upload_step["with"]["if-no-files-found"] == "error"
 
 
 def test_template_bot_comment_handler_passes_agents_ignore() -> None:


### PR DESCRIPTION
## Summary
- add warning-only bot-comment App auth coverage artifacts for the canonical wrapper and reusable handler
- expose reusable bot-comment app_auth_mode as a workflow_call output
- document client-ID secret coverage and preferred setup paths

## Verification
- python -m pytest tests/workflows/test_bot_comment_handler.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m black --check --line-length 100 --target-version py312 tests/workflows/test_bot_comment_handler.py
- python scripts/validate_template_sync.py
- python -m pytest tests/scripts/test_validate_template_sync.py -q
- scripts/sync_templates.sh
- python scripts/validate_template_completeness.py --source sync-manifest --template-dir templates/consumer-repo/.github/workflows --manifest .github/sync-manifest.yml
- actionlint .github/workflows/agents-bot-comment-handler.yml .github/workflows/reusable-bot-comment-handler.yml
- git diff --check
- retired CODESPACES_WORKFLOWS grep