### PR TITLE
Ignore auth artifact zips in coverage scanner

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -188,6 +188,10 @@ test('identifies only bot-comment auth coverage candidate files', () => {
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-reusable-1/reusable.json'),
     true
   );
+  assert.equal(
+    isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/123.zip'),
+    false
+  );
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/metric-artifacts-selection.json'), false);
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/run-view.json'), false);
 });

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -337,6 +337,7 @@ function collectJsonFiles(rootDir) {
 function isPotentialAuthCoverageFile(file) {
   const normalized = cleanString(file).split(path.sep).join('/');
   const basename = path.basename(normalized);
+  if (!normalized.endsWith('.json')) return false;
   return normalized.includes('/bot-comment-auth-coverage-wrapper-') ||
     normalized.includes('/bot-comment-auth-coverage-reusable-') ||
     basename === 'wrapper.json' ||

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -337,6 +337,7 @@ function collectJsonFiles(rootDir) {
 function isPotentialAuthCoverageFile(file) {
   const normalized = cleanString(file).split(path.sep).join('/');
   const basename = path.basename(normalized);
+  if (!normalized.endsWith('.json')) return false;
   return normalized.includes('/bot-comment-auth-coverage-wrapper-') ||
     normalized.includes('/bot-comment-auth-coverage-reusable-') ||
     basename === 'wrapper.json' ||


### PR DESCRIPTION
## Summary
- require bot-comment auth coverage scanner candidates to be JSON files
- prevent downloaded artifact zip files from being counted as parse errors
- sync the consumer template helper copy

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python scripts/validate_template_sync.py
- git diff --check