### PR TITLE
Harden sync/dependabot campaign queue

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -6,13 +6,18 @@ const assert = require('node:assert/strict');
 const {
   buildQueueItem,
   collectActiveBotThreads,
+  discoverRepoWork,
+  findCampaignIssue,
   formatCampaignBody,
   formatCampaignMarker,
+  formatDryRunSummary,
   isDependabotPullRequest,
   isSyncPullRequest,
   mergeCampaignState,
+  paginateWithRetry,
   parseCampaignMarker,
   replaceCampaignMarker,
+  verboseDryRunLoggingEnabled,
 } = require('../sync_dependabot_campaign.js');
 
 test('formats and parses campaign marker', () => {
@@ -115,7 +120,6 @@ test('collectActiveBotThreads keeps active bot review threads only', () => {
 test('buildQueueItem creates stable PR-scoped work items', () => {
   const item = buildQueueItem({
     repoFullName: 'stranske/TPP',
-    classification: 'sync',
     defaultOwner: 'stranske',
     now: '2026-04-21T05:52:00Z',
     pr: {
@@ -143,6 +147,27 @@ test('buildQueueItem creates stable PR-scoped work items', () => {
   assert.equal(item.source_repo, 'stranske/Workflows');
   assert.equal(item.preferred_workdir, 'Workflows');
   assert.equal(item.review_thread_count, 1);
+});
+
+test('mergeCampaignState preserves active items when repo discovery fails', () => {
+  const active = {
+    id: 'sync-review-comments:stranske/TPP#850:abc',
+    status: 'needs-local-codex',
+    repo: 'stranske/TPP',
+    pr_number: 850,
+    updated_at: '2026-04-21T05:30:00Z',
+  };
+
+  const state = mergeCampaignState(
+    { items: [active] },
+    [],
+    '2026-04-21T05:52:00Z',
+    { reposRequested: 1, reposChecked: 0, reposFailed: 1, failedRepos: ['stranske/TPP'] },
+  );
+
+  assert.equal(state.items[0].status, 'needs-local-codex');
+  assert.equal(state.items[0].preserved_after_scan_error_at, '2026-04-21T05:52:00Z');
+  assert.equal(state.stats.items_needing_local_codex, 1);
 });
 
 test('mergeCampaignState preserves claims, expires old leases, and stales missing items', () => {
@@ -218,4 +243,165 @@ test('formatCampaignBody renders queue rows and marker', () => {
   assert.match(body, /Sync\/Dependabot Campaign Queue/);
   assert.match(body, /stranske\/App#10/);
   assert.equal(parseCampaignMarker(body).stats.items_needing_local_codex, 1);
+});
+
+test('paginateWithRetry uses the paginated GitHub API', async () => {
+  const endpoint = function listForRepo() {};
+  const github = {
+    paginate: async (method, params) => {
+      assert.equal(method, endpoint);
+      assert.deepEqual(params, { owner: 'stranske', repo: 'Workflows', per_page: 100 });
+      return [{ number: 101 }, { number: 102 }];
+    },
+  };
+
+  const items = await paginateWithRetry({
+    github,
+    core: console,
+    method: () => endpoint,
+    params: { owner: 'stranske', repo: 'Workflows', per_page: 100 },
+    label: 'test pagination',
+  });
+
+  assert.deepEqual(items.map((item) => item.number), [101, 102]);
+});
+
+test('discoverRepoWork scans paginated PR results', async () => {
+  const pullsList = function pullsList() {};
+  const calls = [];
+  const github = {
+    rest: { pulls: { list: pullsList } },
+    paginate: async (method, params) => {
+      calls.push({ method, params });
+      return [
+        {
+          number: 101,
+          title: 'human PR',
+          user: { login: 'stranske' },
+          head: { ref: 'feature/human', sha: 'human-sha' },
+        },
+        {
+          number: 102,
+          title: 'Bump package',
+          html_url: 'https://github.com/stranske/App/pull/102',
+          user: { login: 'dependabot[bot]' },
+          head: { ref: 'dependabot/npm/pkg-2', sha: 'dep-sha' },
+          base: { ref: 'main' },
+        },
+      ];
+    },
+    graphql: async (_query, variables) => {
+      assert.equal(variables.number, 102);
+      return {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: 'thread-102',
+                  isResolved: false,
+                  isOutdated: false,
+                  path: 'package.json',
+                  line: 12,
+                  comments: {
+                    nodes: [
+                      {
+                        id: 'comment-102',
+                        url: 'https://github.test/comment-102',
+                        body: 'Please update the lockfile.',
+                        author: { login: 'Copilot' },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+    },
+  };
+
+  const result = await discoverRepoWork({
+    github,
+    core: console,
+    repoEntry: { owner: 'stranske', repo: 'App', fullName: 'stranske/App' },
+    now: '2026-04-21T05:52:00Z',
+    defaultOwner: 'stranske',
+  });
+
+  assert.equal(calls[0].method, pullsList);
+  assert.equal(calls[0].params.per_page, 100);
+  assert.equal(result.dependabotPrsOpen, 1);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].pr_number, 102);
+});
+
+test('findCampaignIssue only returns marker-backed campaign issues', async () => {
+  const issueList = function issueList() {};
+  const markerBody = formatCampaignBody(mergeCampaignState({}, [], '2026-04-21T05:52:00Z'));
+  const github = {
+    rest: {
+      issues: {
+        listForRepo: issueList,
+        get: async ({ issue_number: issueNumber }) => ({
+          data: {
+            number: issueNumber,
+            body: issueNumber === 12 ? 'matching title without marker' : markerBody,
+            html_url: `https://github.test/issues/${issueNumber}`,
+          },
+        }),
+      },
+    },
+    paginate: async (method, params) => {
+      assert.equal(method, issueList);
+      assert.equal(params.per_page, 100);
+      return [
+        { number: 12, title: 'Sync/Dependabot campaign queue - old', pull_request: null },
+        { number: 13, title: 'Sync/Dependabot campaign queue', pull_request: null },
+      ];
+    },
+  };
+
+  const issue = await findCampaignIssue(github, 'stranske', 'Workflows', console);
+
+  assert.equal(issue.number, 13);
+});
+
+test('findCampaignIssue does not fall back to unmarked title matches', async () => {
+  const github = {
+    rest: {
+      issues: {
+        listForRepo: function issueList() {},
+        get: async ({ issue_number: issueNumber }) => ({
+          data: { number: issueNumber, body: 'no marker' },
+        }),
+      },
+    },
+    paginate: async () => [
+      { number: 12, title: 'Sync/Dependabot campaign queue', pull_request: null },
+    ],
+  };
+
+  const issue = await findCampaignIssue(github, 'stranske', 'Workflows', console);
+
+  assert.equal(issue, null);
+});
+
+test('dry-run summary avoids logging generated issue body by default', () => {
+  const state = mergeCampaignState({}, [], '2026-04-21T05:52:00Z', {
+    reposRequested: 2,
+    reposChecked: 1,
+    reposFailed: 1,
+  });
+  const summary = formatDryRunSummary(state);
+
+  assert.match(summary, /Campaign issue update suppressed/);
+  assert.match(summary, /repos_checked=1\/2/);
+  assert.doesNotMatch(summary, /sync-dependabot-campaign:v1/);
+  assert.equal(verboseDryRunLoggingEnabled({}), false);
+  assert.equal(verboseDryRunLoggingEnabled({ ACTIONS_STEP_DEBUG: 'true' }), true);
+  assert.equal(verboseDryRunLoggingEnabled({ RUNNER_DEBUG: '1' }), true);
+  assert.equal(verboseDryRunLoggingEnabled({ SYNC_DEPENDABOT_CAMPAIGN_DEBUG_BODY: 'true' }), true);
 });

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -163,15 +163,16 @@ function buildQueueItem({ repoFullName, pr, threads, classification, now, defaul
   const headSha = cleanString(pr?.head?.sha || pr?.headSha || pr?.head_sha);
   const threadIds = collectThreadIds(threads);
   const fingerprint = sha256Short(`${repo}#${prNumber}:${headSha}:${threadIds.join(',')}`, 20);
-  const kind = `${classification || classifyPullRequest(pr)}-review-comments`;
+  const resolvedClassification = classification || classifyPullRequest(pr);
+  const kind = `${resolvedClassification}-review-comments`;
   const preferredWorkdir =
-    classification === 'sync' ? 'Workflows' : repo.split('/').slice(-1)[0] || '';
+    resolvedClassification === 'sync' ? 'Workflows' : repo.split('/').slice(-1)[0] || '';
 
   return {
     id: `${kind}:${repo}#${prNumber}:${fingerprint}`,
     status: 'needs-local-codex',
     kind,
-    classification: classification || classifyPullRequest(pr),
+    classification: resolvedClassification,
     repo,
     pr_number: prNumber,
     pr_title: cleanString(pr?.title),
@@ -179,7 +180,7 @@ function buildQueueItem({ repoFullName, pr, threads, classification, now, defaul
     head_ref: cleanString(pr?.head?.ref || pr?.headRefName || pr?.headRef),
     head_sha: headSha,
     base_ref: cleanString(pr?.base?.ref || pr?.baseRefName || pr?.baseRef),
-    source_repo: classification === 'sync' ? `${defaultOwner || repo.split('/')[0]}/Workflows` : repo,
+    source_repo: resolvedClassification === 'sync' ? `${defaultOwner || repo.split('/')[0]}/Workflows` : repo,
     preferred_workdir: preferredWorkdir,
     review_thread_count: threads.length,
     review_comment_count: threads.reduce((sum, thread) => sum + (thread.comments_count || 0), 0),
@@ -214,6 +215,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
   const previousItems = cleanArray(previousState.items);
   const previousById = new Map(previousItems.map((item) => [item.id, item]));
   const discoveredById = new Map(discoveredItems.map((item) => [item.id, item]));
+  const failedRepos = new Set(parseCsv(options.failedRepos));
   const nextItems = [];
 
   for (const discovered of discoveredItems) {
@@ -258,7 +260,13 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     if (discoveredById.has(previous.id)) {
       continue;
     }
-    if (ACTIVE_STATUSES.has(previous.status)) {
+    if (ACTIVE_STATUSES.has(previous.status) && failedRepos.has(previous.repo)) {
+      nextItems.push({
+        ...previous,
+        preserved_after_scan_error_at: now,
+        updated_at: now,
+      });
+    } else if (ACTIVE_STATUSES.has(previous.status)) {
       nextItems.push({
         ...previous,
         status: 'stale',
@@ -476,6 +484,24 @@ async function callWithRetry(fn, label, core, maxRetries = 3, withRetry = null, 
   throw lastError;
 }
 
+async function paginateWithRetry({ github, core, withRetry, method, params, label }) {
+  return callWithRetry(
+    (client) => {
+      const api = client || github;
+      if (!api || typeof api.paginate !== 'function') {
+        throw new Error(`${label} requires github.paginate`);
+      }
+      const endpoint = typeof method === 'function' ? method(api) : method;
+      return api.paginate(endpoint, params);
+    },
+    label,
+    core,
+    3,
+    withRetry,
+    github,
+  );
+}
+
 async function fetchReviewThreads(github, owner, repo, number, core, withRetry = null) {
   const query = `
     query($owner: String!, $repo: String!, $number: Int!, $after: String) {
@@ -547,15 +573,14 @@ async function discoverRepoWork({
     dependabotPrsOpen: 0,
   };
 
-  const response = await callWithRetry(
-    (client) => client.rest.pulls.list({ owner, repo, state: 'open', per_page: 100 }),
-    `${fullName} open pulls`,
-    core,
-    3,
-    withRetry,
+  const prs = cleanArray(await paginateWithRetry({
     github,
-  );
-  const prs = cleanArray(response.data);
+    core,
+    withRetry,
+    method: (client) => client.rest.pulls.list,
+    params: { owner, repo, state: 'open', per_page: 100 },
+    label: `${fullName} open pulls`,
+  }));
 
   for (const pr of prs) {
     const classification = classifyPullRequest(pr);
@@ -586,15 +611,15 @@ async function discoverRepoWork({
 }
 
 async function findCampaignIssue(github, owner, repo, core, withRetry = null) {
-  const response = await callWithRetry(
-    (client) => client.rest.issues.listForRepo({ owner, repo, state: 'open', per_page: 100 }),
-    `${owner}/${repo} campaign issue list`,
-    core,
-    3,
-    withRetry,
+  const issues = cleanArray(await paginateWithRetry({
     github,
-  );
-  const candidates = cleanArray(response.data).filter((issue) =>
+    core,
+    withRetry,
+    method: (client) => client.rest.issues.listForRepo,
+    params: { owner, repo, state: 'open', per_page: 100 },
+    label: `${owner}/${repo} campaign issue list`,
+  }));
+  const candidates = issues.filter((issue) =>
     !issue.pull_request && cleanString(issue.title).startsWith(CAMPAIGN_TITLE)
   );
 
@@ -612,7 +637,7 @@ async function findCampaignIssue(github, owner, repo, core, withRetry = null) {
     }
   }
 
-  return candidates[0] || null;
+  return null;
 }
 
 async function ensureLabel(github, owner, repo, name, color, description, core, withRetry = null) {
@@ -704,6 +729,26 @@ function log(core, level, message) {
   }
 }
 
+function verboseDryRunLoggingEnabled(env = process.env) {
+  return (
+    cleanString(env.ACTIONS_STEP_DEBUG).toLowerCase() === 'true' ||
+    cleanString(env.RUNNER_DEBUG) === '1' ||
+    cleanString(env.SYNC_DEPENDABOT_CAMPAIGN_DEBUG_BODY).toLowerCase() === 'true'
+  );
+}
+
+function formatDryRunSummary(state = {}) {
+  const stats = state.stats || {};
+  return [
+    '[dry-run] Campaign issue update suppressed from logs.',
+    `repos_checked=${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
+    `repos_failed=${stats.repos_failed || 0}`,
+    `sync_prs_open=${stats.sync_prs_open || 0}`,
+    `dependabot_prs_open=${stats.dependabot_prs_open || 0}`,
+    `items_needing_local_codex=${stats.items_needing_local_codex || 0}`,
+  ].join(' ');
+}
+
 async function runCampaign({
   github,
   context,
@@ -765,6 +810,7 @@ async function runCampaign({
     reposFailed: errors.length,
     syncPrsOpen,
     dependabotPrsOpen,
+    failedRepos: errors.map((error) => error.repo),
   });
   if (errors.length) {
     state.errors = errors.slice(0, 20);
@@ -774,8 +820,11 @@ async function runCampaign({
   const needsLocalCodex = Number(state.stats.items_needing_local_codex || 0) > 0;
 
   if (dryRun) {
-    log(core, 'info', '[dry-run] Campaign issue body preview:');
-    log(core, 'info', body);
+    log(core, 'info', formatDryRunSummary(state));
+    if (verboseDryRunLoggingEnabled()) {
+      log(core, 'info', '[dry-run] Campaign issue body preview:');
+      log(core, 'info', body);
+    }
   } else if (campaignIssue?.number) {
     const updated = await callWithRetry(
       (client) => client.rest.issues.update({
@@ -831,12 +880,17 @@ module.exports = {
   collectActiveBotThreads,
   buildQueueItem,
   classifyPullRequest,
+  discoverRepoWork,
+  findCampaignIssue,
   formatCampaignBody,
   formatCampaignMarker,
+  formatDryRunSummary,
   isDependabotPullRequest,
   isSyncPullRequest,
   mergeCampaignState,
+  paginateWithRetry,
   parseCampaignMarker,
   replaceCampaignMarker,
   runCampaign,
+  verboseDryRunLoggingEnabled,
 };

--- a/.github/workflows/maint-82-sync-dependabot-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependabot-campaign.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Refresh campaign issue
         id: campaign
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.CAMPAIGN_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary
- Preserve active campaign queue items when a repo scan fails so transient GitHub/API failures do not stale local work.
- Use paginated PR and campaign issue discovery, and require marker-backed campaign issues before updating.
- Redact generated campaign issue bodies from dry-run logs unless debug logging is explicitly enabled.
- Move maint-82 campaign workflow to actions/github-script@v9 and add focused unit coverage.

## Verification
- node --check .github/scripts/sync_dependabot_campaign.js
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js
- python -m pytest tests/workflows/test_workflow_naming.py tests/workflows/test_disable_legacy_workflows.py -q
- git diff --check