### PR TITLE
Fix auto-label pagination retry call

### DIFF
--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -83,10 +83,7 @@ jobs:
                   paginateWithRetry: (githubInstance, method, params) =>
                     githubInstance.paginate(method, params),
                 };
-            const paginateWithRetry = (method, params, options) =>
-              retryHelpers.paginateWithRetry.length >= 3
-                ? retryHelpers.paginateWithRetry(github, method, params, options)
-                : retryHelpers.paginateWithRetry(method, params, options);
+            const { paginateWithRetry } = retryHelpers;
 
             // Paginate to get all labels (handles repos with >100 labels)
             const labels = await paginateWithRetry(

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -204,6 +204,20 @@ def test_consumer_sync_run_uploads_machine_readable_report():
     ), "Maint 68 report must distinguish sync failures from PR creation failures"
 
 
+def test_auto_label_uses_retry_paginate_with_github_client_first():
+    text = (WORKFLOWS_DIR / "agents-auto-label.yml").read_text(encoding="utf-8")
+    assert (
+        "const { paginateWithRetry } = retryHelpers;" in text
+    ), "Auto-label should call the shared pagination helper directly"
+    assert (
+        "retryHelpers.paginateWithRetry(github, method, params, options)" not in text
+    ), "Auto-label must not wrap paginateWithRetry with an arity guess"
+    assert (
+        "const labels = await paginateWithRetry(\n              github, github.rest.issues.listLabelsForRepo,"
+        in text
+    ), "Auto-label label discovery must pass the GitHub client as the first pagination argument"
+
+
 def test_consumer_sync_diff_keeps_functional_lines_in_comparison():
     text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#878](https://github.com/stranske/Travel-Plan-Permission/issues/878)
- [stranske/Travel-Plan-Permission#877](https://github.com/stranske/Travel-Plan-Permission/issues/877)
- [stranske/Travel-Plan-Permission#876](https://github.com/stranske/Travel-Plan-Permission/issues/876)
- [stranske/Travel-Plan-Permission#875](https://github.com/stranske/Travel-Plan-Permission/issues/875)
- [stranske/Travel-Plan-Permission#874](https://github.com/stranske/Travel-Plan-Permission/issues/874)
- [stranske/Template#565](https://github.com/stranske/Template/issues/565)
- [stranske/Template#564](https://github.com/stranske/Template/issues/564)
- [stranske/Template#562](https://github.com/stranske/Template/issues/562)
- [stranske/Template#561](https://github.com/stranske/Template/issues/561)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [stranske/Inv-Man-Intake#245](https://github.com/stranske/Inv-Man-Intake/issues/245)
- [stranske/Inv-Man-Intake#244](https://github.com/stranske/Inv-Man-Intake/issues/244)
- [stranske/Inv-Man-Intake#243](https://github.com/stranske/Inv-Man-Intake/issues/243)
- [stranske/Inv-Man-Intake#242](https://github.com/stranske/Inv-Man-Intake/issues/242)
- [stranske/Ready#89](https://github.com/stranske/Ready/issues/89)
- [stranske/Ready#88](https://github.com/stranske/Ready/issues/88)
- [stranske/Ready#87](https://github.com/stranske/Ready/issues/87)
- [stranske/Ready#84](https://github.com/stranske/Ready/issues/84)
- [stranske/Ready#83](https://github.com/stranske/Ready/issues/83)
- [stranske/Ready#82](https://github.com/stranske/Ready/issues/82)
- [stranske/trip-planner#897](https://github.com/stranske/trip-planner/issues/897)
- [stranske/trip-planner#896](https://github.com/stranske/trip-planner/issues/896)
- [stranske/trip-planner#895](https://github.com/stranske/trip-planner/issues/895)
- [stranske/trip-planner#894](https://github.com/stranske/trip-planner/issues/894)
- [stranske/trip-planner#893](https://github.com/stranske/trip-planner/issues/893)
- [stranske/trip-planner#892](https://github.com/stranske/trip-planner/issues/892)
- [stranske/Manager-Database#844](https://github.com/stranske/Manager-Database/issues/844)
- [stranske/Manager-Database#843](https://github.com/stranske/Manager-Database/issues/843)
- [stranske/Manager-Database#842](https://github.com/stranske/Manager-Database/issues/842)
- [stranske/Manager-Database#841](https://github.com/stranske/Manager-Database/issues/841)
- [stranske/Manager-Database#840](https://github.com/stranske/Manager-Database/issues/840)
- [stranske/Manager-Database#839](https://github.com/stranske/Manager-Database/issues/839)
- [stranske/Manager-Database#838](https://github.com/stranske/Manager-Database/issues/838)
- [stranske/Manager-Database#837](https://github.com/stranske/Manager-Database/issues/837)
- [stranske/Portable-Alpha-Extension-Model#1622](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1622)
- [stranske/Portable-Alpha-Extension-Model#1620](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1620)
- [stranske/Portable-Alpha-Extension-Model#1619](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1619)
- [stranske/Portable-Alpha-Extension-Model#1618](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1618)
- [stranske/Portable-Alpha-Extension-Model#1617](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1617)
- [stranske/Portable-Alpha-Extension-Model#1616](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1616)
- [stranske/Portable-Alpha-Extension-Model#1615](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1615)
- [stranske/Trend_Model_Project#5109](https://github.com/stranske/Trend_Model_Project/issues/5109)
- [stranske/Trend_Model_Project#5108](https://github.com/stranske/Trend_Model_Project/issues/5108)
- [stranske/Trend_Model_Project#5106](https://github.com/stranske/Trend_Model_Project/issues/5106)
- [stranske/Trend_Model_Project#5105](https://github.com/stranske/Trend_Model_Project/issues/5105)
- [stranske/Trend_Model_Project#5104](https://github.com/stranske/Trend_Model_Project/issues/5104)
- [stranske/Trend_Model_Project#5103](https://github.com/stranske/Trend_Model_Project/issues/5103)
- [stranske/Trend_Model_Project#5102](https://github.com/stranske/Trend_Model_Project/issues/5102)
- [stranske/Collab-Admin#583](https://github.com/stranske/Collab-Admin/issues/583)
- [stranske/Collab-Admin#581](https://github.com/stranske/Collab-Admin/issues/581)
- [stranske/Collab-Admin#580](https://github.com/stranske/Collab-Admin/issues/580)
- [stranske/Collab-Admin#579](https://github.com/stranske/Collab-Admin/issues/579)
- [stranske/Collab-Admin#578](https://github.com/stranske/Collab-Admin/issues/578)
- [stranske/Collab-Admin#577](https://github.com/stranske/Collab-Admin/issues/577)
- [stranske/Collab-Admin#576](https://github.com/stranske/Collab-Admin/issues/576)
- [stranske/Travel-Plan-Permission#879](https://github.com/stranske/Travel-Plan-Permission/issues/879)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-25T18:06:12.605Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 88
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 159
- [ ] Items needing local Codex: 71

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 11000cb5e979ba15e41eb2147009cf8e82d714e0
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24937337615) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937337690) |
| Agents Keepalive Loop | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24937337754) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937337866) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24937335427) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937337869) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937336105) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24937337736) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24937337738) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24937337682) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335513) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335491) |
| Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24937337735) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335481) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335490) |
| Health 74 Template Drift | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335498) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335496) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335488) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335484) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24937335497) |
<!-- auto-status-summary:end -->