### PR TITLE
Harden bot auth coverage diagnostics

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -130,6 +130,28 @@ test('normalizes string boolean auth fields without false fallback warnings', ()
   assert.deepEqual(report.enforcement.blockers, []);
 });
 
+test('treats unrecognized string boolean fields as false', () => {
+  const report = summarizeBotCommentAuthCoverage([
+    record('agents-bot-comment-handler-wrapper', 'client-id', 106, {
+      client_id_configured: 'unknown',
+      legacy_app_id_configured: 'n/a',
+      private_key_configured: 'not reported',
+      fallback_warning_active: 'unknown',
+    }),
+    record('reusable-bot-comment-handler', 'none', 106),
+  ]);
+
+  assert.equal(report.components[0].latest.client_id_configured, false);
+  assert.equal(report.components[0].latest.legacy_app_id_configured, false);
+  assert.equal(report.components[0].latest.private_key_configured, false);
+  assert.equal(report.components[0].latest.fallback_warning_active, false);
+  assert.ok(
+    !report.components[0].blockers.includes(
+      'legacy-agents-bot-comment-handler-wrapper-fallback-active'
+    )
+  );
+});
+
 test('keeps hard blocking disabled without explicit approval', () => {
   const report = summarizeBotCommentAuthCoverage(
     [record('agents-bot-comment-handler-wrapper', 'legacy-app-id', 103)],
@@ -205,6 +227,7 @@ test('warns when configured artifact selection report is missing', () => {
   assert.equal(report.artifact_selection.status, 'missing');
   assert.match(report.artifact_selection.error_message, /not found/);
   assert.ok(report.enforcement.blockers.includes('artifact-selection-warning'));
+  assert.match(markdown, /Artifact selection status: missing/);
   assert.match(markdown, /Artifact selector error:/);
 });
 

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -39,6 +39,7 @@ function normalizeRecordBoolean(value) {
   const text = cleanString(value).toLowerCase();
   if (['1', 'true', 'yes', 'y', 'on'].includes(text)) return true;
   if (['0', 'false', 'no', 'n', 'off', ''].includes(text)) return false;
+  if (typeof value === 'string') return false;
   return Boolean(value);
 }
 
@@ -455,6 +456,7 @@ function formatBotCommentAuthCoverageMarkdown(report) {
   ];
 
   if (report.artifact_selection) {
+    lines.push(`- Artifact selection status: ${report.artifact_selection.status || 'unknown'}`);
     lines.push(`- Selected auth artifacts: ${report.artifact_selection.selected_auth_artifact_count}`);
     if (report.artifact_selection.error_message) {
       lines.push(`- Artifact selector error: ${report.artifact_selection.error_message}`);

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -39,6 +39,7 @@ function normalizeRecordBoolean(value) {
   const text = cleanString(value).toLowerCase();
   if (['1', 'true', 'yes', 'y', 'on'].includes(text)) return true;
   if (['0', 'false', 'no', 'n', 'off', ''].includes(text)) return false;
+  if (typeof value === 'string') return false;
   return Boolean(value);
 }
 
@@ -455,6 +456,7 @@ function formatBotCommentAuthCoverageMarkdown(report) {
   ];
 
   if (report.artifact_selection) {
+    lines.push(`- Artifact selection status: ${report.artifact_selection.status || 'unknown'}`);
     lines.push(`- Selected auth artifacts: ${report.artifact_selection.selected_auth_artifact_count}`);
     if (report.artifact_selection.error_message) {
       lines.push(`- Artifact selector error: ${report.artifact_selection.error_message}`);


### PR DESCRIPTION
## Summary
- Treat unrecognized string boolean fields as false instead of JavaScript truthy values.
- Add artifact selection status to the bot-auth coverage markdown summary.
- Mirror the source script into the consumer template and add focused node tests for both contracts.

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_bot_comment_handler.py -q
- git diff --check origin/main..HEAD

## Coordination
- Rebased after main advanced to 41994d3c, which already handled the zero-record organic-evidence queue item.