### PR TITLE
Harden bot auth coverage input contracts

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -265,6 +265,20 @@ test('normalizes invalid artifact selection reports as parse errors', () => {
   });
 });
 
+test('normalizes missing artifact selection reports after object validation', () => {
+  const summary = normalizeArtifactSelectionSummary({
+    schema: 'workflows-weekly-metrics-artifact-selection/v1',
+    status: 'missing',
+    error_message: 'not found',
+    selected_artifacts: [{ name: 'bot-comment-auth-coverage-wrapper-1' }],
+  });
+
+  assert.equal(summary.status, 'missing');
+  assert.equal(summary.error_message, 'not found');
+  assert.equal(summary.selected_auth_artifact_count, 0);
+  assert.deepEqual(summary.selected_auth_artifacts, []);
+});
+
 test('reports selected auth artifacts without readable input files', () => {
   const report = summarizeBotCommentAuthCoverage([], {
     artifact_selection_report: {
@@ -286,12 +300,47 @@ test('reports selected auth artifacts without readable input files', () => {
   assert.ok(report.enforcement.blockers.includes('selected-auth-artifacts-without-input-files'));
 });
 
+test('keeps no-data missing components out of global blockers', () => {
+  const report = summarizeBotCommentAuthCoverage([
+    record('agents-bot-comment-handler-wrapper', 'client-id', 109),
+  ]);
+  const reusable = report.components.find(
+    (component) => component.component === 'reusable-bot-comment-handler'
+  );
+
+  assert.equal(reusable.status, 'no-data');
+  assert.deepEqual(reusable.blockers, ['missing-reusable-bot-comment-handler']);
+  assert.equal(report.status, 'pass');
+  assert.deepEqual(report.enforcement.blockers, []);
+});
+
+test('warns on invalid expected mode even when component records are missing', () => {
+  const report = summarizeBotCommentAuthCoverage([], {
+    reusable_expected_mode: 'client_id',
+  });
+  const reusable = report.components.find(
+    (component) => component.component === 'reusable-bot-comment-handler'
+  );
+
+  assert.equal(reusable.status, 'warning');
+  assert.ok(reusable.blockers.includes('invalid-reusable-bot-comment-handler-expected-auth-mode'));
+  assert.ok(reusable.blockers.includes('missing-reusable-bot-comment-handler'));
+  assert.ok(
+    report.enforcement.blockers.includes('invalid-reusable-bot-comment-handler-expected-auth-mode')
+  );
+  assert.ok(!report.enforcement.blockers.includes('missing-reusable-bot-comment-handler'));
+  assert.equal(report.status, 'warning');
+});
+
 test('reads only valid auth coverage JSON records from downloaded artifacts', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-auth-coverage-'));
   fs.mkdirSync(path.join(dir, 'bot-comment-auth-coverage-wrapper-1'));
   fs.writeFileSync(
     path.join(dir, 'bot-comment-auth-coverage-wrapper-1', 'wrapper.json'),
-    JSON.stringify(record('agents-bot-comment-handler-wrapper', 'client-id', 1)),
+    JSON.stringify({
+      ...record('agents-bot-comment-handler-wrapper', 'client-id', 1),
+      schema: ` ${AUTH_SCHEMA} `,
+    }),
     'utf8'
   );
   fs.writeFileSync(path.join(dir, 'other.json'), '{"schema":"other"}', 'utf8');
@@ -304,8 +353,50 @@ test('reads only valid auth coverage JSON records from downloaded artifacts', ()
   assert.equal(files.length, 1);
   assert.equal(result.records.length, 1);
   assert.equal(result.parse_errors, 0);
+  assert.equal(result.read_errors, 0);
+  assert.equal(result.parsed_json_record_count, 1);
+  assert.equal(result.non_auth_record_count, 0);
   assert.equal(result.file_count, 1);
   assert.ok(files[0].endsWith('wrapper.json'));
+});
+
+test('counts valid JSON with unexpected schema as non-auth records', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-auth-coverage-'));
+  const artifactDir = path.join(dir, 'bot-comment-auth-coverage-wrapper-2');
+  fs.mkdirSync(artifactDir);
+  fs.writeFileSync(path.join(artifactDir, 'wrapper.json'), '{"schema":"other"}', 'utf8');
+
+  const files = collectJsonFiles(dir);
+  const result = readJsonRecords(files);
+  const report = summarizeBotCommentAuthCoverage(result.records, {
+    parsed_json_record_count: result.parsed_json_record_count,
+    non_auth_record_count: result.non_auth_record_count,
+  });
+  const markdown = formatBotCommentAuthCoverageMarkdown(report);
+
+  assert.equal(result.records.length, 0);
+  assert.equal(result.parsed_json_record_count, 1);
+  assert.equal(result.non_auth_record_count, 1);
+  assert.equal(report.scanned_record_count, 1);
+  assert.equal(report.non_auth_record_count, 1);
+  assert.ok(report.enforcement.blockers.includes('non-auth-records'));
+  assert.match(markdown, /Non-auth records: 1/);
+});
+
+test('keeps unreadable auth files separate from JSON parse errors', () => {
+  const missingFile = path.join(os.tmpdir(), `missing-auth-${process.pid}.json`);
+  const result = readJsonRecords([missingFile]);
+  const report = summarizeBotCommentAuthCoverage([], {
+    parse_errors: result.parse_errors,
+    read_errors: result.read_errors,
+  });
+  const markdown = formatBotCommentAuthCoverageMarkdown(report);
+
+  assert.equal(result.parse_errors, 0);
+  assert.equal(result.read_errors, 1);
+  assert.equal(report.read_errors, 1);
+  assert.ok(report.enforcement.blockers.includes('read-errors'));
+  assert.match(markdown, /Read errors: 1/);
 });
 
 test('keeps selector JSON out of auth input counts for mismatch enforcement', () => {

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -109,7 +109,7 @@ function normalizeRecord(raw = {}, sourcePath = '') {
 }
 
 function isAuthCoverageRecord(record) {
-  return Boolean(record && typeof record === 'object' && record.schema === AUTH_SCHEMA);
+  return Boolean(record && typeof record === 'object' && cleanString(record.schema) === AUTH_SCHEMA);
 }
 
 function parseAllowedModes(value, fallback) {
@@ -196,7 +196,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
 
   for (const record of records) {
     if (!record.component || !record.event_name) continue;
-    eventCounts[record.component] ||= {};
+    eventCounts[record.component] = eventCounts[record.component] || {};
     eventCounts[record.component][record.event_name] =
       (eventCounts[record.component][record.event_name] || 0) + 1;
     const key = `${record.component}:${record.event_name}`;
@@ -294,20 +294,20 @@ function compareRecords(a, b) {
 
 function normalizeArtifactSelectionSummary(report) {
   if (!report) return null;
-  if (report.status === 'missing' || report.status === 'parse-error') {
-    return {
-      schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
-      status: report.status,
-      error_message: cleanString(report.error_message),
-      selected_auth_artifact_count: 0,
-      selected_auth_artifacts: [],
-    };
-  }
   if (typeof report !== 'object' || Array.isArray(report)) {
     return {
       schema: 'workflows-weekly-metrics-artifact-selection/v1',
       status: 'parse-error',
       error_message: 'artifact selection report is not a JSON object',
+      selected_auth_artifact_count: 0,
+      selected_auth_artifacts: [],
+    };
+  }
+  if (report.status === 'missing' || report.status === 'parse-error') {
+    return {
+      schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
+      status: report.status,
+      error_message: cleanString(report.error_message),
       selected_auth_artifact_count: 0,
       selected_auth_artifacts: [],
     };
@@ -346,7 +346,10 @@ function artifactFamilyFromSelection(artifact = {}) {
 
 function componentCoverageStatus(blockers, policy, latest) {
   if (blockers.length === 0) return 'pass';
-  if (!latest && policy.missing_record_severity === 'no-data') return 'no-data';
+  const onlyMissingBlockers = blockers.every((blocker) => isComponentMissingBlocker(blocker));
+  if (!latest && policy.missing_record_severity === 'no-data' && onlyMissingBlockers) {
+    return 'no-data';
+  }
   return 'warning';
 }
 
@@ -357,6 +360,15 @@ function isComponentMissingBlocker(blocker) {
 function summarizeBotCommentAuthCoverage(records = [], options = {}) {
   const policy = normalizePolicy(options);
   const parseErrors = Number(options.parse_errors ?? options.parseErrors ?? 0);
+  const readErrors = Number(options.read_errors ?? options.readErrors ?? 0);
+  const parsedJsonRecordCount = Number(
+    options.parsed_json_record_count ?? options.parsedJsonRecordCount ?? records.length
+  );
+  const nonAuthRecordCount = Number(
+    options.non_auth_record_count ??
+      options.nonAuthRecordCount ??
+      Math.max(0, parsedJsonRecordCount - records.length)
+  );
   const artifactSelection = normalizeArtifactSelectionSummary(
     options.artifact_selection_report ?? options.artifactSelectionReport
   );
@@ -411,6 +423,7 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
       expected_mode: componentPolicyConfig.expected_mode,
       invalid_expected_mode: componentPolicyConfig.invalid_expected_mode,
       allowed_modes: componentPolicyConfig.allowed_modes,
+      missing_record_severity: componentPolicyConfig.missing_record_severity,
       status: componentCoverageStatus(blockers, componentPolicyConfig, latest),
       blockers,
     };
@@ -421,8 +434,15 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
     artifactSelection.status !== 'not-configured';
   const selectedAuthArtifactCount = artifactSelection?.selected_auth_artifact_count || 0;
   const authArtifactInputMismatch = selectedAuthArtifactCount > 0 && inputFileCount === 0;
-  const blockers = componentSummaries.flatMap((summary) => summary.blockers);
+  const blockers = componentSummaries.flatMap((summary) =>
+    summary.blockers.filter(
+      (blocker) =>
+        !(summary.missing_record_severity === 'no-data' && isComponentMissingBlocker(blocker))
+    )
+  );
   if (parseErrors > 0) blockers.push('parse-errors');
+  if (readErrors > 0) blockers.push('read-errors');
+  if (nonAuthRecordCount > 0) blockers.push('non-auth-records');
   if (artifactSelectionWarning) blockers.push('artifact-selection-warning');
   if (authArtifactInputMismatch) blockers.push('selected-auth-artifacts-without-input-files');
   blockers.push(...organicEvidence.blockers);
@@ -455,9 +475,11 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
     },
     input_file_count: inputFileCount,
     input_files: inputFiles,
-    scanned_record_count: records.length,
+    scanned_record_count: parsedJsonRecordCount,
     auth_record_count: authRecords.length,
+    non_auth_record_count: nonAuthRecordCount,
     parse_errors: parseErrors,
+    read_errors: readErrors,
     auth_artifact_input_mismatch: authArtifactInputMismatch,
     artifact_selection: artifactSelection,
     organic_evidence: organicEvidence,
@@ -475,8 +497,11 @@ function formatBotCommentAuthCoverageMarkdown(report) {
     `- Mode: ${report.mode}`,
     `- Hard block active: ${report.enforcement.hard_block_active}`,
     `- Input files: ${report.input_file_count}`,
+    `- Scanned JSON records: ${report.scanned_record_count}`,
     `- Auth records: ${report.auth_record_count}`,
+    `- Non-auth records: ${report.non_auth_record_count}`,
     `- Parse errors: ${report.parse_errors}`,
+    `- Read errors: ${report.read_errors}`,
   ];
 
   if (report.artifact_selection) {
@@ -545,17 +570,37 @@ function isPotentialAuthCoverageFile(file) {
 function readJsonRecords(files = []) {
   const records = [];
   let parseErrors = 0;
+  let readErrors = 0;
+  let parsedJsonRecordCount = 0;
+  let nonAuthRecordCount = 0;
   for (const file of files) {
+    let content = '';
     try {
-      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      content = fs.readFileSync(file, 'utf8');
+    } catch (_error) {
+      readErrors += 1;
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(content);
+      parsedJsonRecordCount += 1;
       if (isAuthCoverageRecord(parsed)) {
         records.push({ ...parsed, source_path: file });
+      } else {
+        nonAuthRecordCount += 1;
       }
     } catch (_error) {
       parseErrors += 1;
     }
   }
-  return { records, parse_errors: parseErrors, file_count: files.length };
+  return {
+    records,
+    parse_errors: parseErrors,
+    read_errors: readErrors,
+    parsed_json_record_count: parsedJsonRecordCount,
+    non_auth_record_count: nonAuthRecordCount,
+    file_count: files.length,
+  };
 }
 
 function readArtifactSelectionReport(file) {
@@ -620,6 +665,9 @@ function main() {
   const readResult = readJsonRecords(files);
   const report = summarizeBotCommentAuthCoverage(readResult.records, {
     parse_errors: readResult.parse_errors,
+    read_errors: readResult.read_errors,
+    parsed_json_record_count: readResult.parsed_json_record_count,
+    non_auth_record_count: readResult.non_auth_record_count,
     input_files: files,
     input_file_count: readResult.file_count,
     artifact_selection_report: readArtifactSelectionReport(options.artifact_selection_report),

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -109,7 +109,7 @@ function normalizeRecord(raw = {}, sourcePath = '') {
 }
 
 function isAuthCoverageRecord(record) {
-  return Boolean(record && typeof record === 'object' && record.schema === AUTH_SCHEMA);
+  return Boolean(record && typeof record === 'object' && cleanString(record.schema) === AUTH_SCHEMA);
 }
 
 function parseAllowedModes(value, fallback) {
@@ -196,7 +196,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
 
   for (const record of records) {
     if (!record.component || !record.event_name) continue;
-    eventCounts[record.component] ||= {};
+    eventCounts[record.component] = eventCounts[record.component] || {};
     eventCounts[record.component][record.event_name] =
       (eventCounts[record.component][record.event_name] || 0) + 1;
     const key = `${record.component}:${record.event_name}`;
@@ -294,20 +294,20 @@ function compareRecords(a, b) {
 
 function normalizeArtifactSelectionSummary(report) {
   if (!report) return null;
-  if (report.status === 'missing' || report.status === 'parse-error') {
-    return {
-      schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
-      status: report.status,
-      error_message: cleanString(report.error_message),
-      selected_auth_artifact_count: 0,
-      selected_auth_artifacts: [],
-    };
-  }
   if (typeof report !== 'object' || Array.isArray(report)) {
     return {
       schema: 'workflows-weekly-metrics-artifact-selection/v1',
       status: 'parse-error',
       error_message: 'artifact selection report is not a JSON object',
+      selected_auth_artifact_count: 0,
+      selected_auth_artifacts: [],
+    };
+  }
+  if (report.status === 'missing' || report.status === 'parse-error') {
+    return {
+      schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
+      status: report.status,
+      error_message: cleanString(report.error_message),
       selected_auth_artifact_count: 0,
       selected_auth_artifacts: [],
     };
@@ -346,7 +346,10 @@ function artifactFamilyFromSelection(artifact = {}) {
 
 function componentCoverageStatus(blockers, policy, latest) {
   if (blockers.length === 0) return 'pass';
-  if (!latest && policy.missing_record_severity === 'no-data') return 'no-data';
+  const onlyMissingBlockers = blockers.every((blocker) => isComponentMissingBlocker(blocker));
+  if (!latest && policy.missing_record_severity === 'no-data' && onlyMissingBlockers) {
+    return 'no-data';
+  }
   return 'warning';
 }
 
@@ -357,6 +360,15 @@ function isComponentMissingBlocker(blocker) {
 function summarizeBotCommentAuthCoverage(records = [], options = {}) {
   const policy = normalizePolicy(options);
   const parseErrors = Number(options.parse_errors ?? options.parseErrors ?? 0);
+  const readErrors = Number(options.read_errors ?? options.readErrors ?? 0);
+  const parsedJsonRecordCount = Number(
+    options.parsed_json_record_count ?? options.parsedJsonRecordCount ?? records.length
+  );
+  const nonAuthRecordCount = Number(
+    options.non_auth_record_count ??
+      options.nonAuthRecordCount ??
+      Math.max(0, parsedJsonRecordCount - records.length)
+  );
   const artifactSelection = normalizeArtifactSelectionSummary(
     options.artifact_selection_report ?? options.artifactSelectionReport
   );
@@ -411,6 +423,7 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
       expected_mode: componentPolicyConfig.expected_mode,
       invalid_expected_mode: componentPolicyConfig.invalid_expected_mode,
       allowed_modes: componentPolicyConfig.allowed_modes,
+      missing_record_severity: componentPolicyConfig.missing_record_severity,
       status: componentCoverageStatus(blockers, componentPolicyConfig, latest),
       blockers,
     };
@@ -421,8 +434,15 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
     artifactSelection.status !== 'not-configured';
   const selectedAuthArtifactCount = artifactSelection?.selected_auth_artifact_count || 0;
   const authArtifactInputMismatch = selectedAuthArtifactCount > 0 && inputFileCount === 0;
-  const blockers = componentSummaries.flatMap((summary) => summary.blockers);
+  const blockers = componentSummaries.flatMap((summary) =>
+    summary.blockers.filter(
+      (blocker) =>
+        !(summary.missing_record_severity === 'no-data' && isComponentMissingBlocker(blocker))
+    )
+  );
   if (parseErrors > 0) blockers.push('parse-errors');
+  if (readErrors > 0) blockers.push('read-errors');
+  if (nonAuthRecordCount > 0) blockers.push('non-auth-records');
   if (artifactSelectionWarning) blockers.push('artifact-selection-warning');
   if (authArtifactInputMismatch) blockers.push('selected-auth-artifacts-without-input-files');
   blockers.push(...organicEvidence.blockers);
@@ -455,9 +475,11 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
     },
     input_file_count: inputFileCount,
     input_files: inputFiles,
-    scanned_record_count: records.length,
+    scanned_record_count: parsedJsonRecordCount,
     auth_record_count: authRecords.length,
+    non_auth_record_count: nonAuthRecordCount,
     parse_errors: parseErrors,
+    read_errors: readErrors,
     auth_artifact_input_mismatch: authArtifactInputMismatch,
     artifact_selection: artifactSelection,
     organic_evidence: organicEvidence,
@@ -475,8 +497,11 @@ function formatBotCommentAuthCoverageMarkdown(report) {
     `- Mode: ${report.mode}`,
     `- Hard block active: ${report.enforcement.hard_block_active}`,
     `- Input files: ${report.input_file_count}`,
+    `- Scanned JSON records: ${report.scanned_record_count}`,
     `- Auth records: ${report.auth_record_count}`,
+    `- Non-auth records: ${report.non_auth_record_count}`,
     `- Parse errors: ${report.parse_errors}`,
+    `- Read errors: ${report.read_errors}`,
   ];
 
   if (report.artifact_selection) {
@@ -545,17 +570,37 @@ function isPotentialAuthCoverageFile(file) {
 function readJsonRecords(files = []) {
   const records = [];
   let parseErrors = 0;
+  let readErrors = 0;
+  let parsedJsonRecordCount = 0;
+  let nonAuthRecordCount = 0;
   for (const file of files) {
+    let content = '';
     try {
-      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      content = fs.readFileSync(file, 'utf8');
+    } catch (_error) {
+      readErrors += 1;
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(content);
+      parsedJsonRecordCount += 1;
       if (isAuthCoverageRecord(parsed)) {
         records.push({ ...parsed, source_path: file });
+      } else {
+        nonAuthRecordCount += 1;
       }
     } catch (_error) {
       parseErrors += 1;
     }
   }
-  return { records, parse_errors: parseErrors, file_count: files.length };
+  return {
+    records,
+    parse_errors: parseErrors,
+    read_errors: readErrors,
+    parsed_json_record_count: parsedJsonRecordCount,
+    non_auth_record_count: nonAuthRecordCount,
+    file_count: files.length,
+  };
 }
 
 function readArtifactSelectionReport(file) {
@@ -620,6 +665,9 @@ function main() {
   const readResult = readJsonRecords(files);
   const report = summarizeBotCommentAuthCoverage(readResult.records, {
     parse_errors: readResult.parse_errors,
+    read_errors: readResult.read_errors,
+    parsed_json_record_count: readResult.parsed_json_record_count,
+    non_auth_record_count: readResult.non_auth_record_count,
     input_files: files,
     input_file_count: readResult.file_count,
     artifact_selection_report: readArtifactSelectionReport(options.artifact_selection_report),


### PR DESCRIPTION
## Summary
- make organic auth evidence pass when no organic event/component checks are configured while preserving no-data for configured checks without records
- normalize selector reports only after object validation and trim auth coverage schemas
- split auth coverage JSON read errors from parse errors in reports, markdown, and enforcement blockers
- count valid non-auth JSON records separately and keep no-data missing components out of global blockers

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_bot_comment_handler.py -q
- node --check .github/scripts/bot_comment_auth_coverage.js
- node --check templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
- git diff --check