### PR TITLE
Guard bot auth artifact scanning

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -425,6 +425,40 @@ test('keeps selector JSON out of auth input counts for mismatch enforcement', ()
   assert.equal(report.auth_artifact_input_mismatch, true);
 });
 
+test('continues collecting auth files when artifact entries race or become unreadable', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bot-auth-coverage-'));
+  const artifactDir = path.join(dir, 'bot-comment-auth-coverage-wrapper-3');
+  const missingArtifactDir = path.join(dir, 'bot-comment-auth-coverage-wrapper-missing');
+  fs.mkdirSync(artifactDir);
+  fs.writeFileSync(
+    path.join(artifactDir, 'wrapper.json'),
+    JSON.stringify(record('agents-bot-comment-handler-wrapper', 'client-id', 3)),
+    'utf8'
+  );
+  const originalReaddirSync = fs.readdirSync;
+  const originalStatSync = fs.statSync;
+  fs.readdirSync = function readdirSyncWithRace(current, ...args) {
+    const entries = originalReaddirSync.call(this, current, ...args);
+    return current === dir ? [...entries, path.basename(missingArtifactDir)] : entries;
+  };
+  fs.statSync = function statSyncWithRace(current, ...args) {
+    if (current === missingArtifactDir) {
+      const error = new Error('entry disappeared');
+      error.code = 'ENOENT';
+      throw error;
+    }
+    return originalStatSync.call(this, current, ...args);
+  };
+  try {
+    const files = collectJsonFiles(dir);
+    assert.equal(files.length, 1);
+    assert.ok(files[0].endsWith('wrapper.json'));
+  } finally {
+    fs.readdirSync = originalReaddirSync;
+    fs.statSync = originalStatSync;
+  }
+});
+
 test('identifies only bot-comment auth coverage candidate files', () => {
   assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/wrapper.json'),

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -544,9 +544,21 @@ function collectJsonFiles(rootDir) {
   const stack = [rootDir];
   while (stack.length > 0) {
     const current = stack.pop();
-    const stat = fs.statSync(current);
+    if (!current || !fs.existsSync(current)) continue;
+    let stat;
+    try {
+      stat = fs.statSync(current);
+    } catch (_error) {
+      continue;
+    }
     if (stat.isDirectory()) {
-      for (const entry of fs.readdirSync(current)) {
+      let entries = [];
+      try {
+        entries = fs.readdirSync(current);
+      } catch (_error) {
+        continue;
+      }
+      for (const entry of entries) {
         stack.push(path.join(current, entry));
       }
     } else if (stat.isFile() && isPotentialAuthCoverageFile(current)) {

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -544,9 +544,21 @@ function collectJsonFiles(rootDir) {
   const stack = [rootDir];
   while (stack.length > 0) {
     const current = stack.pop();
-    const stat = fs.statSync(current);
+    if (!current || !fs.existsSync(current)) continue;
+    let stat;
+    try {
+      stat = fs.statSync(current);
+    } catch (_error) {
+      continue;
+    }
     if (stat.isDirectory()) {
-      for (const entry of fs.readdirSync(current)) {
+      let entries = [];
+      try {
+        entries = fs.readdirSync(current);
+      } catch (_error) {
+        continue;
+      }
+      for (const entry of entries) {
         stack.push(path.join(current, entry));
       }
     } else if (stat.isFile() && isPotentialAuthCoverageFile(current)) {


### PR DESCRIPTION
## Summary
- guard bot auth artifact traversal against missing, unreadable, or racing filesystem entries
- keep source and consumer template scanner behavior in sync
- add focused coverage for an artifact entry disappearing between directory read and stat

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_bot_comment_handler.py -q
- node --check .github/scripts/bot_comment_auth_coverage.js
- node --check templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
- git diff --check