### PR TITLE
Clarify bot auth hard-block diagnostics

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 const {
   AUTH_SCHEMA,
   collectJsonFiles,
+  componentPolicy,
   formatBotCommentAuthCoverageMarkdown,
   isPotentialAuthCoverageFile,
   normalizeArtifactSelectionSummary,
@@ -91,6 +92,22 @@ test('warns on invalid reusable expected auth mode policy', () => {
   assert.equal(reusable.invalid_expected_mode, 'client_id');
   assert.ok(reusable.blockers.includes('invalid-reusable-bot-comment-handler-expected-auth-mode'));
   assert.equal(report.status, 'warning');
+});
+
+test('normalizes component policy overrides through one contract', () => {
+  const wrapper = componentPolicy('agents-bot-comment-handler-wrapper', {
+    wrapper_expected_mode: 'client-id',
+    wrapper_allowed_modes: 'client-id,legacy-app-id',
+  });
+  const reusable = componentPolicy('reusable-bot-comment-handler', {
+    reusable_expected_mode: 'client-id',
+    reusable_allowed_modes: 'client-id',
+  });
+
+  assert.equal(wrapper.expected_mode, 'client-id');
+  assert.deepEqual(wrapper.allowed_modes, ['client-id', 'legacy-app-id']);
+  assert.equal(reusable.expected_mode, 'client-id');
+  assert.deepEqual(reusable.allowed_modes, ['client-id']);
 });
 
 test('warns while the canonical wrapper still uses the legacy App ID fallback', () => {
@@ -200,6 +217,20 @@ test('fails only when hard blocking is approved', () => {
   assert.equal(report.status, 'fail');
   assert.equal(report.enforcement.hard_block_active, true);
   assert.equal(report.enforcement.should_fail, true);
+});
+
+test('does not hard-block pure no-data telemetry', () => {
+  const report = summarizeBotCommentAuthCoverage([], {
+    mode: 'hard-block',
+    hard_block_approved: true,
+    parse_errors: 0,
+  });
+
+  assert.equal(report.coverage_status, 'no-data');
+  assert.equal(report.status, 'no-data');
+  assert.equal(report.mode, 'hard-block');
+  assert.equal(report.enforcement.hard_block_active, true);
+  assert.equal(report.enforcement.should_fail, false);
 });
 
 test('summarizes selected auth artifacts from weekly artifact selection', () => {
@@ -476,6 +507,14 @@ test('identifies only bot-comment auth coverage candidate files', () => {
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/run-view.json'), false);
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/wrapper.json'), false);
   assert.equal(
+    isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1-copy/wrapper.json'),
+    false
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-reusable-latest/reusable.json'),
+    false
+  );
+  assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/reusable.json'),
     false
   );
@@ -680,11 +719,12 @@ test('CLI writes report files and prints markdown summary', () => {
     { encoding: 'utf8', env: cliEnv }
   );
 
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0);
   assert.match(result.stdout, /^## Bot Comment App Auth Coverage/);
   assert.doesNotMatch(result.stdout, /^\{/);
   const report = JSON.parse(fs.readFileSync(outputJson, 'utf8'));
   assert.equal(report.requested_mode, 'hard-block');
-  assert.equal(report.enforcement.should_fail, true);
+  assert.equal(report.coverage_status, 'no-data');
+  assert.equal(report.enforcement.should_fail, false);
   assert.equal(fs.readFileSync(outputMd, 'utf8'), result.stdout);
 });

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -9,6 +9,10 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
+const AUTH_ARTIFACT_DIR_PATTERNS = {
+  wrapper: /^bot-comment-auth-coverage-wrapper-\d+$/,
+  reusable: /^bot-comment-auth-coverage-reusable-\d+$/,
+};
 
 const COMPONENT_POLICIES = {
   'agents-bot-comment-handler-wrapper': {
@@ -20,6 +24,21 @@ const COMPONENT_POLICIES = {
     expected_mode: '',
     allowed_modes: ['client-id', 'none'],
     missing_record_severity: 'no-data',
+  },
+};
+
+const COMPONENT_POLICY_OVERRIDES = {
+  'agents-bot-comment-handler-wrapper': {
+    expected_option: 'wrapper_expected_mode',
+    expected_env: 'BOT_COMMENT_WRAPPER_EXPECTED_AUTH_MODE',
+    allowed_option: 'wrapper_allowed_modes',
+    allowed_env: 'BOT_COMMENT_WRAPPER_ALLOWED_AUTH_MODES',
+  },
+  'reusable-bot-comment-handler': {
+    expected_option: 'reusable_expected_mode',
+    expected_env: 'BOT_COMMENT_REUSABLE_EXPECTED_AUTH_MODE',
+    allowed_option: 'reusable_allowed_modes',
+    allowed_env: 'BOT_COMMENT_REUSABLE_ALLOWED_AUTH_MODES',
   },
 };
 
@@ -243,35 +262,20 @@ function componentPolicy(component, options = {}) {
     allowed_modes: ['client-id', 'none'],
     missing_record_severity: 'no-data',
   };
-  if (component === 'agents-bot-comment-handler-wrapper') {
-    const expectedMode = parseExpectedMode(
-      options.wrapper_expected_mode ?? process.env.BOT_COMMENT_WRAPPER_EXPECTED_AUTH_MODE,
-      base.expected_mode
-    );
-    return {
-      ...base,
-      ...expectedMode,
-      allowed_modes: parseAllowedModes(
-        options.wrapper_allowed_modes ?? process.env.BOT_COMMENT_WRAPPER_ALLOWED_AUTH_MODES,
-        base.allowed_modes
-      ),
-    };
-  }
-  if (component === 'reusable-bot-comment-handler') {
-    const expectedMode = parseExpectedMode(
-      options.reusable_expected_mode ?? process.env.BOT_COMMENT_REUSABLE_EXPECTED_AUTH_MODE,
-      base.expected_mode
-    );
-    return {
-      ...base,
-      ...expectedMode,
-      allowed_modes: parseAllowedModes(
-        options.reusable_allowed_modes ?? process.env.BOT_COMMENT_REUSABLE_ALLOWED_AUTH_MODES,
-        base.allowed_modes
-      ),
-    };
-  }
-  return base;
+  const override = COMPONENT_POLICY_OVERRIDES[component];
+  if (!override) return base;
+  const expectedMode = parseExpectedMode(
+    options[override.expected_option] ?? process.env[override.expected_env],
+    base.expected_mode
+  );
+  return {
+    ...base,
+    ...expectedMode,
+    allowed_modes: parseAllowedModes(
+      options[override.allowed_option] ?? process.env[override.allowed_env],
+      base.allowed_modes
+    ),
+  };
 }
 
 function runSortKey(record) {
@@ -456,7 +460,7 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
   }
 
   const hardBlockActive = policy.effective_mode === HARD_BLOCK_MODE;
-  const shouldFail = hardBlockActive && coverageStatus !== 'pass';
+  const shouldFail = hardBlockActive && coverageStatus === 'warning';
   return {
     schema: COVERAGE_SCHEMA,
     status: shouldFail ? 'fail' : coverageStatus,
@@ -574,8 +578,8 @@ function isPotentialAuthCoverageFile(file) {
   if (!normalized.endsWith('.json')) return false;
   const artifactDir = path.basename(path.dirname(normalized));
   return (
-    (basename === 'wrapper.json' && artifactDir.startsWith('bot-comment-auth-coverage-wrapper-')) ||
-    (basename === 'reusable.json' && artifactDir.startsWith('bot-comment-auth-coverage-reusable-'))
+    (basename === 'wrapper.json' && AUTH_ARTIFACT_DIR_PATTERNS.wrapper.test(artifactDir)) ||
+    (basename === 'reusable.json' && AUTH_ARTIFACT_DIR_PATTERNS.reusable.test(artifactDir))
   );
 }
 

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -280,9 +280,10 @@ jobs:
           terminal_status="${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"
           bot_comment_auth_status="${BOT_COMMENT_AUTH_COVERAGE_EXIT_STATUS:-0}"
           if [ "${terminal_status}" != "0" ] || [ "${bot_comment_auth_status}" != "0" ]; then
-            echo "::error::Coverage hard-block triggered: " \
-              "terminal-disposition=${terminal_status}, " \
-              "bot-comment-auth=${bot_comment_auth_status}"
+            echo "::error title=Coverage hard-block failed::" \
+              "terminal-disposition-exit-status=${terminal_status}; " \
+              "bot-comment-auth-exit-status=${bot_comment_auth_status}; " \
+              "coverage reports were uploaded before this failure"
             if [ "${terminal_status}" != "0" ]; then
               echo "Failed check: Review-thread terminal coverage preflight"
             fi

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -9,6 +9,10 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
+const AUTH_ARTIFACT_DIR_PATTERNS = {
+  wrapper: /^bot-comment-auth-coverage-wrapper-\d+$/,
+  reusable: /^bot-comment-auth-coverage-reusable-\d+$/,
+};
 
 const COMPONENT_POLICIES = {
   'agents-bot-comment-handler-wrapper': {
@@ -20,6 +24,21 @@ const COMPONENT_POLICIES = {
     expected_mode: '',
     allowed_modes: ['client-id', 'none'],
     missing_record_severity: 'no-data',
+  },
+};
+
+const COMPONENT_POLICY_OVERRIDES = {
+  'agents-bot-comment-handler-wrapper': {
+    expected_option: 'wrapper_expected_mode',
+    expected_env: 'BOT_COMMENT_WRAPPER_EXPECTED_AUTH_MODE',
+    allowed_option: 'wrapper_allowed_modes',
+    allowed_env: 'BOT_COMMENT_WRAPPER_ALLOWED_AUTH_MODES',
+  },
+  'reusable-bot-comment-handler': {
+    expected_option: 'reusable_expected_mode',
+    expected_env: 'BOT_COMMENT_REUSABLE_EXPECTED_AUTH_MODE',
+    allowed_option: 'reusable_allowed_modes',
+    allowed_env: 'BOT_COMMENT_REUSABLE_ALLOWED_AUTH_MODES',
   },
 };
 
@@ -243,35 +262,20 @@ function componentPolicy(component, options = {}) {
     allowed_modes: ['client-id', 'none'],
     missing_record_severity: 'no-data',
   };
-  if (component === 'agents-bot-comment-handler-wrapper') {
-    const expectedMode = parseExpectedMode(
-      options.wrapper_expected_mode ?? process.env.BOT_COMMENT_WRAPPER_EXPECTED_AUTH_MODE,
-      base.expected_mode
-    );
-    return {
-      ...base,
-      ...expectedMode,
-      allowed_modes: parseAllowedModes(
-        options.wrapper_allowed_modes ?? process.env.BOT_COMMENT_WRAPPER_ALLOWED_AUTH_MODES,
-        base.allowed_modes
-      ),
-    };
-  }
-  if (component === 'reusable-bot-comment-handler') {
-    const expectedMode = parseExpectedMode(
-      options.reusable_expected_mode ?? process.env.BOT_COMMENT_REUSABLE_EXPECTED_AUTH_MODE,
-      base.expected_mode
-    );
-    return {
-      ...base,
-      ...expectedMode,
-      allowed_modes: parseAllowedModes(
-        options.reusable_allowed_modes ?? process.env.BOT_COMMENT_REUSABLE_ALLOWED_AUTH_MODES,
-        base.allowed_modes
-      ),
-    };
-  }
-  return base;
+  const override = COMPONENT_POLICY_OVERRIDES[component];
+  if (!override) return base;
+  const expectedMode = parseExpectedMode(
+    options[override.expected_option] ?? process.env[override.expected_env],
+    base.expected_mode
+  );
+  return {
+    ...base,
+    ...expectedMode,
+    allowed_modes: parseAllowedModes(
+      options[override.allowed_option] ?? process.env[override.allowed_env],
+      base.allowed_modes
+    ),
+  };
 }
 
 function runSortKey(record) {
@@ -456,7 +460,7 @@ function summarizeBotCommentAuthCoverage(records = [], options = {}) {
   }
 
   const hardBlockActive = policy.effective_mode === HARD_BLOCK_MODE;
-  const shouldFail = hardBlockActive && coverageStatus !== 'pass';
+  const shouldFail = hardBlockActive && coverageStatus === 'warning';
   return {
     schema: COVERAGE_SCHEMA,
     status: shouldFail ? 'fail' : coverageStatus,
@@ -574,8 +578,8 @@ function isPotentialAuthCoverageFile(file) {
   if (!normalized.endsWith('.json')) return false;
   const artifactDir = path.basename(path.dirname(normalized));
   return (
-    (basename === 'wrapper.json' && artifactDir.startsWith('bot-comment-auth-coverage-wrapper-')) ||
-    (basename === 'reusable.json' && artifactDir.startsWith('bot-comment-auth-coverage-reusable-'))
+    (basename === 'wrapper.json' && AUTH_ARTIFACT_DIR_PATTERNS.wrapper.test(artifactDir)) ||
+    (basename === 'reusable.json' && AUTH_ARTIFACT_DIR_PATTERNS.reusable.test(artifactDir))
   );
 }
 

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -292,9 +292,10 @@ jobs:
           terminal_status="${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"
           bot_comment_auth_status="${BOT_COMMENT_AUTH_COVERAGE_EXIT_STATUS:-0}"
           if [ "${terminal_status}" != "0" ] || [ "${bot_comment_auth_status}" != "0" ]; then
-            echo "::error::Coverage hard-block triggered: " \
-              "terminal-disposition=${terminal_status}, " \
-              "bot-comment-auth=${bot_comment_auth_status}"
+            echo "::error title=Coverage hard-block failed::" \
+              "terminal-disposition-exit-status=${terminal_status}; " \
+              "bot-comment-auth-exit-status=${bot_comment_auth_status}; " \
+              "coverage reports were uploaded before this failure"
             if [ "${terminal_status}" != "0" ]; then
               echo "Failed check: Review-thread terminal coverage preflight"
             fi

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -341,6 +341,11 @@ def test_weekly_metrics_uploads_selector_report_on_failure():
             'terminal_status="${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"' in text
             and 'bot_comment_auth_status="${BOT_COMMENT_AUTH_COVERAGE_EXIT_STATUS:-0}"' in text
         ), "Coverage hard-block status must be aggregated in one final step"
+        assert (
+            "terminal-disposition-exit-status=${terminal_status}" in text
+            and "bot-comment-auth-exit-status=${bot_comment_auth_status}" in text
+            and "coverage reports were uploaded before this failure" in text
+        ), "Coverage hard-block diagnostics must preserve both preflight exit statuses"
         assert text.index("Upload weekly summary") < text.index(
             "Honor coverage hard-blocks"
         ), "Terminal coverage hard-block failure must wait for artifact upload"


### PR DESCRIPTION
## Summary
- keep pure bot-auth no-data telemetry from failing approved hard-block mode
- centralize bot-auth component policy override handling in source and template scripts
- tighten bot-auth coverage candidate matching to exact numeric artifact directories
- make weekly coverage hard-block diagnostics report both preserved preflight exit statuses after upload/post steps

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- python scripts/validate_workflow_yaml.py .github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
- python scripts/validate_template_sync.py
- /opt/homebrew/bin/actionlint .github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
- black --check --line-length 100 tests/workflows/test_workflow_agents_consolidation.py
- git diff --check