### PR TITLE
Clarify bot auth artifact and campaign contracts

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -520,6 +520,18 @@ test('identifies only bot-comment auth coverage candidate files', () => {
     true
   );
   assert.equal(
+    isPotentialAuthCoverageFile(
+      '/tmp/artifacts/bot-comment-auth-coverage-wrapper-123456789/wrapper.json'
+    ),
+    true
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile(
+      '/tmp/artifacts/bot-comment-auth-coverage-reusable-123456789/reusable.json'
+    ),
+    true
+  );
+  assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/123.zip'),
     false
   );
@@ -547,6 +559,12 @@ test('identifies only bot-comment auth coverage candidate files', () => {
       '/tmp/artifacts/bot-comment-auth-coverage-reusable-1/nested/reusable.json'
     ),
     false
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile(
+      '/tmp/artifacts/agent-metrics/bot-comment-auth-coverage-wrapper-1/wrapper.json'
+    ),
+    true
   );
 });
 

--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -148,6 +148,8 @@ test('buildQueueItem creates stable PR-scoped work items', () => {
   assert.equal(item.status, 'needs-local-codex');
   assert.equal(item.source_repo, 'stranske/Workflows');
   assert.equal(item.preferred_workdir, 'Workflows');
+  assert.match(item.review_signature, /^[0-9a-f]{20}$/);
+  assert.match(item.source_review_key, /^stranske\/Workflows:sync:[0-9a-f]{20}$/);
   assert.equal(item.review_thread_count, 1);
 });
 
@@ -215,6 +217,86 @@ test('mergeCampaignState preserves claims, expires old leases, and stales missin
   assert.equal(byId.get(stalePrevious.id).status, 'stale');
   assert.equal(state.stats.items_needing_local_codex, 1);
   assert.equal(state.stats.items_claimed, 1);
+});
+
+test('mergeCampaignState flags repeated source-fixed review signatures without hiding the item', () => {
+  const now = '2026-04-21T05:52:00Z';
+  const finished = buildQueueItem({
+    repoFullName: 'stranske/TPP',
+    defaultOwner: 'stranske',
+    now: '2026-04-21T05:20:00Z',
+    pr: {
+      number: 850,
+      title: 'chore: sync workflow templates',
+      html_url: 'https://github.com/stranske/TPP/pull/850',
+      head: { ref: 'sync/workflows-old', sha: 'old-sha' },
+      base: { ref: 'main' },
+    },
+    threads: [
+      {
+        id: 'thread-old',
+        path: '.github/scripts/bot_comment_auth_coverage.js',
+        line: 12,
+        url: 'https://github.test/thread-old',
+        author: 'copilot-pull-request-reviewer',
+        body_preview: 'Please tighten this auth coverage condition.',
+        comments_count: 1,
+      },
+    ],
+  });
+  const repeated = buildQueueItem({
+    repoFullName: 'stranske/TPP',
+    defaultOwner: 'stranske',
+    now,
+    pr: {
+      number: 851,
+      title: 'chore: sync workflow templates',
+      html_url: 'https://github.com/stranske/TPP/pull/851',
+      head: { ref: 'sync/workflows-new', sha: 'new-sha' },
+      base: { ref: 'main' },
+    },
+    threads: [
+      {
+        id: 'thread-new',
+        path: '.github/scripts/bot_comment_auth_coverage.js',
+        line: 30,
+        url: 'https://github.test/thread-new',
+        author: 'copilot-pull-request-reviewer',
+        body_preview: 'Please tighten this auth coverage condition.',
+        comments_count: 1,
+      },
+    ],
+  });
+
+  const state = mergeCampaignState(
+    {
+      items: [
+        {
+          ...finished,
+          status: 'local-codex-finished',
+          finished_at: '2026-04-21T05:30:00Z',
+          result: {
+            exit_code: 0,
+            summary: 'Handled through the Workflows source path.',
+          },
+        },
+      ],
+    },
+    [repeated],
+    now,
+    { reposRequested: 1, reposChecked: 1 },
+  );
+  const repeatedItem = state.items.find((item) => item.id === repeated.id);
+  const marker = parseCampaignMarker(formatCampaignMarker(state));
+  const markerItem = marker.items.find((item) => item.id === repeated.id);
+  const body = formatCampaignBody(state);
+
+  assert.equal(repeatedItem.status, 'needs-local-codex');
+  assert.equal(repeatedItem.source_fixed_candidate.matching_item_id, finished.id);
+  assert.equal(repeatedItem.source_fixed_candidate.finished_at, '2026-04-21T05:30:00Z');
+  assert.equal(state.stats.items_needing_local_codex, 1);
+  assert.equal(markerItem.source_fixed_candidate.matching_item_id, finished.id);
+  assert.match(body, /Prior source-fix match:/);
 });
 
 test('formatCampaignBody renders queue rows and marker', () => {

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -9,9 +9,15 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
-const AUTH_ARTIFACT_DIR_PATTERNS = {
-  wrapper: /^bot-comment-auth-coverage-wrapper-\d+$/,
-  reusable: /^bot-comment-auth-coverage-reusable-\d+$/,
+const AUTH_ARTIFACT_FILE_CONTRACTS = {
+  'wrapper.json': {
+    family: 'bot-comment-auth-coverage-wrapper',
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+  },
+  'reusable.json': {
+    family: 'bot-comment-auth-coverage-reusable',
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+  },
 };
 
 const COMPONENT_POLICIES = {
@@ -584,11 +590,10 @@ function isPotentialAuthCoverageFile(file) {
   const normalized = cleanString(file).split(path.sep).join('/');
   const basename = path.basename(normalized);
   if (!normalized.endsWith('.json')) return false;
+  const contract = AUTH_ARTIFACT_FILE_CONTRACTS[basename];
+  if (!contract) return false;
   const artifactDir = path.basename(path.dirname(normalized));
-  return (
-    (basename === 'wrapper.json' && AUTH_ARTIFACT_DIR_PATTERNS.wrapper.test(artifactDir)) ||
-    (basename === 'reusable.json' && AUTH_ARTIFACT_DIR_PATTERNS.reusable.test(artifactDir))
-  );
+  return contract.artifact_dir_pattern.test(artifactDir);
 }
 
 function readJsonRecords(files = []) {

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -169,6 +169,13 @@ function buildQueueItem({ repoFullName, pr, threads, classification, now, defaul
   const fingerprint = sha256Short(`${repo}#${prNumber}:${headSha}:${threadIds.join(',')}`, 20);
   const resolvedClassification = classification || classifyPullRequest(pr);
   const kind = `${resolvedClassification}-review-comments`;
+  const sourceRepo = resolvedClassification === 'sync'
+    ? `${defaultOwner || repo.split('/')[0]}/Workflows`
+    : repo;
+  const reviewSignature = reviewSignatureForThreads(threads);
+  const sourceReviewKey = reviewSignature
+    ? `${sourceRepo}:${resolvedClassification}:${reviewSignature}`
+    : '';
   const preferredWorkdir =
     resolvedClassification === 'sync' ? 'Workflows' : repo.split('/').slice(-1)[0] || '';
 
@@ -184,8 +191,10 @@ function buildQueueItem({ repoFullName, pr, threads, classification, now, defaul
     head_ref: cleanString(pr?.head?.ref || pr?.headRefName || pr?.headRef),
     head_sha: headSha,
     base_ref: cleanString(pr?.base?.ref || pr?.baseRefName || pr?.baseRef),
-    source_repo: resolvedClassification === 'sync' ? `${defaultOwner || repo.split('/')[0]}/Workflows` : repo,
+    source_repo: sourceRepo,
     preferred_workdir: preferredWorkdir,
+    review_signature: reviewSignature,
+    source_review_key: sourceReviewKey,
     review_thread_count: threads.length,
     review_comment_count: threads.reduce((sum, thread) => sum + (thread.comments_count || 0), 0),
     review_thread_ids: threadIds,
@@ -217,6 +226,34 @@ function collectThreadIds(threads = []) {
     .sort();
 }
 
+function reviewSignatureForThreads(threads = []) {
+  const entries = cleanArray(threads)
+    .map((thread) => [
+      cleanString(thread.path),
+      truncate(thread.body_preview || thread.bodyText || thread.body || '', 200),
+    ].join(':'))
+    .filter((entry) => entry !== ':')
+    .sort();
+  return entries.length ? sha256Short(entries.join('\n'), 20) : '';
+}
+
+function sourceFixedCandidateFor(discovered = {}, finishedBySourceReviewKey = new Map()) {
+  const key = cleanString(discovered.source_review_key);
+  if (!key) {
+    return null;
+  }
+  const finished = finishedBySourceReviewKey.get(key);
+  if (!finished || finished.id === discovered.id) {
+    return null;
+  }
+  return {
+    matching_item_id: cleanString(finished.id),
+    matching_pr_url: cleanString(finished.pr_url),
+    finished_at: cleanString(finished.finished_at),
+    result_summary: truncate(finished.result?.summary, 180),
+  };
+}
+
 function isLeaseExpired(item = {}, now = new Date()) {
   const expiresAt = cleanString(item.lease?.expires_at);
   if (!expiresAt) {
@@ -232,11 +269,19 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
   const previousItems = cleanArray(previousState.items);
   const previousById = new Map(previousItems.map((item) => [item.id, item]));
   const discoveredById = new Map(discoveredItems.map((item) => [item.id, item]));
+  const finishedBySourceReviewKey = new Map(
+    previousItems
+      .filter(
+        (item) => item.status === 'local-codex-finished' && cleanString(item.source_review_key)
+      )
+      .map((item) => [cleanString(item.source_review_key), item])
+  );
   const failedRepos = new Set(parseCsv(options.failedRepos));
   const nextItems = [];
 
   for (const discovered of discoveredItems) {
     const previous = previousById.get(discovered.id);
+    const sourceFixedCandidate = sourceFixedCandidateFor(discovered, finishedBySourceReviewKey);
     if (!previous) {
       nextItems.push({
         ...discovered,
@@ -245,6 +290,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
         updated_at: now,
         attempts: Number(discovered.attempts || 0),
         lease: null,
+        source_fixed_candidate: sourceFixedCandidate,
       });
       continue;
     }
@@ -270,6 +316,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
       attempts,
       lease: status === 'local-codex-claimed' ? lease : null,
       result: previous.result || null,
+      source_fixed_candidate: sourceFixedCandidate || previous.source_fixed_candidate || null,
     });
   }
 
@@ -414,6 +461,16 @@ function compactStateForMarker(state = {}) {
       base_ref: cleanString(item.base_ref),
       source_repo: cleanString(item.source_repo),
       preferred_workdir: cleanString(item.preferred_workdir),
+      review_signature: cleanString(item.review_signature),
+      source_review_key: cleanString(item.source_review_key),
+      source_fixed_candidate: item.source_fixed_candidate
+        ? {
+            matching_item_id: cleanString(item.source_fixed_candidate.matching_item_id),
+            matching_pr_url: cleanString(item.source_fixed_candidate.matching_pr_url),
+            finished_at: cleanString(item.source_fixed_candidate.finished_at),
+            result_summary: truncate(item.source_fixed_candidate.result_summary, 160),
+          }
+        : null,
       review_thread_count: Number(item.review_thread_count || 0),
       review_comment_count: Number(item.review_comment_count || 0),
       first_seen_at: cleanString(item.first_seen_at),
@@ -535,6 +592,16 @@ function formatItemDetails(items = []) {
     lines.push(`- Preferred local workdir: ${item.preferred_workdir || '-'}`);
     lines.push(`- Head: \`${item.head_ref || '-'}\` ${item.head_sha ? `(${item.head_sha.slice(0, 12)})` : ''}`);
     lines.push(`- Attempts: ${item.attempts || 0}`);
+    if (item.source_fixed_candidate) {
+      const candidate = item.source_fixed_candidate;
+      lines.push(
+        `- Prior source-fix match: ${markdownLink(candidate.matching_item_id, candidate.matching_pr_url)} ` +
+          `${candidate.finished_at ? `(${candidate.finished_at})` : ''}`
+      );
+      if (candidate.result_summary) {
+        lines.push(`- Prior source-fix summary: ${truncate(candidate.result_summary, 180)}`);
+      }
+    }
     for (const thread of cleanArray(item.review_threads).slice(0, 2)) {
       const location = `${thread.path || '-'}${thread.line ? `:${thread.line}` : ''}`;
       lines.push(`  - ${markdownLink(location, thread.url)} (${thread.author || 'bot'}): ${truncate(thread.body_preview, 120)}`);

--- a/docs/bot-comment-handler.md
+++ b/docs/bot-comment-handler.md
@@ -171,6 +171,17 @@ canonical wrapper to reach `client-id` while allowing reusable calls to remain
 `client-id` or `none`; hard blocking remains disabled unless explicitly approved
 with repository variables.
 
+Weekly metrics downloads each selected auth artifact into
+`artifacts/<artifact-name>/`. The auth scanner therefore accepts only:
+
+| Artifact family | Accepted file |
+|-----------------|---------------|
+| `bot-comment-auth-coverage-wrapper-<run_id>` | `wrapper.json` as a direct child |
+| `bot-comment-auth-coverage-reusable-<run_id>` | `reusable.json` as a direct child |
+
+Nested copies and loose artifact-name suffixes are ignored so unrelated JSON
+files in downloaded metrics bundles cannot become auth evidence.
+
 Repository variables can make the policy stricter without changing workflow
 code:
 

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -9,9 +9,15 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
-const AUTH_ARTIFACT_DIR_PATTERNS = {
-  wrapper: /^bot-comment-auth-coverage-wrapper-\d+$/,
-  reusable: /^bot-comment-auth-coverage-reusable-\d+$/,
+const AUTH_ARTIFACT_FILE_CONTRACTS = {
+  'wrapper.json': {
+    family: 'bot-comment-auth-coverage-wrapper',
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+  },
+  'reusable.json': {
+    family: 'bot-comment-auth-coverage-reusable',
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+  },
 };
 
 const COMPONENT_POLICIES = {
@@ -584,11 +590,10 @@ function isPotentialAuthCoverageFile(file) {
   const normalized = cleanString(file).split(path.sep).join('/');
   const basename = path.basename(normalized);
   if (!normalized.endsWith('.json')) return false;
+  const contract = AUTH_ARTIFACT_FILE_CONTRACTS[basename];
+  if (!contract) return false;
   const artifactDir = path.basename(path.dirname(normalized));
-  return (
-    (basename === 'wrapper.json' && AUTH_ARTIFACT_DIR_PATTERNS.wrapper.test(artifactDir)) ||
-    (basename === 'reusable.json' && AUTH_ARTIFACT_DIR_PATTERNS.reusable.test(artifactDir))
-  );
+  return contract.artifact_dir_pattern.test(artifactDir);
 }
 
 function readJsonRecords(files = []) {


### PR DESCRIPTION
## Summary

- make bot-comment auth artifact file matching table-driven for wrapper/reusable coverage files
- document the weekly metrics extraction layout and keep nested/loose JSON ignored
- add campaign review signatures and prior source-fix candidate metadata so repeated sync review churn is cheaper to triage without hiding active items

## Verification

- `node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js`
- `node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js`
- `node --check .github/scripts/bot_comment_auth_coverage.js`
- `node --check templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js`
- `node --check .github/scripts/sync_dependabot_campaign.js`
- `python scripts/validate_template_sync.py`
- `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q`
- `git diff --check`