### PR TITLE
Tighten bot auth artifact attempt contracts

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -529,7 +529,19 @@ test('identifies only bot-comment auth coverage candidate files', () => {
   );
   assert.equal(
     isPotentialAuthCoverageFile(
+      '/tmp/artifacts/bot-comment-auth-coverage-wrapper-123456789-2/wrapper.json'
+    ),
+    true
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile(
       '/tmp/artifacts/bot-comment-auth-coverage-reusable-123456789/reusable.json'
+    ),
+    true
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile(
+      '/tmp/artifacts/bot-comment-auth-coverage-reusable-123456789-2/reusable.json'
     ),
     true
   );
@@ -542,6 +554,12 @@ test('identifies only bot-comment auth coverage candidate files', () => {
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/wrapper.json'), false);
   assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1-copy/wrapper.json'),
+    false
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile(
+      '/tmp/artifacts/bot-comment-auth-coverage-wrapper-123-extra/wrapper.json'
+    ),
     false
   );
   assert.equal(

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -37,11 +37,20 @@ test('maps metrics artifact names to stable families', () => {
     'bot-comment-auth-coverage-wrapper'
   );
   assert.equal(
+    artifactFamily('bot-comment-auth-coverage-wrapper-123-2'),
+    'bot-comment-auth-coverage-wrapper'
+  );
+  assert.equal(
     artifactFamily('bot-comment-auth-coverage-reusable-123'),
+    'bot-comment-auth-coverage-reusable'
+  );
+  assert.equal(
+    artifactFamily('bot-comment-auth-coverage-reusable-123-2'),
     'bot-comment-auth-coverage-reusable'
   );
   assert.equal(artifactFamily('bot-comment-auth-coverage-wrapper-latest'), '');
   assert.equal(artifactFamily('bot-comment-auth-coverage-reusable-run-123'), '');
+  assert.equal(artifactFamily('bot-comment-auth-coverage-wrapper-123-extra'), '');
   assert.equal(artifactFamily('coverage-summary'), '');
 });
 
@@ -55,31 +64,34 @@ test('selects only recent matching artifacts with a machine-readable report', ()
       artifact(5, 'review-thread-terminal-disposition-77', '2026-04-25T11:00:00Z'),
       artifact(6, 'agents-verifier-metrics', '2026-04-25T09:00:00Z', { expired: true }),
       artifact(7, 'bot-comment-auth-coverage-wrapper-latest', '2026-04-25T08:00:00Z'),
+      artifact(8, 'bot-comment-auth-coverage-wrapper-77-2', '2026-04-25T08:30:00Z'),
     ],
     { now_ms: NOW, lookback_days: 14 }
   );
 
   assert.equal(report.schema, SELECTION_SCHEMA);
   assert.equal(report.status, 'pass');
-  assert.equal(report.scanned_count, 7);
-  assert.equal(report.candidate_count, 3);
-  assert.equal(report.selected_count, 3);
+  assert.equal(report.scanned_count, 8);
+  assert.equal(report.candidate_count, 4);
+  assert.equal(report.selected_count, 4);
   assert.equal(report.ignored_name_count, 2);
   assert.equal(report.ignored_old_count, 1);
   assert.equal(report.ignored_expired_count, 1);
   assert.deepEqual(report.candidate_family_counts, {
     'autopilot-metrics': 1,
+    'bot-comment-auth-coverage-wrapper': 1,
     'keepalive-metrics': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(report.selected_family_counts, {
     'autopilot-metrics': 1,
+    'bot-comment-auth-coverage-wrapper': 1,
     'keepalive-metrics': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(
     report.selected_artifacts.map((selected) => selected.id),
-    [5, 4, 1]
+    [5, 8, 4, 1]
   );
 });
 

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -11,12 +11,10 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
 ]);
 const AUTH_ARTIFACT_FILE_CONTRACTS = {
   'wrapper.json': {
-    family: 'bot-comment-auth-coverage-wrapper',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
   'reusable.json': {
-    family: 'bot-comment-auth-coverage-reusable',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 };
 

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -25,11 +25,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
 const PATTERNED_METRICS_ARTIFACTS = [
   {
     family: 'bot-comment-auth-coverage-wrapper',
-    pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+    pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
   {
     family: 'bot-comment-auth-coverage-reusable',
-    pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+    pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 ];
 

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -11,12 +11,10 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
 ]);
 const AUTH_ARTIFACT_FILE_CONTRACTS = {
   'wrapper.json': {
-    family: 'bot-comment-auth-coverage-wrapper',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
   'reusable.json': {
-    family: 'bot-comment-auth-coverage-reusable',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 };
 

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -25,11 +25,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
 const PATTERNED_METRICS_ARTIFACTS = [
   {
     family: 'bot-comment-auth-coverage-wrapper',
-    pattern: /^bot-comment-auth-coverage-wrapper-\d+$/,
+    pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
   {
     family: 'bot-comment-auth-coverage-reusable',
-    pattern: /^bot-comment-auth-coverage-reusable-\d+$/,
+    pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 ];
 


### PR DESCRIPTION
## Summary
- remove the unused family field from bot auth artifact file contracts
- align bot-auth scanner and weekly artifact selector on numeric run IDs with optional numeric run-attempt suffixes
- add tests for accepted numeric attempt suffixes and rejected free-form suffixes

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- node --check .github/scripts/bot_comment_auth_coverage.js && node --check templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js && node --check .github/scripts/weekly_metrics_artifacts.js && node --check templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- git diff --check