### PR TITLE
Track sync source freshness in campaign queue

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -571,6 +571,10 @@ test('identifies only bot-comment auth coverage candidate files', () => {
     false
   );
   assert.equal(
+    isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-reusable-1/wrapper.json'),
+    false
+  );
+  assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/nested/wrapper.json'),
     false
   );

--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -142,15 +142,56 @@ test('buildQueueItem creates stable PR-scoped work items', () => {
         comments_count: 1,
       },
     ],
+    currentSyncHash: 'abc123',
   });
 
   assert.match(item.id, /^sync-review-comments:stranske\/TPP#850:/);
   assert.equal(item.status, 'needs-local-codex');
   assert.equal(item.source_repo, 'stranske/Workflows');
   assert.equal(item.preferred_workdir, 'Workflows');
+  assert.deepEqual(item.source_sync, {
+    schema: 'sync-dependabot-campaign-source-sync/v1',
+    current_sync_hash: 'abc123',
+    pr_sync_hash: 'abc123',
+    status: 'current',
+  });
   assert.match(item.review_signature, /^[0-9a-f]{20}$/);
   assert.match(item.source_review_key, /^stranske\/Workflows:sync:[0-9a-f]{20}$/);
   assert.equal(item.review_thread_count, 1);
+});
+
+test('buildQueueItem marks old sync branches as superseded by the current template hash', () => {
+  const item = buildQueueItem({
+    repoFullName: 'stranske/TPP',
+    defaultOwner: 'stranske',
+    now: '2026-04-21T05:52:00Z',
+    currentSyncHash: 'newhash123456',
+    pr: {
+      number: 851,
+      title: 'chore: sync workflow templates',
+      html_url: 'https://github.com/stranske/TPP/pull/851',
+      head: { ref: 'sync/workflows-oldhash123456', sha: 'abcdef123456' },
+      base: { ref: 'main' },
+    },
+    threads: [
+      {
+        id: 'thread-1',
+        path: '.github/scripts/bot_comment_auth_coverage.js',
+        line: 12,
+        url: 'https://github.test/comment-1',
+        author: 'Copilot',
+        body_preview: 'Please tighten this condition.',
+        comments_count: 1,
+      },
+    ],
+  });
+  const body = formatCampaignBody({ items: [item], stats: {}, updated_at: 'now' });
+  const markerItem = parseCampaignMarker(formatCampaignMarker({ items: [item] })).items[0];
+
+  assert.equal(item.source_sync.status, 'superseded');
+  assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
+  assert.equal(markerItem.source_sync.status, 'superseded');
+  assert.match(body, /Source sync state: superseded/);
 });
 
 test('mergeCampaignState preserves active items when repo discovery fails', () => {

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -9,14 +9,21 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
-const AUTH_ARTIFACT_FILE_CONTRACTS = {
-  'wrapper.json': {
+const AUTH_ARTIFACT_FAMILY_CONTRACTS = {
+  'bot-comment-auth-coverage-wrapper': {
+    family: 'bot-comment-auth-coverage-wrapper',
+    filename: 'wrapper.json',
     artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
-  'reusable.json': {
+  'bot-comment-auth-coverage-reusable': {
+    family: 'bot-comment-auth-coverage-reusable',
+    filename: 'reusable.json',
     artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 };
+const AUTH_ARTIFACT_FILE_CONTRACTS = Object.fromEntries(
+  Object.values(AUTH_ARTIFACT_FAMILY_CONTRACTS).map((contract) => [contract.filename, contract])
+);
 
 const COMPONENT_POLICIES = {
   'agents-bot-comment-handler-wrapper': {
@@ -342,14 +349,15 @@ function normalizeArtifactSelectionSummary(report) {
 function artifactFamilyFromSelection(artifact = {}) {
   const family = cleanString(artifact.family);
   if (AUTH_ARTIFACT_FAMILIES.has(family)) return family;
-  const name = cleanString(artifact.name);
-  if (name.startsWith('bot-comment-auth-coverage-wrapper-')) {
-    return 'bot-comment-auth-coverage-wrapper';
-  }
-  if (name.startsWith('bot-comment-auth-coverage-reusable-')) {
-    return 'bot-comment-auth-coverage-reusable';
-  }
-  return '';
+  return artifactFamilyFromName(artifact.name);
+}
+
+function artifactFamilyFromName(name) {
+  const artifactName = cleanString(name);
+  const contract = Object.values(AUTH_ARTIFACT_FAMILY_CONTRACTS).find((candidate) =>
+    candidate.artifact_dir_pattern.test(artifactName)
+  );
+  return contract?.family || '';
 }
 
 function componentCoverageStatus(blockers, policy, latest) {
@@ -595,7 +603,7 @@ function isPotentialAuthCoverageFile(file) {
   const contract = AUTH_ARTIFACT_FILE_CONTRACTS[basename];
   if (!contract) return false;
   const artifactDir = path.basename(path.dirname(normalized));
-  return contract.artifact_dir_pattern.test(artifactDir);
+  return artifactFamilyFromName(artifactDir) === contract.family;
 }
 
 function readJsonRecords(files = []) {

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -161,10 +161,19 @@ function collectActiveBotThreads(reviewThreads = [], options = {}) {
     });
 }
 
-function buildQueueItem({ repoFullName, pr, threads, classification, now, defaultOwner } = {}) {
+function buildQueueItem({
+  repoFullName,
+  pr,
+  threads,
+  classification,
+  now,
+  defaultOwner,
+  currentSyncHash = '',
+} = {}) {
   const repo = cleanString(repoFullName);
   const prNumber = cleanInteger(pr?.number);
   const headSha = cleanString(pr?.head?.sha || pr?.headSha || pr?.head_sha);
+  const headRef = cleanString(pr?.head?.ref || pr?.headRefName || pr?.headRef);
   const threadIds = collectThreadIds(threads);
   const fingerprint = sha256Short(`${repo}#${prNumber}:${headSha}:${threadIds.join(',')}`, 20);
   const resolvedClassification = classification || classifyPullRequest(pr);
@@ -188,11 +197,12 @@ function buildQueueItem({ repoFullName, pr, threads, classification, now, defaul
     pr_number: prNumber,
     pr_title: cleanString(pr?.title),
     pr_url: cleanString(pr?.html_url || pr?.url),
-    head_ref: cleanString(pr?.head?.ref || pr?.headRefName || pr?.headRef),
+    head_ref: headRef,
     head_sha: headSha,
     base_ref: cleanString(pr?.base?.ref || pr?.baseRefName || pr?.baseRef),
     source_repo: sourceRepo,
     preferred_workdir: preferredWorkdir,
+    source_sync: sourceSyncStateFor(resolvedClassification, headRef, currentSyncHash),
     review_signature: reviewSignature,
     source_review_key: sourceReviewKey,
     review_thread_count: threads.length,
@@ -224,6 +234,33 @@ function collectThreadIds(threads = []) {
     .map((thread) => cleanString(thread.id))
     .filter(Boolean)
     .sort();
+}
+
+function normalizeSyncHash(value) {
+  const text = cleanString(value);
+  if (!text) return '';
+  return text.startsWith(SYNC_BRANCH_PREFIX) ? text.slice(SYNC_BRANCH_PREFIX.length) : text;
+}
+
+function sourceSyncStateFor(classification, headRef, currentSyncHash) {
+  if (classification !== 'sync') {
+    return null;
+  }
+  const cleanHeadRef = cleanString(headRef);
+  const pr_sync_hash = cleanHeadRef.startsWith(SYNC_BRANCH_PREFIX)
+    ? normalizeSyncHash(cleanHeadRef)
+    : '';
+  const current_sync_hash = normalizeSyncHash(currentSyncHash);
+  let status = 'unknown';
+  if (pr_sync_hash && current_sync_hash) {
+    status = pr_sync_hash === current_sync_hash ? 'current' : 'superseded';
+  }
+  return {
+    schema: 'sync-dependabot-campaign-source-sync/v1',
+    current_sync_hash,
+    pr_sync_hash,
+    status,
+  };
 }
 
 function reviewSignatureForThreads(threads = []) {
@@ -461,6 +498,14 @@ function compactStateForMarker(state = {}) {
       base_ref: cleanString(item.base_ref),
       source_repo: cleanString(item.source_repo),
       preferred_workdir: cleanString(item.preferred_workdir),
+      source_sync: item.source_sync
+        ? {
+            schema: cleanString(item.source_sync.schema),
+            current_sync_hash: cleanString(item.source_sync.current_sync_hash),
+            pr_sync_hash: cleanString(item.source_sync.pr_sync_hash),
+            status: cleanString(item.source_sync.status),
+          }
+        : null,
       review_signature: cleanString(item.review_signature),
       source_review_key: cleanString(item.source_review_key),
       source_fixed_candidate: item.source_fixed_candidate
@@ -591,6 +636,12 @@ function formatItemDetails(items = []) {
     lines.push(`- Source repo: ${item.source_repo || '-'}`);
     lines.push(`- Preferred local workdir: ${item.preferred_workdir || '-'}`);
     lines.push(`- Head: \`${item.head_ref || '-'}\` ${item.head_sha ? `(${item.head_sha.slice(0, 12)})` : ''}`);
+    if (item.source_sync) {
+      lines.push(
+        `- Source sync state: ${item.source_sync.status || 'unknown'} ` +
+          `(PR ${item.source_sync.pr_sync_hash || '-'} / current ${item.source_sync.current_sync_hash || '-'})`
+      );
+    }
     lines.push(`- Attempts: ${item.attempts || 0}`);
     if (item.source_fixed_candidate) {
       const candidate = item.source_fixed_candidate;
@@ -794,6 +845,7 @@ async function discoverRepoWork({
   botAuthors,
   ignoredPaths,
   withRetry = null,
+  currentSyncHash = '',
 }) {
   const { owner, repo, fullName } = repoEntry;
   const result = {
@@ -834,6 +886,7 @@ async function discoverRepoWork({
       classification,
       now,
       defaultOwner,
+      currentSyncHash,
     }));
   }
 
@@ -1025,6 +1078,7 @@ async function runCampaign({
   maxRepos = 0,
   botAuthors = DEFAULT_BOT_AUTHORS,
   ignoredPaths = DEFAULT_IGNORED_PATHS,
+  currentSyncHash = '',
   now = new Date().toISOString(),
 } = {}) {
   if (!github || !context?.repo) {
@@ -1060,6 +1114,7 @@ async function runCampaign({
         botAuthors,
         ignoredPaths,
         withRetry,
+        currentSyncHash,
       });
       discoveredItems.push(...result.items);
       syncPrsOpen += result.syncPrsOpen;

--- a/.github/workflows/maint-82-sync-dependabot-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependabot-campaign.yml
@@ -52,6 +52,20 @@ jobs:
           repos=$(python scripts/list_registered_consumer_repos.py --separator ',')
           echo "repos=${repos}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute current sync hash
+        id: hash
+        run: |
+          hash=$({
+            find templates/consumer-repo -type f -exec sha256sum {} \;
+            find tools -name "*.py" -type f -exec sha256sum {} \; 2>/dev/null || true
+            find scripts -name "*.py" -type f -exec sha256sum {} \; 2>/dev/null || true
+            find scripts -name "*.sh" -type f -exec sha256sum {} \; 2>/dev/null || true
+            find .github/scripts -type f -exec sha256sum {} \;
+            sha256sum .github/sync-manifest.yml
+          } | sort | sha256sum | cut -d' ' -f1)
+          echo "hash=${hash:0:12}" >> "$GITHUB_OUTPUT"
+          echo "Current sync hash: ${hash:0:12}"
+
       - name: Resolve inputs
         id: inputs
         env:
@@ -94,6 +108,7 @@ jobs:
               : requestedRepos.split(',').map((repo) => repo.trim()).filter(Boolean);
             const dryRun = '${{ steps.inputs.outputs.dry_run }}' === 'true';
             const maxRepos = Number('${{ steps.inputs.outputs.max_repos }}') || 0;
+            const currentSyncHash = '${{ steps.hash.outputs.hash }}';
 
             const result = await runCampaign({
               github,
@@ -102,6 +117,7 @@ jobs:
               repos,
               dryRun,
               maxRepos,
+              currentSyncHash,
             });
 
             const stats = result.state.stats || {};

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -9,14 +9,21 @@ const AUTH_ARTIFACT_FAMILIES = new Set([
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
 ]);
-const AUTH_ARTIFACT_FILE_CONTRACTS = {
-  'wrapper.json': {
+const AUTH_ARTIFACT_FAMILY_CONTRACTS = {
+  'bot-comment-auth-coverage-wrapper': {
+    family: 'bot-comment-auth-coverage-wrapper',
+    filename: 'wrapper.json',
     artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
   },
-  'reusable.json': {
+  'bot-comment-auth-coverage-reusable': {
+    family: 'bot-comment-auth-coverage-reusable',
+    filename: 'reusable.json',
     artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
   },
 };
+const AUTH_ARTIFACT_FILE_CONTRACTS = Object.fromEntries(
+  Object.values(AUTH_ARTIFACT_FAMILY_CONTRACTS).map((contract) => [contract.filename, contract])
+);
 
 const COMPONENT_POLICIES = {
   'agents-bot-comment-handler-wrapper': {
@@ -342,14 +349,15 @@ function normalizeArtifactSelectionSummary(report) {
 function artifactFamilyFromSelection(artifact = {}) {
   const family = cleanString(artifact.family);
   if (AUTH_ARTIFACT_FAMILIES.has(family)) return family;
-  const name = cleanString(artifact.name);
-  if (name.startsWith('bot-comment-auth-coverage-wrapper-')) {
-    return 'bot-comment-auth-coverage-wrapper';
-  }
-  if (name.startsWith('bot-comment-auth-coverage-reusable-')) {
-    return 'bot-comment-auth-coverage-reusable';
-  }
-  return '';
+  return artifactFamilyFromName(artifact.name);
+}
+
+function artifactFamilyFromName(name) {
+  const artifactName = cleanString(name);
+  const contract = Object.values(AUTH_ARTIFACT_FAMILY_CONTRACTS).find((candidate) =>
+    candidate.artifact_dir_pattern.test(artifactName)
+  );
+  return contract?.family || '';
 }
 
 function componentCoverageStatus(blockers, policy, latest) {
@@ -595,7 +603,7 @@ function isPotentialAuthCoverageFile(file) {
   const contract = AUTH_ARTIFACT_FILE_CONTRACTS[basename];
   if (!contract) return false;
   const artifactDir = path.basename(path.dirname(normalized));
-  return contract.artifact_dir_pattern.test(artifactDir);
+  return artifactFamilyFromName(artifactDir) === contract.family;
 }
 
 function readJsonRecords(files = []) {


### PR DESCRIPTION
## Summary
- make bot auth artifact file matching use the declared artifact family contract
- add campaign source_sync metadata for sync PRs, including current vs PR sync hash status
- compute and pass the current sync hash in the remote Sync/Dependabot campaign workflow

## Verification
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js
- node --check .github/scripts/bot_comment_auth_coverage.js
- node --check templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
- node --check .github/scripts/sync_dependabot_campaign.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- git diff --check