### PR TITLE
Retain source review history in campaign state

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -335,9 +335,67 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   assert.equal(repeatedItem.status, 'needs-local-codex');
   assert.equal(repeatedItem.source_fixed_candidate.matching_item_id, finished.id);
   assert.equal(repeatedItem.source_fixed_candidate.finished_at, '2026-04-21T05:30:00Z');
+  assert.equal(state.source_review_history.length, 1);
+  assert.equal(state.source_review_history[0].source_review_key, finished.source_review_key);
   assert.equal(state.stats.items_needing_local_codex, 1);
   assert.equal(markerItem.source_fixed_candidate.matching_item_id, finished.id);
+  assert.equal(marker.source_review_history[0].matching_item_id, finished.id);
   assert.match(body, /Prior source-fix match:/);
+});
+
+test('mergeCampaignState matches source-fixed candidates from compact retained history', () => {
+  const now = '2026-04-21T06:52:00Z';
+  const repeated = buildQueueItem({
+    repoFullName: 'stranske/TPP',
+    defaultOwner: 'stranske',
+    now,
+    pr: {
+      number: 852,
+      title: 'chore: sync workflow templates',
+      html_url: 'https://github.com/stranske/TPP/pull/852',
+      head: { ref: 'sync/workflows-new', sha: 'new-sha' },
+      base: { ref: 'main' },
+    },
+    threads: [
+      {
+        id: 'thread-new',
+        path: '.github/scripts/bot_comment_auth_coverage.js',
+        line: 30,
+        url: 'https://github.test/thread-new',
+        author: 'copilot-pull-request-reviewer',
+        body_preview: 'Please tighten this auth coverage condition.',
+        comments_count: 1,
+      },
+    ],
+  });
+  const state = mergeCampaignState(
+    {
+      source_review_history: [
+        {
+          source_review_key: repeated.source_review_key,
+          review_signature: repeated.review_signature,
+          matching_item_id: 'sync-review-comments:stranske/TPP#850:old',
+          matching_pr_url: 'https://github.com/stranske/TPP/pull/850',
+          finished_at: '2026-04-21T05:30:00Z',
+          result_summary: 'Handled through the Workflows source path.',
+        },
+      ],
+      items: Array.from({ length: 3 }, (_value, index) => ({
+        id: `active-${index}`,
+        status: 'needs-local-codex',
+        repo: 'stranske/Other',
+        pr_number: index + 1,
+      })),
+    },
+    [repeated],
+    now,
+    { reposRequested: 1, reposChecked: 1, maxRetainedItems: 1 },
+  );
+  const repeatedItem = state.items.find((item) => item.id === repeated.id);
+
+  assert.equal(repeatedItem.source_fixed_candidate.matching_item_id, 'sync-review-comments:stranske/TPP#850:old');
+  assert.equal(state.source_review_history.length, 1);
+  assert.equal(state.items.some((item) => item.status === 'local-codex-finished'), false);
 });
 
 test('formatCampaignBody renders queue rows and marker', () => {

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -11,6 +11,7 @@ const LABEL_NEEDS_LOCAL_CODEX = 'campaign:needs-local-codex';
 const SYNC_BRANCH_PREFIX = 'sync/workflows-';
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_MAX_RETAINED_ITEMS = 120;
+const DEFAULT_MAX_SOURCE_REVIEW_HISTORY = 80;
 const MAX_ISSUE_BODY_LENGTH = 60000;
 const MAX_QUEUE_ROWS = 15;
 const MAX_DETAIL_ITEMS = 10;
@@ -284,11 +285,43 @@ function sourceFixedCandidateFor(discovered = {}, finishedBySourceReviewKey = ne
     return null;
   }
   return {
-    matching_item_id: cleanString(finished.id),
-    matching_pr_url: cleanString(finished.pr_url),
+    matching_item_id: cleanString(finished.matching_item_id || finished.id),
+    matching_pr_url: cleanString(finished.matching_pr_url || finished.pr_url),
     finished_at: cleanString(finished.finished_at),
-    result_summary: truncate(finished.result?.summary, 180),
+    result_summary: truncate(finished.result_summary || finished.result?.summary, 180),
   };
+}
+
+function compactSourceReviewHistoryEntry(item = {}) {
+  const sourceReviewKey = cleanString(item.source_review_key);
+  if (!sourceReviewKey) {
+    return null;
+  }
+  return {
+    source_review_key: sourceReviewKey,
+    review_signature: cleanString(item.review_signature),
+    matching_item_id: cleanString(item.matching_item_id || item.id),
+    matching_pr_url: cleanString(item.matching_pr_url || item.pr_url),
+    finished_at: cleanString(item.finished_at),
+    result_summary: truncate(item.result_summary || item.result?.summary, 180),
+  };
+}
+
+function buildSourceReviewHistory(previousState = {}, previousItems = [], limit = DEFAULT_MAX_SOURCE_REVIEW_HISTORY) {
+  const retainedHistory = cleanArray(previousState.source_review_history)
+    .map(compactSourceReviewHistoryEntry)
+    .filter(Boolean);
+  const newlyFinished = cleanArray(previousItems)
+    .filter((item) => item.status === 'local-codex-finished')
+    .map(compactSourceReviewHistoryEntry)
+    .filter(Boolean);
+  const byKey = new Map();
+  for (const entry of [...retainedHistory, ...newlyFinished]) {
+    byKey.set(entry.source_review_key, entry);
+  }
+  return [...byKey.values()]
+    .sort((a, b) => cleanString(b.finished_at).localeCompare(cleanString(a.finished_at)))
+    .slice(0, Number(limit) || DEFAULT_MAX_SOURCE_REVIEW_HISTORY);
 }
 
 function isLeaseExpired(item = {}, now = new Date()) {
@@ -306,12 +339,13 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
   const previousItems = cleanArray(previousState.items);
   const previousById = new Map(previousItems.map((item) => [item.id, item]));
   const discoveredById = new Map(discoveredItems.map((item) => [item.id, item]));
+  const sourceReviewHistory = buildSourceReviewHistory(
+    previousState,
+    previousItems,
+    options.maxSourceReviewHistory || DEFAULT_MAX_SOURCE_REVIEW_HISTORY
+  );
   const finishedBySourceReviewKey = new Map(
-    previousItems
-      .filter(
-        (item) => item.status === 'local-codex-finished' && cleanString(item.source_review_key)
-      )
-      .map((item) => [cleanString(item.source_review_key), item])
+    sourceReviewHistory.map((item) => [cleanString(item.source_review_key), item])
   );
   const failedRepos = new Set(parseCsv(options.failedRepos));
   const nextItems = [];
@@ -387,6 +421,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     run_id: cleanString(options.runId || previousState.run_id),
     controller: 'maint-82-sync-dependabot-campaign',
     stats: buildStats(items, discoveredItems, options),
+    source_review_history: sourceReviewHistory,
     items,
   };
 }
@@ -484,6 +519,9 @@ function compactStateForMarker(state = {}) {
     controller: cleanString(state.controller),
     stats: state.stats || {},
     validation: state.validation || null,
+    source_review_history: cleanArray(state.source_review_history)
+      .map(compactSourceReviewHistoryEntry)
+      .filter(Boolean),
     items: cleanArray(state.items).map((item) => ({
       id: cleanString(item.id),
       status: cleanString(item.status),

--- a/tests/scripts/test_repo_review_evaluator.py
+++ b/tests/scripts/test_repo_review_evaluator.py
@@ -144,7 +144,9 @@ def test_run_git_preserves_status_leading_columns(tmp_path: Path) -> None:
     tracked.parent.mkdir(parents=True)
     tracked.write_text("one\n", encoding="utf-8")
     subprocess.run(["git", "-C", str(repo), "add", str(tracked)], check=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "initial"], check=True, capture_output=True
+    )
 
     tracked.write_text("two\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- retain compact finished source-review history outside the active item cap
- use retained history for source_fixed_candidate matching when finished items are pruned
- keep the retained history in the campaign marker as GitHub-visible state

## Verification
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js
- node --check .github/scripts/sync_dependabot_campaign.js
- node --test .github/scripts/__tests__/bot-comment-auth-coverage.test.js
- python scripts/validate_template_sync.py
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q
- git diff --check