### PR TITLE
Handle empty weekly agent metrics

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -398,7 +398,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'] or 1)}",
+                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]
@@ -427,8 +427,14 @@ def main() -> int:
 
     files = _gather_metrics_files(metrics_paths, metrics_dir)
     if not files:
-        print("No metrics files found to aggregate.", file=sys.stderr)
-        return 1
+        summary = (
+            "# Agent Metrics Summary\n\n"
+            "No metrics files were found. No data was available for this run.\n"
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(summary, encoding="utf-8")
+        print(f"No metrics files found to aggregate. Wrote empty summary to {output_path}")
+        return 0
 
     entries, errors = _read_ndjson(files)
     summary = build_summary(entries, errors)

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -398,7 +398,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'] or 1)}",
+                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]
@@ -427,8 +427,14 @@ def main() -> int:
 
     files = _gather_metrics_files(metrics_paths, metrics_dir)
     if not files:
-        print("No metrics files found to aggregate.", file=sys.stderr)
-        return 1
+        summary = (
+            "# Agent Metrics Summary\n\n"
+            "No metrics files were found. No data was available for this run.\n"
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(summary, encoding="utf-8")
+        print(f"No metrics files found to aggregate. Wrote empty summary to {output_path}")
+        return 0
 
     entries, errors = _read_ndjson(files)
     summary = build_summary(entries, errors)

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -298,14 +298,21 @@ def test_format_helpers_and_summary_range() -> None:
     assert "Range: 2025-01-01T00:00:00Z to 2025-01-02T00:00:00Z" in summary
 
 
-def test_main_returns_error_when_no_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_writes_empty_summary_when_no_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "summary.md"
     monkeypatch.setenv("METRICS_PATHS", "")
     monkeypatch.setenv("METRICS_DIR", str(tmp_path / "missing"))
-    monkeypatch.setenv("OUTPUT_PATH", str(tmp_path / "summary.md"))
+    monkeypatch.setenv("OUTPUT_PATH", str(output_path))
 
     exit_code = aggregate_agent_metrics.main()
 
-    assert exit_code == 1
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == (
+        "# Agent Metrics Summary\n\n"
+        "No metrics files were found. No data was available for this run.\n"
+    )
 
 
 def test_autopilot_metrics_summarised() -> None:
@@ -354,6 +361,21 @@ def test_autopilot_metrics_summarised() -> None:
     assert "format:" in summary
     assert "capability-check:" in summary
     assert "step-failed (1)" in summary
+
+
+def test_autopilot_needs_human_rate_is_na_without_issue_numbers() -> None:
+    summary = aggregate_agent_metrics.build_summary(
+        [
+            {
+                "metric_type": "escalation",
+                "escalation_reason": "needs-human-complexity",
+            }
+        ],
+        errors=0,
+    )
+
+    assert "Issues: 0" in summary
+    assert "Needs-human rate: n/a" in summary
 
 
 def test_classify_autopilot_step_entry() -> None:


### PR DESCRIPTION
## Summary
- Treat no weekly agent metrics artifacts as a successful empty-summary run instead of failing the scheduled job.
- Compute the auto-pilot needs-human rate with the actual issue count so missing issue numbers render as n/a.
- Keep the consumer template copy aligned with the source script.

## Validation
- pytest tests/scripts/test_aggregate_agent_metrics.py -q
- pytest tests/workflows/test_workflow_agents_consolidation.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check