### PR TITLE
[codex] Tighten campaign queue source-fixed contracts

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -572,17 +572,21 @@ test('identifies only bot-comment auth coverage candidate files', () => {
   assert.equal(isPotentialAuthCoverageFile('/tmp/artifacts/wrapper.json'), false);
   assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1-copy/wrapper.json'),
-    false
+    true
   );
   assert.equal(
     isPotentialAuthCoverageFile(
       '/tmp/artifacts/bot-comment-auth-coverage-wrapper-123-extra/wrapper.json'
     ),
-    false
+    true
   );
   assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-reusable-latest/reusable.json'),
-    false
+    true
+  );
+  assert.equal(
+    isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper/wrapper.json'),
+    true
   );
   assert.equal(
     isPotentialAuthCoverageFile('/tmp/artifacts/bot-comment-auth-coverage-wrapper-1/reusable.json'),

--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -337,9 +337,14 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   assert.equal(repeatedItem.source_fixed_candidate.finished_at, '2026-04-21T05:30:00Z');
   assert.equal(state.source_review_history.length, 1);
   assert.equal(state.source_review_history[0].source_review_key, finished.source_review_key);
-  assert.equal(state.stats.items_needing_local_codex, 1);
+  assert.equal(state.stats.items_needing_local_codex, 0);
+  assert.equal(state.stats.items_actionable_local_codex, 0);
+  assert.equal(state.stats.items_source_fixed_candidates, 1);
+  assert.equal(state.stats.status_counts['needs-local-codex'], 1);
   assert.equal(markerItem.source_fixed_candidate.matching_item_id, finished.id);
   assert.equal(marker.source_review_history[0].matching_item_id, finished.id);
+  assert.match(body, /No local Codex work is queued/);
+  assert.match(body, /Source-fixed candidates: 1/);
   assert.match(body, /Prior source-fix match:/);
 });
 
@@ -426,6 +431,68 @@ test('formatCampaignBody renders queue rows and marker', () => {
   assert.match(body, /Sync\/Dependabot Campaign Queue/);
   assert.match(body, /stranske\/App#10/);
   assert.equal(parseCampaignMarker(body).stats.items_needing_local_codex, 1);
+});
+
+test('formatCampaignBody keeps source-fixed candidates out of the visible local queue', () => {
+  const state = {
+    schema: 'sync-dependabot-campaign/v1',
+    updated_at: '2026-04-21T05:52:00Z',
+    stats: {
+      repos_requested: 1,
+      repos_checked: 1,
+      active_review_threads: 3,
+      items_needing_local_codex: 1,
+      items_actionable_local_codex: 1,
+      items_source_fixed_candidates: 1,
+      status_counts: { 'needs-local-codex': 2 },
+    },
+    items: [
+      {
+        id: 'sync-review-comments:stranske/App#22:abc',
+        status: 'needs-local-codex',
+        kind: 'sync-review-comments',
+        classification: 'sync',
+        repo: 'stranske/App',
+        pr_number: 22,
+        pr_title: 'source fixed already',
+        pr_url: 'https://github.com/stranske/App/pull/22',
+        source_repo: 'stranske/Workflows',
+        preferred_workdir: 'Workflows',
+        review_thread_count: 2,
+        source_fixed_candidate: {
+          matching_item_id: 'sync-review-comments:stranske/App#20:old',
+          matching_pr_url: 'https://github.com/stranske/App/pull/20',
+          finished_at: '2026-04-21T05:30:00Z',
+          result_summary: 'Handled in Workflows source.',
+        },
+        review_threads: [],
+      },
+      {
+        id: 'sync-review-comments:stranske/App#23:def',
+        status: 'needs-local-codex',
+        kind: 'sync-review-comments',
+        classification: 'sync',
+        repo: 'stranske/App',
+        pr_number: 23,
+        pr_title: 'needs source work',
+        pr_url: 'https://github.com/stranske/App/pull/23',
+        source_repo: 'stranske/Workflows',
+        preferred_workdir: 'Workflows',
+        review_thread_count: 1,
+        review_threads: [],
+      },
+    ],
+  };
+
+  const body = formatCampaignBody(state);
+
+  assert.equal(state.stats.items_needing_local_codex, 1);
+  assert.equal(state.stats.items_source_fixed_candidates, 1);
+  assert.match(body, /Items needing local Codex: 1/);
+  assert.match(body, /Source-fixed candidates: 1/);
+  assert.match(body, /\| needs-local-codex \| \[stranske\/App#23\]/);
+  assert.doesNotMatch(body, /\| needs-local-codex \| \[stranske\/App#22\]/);
+  assert.match(body, /### stranske\/App#22/);
 });
 
 test('paginateWithRetry uses the paginated GitHub API', async () => {

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -48,9 +48,22 @@ test('maps metrics artifact names to stable families', () => {
     artifactFamily('bot-comment-auth-coverage-reusable-123-2'),
     'bot-comment-auth-coverage-reusable'
   );
-  assert.equal(artifactFamily('bot-comment-auth-coverage-wrapper-latest'), '');
-  assert.equal(artifactFamily('bot-comment-auth-coverage-reusable-run-123'), '');
-  assert.equal(artifactFamily('bot-comment-auth-coverage-wrapper-123-extra'), '');
+  assert.equal(
+    artifactFamily('bot-comment-auth-coverage-wrapper-latest'),
+    'bot-comment-auth-coverage-wrapper'
+  );
+  assert.equal(
+    artifactFamily('bot-comment-auth-coverage-reusable-run-123'),
+    'bot-comment-auth-coverage-reusable'
+  );
+  assert.equal(
+    artifactFamily('bot-comment-auth-coverage-wrapper-123-extra'),
+    'bot-comment-auth-coverage-wrapper'
+  );
+  assert.equal(
+    artifactFamily('bot-comment-auth-coverage-reusable'),
+    'bot-comment-auth-coverage-reusable'
+  );
   assert.equal(artifactFamily('coverage-summary'), '');
 });
 
@@ -72,26 +85,26 @@ test('selects only recent matching artifacts with a machine-readable report', ()
   assert.equal(report.schema, SELECTION_SCHEMA);
   assert.equal(report.status, 'pass');
   assert.equal(report.scanned_count, 8);
-  assert.equal(report.candidate_count, 4);
-  assert.equal(report.selected_count, 4);
-  assert.equal(report.ignored_name_count, 2);
+  assert.equal(report.candidate_count, 5);
+  assert.equal(report.selected_count, 5);
+  assert.equal(report.ignored_name_count, 1);
   assert.equal(report.ignored_old_count, 1);
   assert.equal(report.ignored_expired_count, 1);
   assert.deepEqual(report.candidate_family_counts, {
     'autopilot-metrics': 1,
-    'bot-comment-auth-coverage-wrapper': 1,
+    'bot-comment-auth-coverage-wrapper': 2,
     'keepalive-metrics': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(report.selected_family_counts, {
     'autopilot-metrics': 1,
-    'bot-comment-auth-coverage-wrapper': 1,
+    'bot-comment-auth-coverage-wrapper': 2,
     'keepalive-metrics': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(
     report.selected_artifacts.map((selected) => selected.id),
-    [5, 8, 4, 1]
+    [5, 8, 4, 7, 1]
   );
 });
 

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -13,12 +13,12 @@ const AUTH_ARTIFACT_FAMILY_CONTRACTS = {
   'bot-comment-auth-coverage-wrapper': {
     family: 'bot-comment-auth-coverage-wrapper',
     filename: 'wrapper.json',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
   'bot-comment-auth-coverage-reusable': {
     family: 'bot-comment-auth-coverage-reusable',
     filename: 'reusable.json',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
 };
 const AUTH_ARTIFACT_FILE_CONTRACTS = Object.fromEntries(

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -434,11 +434,25 @@ function pruneItems(items, limit) {
   return [...active, ...inactive].slice(0, limit);
 }
 
+function isSourceFixedCandidate(item = {}) {
+  return Boolean(item && item.source_fixed_candidate);
+}
+
+function isActionableLocalCodexItem(item = {}) {
+  return item.status === 'needs-local-codex' && !isSourceFixedCandidate(item);
+}
+
+function isVisibleQueueItem(item = {}) {
+  return isActionableLocalCodexItem(item) || item.status === 'local-codex-claimed';
+}
+
 function buildStats(items, discoveredItems, options = {}) {
   const statusCounts = items.reduce((counts, item) => {
     counts[item.status] = (counts[item.status] || 0) + 1;
     return counts;
   }, {});
+  const sourceFixedCandidateCount = items.filter(isSourceFixedCandidate).length;
+  const actionableLocalCodexCount = items.filter(isActionableLocalCodexItem).length;
   return {
     repos_requested: Number(options.reposRequested || 0),
     repos_checked: Number(options.reposChecked || 0),
@@ -450,7 +464,9 @@ function buildStats(items, discoveredItems, options = {}) {
       (sum, item) => sum + Number(item.review_thread_count || 0),
       0,
     ),
-    items_needing_local_codex: statusCounts['needs-local-codex'] || 0,
+    items_needing_local_codex: actionableLocalCodexCount,
+    items_actionable_local_codex: actionableLocalCodexCount,
+    items_source_fixed_candidates: sourceFixedCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
@@ -459,12 +475,17 @@ function buildStats(items, discoveredItems, options = {}) {
 }
 
 function deriveItemStats(items = []) {
-  const statusCounts = cleanArray(items).reduce((counts, item) => {
+  const queueItems = cleanArray(items);
+  const statusCounts = queueItems.reduce((counts, item) => {
     counts[item.status] = (counts[item.status] || 0) + 1;
     return counts;
   }, {});
+  const sourceFixedCandidateCount = queueItems.filter(isSourceFixedCandidate).length;
+  const actionableLocalCodexCount = queueItems.filter(isActionableLocalCodexItem).length;
   return {
-    items_needing_local_codex: statusCounts['needs-local-codex'] || 0,
+    items_needing_local_codex: actionableLocalCodexCount,
+    items_actionable_local_codex: actionableLocalCodexCount,
+    items_source_fixed_candidates: sourceFixedCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
@@ -478,6 +499,8 @@ function validateCampaignState(state = {}) {
   const blockers = [];
   const fields = [
     'items_needing_local_codex',
+    'items_actionable_local_codex',
+    'items_source_fixed_candidates',
     'items_claimed',
     'items_finished',
     'items_blocked',
@@ -621,7 +644,7 @@ function markdownLink(label, url) {
 function formatCampaignBody(state) {
   const stats = state.stats || {};
   const queueItems = cleanArray(state.items)
-    .filter((item) => item.status === 'needs-local-codex' || item.status === 'local-codex-claimed')
+    .filter(isVisibleQueueItem)
     .slice(0, MAX_QUEUE_ROWS);
   const rows = queueItems.length
     ? queueItems.map((item) => (
@@ -643,6 +666,7 @@ function formatCampaignBody(state) {
     `- Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
+    `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     '',
     '## Local Queue',
     '',
@@ -653,6 +677,12 @@ function formatCampaignBody(state) {
     '<details><summary>Queue item details</summary>',
     '',
     ...formatItemDetails(state.items),
+    '',
+    '</details>',
+    '',
+    '<details><summary>Source-fixed candidates</summary>',
+    '',
+    ...formatSourceFixedCandidateDetails(state.items),
     '',
     '</details>',
     '',
@@ -667,7 +697,8 @@ function formatCampaignBody(state) {
 
 function formatItemDetails(items = []) {
   const lines = [];
-  for (const item of cleanArray(items).slice(0, MAX_DETAIL_ITEMS)) {
+  const detailItems = cleanArray(items).filter((item) => !isSourceFixedCandidate(item));
+  for (const item of detailItems.slice(0, MAX_DETAIL_ITEMS)) {
     lines.push(`### ${item.status}: ${item.repo}#${item.pr_number}`);
     lines.push('');
     lines.push(`- Kind: ${item.kind}`);
@@ -697,17 +728,46 @@ function formatItemDetails(items = []) {
     }
     lines.push('');
   }
-  const remaining = Math.max(0, cleanArray(items).length - MAX_DETAIL_ITEMS);
+  const remaining = Math.max(0, detailItems.length - MAX_DETAIL_ITEMS);
   if (remaining > 0) {
     lines.push(`Additional retained items omitted from the rendered issue body: ${remaining}.`);
   }
   return lines.length ? lines : ['No retained queue items.'];
 }
 
+function formatSourceFixedCandidateDetails(items = []) {
+  const lines = [];
+  const candidates = cleanArray(items).filter(isSourceFixedCandidate);
+  for (const item of candidates.slice(0, MAX_DETAIL_ITEMS)) {
+    const candidate = item.source_fixed_candidate || {};
+    lines.push(`### ${item.repo}#${item.pr_number}`);
+    lines.push('');
+    lines.push(`- Status: ${item.status}`);
+    lines.push(`- Source repo: ${item.source_repo || '-'}`);
+    lines.push(
+      `- Prior source-fix match: ${markdownLink(candidate.matching_item_id, candidate.matching_pr_url)} ` +
+        `${candidate.finished_at ? `(${candidate.finished_at})` : ''}`
+    );
+    if (candidate.result_summary) {
+      lines.push(`- Prior source-fix summary: ${truncate(candidate.result_summary, 180)}`);
+    }
+    for (const thread of cleanArray(item.review_threads).slice(0, 2)) {
+      const location = `${thread.path || '-'}${thread.line ? `:${thread.line}` : ''}`;
+      lines.push(`  - ${markdownLink(location, thread.url)} (${thread.author || 'bot'}): ${truncate(thread.body_preview, 120)}`);
+    }
+    lines.push('');
+  }
+  const remaining = Math.max(0, candidates.length - MAX_DETAIL_ITEMS);
+  if (remaining > 0) {
+    lines.push(`Additional source-fixed candidates omitted from the rendered issue body: ${remaining}.`);
+  }
+  return lines.length ? lines : ['No source-fixed candidates retained.'];
+}
+
 function formatCompactCampaignBody(state) {
   const stats = state.stats || {};
   const queueItems = cleanArray(state.items)
-    .filter((item) => item.status === 'needs-local-codex' || item.status === 'local-codex-claimed')
+    .filter(isVisibleQueueItem)
     .slice(0, 10);
   const rows = queueItems.length
     ? queueItems.map((item) => (
@@ -726,6 +786,7 @@ function formatCompactCampaignBody(state) {
     `- Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
+    `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     '',
     '| Status | PR | Threads |',
     '| --- | --- | ---: |',

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -25,11 +25,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
 const PATTERNED_METRICS_ARTIFACTS = [
   {
     family: 'bot-comment-auth-coverage-wrapper',
-    pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
+    pattern: /^bot-comment-auth-coverage-wrapper(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
   {
     family: 'bot-comment-auth-coverage-reusable',
-    pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
+    pattern: /^bot-comment-auth-coverage-reusable(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
 ];
 

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -13,12 +13,12 @@ const AUTH_ARTIFACT_FAMILY_CONTRACTS = {
   'bot-comment-auth-coverage-wrapper': {
     family: 'bot-comment-auth-coverage-wrapper',
     filename: 'wrapper.json',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-wrapper(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
   'bot-comment-auth-coverage-reusable': {
     family: 'bot-comment-auth-coverage-reusable',
     filename: 'reusable.json',
-    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
+    artifact_dir_pattern: /^bot-comment-auth-coverage-reusable(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
 };
 const AUTH_ARTIFACT_FILE_CONTRACTS = Object.fromEntries(

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -25,11 +25,11 @@ const PREFIXED_METRICS_ARTIFACTS = [
 const PATTERNED_METRICS_ARTIFACTS = [
   {
     family: 'bot-comment-auth-coverage-wrapper',
-    pattern: /^bot-comment-auth-coverage-wrapper-\d+(?:-\d+)?$/,
+    pattern: /^bot-comment-auth-coverage-wrapper(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
   {
     family: 'bot-comment-auth-coverage-reusable',
-    pattern: /^bot-comment-auth-coverage-reusable-\d+(?:-\d+)?$/,
+    pattern: /^bot-comment-auth-coverage-reusable(?:-[A-Za-z0-9][A-Za-z0-9._-]*)?$/,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Counts source-fixed campaign matches separately from actionable local Codex work so already-fixed sync review items no longer occupy the visible queue or needs-local-codex total.
- Renders retained source-fixed candidates in their own details section while keeping machine-readable marker state and status counts intact.
- Broadens bot-comment auth artifact family matching in source and consumer templates so scanner and weekly selector accept stable family-prefixed artifact names beyond numeric run-id suffixes.

## Verification

- `node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js .github/scripts/__tests__/bot-comment-auth-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js`
- `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `git diff --check`

## Campaign Impact

Using durable campaign run `24941404418`, the new derived stats would show 118 actionable local Codex items and 2 source-fixed candidates, moving `Travel-Plan-Permission#896/#894` out of the top visible queue.