### PR TITLE
[codex] Relax weekly aggregate empty inputs

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -398,7 +398,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'] or 1)}",
+                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]
@@ -427,8 +427,10 @@ def main() -> int:
 
     files = _gather_metrics_files(metrics_paths, metrics_dir)
     if not files:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("No metrics files found to aggregate.\n", encoding="utf-8")
         print("No metrics files found to aggregate.", file=sys.stderr)
-        return 1
+        return 0
 
     entries, errors = _read_ndjson(files)
     summary = build_summary(entries, errors)

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -155,7 +155,9 @@ def load_registry(path: Path) -> tuple[Path, list[str], list[RepoConfig], list[P
         workspace_root = (path.parent.parent / workspace_root).resolve()
 
     excluded = [str(item).lower() for item in data.get("excluded_repo_names", [])]
-    archive_paths = [Path(item).expanduser() for item in data.get("archive_review", {}).get("paths", [])]
+    archive_paths = [
+        Path(item).expanduser() for item in data.get("archive_review", {}).get("paths", [])
+    ]
     repos: list[RepoConfig] = []
     seen: set[str] = set()
     for raw in data.get("repos", []):
@@ -324,8 +326,7 @@ def is_repo_review_session(user_text: str) -> bool:
     if not REVIEW_PROMPT_RE.search(user_text):
         return False
     return not (
-        MAINTENANCE_SESSION_RE.search(user_text)
-        and not STRICT_REVIEW_PROMPT_RE.search(user_text)
+        MAINTENANCE_SESSION_RE.search(user_text) and not STRICT_REVIEW_PROMPT_RE.search(user_text)
     )
 
 
@@ -334,10 +335,7 @@ def content_text(content: list[dict[str, Any]]) -> str:
     for item in content:
         if isinstance(item, dict):
             parts.append(
-                item.get("text")
-                or item.get("input_text")
-                or item.get("output_text")
-                or ""
+                item.get("text") or item.get("input_text") or item.get("output_text") or ""
             )
     return "\n".join(part for part in parts if part)
 
@@ -360,7 +358,9 @@ def title_from_recommendation(text: str) -> str:
     return title
 
 
-def extract_archive_candidates(text: str, source_file: Path, thread_name: str, timestamp: str) -> list[ArchiveCandidate]:
+def extract_archive_candidates(
+    text: str, source_file: Path, thread_name: str, timestamp: str
+) -> list[ArchiveCandidate]:
     candidates: list[ArchiveCandidate] = []
     seen: set[str] = set()
     for line in text.splitlines():
@@ -390,7 +390,9 @@ def extract_archive_candidates(text: str, source_file: Path, thread_name: str, t
     return candidates
 
 
-def collect_archive_candidates(archive_paths: list[Path], repos: list[RepoConfig]) -> dict[str, list[ArchiveCandidate]]:
+def collect_archive_candidates(
+    archive_paths: list[Path], repos: list[RepoConfig]
+) -> dict[str, list[ArchiveCandidate]]:
     candidates_by_repo: dict[str, list[ArchiveCandidate]] = {repo.repo: [] for repo in repos}
     for path in archive_files(archive_paths):
         timestamp = ""

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -398,7 +398,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'] or 1)}",
+                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]
@@ -427,8 +427,10 @@ def main() -> int:
 
     files = _gather_metrics_files(metrics_paths, metrics_dir)
     if not files:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("No metrics files found to aggregate.\n", encoding="utf-8")
         print("No metrics files found to aggregate.", file=sys.stderr)
-        return 1
+        return 0
 
     entries, errors = _read_ndjson(files)
     summary = build_summary(entries, errors)

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -298,14 +298,18 @@ def test_format_helpers_and_summary_range() -> None:
     assert "Range: 2025-01-01T00:00:00Z to 2025-01-02T00:00:00Z" in summary
 
 
-def test_main_returns_error_when_no_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_writes_placeholder_when_no_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("METRICS_PATHS", "")
     monkeypatch.setenv("METRICS_DIR", str(tmp_path / "missing"))
-    monkeypatch.setenv("OUTPUT_PATH", str(tmp_path / "summary.md"))
+    output_path = tmp_path / "summary.md"
+    monkeypatch.setenv("OUTPUT_PATH", str(output_path))
 
     exit_code = aggregate_agent_metrics.main()
 
-    assert exit_code == 1
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == "No metrics files found to aggregate.\n"
 
 
 def test_autopilot_metrics_summarised() -> None:
@@ -354,6 +358,20 @@ def test_autopilot_metrics_summarised() -> None:
     assert "format:" in summary
     assert "capability-check:" in summary
     assert "step-failed (1)" in summary
+
+
+def test_autopilot_needs_human_rate_is_na_without_issue_denominator() -> None:
+    summary = aggregate_agent_metrics.build_summary(
+        [
+            {
+                "metric_type": "escalation",
+                "escalation_reason": "needs-human-complexity",
+            },
+        ],
+        errors=0,
+    )
+
+    assert "Needs-human rate: n/a" in summary
 
 
 def test_classify_autopilot_step_entry() -> None:

--- a/tests/scripts/test_repo_review_evaluator.py
+++ b/tests/scripts/test_repo_review_evaluator.py
@@ -222,9 +222,7 @@ def test_collect_archive_candidates_reads_review_sessions(tmp_path: Path) -> Non
                         "type": "event_msg",
                         "payload": {
                             "type": "agent_message",
-                            "message": (
-                                "1. Add inventory acceptance tests before implementation."
-                            ),
+                            "message": ("1. Add inventory acceptance tests before implementation."),
                         },
                     }
                 ),


### PR DESCRIPTION
## Summary

- Keeps weekly aggregate metrics runs successful when no input metrics files are available by writing a placeholder summary instead of returning exit code 1.
- Reports the auto-pilot needs-human rate as `n/a` when no issue denominator exists, avoiding a fabricated 100% style rate from the previous `or 1` fallback.
- Applies the same aggregate script behavior to the consumer template copy.

## Verification

- `python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q`
- `python -m py_compile scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q`
- `git diff --check`

## Campaign Context

Addresses the source-side feedback surfaced at `Travel-Plan-Permission#899` for `scripts/aggregate_agent_metrics.py`.