### PR TITLE
Tighten campaign queue and aggregate metrics contracts

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -185,12 +185,24 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
       },
     ],
   });
-  const body = formatCampaignBody({ items: [item], stats: {}, updated_at: 'now' });
+  const state = mergeCampaignState(
+    {},
+    [item],
+    '2026-04-21T05:52:00Z',
+    { reposRequested: 1, reposChecked: 1 },
+  );
+  const body = formatCampaignBody(state);
   const markerItem = parseCampaignMarker(formatCampaignMarker({ items: [item] })).items[0];
 
   assert.equal(item.source_sync.status, 'superseded');
   assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
+  assert.equal(state.stats.items_needing_local_codex, 0);
+  assert.equal(state.stats.items_actionable_local_codex, 0);
+  assert.equal(state.stats.items_superseded_sync_candidates, 1);
+  assert.equal(state.stats.status_counts['needs-local-codex'], 1);
   assert.equal(markerItem.source_sync.status, 'superseded');
+  assert.match(body, /No local Codex work is queued/);
+  assert.match(body, /Superseded sync candidates: 1/);
   assert.match(body, /Source sync state: superseded/);
 });
 
@@ -444,6 +456,7 @@ test('formatCampaignBody keeps source-fixed candidates out of the visible local 
       items_needing_local_codex: 1,
       items_actionable_local_codex: 1,
       items_source_fixed_candidates: 1,
+      items_superseded_sync_candidates: 0,
       status_counts: { 'needs-local-codex': 2 },
     },
     items: [
@@ -493,6 +506,74 @@ test('formatCampaignBody keeps source-fixed candidates out of the visible local 
   assert.match(body, /\| needs-local-codex \| \[stranske\/App#23\]/);
   assert.doesNotMatch(body, /\| needs-local-codex \| \[stranske\/App#22\]/);
   assert.match(body, /### stranske\/App#22/);
+});
+
+test('formatCampaignBody keeps superseded sync candidates out of the visible local queue', () => {
+  const state = {
+    schema: 'sync-dependabot-campaign/v1',
+    updated_at: '2026-04-21T05:52:00Z',
+    stats: {
+      repos_requested: 1,
+      repos_checked: 1,
+      active_review_threads: 2,
+      items_needing_local_codex: 1,
+      items_actionable_local_codex: 1,
+      items_source_fixed_candidates: 0,
+      items_superseded_sync_candidates: 1,
+      status_counts: { 'needs-local-codex': 2 },
+    },
+    items: [
+      {
+        id: 'sync-review-comments:stranske/App#22:abc',
+        status: 'needs-local-codex',
+        kind: 'sync-review-comments',
+        classification: 'sync',
+        repo: 'stranske/App',
+        pr_number: 22,
+        pr_title: 'old sync branch',
+        pr_url: 'https://github.com/stranske/App/pull/22',
+        source_repo: 'stranske/Workflows',
+        preferred_workdir: 'Workflows',
+        source_sync: {
+          schema: 'sync-dependabot-campaign-source-sync/v1',
+          current_sync_hash: 'newhash',
+          pr_sync_hash: 'oldhash',
+          status: 'superseded',
+        },
+        review_thread_count: 1,
+        review_threads: [],
+      },
+      {
+        id: 'sync-review-comments:stranske/App#23:def',
+        status: 'needs-local-codex',
+        kind: 'sync-review-comments',
+        classification: 'sync',
+        repo: 'stranske/App',
+        pr_number: 23,
+        pr_title: 'current sync branch',
+        pr_url: 'https://github.com/stranske/App/pull/23',
+        source_repo: 'stranske/Workflows',
+        preferred_workdir: 'Workflows',
+        source_sync: {
+          schema: 'sync-dependabot-campaign-source-sync/v1',
+          current_sync_hash: 'newhash',
+          pr_sync_hash: 'newhash',
+          status: 'current',
+        },
+        review_thread_count: 1,
+        review_threads: [],
+      },
+    ],
+  };
+
+  const body = formatCampaignBody(state);
+
+  assert.match(body, /Items needing local Codex: 1/);
+  assert.match(body, /Superseded sync candidates: 1/);
+  assert.match(body, /\| needs-local-codex \| \[stranske\/App#23\]/);
+  assert.doesNotMatch(body, /\| needs-local-codex \| \[stranske\/App#22\]/);
+  assert.match(body, /### stranske\/App#22/);
+  assert.match(body, /Source sync state: superseded/);
 });
 
 test('paginateWithRetry uses the paginated GitHub API', async () => {

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -438,8 +438,14 @@ function isSourceFixedCandidate(item = {}) {
   return Boolean(item && item.source_fixed_candidate);
 }
 
+function isSupersededSyncCandidate(item = {}) {
+  return item.classification === 'sync' && cleanString(item.source_sync?.status) === 'superseded';
+}
+
 function isActionableLocalCodexItem(item = {}) {
-  return item.status === 'needs-local-codex' && !isSourceFixedCandidate(item);
+  return item.status === 'needs-local-codex' &&
+    !isSourceFixedCandidate(item) &&
+    !isSupersededSyncCandidate(item);
 }
 
 function isVisibleQueueItem(item = {}) {
@@ -452,6 +458,9 @@ function buildStats(items, discoveredItems, options = {}) {
     return counts;
   }, {});
   const sourceFixedCandidateCount = items.filter(isSourceFixedCandidate).length;
+  const supersededSyncCandidateCount = items
+    .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
+    .length;
   const actionableLocalCodexCount = items.filter(isActionableLocalCodexItem).length;
   return {
     repos_requested: Number(options.reposRequested || 0),
@@ -467,6 +476,7 @@ function buildStats(items, discoveredItems, options = {}) {
     items_needing_local_codex: actionableLocalCodexCount,
     items_actionable_local_codex: actionableLocalCodexCount,
     items_source_fixed_candidates: sourceFixedCandidateCount,
+    items_superseded_sync_candidates: supersededSyncCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
@@ -481,11 +491,15 @@ function deriveItemStats(items = []) {
     return counts;
   }, {});
   const sourceFixedCandidateCount = queueItems.filter(isSourceFixedCandidate).length;
+  const supersededSyncCandidateCount = queueItems
+    .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
+    .length;
   const actionableLocalCodexCount = queueItems.filter(isActionableLocalCodexItem).length;
   return {
     items_needing_local_codex: actionableLocalCodexCount,
     items_actionable_local_codex: actionableLocalCodexCount,
     items_source_fixed_candidates: sourceFixedCandidateCount,
+    items_superseded_sync_candidates: supersededSyncCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
@@ -501,6 +515,7 @@ function validateCampaignState(state = {}) {
     'items_needing_local_codex',
     'items_actionable_local_codex',
     'items_source_fixed_candidates',
+    'items_superseded_sync_candidates',
     'items_claimed',
     'items_finished',
     'items_blocked',
@@ -667,6 +682,7 @@ function formatCampaignBody(state) {
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
+    `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     '',
     '## Local Queue',
     '',
@@ -686,6 +702,12 @@ function formatCampaignBody(state) {
     '',
     '</details>',
     '',
+    '<details><summary>Superseded sync candidates</summary>',
+    '',
+    ...formatSupersededSyncCandidateDetails(state.items),
+    '',
+    '</details>',
+    '',
     formatCampaignMarker(state),
   ];
   const body = lines.join('\n');
@@ -697,7 +719,8 @@ function formatCampaignBody(state) {
 
 function formatItemDetails(items = []) {
   const lines = [];
-  const detailItems = cleanArray(items).filter((item) => !isSourceFixedCandidate(item));
+  const detailItems = cleanArray(items)
+    .filter((item) => !isSourceFixedCandidate(item) && !isSupersededSyncCandidate(item));
   for (const item of detailItems.slice(0, MAX_DETAIL_ITEMS)) {
     lines.push(`### ${item.status}: ${item.repo}#${item.pr_number}`);
     lines.push('');
@@ -764,6 +787,32 @@ function formatSourceFixedCandidateDetails(items = []) {
   return lines.length ? lines : ['No source-fixed candidates retained.'];
 }
 
+function formatSupersededSyncCandidateDetails(items = []) {
+  const lines = [];
+  const candidates = cleanArray(items)
+    .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item));
+  for (const item of candidates.slice(0, MAX_DETAIL_ITEMS)) {
+    lines.push(`### ${item.repo}#${item.pr_number}`);
+    lines.push('');
+    lines.push(`- Status: ${item.status}`);
+    lines.push(`- Source repo: ${item.source_repo || '-'}`);
+    lines.push(
+      `- Source sync state: ${item.source_sync.status || 'unknown'} ` +
+        `(PR ${item.source_sync.pr_sync_hash || '-'} / current ${item.source_sync.current_sync_hash || '-'})`
+    );
+    for (const thread of cleanArray(item.review_threads).slice(0, 2)) {
+      const location = `${thread.path || '-'}${thread.line ? `:${thread.line}` : ''}`;
+      lines.push(`  - ${markdownLink(location, thread.url)} (${thread.author || 'bot'}): ${truncate(thread.body_preview, 120)}`);
+    }
+    lines.push('');
+  }
+  const remaining = Math.max(0, candidates.length - MAX_DETAIL_ITEMS);
+  if (remaining > 0) {
+    lines.push(`Additional superseded sync candidates omitted from the rendered issue body: ${remaining}.`);
+  }
+  return lines.length ? lines : ['No superseded sync candidates retained.'];
+}
+
 function formatCompactCampaignBody(state) {
   const stats = state.stats || {};
   const queueItems = cleanArray(state.items)
@@ -787,6 +836,7 @@ function formatCompactCampaignBody(state) {
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
+    `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     '',
     '| Status | PR | Threads |',
     '| --- | --- | ---: |',
@@ -1149,6 +1199,8 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
+    `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
+    `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Items claimed: ${stats.items_claimed || 0}`,
     `- Items blocked: ${stats.items_blocked || 0}`,
     `- State validation: ${validation.status}`,

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Aggregate agent metrics NDJSON into a markdown summary."""
 
 from __future__ import annotations
@@ -55,23 +55,24 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], int]:
     errors = 0
     for path in files:
         try:
-            content = path.read_text(encoding="utf-8")
+            handle = path.open("r", encoding="utf-8")
         except OSError:
             errors += 1
             continue
-        for line in content.splitlines():
-            raw = line.strip()
-            if not raw:
-                continue
-            try:
-                parsed = json.loads(raw)
-            except json.JSONDecodeError:
-                errors += 1
-                continue
-            if isinstance(parsed, dict):
-                entries.append(parsed)
-            else:
-                errors += 1
+        with handle:
+            for line in handle:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    errors += 1
+                    continue
+                if isinstance(parsed, dict):
+                    entries.append(parsed)
+                else:
+                    errors += 1
     return entries, errors
 
 
@@ -398,7 +399,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
+                f"- Needs-human escalation rate: {_format_rate(autopilot['needs_human_count'], autopilot['escalation_count'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Aggregate agent metrics NDJSON into a markdown summary."""
 
 from __future__ import annotations
@@ -55,23 +55,24 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], int]:
     errors = 0
     for path in files:
         try:
-            content = path.read_text(encoding="utf-8")
+            handle = path.open("r", encoding="utf-8")
         except OSError:
             errors += 1
             continue
-        for line in content.splitlines():
-            raw = line.strip()
-            if not raw:
-                continue
-            try:
-                parsed = json.loads(raw)
-            except json.JSONDecodeError:
-                errors += 1
-                continue
-            if isinstance(parsed, dict):
-                entries.append(parsed)
-            else:
-                errors += 1
+        with handle:
+            for line in handle:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    errors += 1
+                    continue
+                if isinstance(parsed, dict):
+                    entries.append(parsed)
+                else:
+                    errors += 1
     return entries, errors
 
 
@@ -398,7 +399,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
                 f"- Escalations: {autopilot['escalation_count']}",
-                f"- Needs-human rate: {_format_rate(autopilot['needs_human_count'], autopilot['issues'])}",
+                f"- Needs-human escalation rate: {_format_rate(autopilot['needs_human_count'], autopilot['escalation_count'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",
                 f"- Failure reasons: {_format_counter(autopilot['failure_reasons'])}",
             ]

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -68,6 +68,25 @@ def test_build_summary_formats_sections() -> None:
     assert "Terminal disposition sources: source-issue:99 (1)" in summary
 
 
+def test_autopilot_needs_human_rate_uses_escalations_not_issue_ids() -> None:
+    entries = [
+        {
+            "metric_type": "escalation",
+            "escalation_reason": "needs-human-review",
+        },
+        {
+            "metric_type": "escalation",
+            "escalation_reason": "rate-limit",
+        },
+    ]
+
+    summary = aggregate_agent_metrics.build_summary(entries, errors=0)
+
+    assert "Issues: 0" in summary
+    assert "Escalations: 2" in summary
+    assert "Needs-human escalation rate: 50.0% (1/2)" in summary
+
+
 def test_main_writes_summary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     keepalive_path = tmp_path / "keepalive.ndjson"
     autofix_path = tmp_path / "autofix.ndjson"
@@ -177,6 +196,21 @@ def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
 
     assert entries == [{"key": "value"}]
     assert errors == 2
+
+
+def test_read_ndjson_streams_file_lines(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    path = tmp_path / "metrics.ndjson"
+    path.write_text('{"key": "value"}\n', encoding="utf-8")
+
+    def fail_read_text(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("read_text should not be used for metrics NDJSON")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+
+    assert entries == [{"key": "value"}]
+    assert errors == 0
 
 
 def test_read_ndjson_counts_unreadable_file(tmp_path: Path) -> None:
@@ -360,7 +394,7 @@ def test_autopilot_metrics_summarised() -> None:
     assert "step-failed (1)" in summary
 
 
-def test_autopilot_needs_human_rate_is_na_without_issue_denominator() -> None:
+def test_autopilot_needs_human_rate_does_not_require_issue_denominator() -> None:
     summary = aggregate_agent_metrics.build_summary(
         [
             {
@@ -371,7 +405,7 @@ def test_autopilot_needs_human_rate_is_na_without_issue_denominator() -> None:
         errors=0,
     )
 
-    assert "Needs-human rate: n/a" in summary
+    assert "Needs-human escalation rate: 100.0% (1/1)" in summary
 
 
 def test_classify_autopilot_step_entry() -> None:


### PR DESCRIPTION
## Summary
- keep source-fixed and superseded sync PR review items machine-readable while excluding them from actionable local Codex counts and visible queue rows
- add superseded sync candidate counts/details to campaign issue, compact issue, run summary, and validation contracts
- stream aggregate metrics NDJSON reads, use python3 shebangs, and report needs-human escalation rate over escalations instead of issue IDs

## Verification
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js .github/scripts/__tests__/bot-comment-auth-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_workflow_agents_consolidation.py -q
- python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py && git diff --check
- python -m py_compile scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py

## Campaign impact
- applying the new derived stats to campaign run 24942259508 reduces actionable local Codex count from 116 to 2, while retaining 4 source-fixed candidates and 114 superseded sync candidates in machine-readable state.