### PR TITLE
Annotate campaign state artifacts with queue state

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -196,6 +196,8 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
 
   assert.equal(item.source_sync.status, 'superseded');
   assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
+  assert.equal(state.items[0].local_codex_queue_state, 'superseded-sync-candidate');
+  assert.equal(state.items[0].local_codex_actionable, false);
   assert.equal(state.stats.items_needing_local_codex, 0);
   assert.equal(state.stats.items_actionable_local_codex, 0);
   assert.equal(state.stats.items_superseded_sync_candidates, 1);
@@ -350,6 +352,8 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   const body = formatCampaignBody(state);
 
   assert.equal(repeatedItem.status, 'needs-local-codex');
+  assert.equal(repeatedItem.local_codex_queue_state, 'source-fixed-candidate');
+  assert.equal(repeatedItem.local_codex_actionable, false);
   assert.equal(repeatedItem.source_fixed_candidate.matching_item_id, finished.id);
   assert.equal(repeatedItem.source_fixed_candidate.finished_at, '2026-04-21T05:30:00Z');
   assert.equal(state.source_review_history.length, 1);

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -414,7 +414,8 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     }
   }
 
-  const items = pruneItems(nextItems, options.maxRetainedItems || DEFAULT_MAX_RETAINED_ITEMS);
+  const items = pruneItems(nextItems, options.maxRetainedItems || DEFAULT_MAX_RETAINED_ITEMS)
+    .map(annotateLocalCodexQueueState);
   return {
     schema: CAMPAIGN_SCHEMA,
     updated_at: now,
@@ -472,6 +473,14 @@ function localCodexQueueStateCounts(items = []) {
     counts[state] = (counts[state] || 0) + 1;
     return counts;
   }, {});
+}
+
+function annotateLocalCodexQueueState(item = {}) {
+  return {
+    ...item,
+    local_codex_queue_state: localCodexQueueState(item),
+    local_codex_actionable: isActionableLocalCodexItem(item),
+  };
 }
 
 function buildStats(items, discoveredItems, options = {}) {


### PR DESCRIPTION
## Summary
- persist local_codex_queue_state and local_codex_actionable on retained Sync/Dependabot campaign state items
- keep the compact issue marker bounded while uploaded JSON artifacts expose the same per-item queue contract
- add regression coverage for superseded and source-fixed retained item annotations

## Verification
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js .github/scripts/__tests__/bot-comment-auth-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_workflow_naming.py -q
- python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py
- git diff --check

Also replayed campaign artifact run 24942895928 through mergeCampaignState and confirmed per-item queue-state annotations are emitted.