### PR TITLE
Tighten aggregate metrics and campaign result contracts

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -375,6 +375,58 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   assert.match(body, /Prior source-fix match:/);
 });
 
+test('mergeCampaignState marks finished local results without published source changes', () => {
+  const now = '2026-04-21T06:52:00Z';
+  const state = mergeCampaignState(
+    {
+      items: [
+        {
+          id: 'sync-review-comments:stranske/TPP#902:finished',
+          status: 'local-codex-finished',
+          kind: 'sync-review-comments',
+          classification: 'sync',
+          repo: 'stranske/TPP',
+          pr_number: 902,
+          pr_title: 'chore: sync workflow templates',
+          pr_url: 'https://github.com/stranske/TPP/pull/902',
+          source_repo: 'stranske/Workflows',
+          source_sync: {
+            schema: 'sync-dependabot-campaign-source-sync/v1',
+            current_sync_hash: 'current',
+            pr_sync_hash: 'old',
+            status: 'superseded',
+          },
+          result: {
+            exit_code: 0,
+            summary: 'Implemented locally but did not commit or push because the worktree was dirty.',
+          },
+          finished_at: now,
+          updated_at: now,
+        },
+      ],
+    },
+    [],
+    now,
+    { reposRequested: 1, reposChecked: 1 },
+  );
+
+  const item = state.items[0];
+  const marker = parseCampaignMarker(formatCampaignMarker(state));
+  const body = formatCampaignBody(state);
+  const runSummary = formatCampaignRunSummaryMarkdown(state, {
+    html_url: 'https://github.com/stranske/Workflows/issues/1836',
+  });
+
+  assert.equal(item.local_codex_result_state, 'unpublished-source-work');
+  assert.equal(state.stats.items_unpublished_source_results, 1);
+  assert.equal(marker.stats.items_unpublished_source_results, 1);
+  assert.equal(marker.items[0].local_codex_result_state, 'unpublished-source-work');
+  assert.equal(validateCampaignState(state).status, 'pass');
+  assert.match(body, /Finished local results without published source changes: 1/);
+  assert.match(body, /Local result state: unpublished-source-work/);
+  assert.match(runSummary, /Finished local results without published source changes: 1/);
+});
+
 test('mergeCampaignState matches source-fixed candidates from compact retained history', () => {
   const now = '2026-04-21T06:52:00Z';
   const repeated = buildQueueItem({

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -443,6 +443,24 @@ function isSupersededSyncCandidate(item = {}) {
   return item.classification === 'sync' && cleanString(item.source_sync?.status) === 'superseded';
 }
 
+function resultSummaryFor(item = {}) {
+  return cleanString(item.result_summary || item.result?.summary);
+}
+
+function hasUnpublishedSourceResult(item = {}) {
+  if (item.status !== 'local-codex-finished') {
+    return false;
+  }
+  const summary = resultSummaryFor(item).toLowerCase();
+  return /\b(did not|didn't|not)\s+(commit|push|commit or push|push or commit)\b/.test(summary) ||
+    /\bwithout\s+(committing|pushing)\b/.test(summary) ||
+    /\b(not committed|not pushed|unpushed|uncommitted)\b/.test(summary);
+}
+
+function localCodexResultState(item = {}) {
+  return hasUnpublishedSourceResult(item) ? 'unpublished-source-work' : '';
+}
+
 function isActionableLocalCodexItem(item = {}) {
   return item.status === 'needs-local-codex' &&
     !isSourceFixedCandidate(item) &&
@@ -476,10 +494,12 @@ function localCodexQueueStateCounts(items = []) {
 }
 
 function annotateLocalCodexQueueState(item = {}) {
+  const resultState = localCodexResultState(item);
   return {
     ...item,
     local_codex_queue_state: localCodexQueueState(item),
     local_codex_actionable: isActionableLocalCodexItem(item),
+    ...(resultState ? { local_codex_result_state: resultState } : {}),
   };
 }
 
@@ -493,6 +513,7 @@ function buildStats(items, discoveredItems, options = {}) {
     .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
     .length;
   const actionableLocalCodexCount = items.filter(isActionableLocalCodexItem).length;
+  const unpublishedSourceResultCount = items.filter(hasUnpublishedSourceResult).length;
   return {
     repos_requested: Number(options.reposRequested || 0),
     repos_checked: Number(options.reposChecked || 0),
@@ -511,6 +532,7 @@ function buildStats(items, discoveredItems, options = {}) {
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
+    items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(items),
   };
@@ -527,6 +549,7 @@ function deriveItemStats(items = []) {
     .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
     .length;
   const actionableLocalCodexCount = queueItems.filter(isActionableLocalCodexItem).length;
+  const unpublishedSourceResultCount = queueItems.filter(hasUnpublishedSourceResult).length;
   return {
     items_needing_local_codex: actionableLocalCodexCount,
     items_actionable_local_codex: actionableLocalCodexCount,
@@ -535,6 +558,7 @@ function deriveItemStats(items = []) {
     items_claimed: statusCounts['local-codex-claimed'] || 0,
     items_finished: statusCounts['local-codex-finished'] || 0,
     items_blocked: statusCounts.blocked || 0,
+    items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(queueItems),
   };
@@ -552,6 +576,7 @@ function validateCampaignState(state = {}) {
     'items_claimed',
     'items_finished',
     'items_blocked',
+    'items_unpublished_source_results',
   ];
   for (const field of fields) {
     if (Number(stats[field] || 0) !== Number(derived[field] || 0)) {
@@ -685,6 +710,9 @@ function compactQueueItemForMarker(item = {}) {
     compact.local_codex_queue_state = queueState;
     compact.local_codex_actionable = false;
   }
+  if (item.local_codex_result_state) {
+    compact.local_codex_result_state = cleanString(item.local_codex_result_state);
+  }
   return compact;
 }
 
@@ -744,6 +772,7 @@ function formatCampaignBody(state) {
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     '',
     '## Local Queue',
     '',
@@ -796,6 +825,9 @@ function formatItemDetails(items = []) {
       );
     }
     lines.push(`- Attempts: ${item.attempts || 0}`);
+    if (item.local_codex_result_state) {
+      lines.push(`- Local result state: ${item.local_codex_result_state}`);
+    }
     if (item.source_fixed_candidate) {
       const candidate = item.source_fixed_candidate;
       lines.push(
@@ -835,6 +867,9 @@ function formatSourceFixedCandidateDetails(items = []) {
     if (candidate.result_summary) {
       lines.push(`- Prior source-fix summary: ${truncate(candidate.result_summary, 180)}`);
     }
+    if (item.local_codex_result_state) {
+      lines.push(`- Local result state: ${item.local_codex_result_state}`);
+    }
     for (const thread of cleanArray(item.review_threads).slice(0, 2)) {
       const location = `${thread.path || '-'}${thread.line ? `:${thread.line}` : ''}`;
       lines.push(`  - ${markdownLink(location, thread.url)} (${thread.author || 'bot'}): ${truncate(thread.body_preview, 120)}`);
@@ -861,6 +896,9 @@ function formatSupersededSyncCandidateDetails(items = []) {
       `- Source sync state: ${item.source_sync.status || 'unknown'} ` +
         `(PR ${item.source_sync.pr_sync_hash || '-'} / current ${item.source_sync.current_sync_hash || '-'})`
     );
+    if (item.local_codex_result_state) {
+      lines.push(`- Local result state: ${item.local_codex_result_state}`);
+    }
     for (const thread of cleanArray(item.review_threads).slice(0, 2)) {
       const location = `${thread.path || '-'}${thread.line ? `:${thread.line}` : ''}`;
       lines.push(`  - ${markdownLink(location, thread.url)} (${thread.author || 'bot'}): ${truncate(thread.body_preview, 120)}`);
@@ -899,6 +937,7 @@ function formatCompactCampaignBody(state) {
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     '',
     '| Status | PR | Threads |',
     '| --- | --- | ---: |',
@@ -1240,6 +1279,7 @@ function formatDryRunSummary(state = {}) {
     `sync_prs_open=${stats.sync_prs_open || 0}`,
     `dependabot_prs_open=${stats.dependabot_prs_open || 0}`,
     `items_needing_local_codex=${stats.items_needing_local_codex || 0}`,
+    `items_unpublished_source_results=${stats.items_unpublished_source_results || 0}`,
   ].join(' ');
 }
 
@@ -1264,6 +1304,7 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     `- Items claimed: ${stats.items_claimed || 0}`,
     `- Items blocked: ${stats.items_blocked || 0}`,
     `- State validation: ${validation.status}`,
@@ -1403,6 +1444,7 @@ async function runCampaign({
     core.setOutput('items_actionable_local_codex', String(state.stats.items_actionable_local_codex || 0));
     core.setOutput('items_source_fixed_candidates', String(state.stats.items_source_fixed_candidates || 0));
     core.setOutput('items_superseded_sync_candidates', String(state.stats.items_superseded_sync_candidates || 0));
+    core.setOutput('items_unpublished_source_results', String(state.stats.items_unpublished_source_results || 0));
     core.setOutput('campaign_issue_url', campaignIssue?.html_url || '');
   }
 

--- a/.github/workflows/maint-82-sync-dependabot-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependabot-campaign.yml
@@ -140,6 +140,7 @@ jobs:
                 `Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
                 `Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
                 `Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+                `Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
                 `Campaign issue: ${result.issue?.html_url || '(dry run)'}`,
               ])
               .write();

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -125,6 +125,7 @@ def _safe_int(value: Any) -> int | None:
 
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
     stop_reasons = Counter()
+    actions = Counter()
     gate_results = Counter()
     iterations: list[int] = []
     prs: set[int] = set()
@@ -133,6 +134,9 @@ def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
         stop_reason = entry.get("stop_reason")
         if stop_reason:
             stop_reasons[str(stop_reason)] += 1
+        action = entry.get("action")
+        if action:
+            actions[str(action)] += 1
         gate = entry.get("gate_conclusion") or entry.get("gate_result")
         if gate:
             gate_results[str(gate)] += 1
@@ -142,7 +146,15 @@ def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
         pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
         if pr_number is not None:
             prs.add(pr_number)
-        if stop_reason == "tasks-complete":
+        tasks_total = _safe_int(entry.get("tasks_total"))
+        entry_tasks_complete = _safe_int(entry.get("tasks_complete"))
+        derived_complete = (
+            tasks_total is not None
+            and tasks_total > 0
+            and entry_tasks_complete is not None
+            and entry_tasks_complete >= tasks_total
+        )
+        if stop_reason == "tasks-complete" or derived_complete:
             tasks_complete += 1
     avg_iterations = sum(iterations) / len(iterations) if iterations else 0.0
     return {
@@ -150,6 +162,7 @@ def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "prs": len(prs),
         "avg_iterations": avg_iterations,
         "stop_reasons": stop_reasons,
+        "actions": actions,
         "gate_results": gate_results,
         "tasks_complete": tasks_complete,
     }
@@ -241,8 +254,12 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     step_durations: dict[str, list[float]] = {}
     step_successes: dict[str, int] = {}
     step_failures: dict[str, int] = {}
+    cycle_counts = Counter()
     failure_reasons = Counter()
     escalation_reasons = Counter()
+    cycle_records = 0
+    cycle_steps_attempted = 0
+    cycle_steps_completed = 0
     escalation_count = 0
     needs_human_count = 0
 
@@ -251,7 +268,7 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
         if issue_num is not None:
             issues.add(issue_num)
 
-        metric_type = entry.get("metric_type", "")
+        metric_type = str(entry.get("metric_type", "")).lower()
 
         if metric_type == "escalation":
             escalation_count += 1
@@ -259,6 +276,19 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
             escalation_reasons[str(reason)] += 1
             if "needs-human" in str(reason).lower() or "needs_human" in str(reason).lower():
                 needs_human_count += 1
+            continue
+
+        if metric_type == "cycle":
+            cycle_records += 1
+            cycle_count = _safe_int(entry.get("cycle_count"))
+            if cycle_count is not None:
+                cycle_counts[str(cycle_count)] += 1
+            steps_attempted = _safe_int(entry.get("steps_attempted"))
+            if steps_attempted is not None:
+                cycle_steps_attempted += steps_attempted
+            steps_completed = _safe_int(entry.get("steps_completed"))
+            if steps_completed is not None:
+                cycle_steps_completed += steps_completed
             continue
 
         step_name = entry.get("step_name")
@@ -292,6 +322,10 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "step_avg_duration_ms": step_avg_duration,
         "step_successes": step_successes,
         "step_failures": step_failures,
+        "cycle_records": cycle_records,
+        "cycle_counts": cycle_counts,
+        "cycle_steps_attempted": cycle_steps_attempted,
+        "cycle_steps_completed": cycle_steps_completed,
         "failure_reasons": failure_reasons,
         "escalation_count": escalation_count,
         "escalation_reasons": escalation_reasons,
@@ -367,6 +401,7 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
             f"- PRs: {keepalive['prs']}",
             f"- Avg iterations: {keepalive['avg_iterations']:.1f}",
             f"- Stop reasons: {_format_counter(keepalive['stop_reasons'])}",
+            f"- Actions: {_format_counter(keepalive['actions'])}",
             f"- Gate conclusions: {_format_counter(keepalive['gate_results'])}",
             f"- Tasks complete rate: {_format_rate(keepalive['tasks_complete'], keepalive['runs'])}",
             "",
@@ -398,6 +433,12 @@ def build_summary(entries: list[dict[str, Any]], errors: int) -> str:
                 f"- Records: {autopilot['records']}",
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
+                f"- Cycle records: {autopilot['cycle_records']}",
+                f"- Cycle count distribution: {_format_counter(autopilot['cycle_counts'])}",
+                (
+                    "- Cycle step completion: "
+                    f"{_format_rate(autopilot['cycle_steps_completed'], autopilot['cycle_steps_attempted'])}"
+                ),
                 f"- Escalations: {autopilot['escalation_count']}",
                 f"- Needs-human escalation rate: {_format_rate(autopilot['needs_human_count'], autopilot['escalation_count'])}",
                 f"- Escalation reasons: {_format_counter(autopilot['escalation_reasons'])}",

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -60,6 +60,7 @@ def test_build_summary_formats_sections() -> None:
     assert "Avg iterations: 3.5" in summary
     assert "tasks-complete (1)" in summary
     assert "max-iterations (1)" in summary
+    assert "Actions: n/a" in summary
     assert "Fixes applied: 100.0% (1/1)" in summary
     assert "Verdicts: pass (1)" in summary
     assert "Avg acceptance criteria: 3.0" in summary
@@ -261,6 +262,7 @@ def test_summary_helpers_cover_branches() -> None:
     )
     assert keepalive["tasks_complete"] == 1
     assert keepalive["stop_reasons"]["tasks-complete"] == 1
+    assert keepalive["actions"] == Counter()
     assert keepalive["gate_results"]["failure"] == 1
     assert keepalive["gate_results"]["success"] == 1
 
@@ -378,15 +380,25 @@ def test_autopilot_metrics_summarised() -> None:
             "issue_number": 99,
             "escalation_reason": "needs-human-complexity",
         },
+        {
+            "metric_type": "cycle",
+            "issue_number": 42,
+            "cycle_count": 2,
+            "steps_attempted": 3,
+            "steps_completed": 2,
+        },
     ]
 
     summary = aggregate_agent_metrics.build_summary(entries, errors=0)
 
     assert "Auto-Pilot Pipeline" in summary
-    assert "Records: 4" in summary
-    assert "autopilot 4" in summary
+    assert "Records: 5" in summary
+    assert "autopilot 5" in summary
     assert "Issues: 2" in summary
     assert "Total step executions: 3" in summary
+    assert "Cycle records: 1" in summary
+    assert "Cycle count distribution: 2 (1)" in summary
+    assert "Cycle step completion: 66.7% (2/3)" in summary
     assert "Escalations: 1" in summary
     assert "Step Average Durations" in summary
     assert "format:" in summary
@@ -406,6 +418,58 @@ def test_autopilot_needs_human_rate_does_not_require_issue_denominator() -> None
     )
 
     assert "Needs-human escalation rate: 100.0% (1/1)" in summary
+
+
+def test_keepalive_completion_uses_task_totals_and_actions() -> None:
+    entries = [
+        {
+            "pr_number": 101,
+            "iteration": 1,
+            "action": "run",
+            "tasks_total": 3,
+            "tasks_complete": 2,
+        },
+        {
+            "pr_number": 101,
+            "iteration": 2,
+            "action": "stop",
+            "tasks_total": 3,
+            "tasks_complete": 3,
+        },
+    ]
+
+    summary = aggregate_agent_metrics.build_summary(entries, errors=0)
+
+    assert "Actions: run (1), stop (1)" in summary
+    assert "Tasks complete rate: 50.0% (1/2)" in summary
+
+
+def test_summarise_autopilot_counts_cycle_records() -> None:
+    summary = aggregate_agent_metrics._summarise_autopilot(
+        [
+            {
+                "metric_type": "cycle",
+                "issue_number": 101,
+                "cycle_count": 1,
+                "steps_attempted": 2,
+                "steps_completed": 2,
+            },
+            {
+                "metric_type": "cycle",
+                "issue_number": 101,
+                "cycle_count": 2,
+                "steps_attempted": 3,
+                "steps_completed": 1,
+            },
+        ]
+    )
+
+    assert summary["records"] == 2
+    assert summary["issues"] == 1
+    assert summary["cycle_records"] == 2
+    assert summary["cycle_counts"] == Counter({"1": 1, "2": 1})
+    assert summary["cycle_steps_attempted"] == 5
+    assert summary["cycle_steps_completed"] == 3
 
 
 def test_classify_autopilot_step_entry() -> None:


### PR DESCRIPTION
## Summary
- add keepalive action counts and task-total completion detection to agent metrics summaries
- add auto-pilot cycle record counts, cycle distribution, and cycle step completion metrics
- expose finished local results that report unpublished source changes in campaign stats, markers, artifacts, summaries, and outputs

## Verification
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js
- pytest -q tests/scripts/test_aggregate_agent_metrics.py
- python -m ruff check scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- python -m black --check scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js .github/scripts/__tests__/bot-comment-auth-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_workflow_naming.py -q
- python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py
- git diff --check