### PR TITLE
Refresh consumer drift issue checkpoint

### DIFF
--- a/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
+++ b/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
@@ -2,9 +2,12 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  compactMarkerPayload,
   countsLine,
   formatIssueBody,
   formatIssueComment,
+  formatIssueMarker,
+  mergeIssueBody,
 } = require('../consumer_sync_drift_issue_body');
 
 const report = {
@@ -30,7 +33,9 @@ test('countsLine renders stable drift counts', () => {
 test('formatIssueBody includes actionable repo, prefix, and command details', () => {
   const body = formatIssueBody(report, {
     runUrl: 'https://github.com/owner/repo/actions/runs/1',
+    runId: '1',
     runNumber: '123',
+    updatedAt: '2026-04-26T00:00:00.000Z',
   });
 
   assert.match(body, /Run #123/);
@@ -38,6 +43,10 @@ test('formatIssueBody includes actionable repo, prefix, and command details', ()
   assert.match(body, /\.github\/scripts=60/);
   assert.match(body, /Top repos first: `gh workflow run maint-68-sync-consumer-repos.yml/);
   assert.match(body, /consumer-sync-drift-report/);
+  assert.match(body, /<!-- consumer-sync-drift:v1 /);
+  assert.match(body, /"schema":"consumer-sync-drift-issue\/v1"/);
+  assert.match(body, /"run_id":"1"/);
+  assert.match(body, /"missing":73/);
 });
 
 test('formatIssueComment stays compact for existing issue updates', () => {
@@ -49,4 +58,59 @@ test('formatIssueComment stays compact for existing issue updates', () => {
   assert.match(body, /Drift still detected in \[run #124\]/);
   assert.match(body, /Counts: drift=27, missing=73, errors=0, obsolete=0/);
   assert.match(body, /Highest-impact repos:/);
+});
+
+test('compactMarkerPayload exposes the current drift checkpoint', () => {
+  const payload = compactMarkerPayload(report, {
+    runUrl: 'https://github.com/owner/repo/actions/runs/1',
+    runId: '1',
+    runNumber: '124',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+  });
+
+  assert.equal(payload.schema, 'consumer-sync-drift-issue/v1');
+  assert.equal(payload.artifact, 'consumer-sync-drift-report');
+  assert.equal(payload.run_id, '1');
+  assert.deepEqual(payload.counts, { drift: 27, missing: 73, errors: 0, obsolete: 0 });
+  assert.equal(payload.top_repo_gaps.length, 2);
+  assert.equal(payload.follow_up.workflow, 'maint-68-sync-consumer-repos.yml');
+});
+
+test('mergeIssueBody refreshes generated issue bodies', () => {
+  const oldBody = formatIssueBody({
+    counts: { drift: 1, missing: 0, errors: 0, obsolete: 0 },
+  }, {
+    runUrl: 'https://github.com/owner/repo/actions/runs/1',
+    runId: '1',
+    runNumber: '123',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+  });
+  const merged = mergeIssueBody(oldBody, report, {
+    runUrl: 'https://github.com/owner/repo/actions/runs/2',
+    runId: '2',
+    runNumber: '124',
+    updatedAt: '2026-04-26T00:05:00.000Z',
+  });
+
+  assert.match(merged, /Run #124/);
+  assert.match(merged, /Counts:\*\* drift=27, missing=73/);
+  assert.match(merged, /"run_id":"2"/);
+  assert.doesNotMatch(merged, /"run_id":"1"/);
+});
+
+test('mergeIssueBody preserves custom human issue content while updating marker', () => {
+  const marker = formatIssueMarker({ counts: { drift: 1, missing: 0, errors: 0, obsolete: 0 } }, {
+    runId: '1',
+    updatedAt: '2026-04-26T00:00:00.000Z',
+  });
+  const customBody = `# Human task list\n\n- [ ] Keep this note\n\n${marker}`;
+  const merged = mergeIssueBody(customBody, report, {
+    runId: '2',
+    updatedAt: '2026-04-26T00:05:00.000Z',
+  });
+
+  assert.match(merged, /# Human task list/);
+  assert.match(merged, /- \[ \] Keep this note/);
+  assert.match(merged, /"run_id":"2"/);
+  assert.doesNotMatch(merged, /"run_id":"1"/);
 });

--- a/.github/scripts/consumer_sync_drift_issue_body.js
+++ b/.github/scripts/consumer_sync_drift_issue_body.js
@@ -1,3 +1,8 @@
+const ISSUE_MARKER_SCHEMA = 'consumer-sync-drift-issue/v1';
+const ISSUE_MARKER_PREFIX = '<!-- consumer-sync-drift:v1 ';
+const ISSUE_MARKER_RE = /<!-- consumer-sync-drift:v1 \{[\s\S]*?\} -->/;
+const GENERATED_BODY_RE = /^\s*## Consumer Repo Drift Detected\b/;
+
 function countsLine(report) {
   const counts = report && report.counts ? report.counts : {};
   return `drift=${counts.drift || 0}, missing=${counts.missing || 0}, errors=${counts.errors || 0}, obsolete=${counts.obsolete || 0}`;
@@ -42,6 +47,42 @@ function followUpLines(report) {
   return lines.length ? lines : ['- Run Maint 68 Sync Consumer Repos from the Workflows repo.'];
 }
 
+function limitedArray(value, limit) {
+  return Array.isArray(value) ? value.slice(0, limit) : [];
+}
+
+function compactMarkerPayload(report, options = {}) {
+  const counts = report && report.counts ? report.counts : {};
+  const followUp = report && report.follow_up ? report.follow_up : {};
+  return {
+    schema: ISSUE_MARKER_SCHEMA,
+    updated_at: options.updatedAt || new Date().toISOString(),
+    run_id: options.runId || '',
+    run_number: options.runNumber || '',
+    run_url: options.runUrl || '',
+    artifact: 'consumer-sync-drift-report',
+    status: report && report.status ? report.status : 'unknown',
+    repo_count: report && Number.isInteger(report.repo_count) ? report.repo_count : 0,
+    counts: {
+      drift: counts.drift || 0,
+      missing: counts.missing || 0,
+      errors: counts.errors || 0,
+      obsolete: counts.obsolete || 0,
+    },
+    top_repo_gaps: limitedArray(report && report.top_repo_gaps, 10),
+    path_prefix_counts: report && report.path_prefix_counts ? report.path_prefix_counts : {},
+    follow_up: {
+      workflow: followUp.workflow || 'maint-68-sync-consumer-repos.yml',
+      all_repos_command: followUp.all_repos_command || '',
+      targeted_repos_command: followUp.targeted_repos_command || '',
+    },
+  };
+}
+
+function formatIssueMarker(report, options = {}) {
+  return `${ISSUE_MARKER_PREFIX}${JSON.stringify(compactMarkerPayload(report, options))} -->`;
+}
+
 function formatIssueBody(report, options = {}) {
   const runUrl = options.runUrl || '';
   const runNumber = options.runNumber || '';
@@ -69,7 +110,22 @@ function formatIssueBody(report, options = {}) {
     '### Notes',
     '- Files marked with `sync_mode: create_only` are excluded from this check.',
     '- Workflows-Integration-Tests is validated separately by Health 67.',
+    '',
+    formatIssueMarker(report, options),
   ].join('\n');
+}
+
+function mergeIssueBody(existingBody, report, options = {}) {
+  const body = existingBody || '';
+  const nextBody = formatIssueBody(report, options);
+  const marker = formatIssueMarker(report, options);
+  if (!body.trim() || GENERATED_BODY_RE.test(body)) {
+    return nextBody;
+  }
+  if (ISSUE_MARKER_RE.test(body)) {
+    return body.replace(ISSUE_MARKER_RE, marker);
+  }
+  return `${body.trimEnd()}\n\n${marker}`;
 }
 
 function formatIssueComment(report, options = {}) {
@@ -92,8 +148,11 @@ function formatIssueComment(report, options = {}) {
 
 module.exports = {
   countsLine,
+  compactMarkerPayload,
   formatIssueBody,
   formatIssueComment,
+  formatIssueMarker,
   formatPrefixCounts,
   formatRepoGaps,
+  mergeIssueBody,
 };

--- a/.github/workflows/health-68-consumer-sync-drift.yml
+++ b/.github/workflows/health-68-consumer-sync-drift.yml
@@ -87,6 +87,7 @@ jobs:
             const {
               formatIssueBody,
               formatIssueComment,
+              mergeIssueBody,
             } = require('./.github/scripts/consumer_sync_drift_issue_body.js');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
             const retryHelpers = fs.existsSync(retryHelperPath)
@@ -111,6 +112,7 @@ jobs:
 
             const body = formatIssueBody(report, {
               runUrl,
+              runId: process.env.GITHUB_RUN_ID,
               runNumber: process.env.GITHUB_RUN_NUMBER,
             });
 
@@ -123,12 +125,27 @@ jobs:
             }));
 
             if (issues.length > 0) {
+              const refreshedBody = mergeIssueBody(issues[0].body || '', report, {
+                runUrl,
+                runId: process.env.GITHUB_RUN_ID,
+                runNumber: process.env.GITHUB_RUN_NUMBER,
+              });
+              if (refreshedBody !== (issues[0].body || '')) {
+                await withRetry(() => github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issues[0].number,
+                  body: refreshedBody,
+                }));
+                console.log(`Refreshed drift issue body for #${issues[0].number}`);
+              }
               await withRetry(() => github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issues[0].number,
                 body: formatIssueComment(report, {
                   runUrl,
+                  runId: process.env.GITHUB_RUN_ID,
                   runNumber: process.env.GITHUB_RUN_NUMBER,
                 })
               }));

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -157,6 +157,9 @@ def test_consumer_sync_drift_uploads_machine_readable_report():
         "consumer_sync_drift_issue_body.js" in text
     ), "Health 68 issue payload must use the structured drift report"
     assert (
+        "mergeIssueBody" in text and "github.rest.issues.update" in text
+    ), "Health 68 must refresh the GitHub-visible drift issue checkpoint"
+    assert (
         "consumer-sync-drift-report" in text
     ), "Health 68 must upload the drift report as a GitHub-visible artifact"
     assert (


### PR DESCRIPTION
## Summary
- add a hidden consumer-sync drift issue marker with current counts, run details, artifact name, repo gaps, prefix counts, and follow-up commands
- refresh generated Health 68 issue bodies on repeated failures while preserving custom human issue content by only upserting the marker
- guard the workflow contract with Node helper tests and workflow invariant coverage

## Verification
- node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
- node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js .github/scripts/__tests__/sync-run-contract.test.js
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_workflow_naming.py tests/scripts/test_check_consumer_sync_drift.py -q
- python -m ruff check tests/workflows/test_workflow_agents_consolidation.py tests/scripts/test_check_consumer_sync_drift.py
- python -m black --check tests/workflows/test_workflow_agents_consolidation.py tests/scripts/test_check_consumer_sync_drift.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check