### PR TITLE
Add campaign claim lease contract

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -272,11 +272,37 @@ test('mergeCampaignState preserves claims, expires old leases, and stales missin
   );
 
   const byId = new Map(state.items.map((item) => [item.id, item]));
+  const body = formatCampaignBody(state);
+  const marker = parseCampaignMarker(formatCampaignMarker(state));
+  const validation = validateCampaignState(state);
+
   assert.equal(byId.get(futureClaim.id).status, 'local-codex-claimed');
   assert.equal(byId.get(expiredClaim.id).status, 'needs-local-codex');
   assert.equal(byId.get(stalePrevious.id).status, 'stale');
   assert.equal(state.stats.items_needing_local_codex, 1);
   assert.equal(state.stats.items_claimed, 1);
+  assert.deepEqual(state.stats.local_codex_claims, {
+    count: 1,
+    leases_with_expires_at: 1,
+    missing_lease_count: 0,
+    next_expires_at: '2026-04-21T06:30:00Z',
+    items: [
+      {
+        id: futureClaim.id,
+        repo: 'stranske/TPP',
+        pr_number: 850,
+        claimed_at: '',
+        lease_owner: 'host:123',
+        lease_expires_at: '2026-04-21T06:30:00Z',
+      },
+    ],
+  });
+  assert.equal(marker.stats.local_codex_claims.next_expires_at, '2026-04-21T06:30:00Z');
+  assert.equal(marker.items[0].local_codex_queue_state, 'claimed');
+  assert.equal(marker.items[0].local_codex_actionable, false);
+  assert.equal(validation.status, 'pass');
+  assert.match(body, /Claimed local Codex items: 1/);
+  assert.match(body, /Next claim lease expires: 2026-04-21T06:30:00Z/);
 });
 
 test('mergeCampaignState flags repeated source-fixed review signatures without hiding the item', () => {
@@ -805,9 +831,21 @@ test('dry-run summary avoids logging generated issue body by default', () => {
 });
 
 test('formats campaign run summary as compact artifact markdown', () => {
+  const claimed = {
+    id: 'sync-review-comments:stranske/App#21:claimed',
+    status: 'local-codex-claimed',
+    kind: 'sync-review-comments',
+    classification: 'sync',
+    repo: 'stranske/App',
+    pr_number: 21,
+    lease: { owner: 'host:123', expires_at: '2026-04-21T06:30:00Z' },
+    review_thread_count: 1,
+    review_threads: [],
+  };
   const state = mergeCampaignState(
-    {},
+    { items: [claimed] },
     [
+      { ...claimed, status: 'needs-local-codex' },
       {
         id: 'sync-review-comments:stranske/App#22:abc',
         status: 'needs-local-codex',
@@ -834,6 +872,8 @@ test('formats campaign run summary as compact artifact markdown', () => {
   assert.match(summary, /Repos checked: 2\/3/);
   assert.match(summary, /Items needing local Codex: 1/);
   assert.match(summary, /Actionable local Codex items: 1/);
+  assert.match(summary, /Items claimed: 1/);
+  assert.match(summary, /Next claim lease expires: 2026-04-21T06:30:00Z/);
   assert.match(summary, /State validation: pass/);
   assert.match(summary, /stranske\/Broken: GraphQL rate limit boundary hit/);
 });

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -493,6 +493,33 @@ function localCodexQueueStateCounts(items = []) {
   }, {});
 }
 
+function localCodexClaimSummary(items = []) {
+  const claims = cleanArray(items)
+    .filter((item) => item.status === 'local-codex-claimed')
+    .map((item) => ({
+      id: cleanString(item.id),
+      repo: cleanString(item.repo),
+      pr_number: cleanInteger(item.pr_number),
+      claimed_at: cleanString(item.claimed_at),
+      lease_owner: cleanString(item.lease?.owner),
+      lease_expires_at: cleanString(item.lease?.expires_at),
+    }))
+    .sort((a, b) => {
+      const aExpires = a.lease_expires_at || '9999-12-31T23:59:59Z';
+      const bExpires = b.lease_expires_at || '9999-12-31T23:59:59Z';
+      if (aExpires !== bExpires) return aExpires.localeCompare(bExpires);
+      return a.id.localeCompare(b.id);
+    });
+  const claimsWithExpiry = claims.filter((claim) => claim.lease_expires_at);
+  return {
+    count: claims.length,
+    leases_with_expires_at: claimsWithExpiry.length,
+    missing_lease_count: claims.length - claimsWithExpiry.length,
+    next_expires_at: claimsWithExpiry[0]?.lease_expires_at || '',
+    items: claims.slice(0, MAX_QUEUE_ROWS),
+  };
+}
+
 function annotateLocalCodexQueueState(item = {}) {
   const resultState = localCodexResultState(item);
   return {
@@ -535,6 +562,7 @@ function buildStats(items, discoveredItems, options = {}) {
     items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(items),
+    local_codex_claims: localCodexClaimSummary(items),
   };
 }
 
@@ -561,6 +589,7 @@ function deriveItemStats(items = []) {
     items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(queueItems),
+    local_codex_claims: localCodexClaimSummary(queueItems),
   };
 }
 
@@ -606,6 +635,13 @@ function validateCampaignState(state = {}) {
     }
   }
 
+  if (
+    JSON.stringify(stats.local_codex_claims || localCodexClaimSummary(state.items)) !==
+    JSON.stringify(derived.local_codex_claims)
+  ) {
+    blockers.push('local-codex-claim-summary-mismatch');
+  }
+
   return {
     schema: 'sync-dependabot-campaign-validation/v1',
     status: blockers.length > 0 ? 'warning' : 'pass',
@@ -630,6 +666,8 @@ function compactStateForMarker(state = {}) {
       ...stats,
       local_codex_queue_state_counts:
         stats.local_codex_queue_state_counts || localCodexQueueStateCounts(state.items),
+      local_codex_claims:
+        stats.local_codex_claims || localCodexClaimSummary(state.items),
     },
     validation: state.validation || null,
     source_review_history: cleanArray(state.source_review_history)
@@ -706,9 +744,9 @@ function compactQueueItemForMarker(item = {}) {
       body_preview: truncate(thread.body_preview, 80),
     })),
   };
-  if (queueState === 'source-fixed-candidate' || queueState === 'superseded-sync-candidate') {
+  if (queueState !== 'actionable' && (queueState !== compact.status || compact.status === 'local-codex-claimed')) {
     compact.local_codex_queue_state = queueState;
-    compact.local_codex_actionable = false;
+    compact.local_codex_actionable = isActionableLocalCodexItem(item);
   }
   if (item.local_codex_result_state) {
     compact.local_codex_result_state = cleanString(item.local_codex_result_state);
@@ -746,6 +784,7 @@ function markdownLink(label, url) {
 
 function formatCampaignBody(state) {
   const stats = state.stats || {};
+  const claims = stats.local_codex_claims || localCodexClaimSummary(state.items);
   const queueItems = cleanArray(state.items)
     .filter(isVisibleQueueItem)
     .slice(0, MAX_QUEUE_ROWS);
@@ -773,6 +812,8 @@ function formatCampaignBody(state) {
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
+    `- Claimed local Codex items: ${claims.count || 0}`,
+    `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
     '',
     '## Local Queue',
     '',
@@ -914,6 +955,7 @@ function formatSupersededSyncCandidateDetails(items = []) {
 
 function formatCompactCampaignBody(state) {
   const stats = state.stats || {};
+  const claims = stats.local_codex_claims || localCodexClaimSummary(state.items);
   const queueItems = cleanArray(state.items)
     .filter(isVisibleQueueItem)
     .slice(0, 10);
@@ -938,6 +980,8 @@ function formatCompactCampaignBody(state) {
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
+    `- Claimed local Codex items: ${claims.count || 0}`,
+    `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
     '',
     '| Status | PR | Threads |',
     '| --- | --- | ---: |',
@@ -1285,6 +1329,7 @@ function formatDryRunSummary(state = {}) {
 
 function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
   const stats = state.stats || {};
+  const claims = stats.local_codex_claims || localCodexClaimSummary(state.items);
   const errors = cleanArray(state.errors);
   const validation = state.validation || validateCampaignState(state);
   const lines = [
@@ -1306,6 +1351,7 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     `- Items claimed: ${stats.items_claimed || 0}`,
+    `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
     `- Items blocked: ${stats.items_blocked || 0}`,
     `- State validation: ${validation.status}`,
   ];
@@ -1439,11 +1485,15 @@ async function runCampaign({
   }
 
   if (core && typeof core.setOutput === 'function') {
+    const claims = state.stats.local_codex_claims || localCodexClaimSummary(state.items);
     core.setOutput('needs_local_codex', needsLocalCodex ? 'true' : 'false');
     core.setOutput('items_needing_local_codex', String(state.stats.items_needing_local_codex || 0));
     core.setOutput('items_actionable_local_codex', String(state.stats.items_actionable_local_codex || 0));
     core.setOutput('items_source_fixed_candidates', String(state.stats.items_source_fixed_candidates || 0));
     core.setOutput('items_superseded_sync_candidates', String(state.stats.items_superseded_sync_candidates || 0));
+    core.setOutput('items_claimed', String(state.stats.items_claimed || 0));
+    core.setOutput('claimed_items_missing_lease', String(claims.missing_lease_count || 0));
+    core.setOutput('next_claim_lease_expires_at', claims.next_expires_at || '');
     core.setOutput('items_unpublished_source_results', String(state.stats.items_unpublished_source_results || 0));
     core.setOutput('campaign_issue_url', campaignIssue?.html_url || '');
   }


### PR DESCRIPTION
## Summary
- add a machine-readable `local_codex_claims` contract to sync/dependabot campaign stats and marker payloads
- expose claimed-item lease expiry in issue bodies, compact bodies, run summaries, and workflow outputs
- keep compact marker annotations scoped so large campaign issues stay below the GitHub body limit

## Source
- Refs #1836

## Verification
- `node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js`
- `node --check .github/scripts/sync_dependabot_campaign.js && node --check .github/scripts/__tests__/sync_dependabot_campaign.test.js`
- `node --test .github/scripts/__tests__/*.test.js` (939 passed)
- `git diff --check`
