### PR TITLE
Harden campaign claimable state contract

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -192,22 +192,27 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
     { reposRequested: 1, reposChecked: 1 },
   );
   const body = formatCampaignBody(state);
-  const markerItem = parseCampaignMarker(formatCampaignMarker({ items: [item] })).items[0];
+  const markerItem = parseCampaignMarker(formatCampaignMarker(state)).items[0];
 
   assert.equal(item.source_sync.status, 'superseded');
   assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
+  assert.equal(state.items[0].status, 'local-codex-superseded-sync-candidate');
   assert.equal(state.items[0].local_codex_queue_state, 'superseded-sync-candidate');
   assert.equal(state.items[0].local_codex_actionable, false);
+  assert.equal(state.items[0].local_codex_claimable, false);
   assert.equal(state.stats.items_needing_local_codex, 0);
   assert.equal(state.stats.items_actionable_local_codex, 0);
+  assert.equal(state.stats.items_claimable_local_codex, 0);
   assert.equal(state.stats.items_superseded_sync_candidates, 1);
-  assert.equal(state.stats.status_counts['needs-local-codex'], 1);
+  assert.equal(state.stats.status_counts['local-codex-superseded-sync-candidate'], 1);
   assert.deepEqual(state.stats.local_codex_queue_state_counts, {
     'superseded-sync-candidate': 1,
   });
+  assert.equal(markerItem.status, 'local-codex-superseded-sync-candidate');
   assert.equal(markerItem.source_sync.status, 'superseded');
   assert.equal(markerItem.local_codex_queue_state, 'superseded-sync-candidate');
   assert.equal(markerItem.local_codex_actionable, false);
+  assert.equal(markerItem.local_codex_claimable, false);
   assert.match(body, /No local Codex work is queued/);
   assert.match(body, /Superseded sync candidates: 1/);
   assert.match(body, /Source sync state: superseded/);
@@ -377,9 +382,10 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   const markerItem = marker.items.find((item) => item.id === repeated.id);
   const body = formatCampaignBody(state);
 
-  assert.equal(repeatedItem.status, 'needs-local-codex');
+  assert.equal(repeatedItem.status, 'local-codex-source-fixed-candidate');
   assert.equal(repeatedItem.local_codex_queue_state, 'source-fixed-candidate');
   assert.equal(repeatedItem.local_codex_actionable, false);
+  assert.equal(repeatedItem.local_codex_claimable, false);
   assert.equal(repeatedItem.source_fixed_candidate.matching_item_id, finished.id);
   assert.equal(repeatedItem.source_fixed_candidate.finished_at, '2026-04-21T05:30:00Z');
   assert.equal(state.source_review_history.length, 1);
@@ -387,14 +393,16 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
   assert.equal(state.stats.items_needing_local_codex, 0);
   assert.equal(state.stats.items_actionable_local_codex, 0);
   assert.equal(state.stats.items_source_fixed_candidates, 1);
-  assert.equal(state.stats.status_counts['needs-local-codex'], 1);
+  assert.equal(state.stats.status_counts['local-codex-source-fixed-candidate'], 1);
   assert.deepEqual(state.stats.local_codex_queue_state_counts, {
     'source-fixed-candidate': 1,
     finished: 1,
   });
+  assert.equal(markerItem.status, 'local-codex-source-fixed-candidate');
   assert.equal(markerItem.source_fixed_candidate.matching_item_id, finished.id);
   assert.equal(markerItem.local_codex_queue_state, 'source-fixed-candidate');
   assert.equal(markerItem.local_codex_actionable, false);
+  assert.equal(markerItem.local_codex_claimable, false);
   assert.equal(marker.source_review_history[0].matching_item_id, finished.id);
   assert.match(body, /No local Codex work is queued/);
   assert.match(body, /Source-fixed candidates: 1/);
@@ -872,6 +880,7 @@ test('formats campaign run summary as compact artifact markdown', () => {
   assert.match(summary, /Repos checked: 2\/3/);
   assert.match(summary, /Items needing local Codex: 1/);
   assert.match(summary, /Actionable local Codex items: 1/);
+  assert.match(summary, /Claimable local Codex items: 1/);
   assert.match(summary, /Items claimed: 1/);
   assert.match(summary, /Next claim lease expires: 2026-04-21T06:30:00Z/);
   assert.match(summary, /State validation: pass/);
@@ -883,6 +892,7 @@ test('validates campaign item stats against retained queue state', () => {
     schema: 'sync-dependabot-campaign/v1',
     stats: {
       items_needing_local_codex: 2,
+      items_claimable_local_codex: 2,
       items_claimed: 0,
       items_finished: 0,
       items_blocked: 0,
@@ -890,7 +900,13 @@ test('validates campaign item stats against retained queue state', () => {
     },
     items: [
       { id: 'one', status: 'needs-local-codex' },
-      { id: 'two', status: 'local-codex-finished' },
+      {
+        id: 'two',
+        status: 'local-codex-finished',
+        local_codex_queue_state: 'claimed',
+        local_codex_actionable: true,
+        local_codex_claimable: true,
+      },
     ],
   };
 
@@ -898,10 +914,14 @@ test('validates campaign item stats against retained queue state', () => {
 
   assert.equal(validation.status, 'warning');
   assert.ok(validation.blockers.includes('stats-mismatch-items_needing_local_codex'));
+  assert.ok(validation.blockers.includes('stats-mismatch-items_claimable_local_codex'));
   assert.ok(validation.blockers.includes('stats-mismatch-items_finished'));
   assert.ok(validation.blockers.includes('status-count-mismatch-local-codex-finished'));
   assert.ok(validation.blockers.includes('local-codex-queue-state-count-mismatch-actionable'));
   assert.ok(validation.blockers.includes('local-codex-queue-state-count-mismatch-finished'));
+  assert.ok(validation.blockers.includes('item-local-codex-queue-state-annotation-mismatch'));
+  assert.ok(validation.blockers.includes('item-local-codex-actionable-annotation-mismatch'));
+  assert.ok(validation.blockers.includes('item-local-codex-claimable-annotation-mismatch'));
 });
 
 test('formatCampaignBody remains below GitHub issue body limit for large queues', () => {

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -28,6 +28,8 @@ const DEFAULT_IGNORED_PATHS = ['.agents/'];
 
 const ACTIVE_STATUSES = new Set([
   'needs-local-codex',
+  'local-codex-source-fixed-candidate',
+  'local-codex-superseded-sync-candidate',
   'local-codex-claimed',
   'retryable-error',
 ]);
@@ -354,7 +356,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     const previous = previousById.get(discovered.id);
     const sourceFixedCandidate = sourceFixedCandidateFor(discovered, finishedBySourceReviewKey);
     if (!previous) {
-      nextItems.push({
+      const item = {
         ...discovered,
         status: discovered.status || 'needs-local-codex',
         first_seen_at: discovered.first_seen_at || now,
@@ -362,6 +364,10 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
         attempts: Number(discovered.attempts || 0),
         lease: null,
         source_fixed_candidate: sourceFixedCandidate,
+      };
+      item.status = localCodexClaimableStatus(item, item.status);
+      nextItems.push({
+        ...item,
       });
       continue;
     }
@@ -369,6 +375,13 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     let status = previous.status || 'needs-local-codex';
     let lease = previous.lease || null;
     const attempts = Number(previous.attempts || 0);
+
+    if (
+      status === 'local-codex-source-fixed-candidate' ||
+      status === 'local-codex-superseded-sync-candidate'
+    ) {
+      status = 'needs-local-codex';
+    }
 
     if (status === 'local-codex-claimed' && isLeaseExpired(previous, nowDate)) {
       status = 'needs-local-codex';
@@ -378,7 +391,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
       lease = null;
     }
 
-    nextItems.push({
+    const item = {
       ...previous,
       ...discovered,
       status,
@@ -388,6 +401,10 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
       lease: status === 'local-codex-claimed' ? lease : null,
       result: previous.result || null,
       source_fixed_candidate: sourceFixedCandidate || previous.source_fixed_candidate || null,
+    };
+    item.status = localCodexClaimableStatus(item, item.status);
+    nextItems.push({
+      ...item,
     });
   }
 
@@ -467,8 +484,22 @@ function isActionableLocalCodexItem(item = {}) {
     !isSupersededSyncCandidate(item);
 }
 
+function localCodexClaimableStatus(item = {}, status = item.status) {
+  if (status !== 'needs-local-codex') {
+    return status;
+  }
+  if (isSourceFixedCandidate(item)) return 'local-codex-source-fixed-candidate';
+  if (isSupersededSyncCandidate(item)) return 'local-codex-superseded-sync-candidate';
+  return status;
+}
+
+function isClaimableLocalCodexItem(item = {}) {
+  return localCodexClaimableStatus(item) === 'needs-local-codex' &&
+    isActionableLocalCodexItem(item);
+}
+
 function isVisibleQueueItem(item = {}) {
-  return isActionableLocalCodexItem(item) || item.status === 'local-codex-claimed';
+  return isClaimableLocalCodexItem(item) || item.status === 'local-codex-claimed';
 }
 
 function localCodexQueueState(item = {}) {
@@ -478,6 +509,8 @@ function localCodexQueueState(item = {}) {
     if (isSupersededSyncCandidate(item)) return 'superseded-sync-candidate';
     return 'actionable';
   }
+  if (status === 'local-codex-source-fixed-candidate') return 'source-fixed-candidate';
+  if (status === 'local-codex-superseded-sync-candidate') return 'superseded-sync-candidate';
   if (status === 'local-codex-claimed') return 'claimed';
   if (status === 'local-codex-finished') return 'finished';
   if (status === 'blocked') return 'blocked';
@@ -526,6 +559,7 @@ function annotateLocalCodexQueueState(item = {}) {
     ...item,
     local_codex_queue_state: localCodexQueueState(item),
     local_codex_actionable: isActionableLocalCodexItem(item),
+    local_codex_claimable: isClaimableLocalCodexItem(item),
     ...(resultState ? { local_codex_result_state: resultState } : {}),
   };
 }
@@ -540,6 +574,7 @@ function buildStats(items, discoveredItems, options = {}) {
     .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
     .length;
   const actionableLocalCodexCount = items.filter(isActionableLocalCodexItem).length;
+  const claimableLocalCodexCount = items.filter(isClaimableLocalCodexItem).length;
   const unpublishedSourceResultCount = items.filter(hasUnpublishedSourceResult).length;
   return {
     repos_requested: Number(options.reposRequested || 0),
@@ -554,6 +589,7 @@ function buildStats(items, discoveredItems, options = {}) {
     ),
     items_needing_local_codex: actionableLocalCodexCount,
     items_actionable_local_codex: actionableLocalCodexCount,
+    items_claimable_local_codex: claimableLocalCodexCount,
     items_source_fixed_candidates: sourceFixedCandidateCount,
     items_superseded_sync_candidates: supersededSyncCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
@@ -577,10 +613,12 @@ function deriveItemStats(items = []) {
     .filter((item) => isSupersededSyncCandidate(item) && !isSourceFixedCandidate(item))
     .length;
   const actionableLocalCodexCount = queueItems.filter(isActionableLocalCodexItem).length;
+  const claimableLocalCodexCount = queueItems.filter(isClaimableLocalCodexItem).length;
   const unpublishedSourceResultCount = queueItems.filter(hasUnpublishedSourceResult).length;
   return {
     items_needing_local_codex: actionableLocalCodexCount,
     items_actionable_local_codex: actionableLocalCodexCount,
+    items_claimable_local_codex: claimableLocalCodexCount,
     items_source_fixed_candidates: sourceFixedCandidateCount,
     items_superseded_sync_candidates: supersededSyncCandidateCount,
     items_claimed: statusCounts['local-codex-claimed'] || 0,
@@ -600,6 +638,7 @@ function validateCampaignState(state = {}) {
   const fields = [
     'items_needing_local_codex',
     'items_actionable_local_codex',
+    'items_claimable_local_codex',
     'items_source_fixed_candidates',
     'items_superseded_sync_candidates',
     'items_claimed',
@@ -640,6 +679,39 @@ function validateCampaignState(state = {}) {
     JSON.stringify(derived.local_codex_claims)
   ) {
     blockers.push('local-codex-claim-summary-mismatch');
+  }
+
+  let queueStateAnnotationMismatch = false;
+  let actionableAnnotationMismatch = false;
+  let claimableAnnotationMismatch = false;
+  for (const item of cleanArray(state.items)) {
+    if (
+      cleanString(item.local_codex_queue_state) &&
+      cleanString(item.local_codex_queue_state) !== localCodexQueueState(item)
+    ) {
+      queueStateAnnotationMismatch = true;
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(item, 'local_codex_actionable') &&
+      Boolean(item.local_codex_actionable) !== isActionableLocalCodexItem(item)
+    ) {
+      actionableAnnotationMismatch = true;
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(item, 'local_codex_claimable') &&
+      Boolean(item.local_codex_claimable) !== isClaimableLocalCodexItem(item)
+    ) {
+      claimableAnnotationMismatch = true;
+    }
+  }
+  if (queueStateAnnotationMismatch) {
+    blockers.push('item-local-codex-queue-state-annotation-mismatch');
+  }
+  if (actionableAnnotationMismatch) {
+    blockers.push('item-local-codex-actionable-annotation-mismatch');
+  }
+  if (claimableAnnotationMismatch) {
+    blockers.push('item-local-codex-claimable-annotation-mismatch');
   }
 
   return {
@@ -747,6 +819,7 @@ function compactQueueItemForMarker(item = {}) {
   if (queueState !== 'actionable' && (queueState !== compact.status || compact.status === 'local-codex-claimed')) {
     compact.local_codex_queue_state = queueState;
     compact.local_codex_actionable = isActionableLocalCodexItem(item);
+    compact.local_codex_claimable = isClaimableLocalCodexItem(item);
   }
   if (item.local_codex_result_state) {
     compact.local_codex_result_state = cleanString(item.local_codex_result_state);
@@ -809,6 +882,7 @@ function formatCampaignBody(state) {
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
+    `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
@@ -977,6 +1051,7 @@ function formatCompactCampaignBody(state) {
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
+    `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
@@ -1323,6 +1398,7 @@ function formatDryRunSummary(state = {}) {
     `sync_prs_open=${stats.sync_prs_open || 0}`,
     `dependabot_prs_open=${stats.dependabot_prs_open || 0}`,
     `items_needing_local_codex=${stats.items_needing_local_codex || 0}`,
+    `items_claimable_local_codex=${stats.items_claimable_local_codex || 0}`,
     `items_unpublished_source_results=${stats.items_unpublished_source_results || 0}`,
   ].join(' ');
 }
@@ -1347,6 +1423,7 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Active review threads queued: ${stats.active_review_threads || 0}`,
     `- Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
     `- Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
+    `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
@@ -1489,6 +1566,7 @@ async function runCampaign({
     core.setOutput('needs_local_codex', needsLocalCodex ? 'true' : 'false');
     core.setOutput('items_needing_local_codex', String(state.stats.items_needing_local_codex || 0));
     core.setOutput('items_actionable_local_codex', String(state.stats.items_actionable_local_codex || 0));
+    core.setOutput('items_claimable_local_codex', String(state.stats.items_claimable_local_codex || 0));
     core.setOutput('items_source_fixed_candidates', String(state.stats.items_source_fixed_candidates || 0));
     core.setOutput('items_superseded_sync_candidates', String(state.stats.items_superseded_sync_candidates || 0));
     core.setOutput('items_claimed', String(state.stats.items_claimed || 0));

--- a/.github/workflows/maint-82-sync-dependabot-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependabot-campaign.yml
@@ -138,6 +138,7 @@ jobs:
                 `Active review threads queued: ${stats.active_review_threads || 0}`,
                 `Items needing local Codex: ${stats.items_needing_local_codex || 0}`,
                 `Actionable local Codex items: ${stats.items_actionable_local_codex || 0}`,
+                `Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
                 `Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
                 `Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
                 `Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#902](https://github.com/stranske/Travel-Plan-Permission/issues/902)
- [stranske/Travel-Plan-Permission#893](https://github.com/stranske/Travel-Plan-Permission/issues/893)
- [stranske/Travel-Plan-Permission#894](https://github.com/stranske/Travel-Plan-Permission/issues/894)
- [stranske/Travel-Plan-Permission#895](https://github.com/stranske/Travel-Plan-Permission/issues/895)
- [stranske/Travel-Plan-Permission#896](https://github.com/stranske/Travel-Plan-Permission/issues/896)
- [stranske/Travel-Plan-Permission#899](https://github.com/stranske/Travel-Plan-Permission/issues/899)
- [stranske/Travel-Plan-Permission#900](https://github.com/stranske/Travel-Plan-Permission/issues/900)
- [stranske/Template#582](https://github.com/stranske/Template/issues/582)
- [stranske/Travel-Plan-Permission#892](https://github.com/stranske/Travel-Plan-Permission/issues/892)
- [stranske/Travel-Plan-Permission#886](https://github.com/stranske/Travel-Plan-Permission/issues/886)
- [stranske/Travel-Plan-Permission#885](https://github.com/stranske/Travel-Plan-Permission/issues/885)
- [stranske/Template#588](https://github.com/stranske/Template/issues/588)
- [stranske/Template#586](https://github.com/stranske/Template/issues/586)
- [stranske/Template#585](https://github.com/stranske/Template/issues/585)
- [stranske/Template#580](https://github.com/stranske/Template/issues/580)
- [stranske/Template#579](https://github.com/stranske/Template/issues/579)
- [stranske/Template#577](https://github.com/stranske/Template/issues/577)
- [stranske/Counter_Risk#430](https://github.com/stranske/Counter_Risk/issues/430)
- [stranske/Counter_Risk#429](https://github.com/stranske/Counter_Risk/issues/429)
- [stranske/Counter_Risk#426](https://github.com/stranske/Counter_Risk/issues/426)
- [stranske/Counter_Risk#425](https://github.com/stranske/Counter_Risk/issues/425)
- [stranske/Counter_Risk#413](https://github.com/stranske/Counter_Risk/issues/413)
- [stranske/Counter_Risk#412](https://github.com/stranske/Counter_Risk/issues/412)
- [stranske/Counter_Risk#409](https://github.com/stranske/Counter_Risk/issues/409)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Pension-Data#284](https://github.com/stranske/Pension-Data/issues/284)
- [stranske/Pension-Data#280](https://github.com/stranske/Pension-Data/issues/280)
- [stranske/Pension-Data#279](https://github.com/stranske/Pension-Data/issues/279)
- [stranske/Pension-Data#278](https://github.com/stranske/Pension-Data/issues/278)
- [stranske/Pension-Data#276](https://github.com/stranske/Pension-Data/issues/276)
- [stranske/Pension-Data#275](https://github.com/stranske/Pension-Data/issues/275)
- [stranske/Pension-Data#274](https://github.com/stranske/Pension-Data/issues/274)
- [stranske/Pension-Data#273](https://github.com/stranske/Pension-Data/issues/273)
- [stranske/Pension-Data#272](https://github.com/stranske/Pension-Data/issues/272)
- [stranske/Pension-Data#270](https://github.com/stranske/Pension-Data/issues/270)
- [stranske/Pension-Data#268](https://github.com/stranske/Pension-Data/issues/268)
- [stranske/Pension-Data#266](https://github.com/stranske/Pension-Data/issues/266)
- [stranske/Pension-Data#265](https://github.com/stranske/Pension-Data/issues/265)
- [stranske/Pension-Data#263](https://github.com/stranske/Pension-Data/issues/263)
- [stranske/Pension-Data#262](https://github.com/stranske/Pension-Data/issues/262)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#272](https://github.com/stranske/Inv-Man-Intake/issues/272)
- [stranske/Inv-Man-Intake#267](https://github.com/stranske/Inv-Man-Intake/issues/267)
- [stranske/Inv-Man-Intake#266](https://github.com/stranske/Inv-Man-Intake/issues/266)
- [stranske/Inv-Man-Intake#263](https://github.com/stranske/Inv-Man-Intake/issues/263)
- [stranske/Inv-Man-Intake#260](https://github.com/stranske/Inv-Man-Intake/issues/260)
- [stranske/Inv-Man-Intake#254](https://github.com/stranske/Inv-Man-Intake/issues/254)
- [stranske/Inv-Man-Intake#252](https://github.com/stranske/Inv-Man-Intake/issues/252)
- [stranske/Inv-Man-Intake#251](https://github.com/stranske/Inv-Man-Intake/issues/251)
- [stranske/Inv-Man-Intake#250](https://github.com/stranske/Inv-Man-Intake/issues/250)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [stranske/Inv-Man-Intake#245](https://github.com/stranske/Inv-Man-Intake/issues/245)
- [stranske/Inv-Man-Intake#244](https://github.com/stranske/Inv-Man-Intake/issues/244)
- [stranske/Inv-Man-Intake#243](https://github.com/stranske/Inv-Man-Intake/issues/243)
- [stranske/Inv-Man-Intake#242](https://github.com/stranske/Inv-Man-Intake/issues/242)
- [stranske/Ready#111](https://github.com/stranske/Ready/issues/111)
- [stranske/Ready#108](https://github.com/stranske/Ready/issues/108)
- [stranske/Ready#107](https://github.com/stranske/Ready/issues/107)
- [stranske/Ready#106](https://github.com/stranske/Ready/issues/106)
- [stranske/Ready#101](https://github.com/stranske/Ready/issues/101)
- [stranske/Ready#99](https://github.com/stranske/Ready/issues/99)
- [stranske/Ready#96](https://github.com/stranske/Ready/issues/96)
- [stranske/Ready#95](https://github.com/stranske/Ready/issues/95)
- [stranske/Ready#94](https://github.com/stranske/Ready/issues/94)
- [stranske/Ready#93](https://github.com/stranske/Ready/issues/93)
- [stranske/Ready#92](https://github.com/stranske/Ready/issues/92)
- [stranske/Ready#90](https://github.com/stranske/Ready/issues/90)
- [stranske/Ready#89](https://github.com/stranske/Ready/issues/89)
- [stranske/Ready#88](https://github.com/stranske/Ready/issues/88)
- [stranske/Ready#87](https://github.com/stranske/Ready/issues/87)
- [stranske/Ready#84](https://github.com/stranske/Ready/issues/84)
- [stranske/Ready#83](https://github.com/stranske/Ready/issues/83)
- [stranske/Ready#82](https://github.com/stranske/Ready/issues/82)
- [stranske/trip-planner#920](https://github.com/stranske/trip-planner/issues/920)
- [stranske/trip-planner#916](https://github.com/stranske/trip-planner/issues/916)
- [stranske/trip-planner#915](https://github.com/stranske/trip-planner/issues/915)
- [stranske/trip-planner#914](https://github.com/stranske/trip-planner/issues/914)
- [stranske/Manager-Database#866](https://github.com/stranske/Manager-Database/issues/866)
- [stranske/Manager-Database#864](https://github.com/stranske/Manager-Database/issues/864)
- [stranske/Manager-Database#862](https://github.com/stranske/Manager-Database/issues/862)
- [stranske/Manager-Database#861](https://github.com/stranske/Manager-Database/issues/861)
- [stranske/Manager-Database#854](https://github.com/stranske/Manager-Database/issues/854)
- [stranske/Manager-Database#848](https://github.com/stranske/Manager-Database/issues/848)
- [stranske/Manager-Database#847](https://github.com/stranske/Manager-Database/issues/847)
- [stranske/Manager-Database#845](https://github.com/stranske/Manager-Database/issues/845)
- [stranske/Manager-Database#844](https://github.com/stranske/Manager-Database/issues/844)
- [stranske/Manager-Database#843](https://github.com/stranske/Manager-Database/issues/843)
- [stranske/Manager-Database#842](https://github.com/stranske/Manager-Database/issues/842)
- [stranske/Manager-Database#841](https://github.com/stranske/Manager-Database/issues/841)
- [stranske/Manager-Database#840](https://github.com/stranske/Manager-Database/issues/840)
- [stranske/Manager-Database#839](https://github.com/stranske/Manager-Database/issues/839)
- [stranske/Manager-Database#838](https://github.com/stranske/Manager-Database/issues/838)
- [stranske/Manager-Database#837](https://github.com/stranske/Manager-Database/issues/837)
- [stranske/Portable-Alpha-Extension-Model#1644](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1644)
- [stranske/Portable-Alpha-Extension-Model#1643](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1643)
- [stranske/Portable-Alpha-Extension-Model#1640](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1640)
- [stranske/Portable-Alpha-Extension-Model#1639](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1639)
- [stranske/Portable-Alpha-Extension-Model#1632](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1632)
- [stranske/Portable-Alpha-Extension-Model#1630](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1630)
- [stranske/Portable-Alpha-Extension-Model#1628](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1628)
- [stranske/Portable-Alpha-Extension-Model#1625](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1625)
- [stranske/Portable-Alpha-Extension-Model#1624](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1624)
- [stranske/Portable-Alpha-Extension-Model#1622](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1622)
- [stranske/Portable-Alpha-Extension-Model#1620](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1620)
- [stranske/Portable-Alpha-Extension-Model#1619](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1619)
- [stranske/Portable-Alpha-Extension-Model#1618](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1618)
- [#902](https://github.com/stranske/Workflows/issues/902)
- [#900](https://github.com/stranske/Workflows/issues/900)
- [#1855](https://github.com/stranske/Workflows/issues/1855)
- [#1860](https://github.com/stranske/Workflows/issues/1860)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T01:11:48.830Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 298
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 296
- [ ] Items needing local Codex: 0
- [ ] Actionable local Codex items: 0
- [ ] Source-fixed candidates: 8
- [ ] Superseded sync candidates: 112
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 1
- [ ] Next claim lease expires: 2026-04-26T02:41:47Z

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 5158711feb675bc765a76520eae20beef26bd83e
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24945452843) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452892) |
| Agents Keepalive Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452895) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452967) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24945452544) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452960) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24945455268) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24945452886) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24945452906) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452889) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452557) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452534) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452888) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452532) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452551) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452543) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452540) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452545) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452531) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24945452549) |
<!-- auto-status-summary:end -->