### PR TITLE
Add telemetry contract detail fields

### DIFF
--- a/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
+++ b/.github/scripts/__tests__/bot-comment-auth-coverage.test.js
@@ -654,6 +654,45 @@ test('warns when required organic bot auth evidence is missing', () => {
       'missing-organic-reusable-bot-comment-handler-workflow_run'
     )
   );
+  assert.deepEqual(
+    report.organic_evidence.missing_requirements.map((item) => ({
+      component: item.component,
+      event_name: item.event_name,
+      blocker: item.blocker,
+      latest_wrapper_run_id: item.latest_wrapper_run_id,
+      latest_wrapper_has_reusable_decision: item.latest_wrapper_has_reusable_decision,
+    })),
+    [
+      {
+        component: 'agents-bot-comment-handler-wrapper',
+        event_name: 'pull_request',
+        blocker: 'missing-organic-agents-bot-comment-handler-wrapper-pull_request',
+        latest_wrapper_run_id: '',
+        latest_wrapper_has_reusable_decision: false,
+      },
+      {
+        component: 'agents-bot-comment-handler-wrapper',
+        event_name: 'workflow_run',
+        blocker: 'missing-organic-agents-bot-comment-handler-wrapper-workflow_run',
+        latest_wrapper_run_id: '',
+        latest_wrapper_has_reusable_decision: false,
+      },
+      {
+        component: 'reusable-bot-comment-handler',
+        event_name: 'pull_request',
+        blocker: 'missing-organic-reusable-bot-comment-handler-pull_request',
+        latest_wrapper_run_id: '',
+        latest_wrapper_has_reusable_decision: false,
+      },
+      {
+        component: 'reusable-bot-comment-handler',
+        event_name: 'workflow_run',
+        blocker: 'missing-organic-reusable-bot-comment-handler-workflow_run',
+        latest_wrapper_run_id: '',
+        latest_wrapper_has_reusable_decision: false,
+      },
+    ]
+  );
 });
 
 test('skips reusable organic requirement when the wrapper intentionally skipped it', () => {
@@ -686,6 +725,7 @@ test('skips reusable organic requirement when the wrapper intentionally skipped 
       'reusable-bot-comment-handler:workflow_run',
     ]
   );
+  assert.deepEqual(report.organic_evidence.missing_requirements, []);
   assert.equal(
     report.enforcement.blockers.some((blocker) =>
       blocker.startsWith('missing-organic-reusable-bot-comment-handler')
@@ -695,6 +735,38 @@ test('skips reusable organic requirement when the wrapper intentionally skipped 
   assert.match(
     markdown,
     /Skipped organic requirements: reusable-bot-comment-handler\/pull_request, reusable-bot-comment-handler\/workflow_run/
+  );
+});
+
+test('reports missing organic reusable requirements with latest wrapper decision metadata', () => {
+  const report = summarizeBotCommentAuthCoverage(
+    [
+      record('agents-bot-comment-handler-wrapper', 'client-id', 601, {
+        event_name: 'workflow_run',
+        reusable_invocation_expected: '',
+        reusable_invocation_reason: '',
+      }),
+    ],
+    {
+      required_organic_events: 'workflow_run',
+      organic_components: 'agents-bot-comment-handler-wrapper,reusable-bot-comment-handler',
+      organic_expected_mode: 'client-id',
+    }
+  );
+  const markdown = formatBotCommentAuthCoverageMarkdown(report);
+  const missing = report.organic_evidence.missing_requirements.find(
+    (item) => item.component === 'reusable-bot-comment-handler'
+  );
+
+  assert.equal(report.organic_evidence.status, 'warning');
+  assert.equal(missing.event_name, 'workflow_run');
+  assert.equal(missing.latest_wrapper_run_id, '601');
+  assert.equal(missing.latest_wrapper_reusable_invocation_expected, null);
+  assert.equal(missing.latest_wrapper_reusable_invocation_reason, '');
+  assert.equal(missing.latest_wrapper_has_reusable_decision, false);
+  assert.match(
+    markdown,
+    /Missing organic requirements: reusable-bot-comment-handler\/workflow_run/
   );
 });
 

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -10,6 +10,7 @@ const {
   formatSelectionMarkdown,
   missingPriorityFamilies,
   normalizeSelectionOptions,
+  priorityFamilyStatuses,
   selectMetricsArtifacts,
 } = require('../weekly_metrics_artifacts.js');
 
@@ -101,6 +102,45 @@ test('selects only recent matching artifacts with a machine-readable report', ()
     'verifier-terminal-disposition',
     'bot-comment-auth-coverage-reusable',
   ]);
+  assert.deepEqual(
+    report.priority_family_statuses.map((family) => ({
+      family: family.family,
+      status: family.status,
+      candidate_count: family.candidate_count,
+      selected_count: family.selected_count,
+      selected_name: family.selected_artifact?.name || '',
+    })),
+    [
+      {
+        family: 'verifier-terminal-disposition',
+        status: 'missing',
+        candidate_count: 0,
+        selected_count: 0,
+        selected_name: '',
+      },
+      {
+        family: 'review-thread-terminal-disposition',
+        status: 'selected',
+        candidate_count: 1,
+        selected_count: 1,
+        selected_name: 'review-thread-terminal-disposition-77',
+      },
+      {
+        family: 'bot-comment-auth-coverage-wrapper',
+        status: 'selected',
+        candidate_count: 2,
+        selected_count: 2,
+        selected_name: 'bot-comment-auth-coverage-wrapper-77-2',
+      },
+      {
+        family: 'bot-comment-auth-coverage-reusable',
+        status: 'missing',
+        candidate_count: 0,
+        selected_count: 0,
+        selected_name: '',
+      },
+    ]
+  );
   assert.deepEqual(report.selected_family_counts, {
     'autopilot-metrics': 1,
     'bot-comment-auth-coverage-wrapper': 2,
@@ -130,6 +170,7 @@ test('builds an error report when artifact selection cannot query GitHub', () =>
     'bot-comment-auth-coverage-wrapper',
     'bot-comment-auth-coverage-reusable',
   ]);
+  assert.ok(report.priority_family_statuses.every((family) => family.status === 'missing'));
   assert.deepEqual(report.selected_artifacts, []);
   assert.match(markdown, /Status: error/);
   assert.match(markdown, /API rate limit exceeded/);
@@ -209,6 +250,39 @@ test('reports priority telemetry families that are absent from the scan', () => 
   ]);
 });
 
+test('builds priority family statuses for available but unselected artifacts', () => {
+  const candidates = [
+    artifact(1, 'bot-comment-auth-coverage-wrapper-1', '2026-04-25T11:00:00Z'),
+    artifact(2, 'bot-comment-auth-coverage-reusable-1', '2026-04-25T10:00:00Z'),
+  ].map((raw) => ({
+    id: raw.id,
+    name: raw.name,
+    family: raw.name.includes('reusable')
+      ? 'bot-comment-auth-coverage-reusable'
+      : 'bot-comment-auth-coverage-wrapper',
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+  }));
+  const statuses = priorityFamilyStatuses({
+    candidates,
+    selected: [candidates[0]],
+    candidateFamilyCounts: new Map([
+      ['bot-comment-auth-coverage-wrapper', 1],
+      ['bot-comment-auth-coverage-reusable', 1],
+    ]),
+    selectedFamilyCounts: new Map([['bot-comment-auth-coverage-wrapper', 1]]),
+  });
+
+  const reusable = statuses.find(
+    (family) => family.family === 'bot-comment-auth-coverage-reusable'
+  );
+  assert.equal(reusable.status, 'available');
+  assert.equal(reusable.candidate_count, 1);
+  assert.equal(reusable.selected_count, 0);
+  assert.equal(reusable.latest_candidate.name, 'bot-comment-auth-coverage-reusable-1');
+  assert.equal(reusable.selected_artifact, null);
+});
+
 test('formats selected artifacts for the workflow download loop', () => {
   const tsv = formatArtifactTsv([
     { id: 42, name: 'keepalive-metrics' },
@@ -237,6 +311,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
     /Missing priority families: verifier-terminal-disposition, review-thread-terminal-disposition, bot-comment-auth-coverage-wrapper, bot-comment-auth-coverage-reusable/
   );
   assert.match(markdown, /Artifact family \| Candidates \| Selected/);
+  assert.match(markdown, /Priority family \| Status \| Candidates \| Selected artifact/);
   assert.match(markdown, /autopilot-metrics/);
   assert.match(markdown, /keepalive-metrics/);
 });

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -227,6 +227,9 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     const blockers = organicChecksDisabled
       ? []
       : missingOrganicEvidenceBlockers(components, requiredEvents);
+    const missingRequirements = organicChecksDisabled
+      ? []
+      : missingOrganicEvidenceRequirements(components, requiredEvents);
     return {
       schema: 'workflows-bot-comment-auth-organic-evidence/v1',
       required_events: requiredEvents,
@@ -234,6 +237,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
       expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
       event_counts: eventCounts,
       skipped_requirements: [],
+      missing_requirements: missingRequirements,
       blockers,
       status: organicChecksDisabled ? 'pass' : 'no-data',
     };
@@ -253,6 +257,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
 
   const blockers = [];
   const skippedRequirements = [];
+  const missingRequirements = [];
   for (const component of components) {
     for (const eventName of requiredEvents) {
       const latest = latestByComponentEvent[`${component}:${eventName}`];
@@ -272,7 +277,14 @@ function summarizeOrganicEvidence(records = [], options = {}) {
         continue;
       }
       if (!latest) {
-        blockers.push(`missing-organic-${component}-${eventName}`);
+        const blocker = `missing-organic-${component}-${eventName}`;
+        blockers.push(blocker);
+        missingRequirements.push(missingOrganicEvidenceRequirement({
+          component,
+          eventName,
+          blocker,
+          latestWrapper,
+        }));
         continue;
       }
       if (latest.fallback_warning_active) {
@@ -294,6 +306,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
     event_counts: eventCounts,
     skipped_requirements: skippedRequirements,
+    missing_requirements: missingRequirements,
     blockers,
     status: blockers.length > 0 ? 'warning' : 'pass',
   };
@@ -303,6 +316,38 @@ function missingOrganicEvidenceBlockers(components = [], requiredEvents = []) {
   return components.flatMap((component) =>
     requiredEvents.map((eventName) => `missing-organic-${component}-${eventName}`)
   );
+}
+
+function missingOrganicEvidenceRequirements(components = [], requiredEvents = []) {
+  return components.flatMap((component) =>
+    requiredEvents.map((eventName) => missingOrganicEvidenceRequirement({
+      component,
+      eventName,
+      blocker: `missing-organic-${component}-${eventName}`,
+      latestWrapper: null,
+    }))
+  );
+}
+
+function missingOrganicEvidenceRequirement({
+  component,
+  eventName,
+  blocker,
+  latestWrapper,
+}) {
+  return {
+    component,
+    event_name: eventName,
+    blocker,
+    latest_wrapper_run_id: latestWrapper?.run_id || '',
+    latest_wrapper_reusable_invocation_expected:
+      latestWrapper?.reusable_invocation_expected ?? null,
+    latest_wrapper_reusable_invocation_reason:
+      latestWrapper?.reusable_invocation_reason || '',
+    latest_wrapper_has_reusable_decision:
+      latestWrapper?.reusable_invocation_expected !== null &&
+      latestWrapper?.reusable_invocation_expected !== undefined,
+  };
 }
 
 function componentPolicy(component, options = {}) {
@@ -588,6 +633,14 @@ function formatBotCommentAuthCoverageMarkdown(report) {
     if (skipped.length > 0) {
       lines.push(
         `- Skipped organic requirements: ${skipped
+          .map((item) => `${item.component}/${item.event_name}`)
+          .join(', ')}`
+      );
+    }
+    const missing = report.organic_evidence.missing_requirements || [];
+    if (missing.length > 0) {
+      lines.push(
+        `- Missing organic requirements: ${missing
           .map((item) => `${item.component}/${item.event_name}`)
           .join(', ')}`
       );

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -132,6 +132,40 @@ function missingPriorityFamilies(candidateFamilyCounts = new Map()) {
   return PRIORITY_METRICS_FAMILIES.filter((family) => !candidateFamilyCounts.has(family));
 }
 
+function priorityFamilyStatuses({
+  candidates = [],
+  selected = [],
+  candidateFamilyCounts = new Map(),
+  selectedFamilyCounts = new Map(),
+} = {}) {
+  return PRIORITY_METRICS_FAMILIES.map((family) => {
+    const latestCandidate = candidates.find((candidate) => candidate.family === family);
+    const selectedArtifact = selected.find((artifact) => artifact.family === family);
+    return {
+      family,
+      status: selectedArtifact ? 'selected' : candidateFamilyCounts.has(family) ? 'available' : 'missing',
+      candidate_count: candidateFamilyCounts.get(family) || 0,
+      selected_count: selectedFamilyCounts.get(family) || 0,
+      latest_candidate: latestCandidate
+        ? {
+            id: latestCandidate.id,
+            name: latestCandidate.name,
+            created_at: latestCandidate.created_at,
+            updated_at: latestCandidate.updated_at,
+          }
+        : null,
+      selected_artifact: selectedArtifact
+        ? {
+            id: selectedArtifact.id,
+            name: selectedArtifact.name,
+            created_at: selectedArtifact.created_at,
+            updated_at: selectedArtifact.updated_at,
+          }
+        : null,
+    };
+  });
+}
+
 function selectMetricsArtifacts(artifacts = [], options = {}) {
   const config = normalizeSelectionOptions(options);
   const stats = {
@@ -228,6 +262,12 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
     candidate_family_counts: sortedCountObject(candidateFamilyCounts),
     selected_family_counts: sortedCountObject(familyCounts),
     missing_priority_families: missingPriorityFamilies(candidateFamilyCounts),
+    priority_family_statuses: priorityFamilyStatuses({
+      candidates,
+      selected,
+      candidateFamilyCounts,
+      selectedFamilyCounts: familyCounts,
+    }),
     selected_artifacts: selected.map((artifact) => ({
       id: artifact.id,
       name: artifact.name,
@@ -263,6 +303,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
     candidate_family_counts: {},
     selected_family_counts: {},
     missing_priority_families: [...PRIORITY_METRICS_FAMILIES],
+    priority_family_statuses: priorityFamilyStatuses(),
     selected_artifacts: [],
   };
 }
@@ -303,6 +344,19 @@ function formatSelectionMarkdown(report) {
     lines.push('', '| Artifact family | Candidates | Selected |', '|-----------------|------------|----------|');
     for (const family of familyNames) {
       lines.push(`| ${family} | ${candidateFamilyCounts[family] || 0} | ${selectedFamilyCounts[family] || 0} |`);
+    }
+  }
+
+  if (Array.isArray(report.priority_family_statuses) && report.priority_family_statuses.length > 0) {
+    lines.push('', '| Priority family | Status | Candidates | Selected artifact |');
+    lines.push('|-----------------|--------|------------|-------------------|');
+    for (const family of report.priority_family_statuses) {
+      lines.push([
+        family.family,
+        family.status,
+        family.candidate_count || 0,
+        family.selected_artifact?.name || 'none',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
     }
   }
 
@@ -437,5 +491,6 @@ module.exports = {
   formatSelectionMarkdown,
   missingPriorityFamilies,
   normalizeSelectionOptions,
+  priorityFamilyStatuses,
   selectMetricsArtifacts,
 };

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -227,6 +227,9 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     const blockers = organicChecksDisabled
       ? []
       : missingOrganicEvidenceBlockers(components, requiredEvents);
+    const missingRequirements = organicChecksDisabled
+      ? []
+      : missingOrganicEvidenceRequirements(components, requiredEvents);
     return {
       schema: 'workflows-bot-comment-auth-organic-evidence/v1',
       required_events: requiredEvents,
@@ -234,6 +237,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
       expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
       event_counts: eventCounts,
       skipped_requirements: [],
+      missing_requirements: missingRequirements,
       blockers,
       status: organicChecksDisabled ? 'pass' : 'no-data',
     };
@@ -253,6 +257,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
 
   const blockers = [];
   const skippedRequirements = [];
+  const missingRequirements = [];
   for (const component of components) {
     for (const eventName of requiredEvents) {
       const latest = latestByComponentEvent[`${component}:${eventName}`];
@@ -272,7 +277,14 @@ function summarizeOrganicEvidence(records = [], options = {}) {
         continue;
       }
       if (!latest) {
-        blockers.push(`missing-organic-${component}-${eventName}`);
+        const blocker = `missing-organic-${component}-${eventName}`;
+        blockers.push(blocker);
+        missingRequirements.push(missingOrganicEvidenceRequirement({
+          component,
+          eventName,
+          blocker,
+          latestWrapper,
+        }));
         continue;
       }
       if (latest.fallback_warning_active) {
@@ -294,6 +306,7 @@ function summarizeOrganicEvidence(records = [], options = {}) {
     expected_mode: expectedMode === 'unknown' ? '' : expectedMode,
     event_counts: eventCounts,
     skipped_requirements: skippedRequirements,
+    missing_requirements: missingRequirements,
     blockers,
     status: blockers.length > 0 ? 'warning' : 'pass',
   };
@@ -303,6 +316,38 @@ function missingOrganicEvidenceBlockers(components = [], requiredEvents = []) {
   return components.flatMap((component) =>
     requiredEvents.map((eventName) => `missing-organic-${component}-${eventName}`)
   );
+}
+
+function missingOrganicEvidenceRequirements(components = [], requiredEvents = []) {
+  return components.flatMap((component) =>
+    requiredEvents.map((eventName) => missingOrganicEvidenceRequirement({
+      component,
+      eventName,
+      blocker: `missing-organic-${component}-${eventName}`,
+      latestWrapper: null,
+    }))
+  );
+}
+
+function missingOrganicEvidenceRequirement({
+  component,
+  eventName,
+  blocker,
+  latestWrapper,
+}) {
+  return {
+    component,
+    event_name: eventName,
+    blocker,
+    latest_wrapper_run_id: latestWrapper?.run_id || '',
+    latest_wrapper_reusable_invocation_expected:
+      latestWrapper?.reusable_invocation_expected ?? null,
+    latest_wrapper_reusable_invocation_reason:
+      latestWrapper?.reusable_invocation_reason || '',
+    latest_wrapper_has_reusable_decision:
+      latestWrapper?.reusable_invocation_expected !== null &&
+      latestWrapper?.reusable_invocation_expected !== undefined,
+  };
 }
 
 function componentPolicy(component, options = {}) {
@@ -588,6 +633,14 @@ function formatBotCommentAuthCoverageMarkdown(report) {
     if (skipped.length > 0) {
       lines.push(
         `- Skipped organic requirements: ${skipped
+          .map((item) => `${item.component}/${item.event_name}`)
+          .join(', ')}`
+      );
+    }
+    const missing = report.organic_evidence.missing_requirements || [];
+    if (missing.length > 0) {
+      lines.push(
+        `- Missing organic requirements: ${missing
           .map((item) => `${item.component}/${item.event_name}`)
           .join(', ')}`
       );

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -132,6 +132,40 @@ function missingPriorityFamilies(candidateFamilyCounts = new Map()) {
   return PRIORITY_METRICS_FAMILIES.filter((family) => !candidateFamilyCounts.has(family));
 }
 
+function priorityFamilyStatuses({
+  candidates = [],
+  selected = [],
+  candidateFamilyCounts = new Map(),
+  selectedFamilyCounts = new Map(),
+} = {}) {
+  return PRIORITY_METRICS_FAMILIES.map((family) => {
+    const latestCandidate = candidates.find((candidate) => candidate.family === family);
+    const selectedArtifact = selected.find((artifact) => artifact.family === family);
+    return {
+      family,
+      status: selectedArtifact ? 'selected' : candidateFamilyCounts.has(family) ? 'available' : 'missing',
+      candidate_count: candidateFamilyCounts.get(family) || 0,
+      selected_count: selectedFamilyCounts.get(family) || 0,
+      latest_candidate: latestCandidate
+        ? {
+            id: latestCandidate.id,
+            name: latestCandidate.name,
+            created_at: latestCandidate.created_at,
+            updated_at: latestCandidate.updated_at,
+          }
+        : null,
+      selected_artifact: selectedArtifact
+        ? {
+            id: selectedArtifact.id,
+            name: selectedArtifact.name,
+            created_at: selectedArtifact.created_at,
+            updated_at: selectedArtifact.updated_at,
+          }
+        : null,
+    };
+  });
+}
+
 function selectMetricsArtifacts(artifacts = [], options = {}) {
   const config = normalizeSelectionOptions(options);
   const stats = {
@@ -228,6 +262,12 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
     candidate_family_counts: sortedCountObject(candidateFamilyCounts),
     selected_family_counts: sortedCountObject(familyCounts),
     missing_priority_families: missingPriorityFamilies(candidateFamilyCounts),
+    priority_family_statuses: priorityFamilyStatuses({
+      candidates,
+      selected,
+      candidateFamilyCounts,
+      selectedFamilyCounts: familyCounts,
+    }),
     selected_artifacts: selected.map((artifact) => ({
       id: artifact.id,
       name: artifact.name,
@@ -263,6 +303,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
     candidate_family_counts: {},
     selected_family_counts: {},
     missing_priority_families: [...PRIORITY_METRICS_FAMILIES],
+    priority_family_statuses: priorityFamilyStatuses(),
     selected_artifacts: [],
   };
 }
@@ -303,6 +344,19 @@ function formatSelectionMarkdown(report) {
     lines.push('', '| Artifact family | Candidates | Selected |', '|-----------------|------------|----------|');
     for (const family of familyNames) {
       lines.push(`| ${family} | ${candidateFamilyCounts[family] || 0} | ${selectedFamilyCounts[family] || 0} |`);
+    }
+  }
+
+  if (Array.isArray(report.priority_family_statuses) && report.priority_family_statuses.length > 0) {
+    lines.push('', '| Priority family | Status | Candidates | Selected artifact |');
+    lines.push('|-----------------|--------|------------|-------------------|');
+    for (const family of report.priority_family_statuses) {
+      lines.push([
+        family.family,
+        family.status,
+        family.candidate_count || 0,
+        family.selected_artifact?.name || 'none',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
     }
   }
 
@@ -437,5 +491,6 @@ module.exports = {
   formatSelectionMarkdown,
   missingPriorityFamilies,
   normalizeSelectionOptions,
+  priorityFamilyStatuses,
   selectMetricsArtifacts,
 };


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#899](https://github.com/stranske/Travel-Plan-Permission/issues/899)
- [stranske/Travel-Plan-Permission#900](https://github.com/stranske/Travel-Plan-Permission/issues/900)
- [stranske/Travel-Plan-Permission#902](https://github.com/stranske/Travel-Plan-Permission/issues/902)
- [stranske/Travel-Plan-Permission#893](https://github.com/stranske/Travel-Plan-Permission/issues/893)
- [stranske/Travel-Plan-Permission#894](https://github.com/stranske/Travel-Plan-Permission/issues/894)
- [stranske/Travel-Plan-Permission#895](https://github.com/stranske/Travel-Plan-Permission/issues/895)
- [stranske/Travel-Plan-Permission#896](https://github.com/stranske/Travel-Plan-Permission/issues/896)
- [stranske/Template#582](https://github.com/stranske/Template/issues/582)
- [stranske/Travel-Plan-Permission#892](https://github.com/stranske/Travel-Plan-Permission/issues/892)
- [stranske/Travel-Plan-Permission#886](https://github.com/stranske/Travel-Plan-Permission/issues/886)
- [stranske/Travel-Plan-Permission#885](https://github.com/stranske/Travel-Plan-Permission/issues/885)
- [stranske/Template#588](https://github.com/stranske/Template/issues/588)
- [stranske/Template#586](https://github.com/stranske/Template/issues/586)
- [stranske/Template#585](https://github.com/stranske/Template/issues/585)
- [stranske/Template#580](https://github.com/stranske/Template/issues/580)
- [stranske/Template#579](https://github.com/stranske/Template/issues/579)
- [stranske/Template#577](https://github.com/stranske/Template/issues/577)
- [stranske/Counter_Risk#430](https://github.com/stranske/Counter_Risk/issues/430)
- [stranske/Counter_Risk#429](https://github.com/stranske/Counter_Risk/issues/429)
- [stranske/Counter_Risk#426](https://github.com/stranske/Counter_Risk/issues/426)
- [stranske/Counter_Risk#425](https://github.com/stranske/Counter_Risk/issues/425)
- [stranske/Counter_Risk#413](https://github.com/stranske/Counter_Risk/issues/413)
- [stranske/Counter_Risk#412](https://github.com/stranske/Counter_Risk/issues/412)
- [stranske/Counter_Risk#409](https://github.com/stranske/Counter_Risk/issues/409)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Pension-Data#284](https://github.com/stranske/Pension-Data/issues/284)
- [stranske/Pension-Data#280](https://github.com/stranske/Pension-Data/issues/280)
- [stranske/Pension-Data#279](https://github.com/stranske/Pension-Data/issues/279)
- [stranske/Pension-Data#278](https://github.com/stranske/Pension-Data/issues/278)
- [stranske/Pension-Data#276](https://github.com/stranske/Pension-Data/issues/276)
- [stranske/Pension-Data#275](https://github.com/stranske/Pension-Data/issues/275)
- [stranske/Pension-Data#274](https://github.com/stranske/Pension-Data/issues/274)
- [stranske/Pension-Data#273](https://github.com/stranske/Pension-Data/issues/273)
- [stranske/Pension-Data#272](https://github.com/stranske/Pension-Data/issues/272)
- [stranske/Pension-Data#270](https://github.com/stranske/Pension-Data/issues/270)
- [stranske/Pension-Data#268](https://github.com/stranske/Pension-Data/issues/268)
- [stranske/Pension-Data#266](https://github.com/stranske/Pension-Data/issues/266)
- [stranske/Pension-Data#265](https://github.com/stranske/Pension-Data/issues/265)
- [stranske/Pension-Data#263](https://github.com/stranske/Pension-Data/issues/263)
- [stranske/Pension-Data#262](https://github.com/stranske/Pension-Data/issues/262)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#272](https://github.com/stranske/Inv-Man-Intake/issues/272)
- [stranske/Inv-Man-Intake#267](https://github.com/stranske/Inv-Man-Intake/issues/267)
- [stranske/Inv-Man-Intake#266](https://github.com/stranske/Inv-Man-Intake/issues/266)
- [stranske/Inv-Man-Intake#263](https://github.com/stranske/Inv-Man-Intake/issues/263)
- [stranske/Inv-Man-Intake#260](https://github.com/stranske/Inv-Man-Intake/issues/260)
- [stranske/Inv-Man-Intake#254](https://github.com/stranske/Inv-Man-Intake/issues/254)
- [stranske/Inv-Man-Intake#252](https://github.com/stranske/Inv-Man-Intake/issues/252)
- [stranske/Inv-Man-Intake#251](https://github.com/stranske/Inv-Man-Intake/issues/251)
- [stranske/Inv-Man-Intake#250](https://github.com/stranske/Inv-Man-Intake/issues/250)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [stranske/Inv-Man-Intake#245](https://github.com/stranske/Inv-Man-Intake/issues/245)
- [stranske/Inv-Man-Intake#244](https://github.com/stranske/Inv-Man-Intake/issues/244)
- [stranske/Inv-Man-Intake#243](https://github.com/stranske/Inv-Man-Intake/issues/243)
- [stranske/Inv-Man-Intake#242](https://github.com/stranske/Inv-Man-Intake/issues/242)
- [stranske/Ready#111](https://github.com/stranske/Ready/issues/111)
- [stranske/Ready#108](https://github.com/stranske/Ready/issues/108)
- [stranske/Ready#107](https://github.com/stranske/Ready/issues/107)
- [stranske/Ready#106](https://github.com/stranske/Ready/issues/106)
- [stranske/Ready#101](https://github.com/stranske/Ready/issues/101)
- [stranske/Ready#99](https://github.com/stranske/Ready/issues/99)
- [stranske/Ready#96](https://github.com/stranske/Ready/issues/96)
- [stranske/Ready#95](https://github.com/stranske/Ready/issues/95)
- [stranske/Ready#94](https://github.com/stranske/Ready/issues/94)
- [stranske/Ready#93](https://github.com/stranske/Ready/issues/93)
- [stranske/Ready#92](https://github.com/stranske/Ready/issues/92)
- [stranske/Ready#90](https://github.com/stranske/Ready/issues/90)
- [stranske/Ready#89](https://github.com/stranske/Ready/issues/89)
- [stranske/Ready#88](https://github.com/stranske/Ready/issues/88)
- [stranske/Ready#87](https://github.com/stranske/Ready/issues/87)
- [stranske/Ready#84](https://github.com/stranske/Ready/issues/84)
- [stranske/Ready#83](https://github.com/stranske/Ready/issues/83)
- [stranske/Ready#82](https://github.com/stranske/Ready/issues/82)
- [stranske/trip-planner#920](https://github.com/stranske/trip-planner/issues/920)
- [stranske/trip-planner#916](https://github.com/stranske/trip-planner/issues/916)
- [stranske/trip-planner#915](https://github.com/stranske/trip-planner/issues/915)
- [stranske/trip-planner#914](https://github.com/stranske/trip-planner/issues/914)
- [stranske/Manager-Database#866](https://github.com/stranske/Manager-Database/issues/866)
- [stranske/Manager-Database#864](https://github.com/stranske/Manager-Database/issues/864)
- [stranske/Manager-Database#862](https://github.com/stranske/Manager-Database/issues/862)
- [stranske/Manager-Database#861](https://github.com/stranske/Manager-Database/issues/861)
- [stranske/Manager-Database#854](https://github.com/stranske/Manager-Database/issues/854)
- [stranske/Manager-Database#848](https://github.com/stranske/Manager-Database/issues/848)
- [stranske/Manager-Database#847](https://github.com/stranske/Manager-Database/issues/847)
- [stranske/Manager-Database#845](https://github.com/stranske/Manager-Database/issues/845)
- [stranske/Manager-Database#844](https://github.com/stranske/Manager-Database/issues/844)
- [stranske/Manager-Database#843](https://github.com/stranske/Manager-Database/issues/843)
- [stranske/Manager-Database#842](https://github.com/stranske/Manager-Database/issues/842)
- [stranske/Manager-Database#841](https://github.com/stranske/Manager-Database/issues/841)
- [stranske/Manager-Database#840](https://github.com/stranske/Manager-Database/issues/840)
- [stranske/Manager-Database#839](https://github.com/stranske/Manager-Database/issues/839)
- [stranske/Manager-Database#838](https://github.com/stranske/Manager-Database/issues/838)
- [stranske/Manager-Database#837](https://github.com/stranske/Manager-Database/issues/837)
- [stranske/Portable-Alpha-Extension-Model#1644](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1644)
- [stranske/Portable-Alpha-Extension-Model#1643](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1643)
- [stranske/Portable-Alpha-Extension-Model#1640](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1640)
- [stranske/Portable-Alpha-Extension-Model#1639](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1639)
- [stranske/Portable-Alpha-Extension-Model#1632](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1632)
- [stranske/Portable-Alpha-Extension-Model#1630](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1630)
- [stranske/Portable-Alpha-Extension-Model#1628](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1628)
- [stranske/Portable-Alpha-Extension-Model#1625](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1625)
- [stranske/Portable-Alpha-Extension-Model#1624](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1624)
- [stranske/Portable-Alpha-Extension-Model#1622](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1622)
- [stranske/Portable-Alpha-Extension-Model#1620](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1620)
- [stranske/Portable-Alpha-Extension-Model#1619](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1619)
- [stranske/Portable-Alpha-Extension-Model#1618](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1618)
- [stranske/Portable-Alpha-Extension-Model#1617](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1617)
- [stranske/Portable-Alpha-Extension-Model#1616](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1616)
- [stranske/Portable-Alpha-Extension-Model#1615](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1615)
- [#900](https://github.com/stranske/Workflows/issues/900)
- [#902](https://github.com/stranske/Workflows/issues/902)
- [#1855](https://github.com/stranske/Workflows/issues/1855)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T01:43:26.407Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 298
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 296
- [ ] Items needing local Codex: 0
- [ ] Actionable local Codex items: 0
- [ ] Claimable local Codex items: 0
- [ ] Source-fixed candidates: 5
- [ ] Superseded sync candidates: 115
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 0
- [ ] Next claim lease expires: -

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** ada58eb1dd623c6b8f4acb5b2a2ca97d45d3c350
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24946929691) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929696) |
| Agents Keepalive Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929694) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929678) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24946929735) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929680) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946930204) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24946929681) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24946929679) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24946929684) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929815) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929805) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929675) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929794) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929782) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929791) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929798) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929795) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24946929796) |
<!-- auto-status-summary:end -->