### PR TITLE
Add terminal monitor artifact family details

### DIFF
--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 const {
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
+  normalizeMonitorArtifactSelection,
   parseArgs,
   readJsonReport,
   SUMMARY_SCHEMA,
@@ -80,6 +81,25 @@ test('surfaces warning blockers without activating hard-block policy', () => {
         blockers: ['missing-review-thread-sources'],
         policy_blockers: ['hard-block-approval-required'],
       },
+      artifact_selection: {
+        status: 'pass',
+        candidate_terminal_artifact_count: 0,
+        selected_terminal_artifact_count: 0,
+        missing_terminal_priority_families: [
+          'verifier-terminal-disposition',
+          'review-thread-terminal-disposition',
+        ],
+        terminal_priority_family_statuses: [
+          {
+            family: 'verifier-terminal-disposition',
+            status: 'missing',
+            candidate_count: 0,
+            selected_count: 0,
+            latest_candidate: null,
+            selected_artifact: null,
+          },
+        ],
+      },
     })
   );
   const botAuth = writeJson(dir, 'bot-auth.json', report('pass'));
@@ -95,6 +115,53 @@ test('surfaces warning blockers without activating hard-block policy', () => {
   assert.equal(summary.next_action, 'keep-warning-only-until-approved');
   assert.deepEqual(summary.monitors[0].blockers, ['missing-review-thread-sources']);
   assert.deepEqual(summary.monitors[0].policy_blockers, ['hard-block-approval-required']);
+  assert.deepEqual(summary.monitors[0].artifact_selection.missing_terminal_priority_families, [
+    'verifier-terminal-disposition',
+    'review-thread-terminal-disposition',
+  ]);
+  assert.deepEqual(summary.monitors[0].artifact_selection.terminal_priority_family_statuses, [
+    {
+      family: 'verifier-terminal-disposition',
+      status: 'missing',
+      candidate_count: 0,
+      selected_count: 0,
+    },
+  ]);
+  assert.match(formatMonitorMarkdown(summary), /terminal-disposition missing artifact families/);
+});
+
+test('normalizes monitor artifact selection detail for summaries', () => {
+  assert.deepEqual(
+    normalizeMonitorArtifactSelection({
+      status: 'pass',
+      candidate_terminal_artifact_count: 4,
+      selected_terminal_artifact_count: 2,
+      missing_terminal_priority_families: ['review-thread-terminal-disposition'],
+      terminal_priority_family_statuses: [
+        {
+          family: 'review-thread-terminal-disposition',
+          status: 'missing',
+          candidate_count: 0,
+          selected_count: 0,
+          latest_candidate: { name: 'ignored' },
+        },
+      ],
+    }),
+    {
+      status: 'pass',
+      candidate_terminal_artifact_count: 4,
+      selected_terminal_artifact_count: 2,
+      missing_terminal_priority_families: ['review-thread-terminal-disposition'],
+      terminal_priority_family_statuses: [
+        {
+          family: 'review-thread-terminal-disposition',
+          status: 'missing',
+          candidate_count: 0,
+          selected_count: 0,
+        },
+      ],
+    }
+  );
 });
 
 test('marks approved hard-block failures as fail but leaves failure enforcement to callers', () => {

--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -264,6 +264,35 @@ test('summarizes terminal artifact selector inputs in coverage report', () => {
         'keepalive-metrics': 1,
         'verifier-terminal-disposition': 2,
       },
+      priority_family_statuses: [
+        {
+          family: 'verifier-terminal-disposition',
+          status: 'selected',
+          candidate_count: 3,
+          selected_count: 2,
+          latest_candidate: {
+            id: 12,
+            name: 'verifier-terminal-disposition-124',
+            created_at: '2026-04-25T12:00:00Z',
+          },
+          selected_artifact: {
+            id: 10,
+            name: 'verifier-terminal-disposition-123',
+            created_at: '2026-04-25T11:00:00Z',
+          },
+        },
+        {
+          family: 'review-thread-terminal-disposition',
+          status: 'available',
+          candidate_count: 1,
+          selected_count: 0,
+          latest_candidate: {
+            id: 13,
+            name: 'review-thread-terminal-disposition-123',
+          },
+          selected_artifact: null,
+        },
+      ],
       selected_artifacts: [
         { id: 10, name: 'verifier-terminal-disposition-123', family: 'verifier-terminal-disposition' },
         { id: 11, name: 'keepalive-metrics', family: 'keepalive-metrics' },
@@ -282,10 +311,41 @@ test('summarizes terminal artifact selector inputs in coverage report', () => {
     selected_terminal_artifacts: [
       { id: 10, name: 'verifier-terminal-disposition-123', family: 'verifier-terminal-disposition' },
     ],
+    terminal_priority_family_statuses: [
+      {
+        family: 'review-thread-terminal-disposition',
+        status: 'available',
+        candidate_count: 1,
+        selected_count: 0,
+        latest_candidate: {
+          id: 13,
+          name: 'review-thread-terminal-disposition-123',
+        },
+        selected_artifact: null,
+      },
+      {
+        family: 'verifier-terminal-disposition',
+        status: 'selected',
+        candidate_count: 3,
+        selected_count: 2,
+        latest_candidate: {
+          id: 12,
+          name: 'verifier-terminal-disposition-124',
+          created_at: '2026-04-25T12:00:00Z',
+        },
+        selected_artifact: {
+          id: 10,
+          name: 'verifier-terminal-disposition-123',
+          created_at: '2026-04-25T11:00:00Z',
+        },
+      },
+    ],
+    missing_terminal_priority_families: [],
   });
   assert.match(markdown, /Artifact selector status: pass/);
   assert.match(markdown, /Terminal artifacts selected: 2/);
   assert.match(markdown, /Terminal artifacts candidates: 4/);
+  assert.match(markdown, /review-thread-terminal-disposition \| available/);
 });
 
 test('warns when selected terminal artifacts do not produce input files', () => {
@@ -347,6 +407,31 @@ test('normalizes artifact selection reports without selected family counts', () 
       selected_terminal_artifacts: [
         { id: 42, name: 'review-thread-terminal-disposition-77', family: 'review-thread-terminal-disposition' },
       ],
+      terminal_priority_family_statuses: [
+        {
+          family: 'review-thread-terminal-disposition',
+          status: 'selected',
+          candidate_count: 1,
+          selected_count: 1,
+          latest_candidate: {
+            id: 42,
+            name: 'review-thread-terminal-disposition-77',
+          },
+          selected_artifact: {
+            id: 42,
+            name: 'review-thread-terminal-disposition-77',
+          },
+        },
+        {
+          family: 'verifier-terminal-disposition',
+          status: 'missing',
+          candidate_count: 0,
+          selected_count: 0,
+          latest_candidate: null,
+          selected_artifact: null,
+        },
+      ],
+      missing_terminal_priority_families: ['verifier-terminal-disposition'],
     }
   );
 });

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -66,6 +66,31 @@ function policyBlockers(report = {}) {
     : [];
 }
 
+function normalizeMonitorArtifactSelection(selection = null) {
+  if (!selection || typeof selection !== 'object' || Array.isArray(selection)) return null;
+  const familyStatuses = Array.isArray(selection.terminal_priority_family_statuses)
+    ? selection.terminal_priority_family_statuses
+      .filter((status) => status && typeof status === 'object' && !Array.isArray(status))
+      .map((status) => ({
+        family: cleanString(status.family),
+        status: cleanString(status.status),
+        candidate_count: Number(status.candidate_count) || 0,
+        selected_count: Number(status.selected_count) || 0,
+      }))
+      .filter((status) => status.family)
+    : [];
+  const missingFamilies = Array.isArray(selection.missing_terminal_priority_families)
+    ? selection.missing_terminal_priority_families.map(cleanString).filter(Boolean)
+    : [];
+  return {
+    status: cleanString(selection.status),
+    candidate_terminal_artifact_count: Number(selection.candidate_terminal_artifact_count) || 0,
+    selected_terminal_artifact_count: Number(selection.selected_terminal_artifact_count) || 0,
+    missing_terminal_priority_families: missingFamilies,
+    terminal_priority_family_statuses: familyStatuses,
+  };
+}
+
 function summarizeReport(readResult) {
   const report = readResult.report || {};
   const enforcement = report.enforcement || {};
@@ -86,6 +111,7 @@ function summarizeReport(readResult) {
     should_fail: Boolean(enforcement.should_fail || status === 'fail'),
     blockers: reportBlockers(report),
     policy_blockers: policyBlockers(report),
+    artifact_selection: normalizeMonitorArtifactSelection(report.artifact_selection),
     read_status: readResult.status,
     error_message: cleanString(readResult.error_message),
   };
@@ -169,6 +195,13 @@ function formatMonitorMarkdown(summary) {
     );
   }
 
+  for (const monitor of summary.monitors) {
+    const missingFamilies = monitor.artifact_selection?.missing_terminal_priority_families || [];
+    if (missingFamilies.length > 0) {
+      lines.push(`- ${monitor.label} missing artifact families: ${missingFamilies.join(', ')}`);
+    }
+  }
+
   return `${lines.join('\n')}\n`;
 }
 
@@ -222,6 +255,7 @@ module.exports = {
   SUMMARY_SCHEMA,
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
+  normalizeMonitorArtifactSelection,
   parseArgs,
   readJsonReport,
 };

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -246,6 +246,59 @@ function terminalFamilyCount(counts = {}) {
   );
 }
 
+function normalizeSelectionArtifact(artifact = {}) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return null;
+  const name = cleanString(artifact.name);
+  const normalized = {
+    id: artifact.id ?? artifact.artifact_id ?? artifact.artifactId ?? null,
+    name,
+  };
+  const createdAt = cleanString(artifact.created_at ?? artifact.createdAt);
+  const updatedAt = cleanString(artifact.updated_at ?? artifact.updatedAt);
+  if (createdAt) normalized.created_at = createdAt;
+  if (updatedAt) normalized.updated_at = updatedAt;
+  return normalized;
+}
+
+function normalizeTerminalPriorityFamilyStatuses(report = {}, selectedArtifacts = []) {
+  const rawStatuses = Array.isArray(report.priority_family_statuses)
+    ? report.priority_family_statuses
+    : [];
+  const byFamily = new Map();
+
+  for (const status of rawStatuses) {
+    if (!status || typeof status !== 'object' || Array.isArray(status)) continue;
+    const family = cleanString(status.family);
+    if (!TERMINAL_ARTIFACT_FAMILIES.has(family)) continue;
+    byFamily.set(family, {
+      family,
+      status: cleanString(status.status) || 'missing',
+      candidate_count: Number(status.candidate_count) || 0,
+      selected_count: Number(status.selected_count) || 0,
+      latest_candidate: normalizeSelectionArtifact(status.latest_candidate),
+      selected_artifact: normalizeSelectionArtifact(status.selected_artifact),
+    });
+  }
+
+  for (const family of TERMINAL_ARTIFACT_FAMILIES) {
+    if (byFamily.has(family)) continue;
+    const candidateCount = Number(report.candidate_family_counts?.[family]) || 0;
+    const selectedCount = Number(report.selected_family_counts?.[family]) ||
+      selectedArtifacts.filter((artifact) => artifact.family === family).length;
+    const selectedArtifact = selectedArtifacts.find((artifact) => artifact.family === family) || null;
+    byFamily.set(family, {
+      family,
+      status: selectedCount > 0 ? 'selected' : (candidateCount > 0 ? 'available' : 'missing'),
+      candidate_count: candidateCount,
+      selected_count: selectedCount,
+      latest_candidate: selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null,
+      selected_artifact: selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null,
+    });
+  }
+
+  return [...byFamily.values()].sort((a, b) => a.family.localeCompare(b.family));
+}
+
 function normalizeArtifactSelectionSummary(report) {
   if (!report) return null;
   if (report.status === 'missing' || report.status === 'parse-error') {
@@ -256,6 +309,8 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
   if (typeof report !== 'object' || Array.isArray(report)) {
@@ -266,6 +321,8 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
 
@@ -278,6 +335,7 @@ function normalizeArtifactSelectionSummary(report) {
       }))
       .filter((artifact) => TERMINAL_ARTIFACT_FAMILIES.has(artifact.family))
     : [];
+  const terminalFamilyStatuses = normalizeTerminalPriorityFamilyStatuses(report, selectedArtifacts);
 
   return {
     schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
@@ -287,6 +345,10 @@ function normalizeArtifactSelectionSummary(report) {
     selected_terminal_artifact_count: terminalFamilyCount(report.selected_family_counts) ||
       selectedArtifacts.length,
     selected_terminal_artifacts: selectedArtifacts,
+    terminal_priority_family_statuses: terminalFamilyStatuses,
+    missing_terminal_priority_families: terminalFamilyStatuses
+      .filter((status) => status.status === 'missing')
+      .map((status) => status.family),
   };
 }
 
@@ -329,6 +391,11 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     if (selection.error_message) {
       lines.push(`- Artifact selector error: ${selection.error_message}`);
     }
+    if (selection.missing_terminal_priority_families?.length > 0) {
+      lines.push(
+        `- Missing terminal artifact families: ${selection.missing_terminal_priority_families.join(', ')}`
+      );
+    }
   }
 
   if (report.terminal_artifact_input_mismatch) {
@@ -355,6 +422,23 @@ function formatTerminalDispositionCoverageMarkdown(report) {
       const prs = source.pr_numbers.length ? source.pr_numbers.map((value) => `#${value}`).join(', ') : 'n/a';
       lines.push(
         `| ${source.source_key} | ${source.count} | ${formatDispositions(source.dispositions)} | ${prs} |`
+      );
+    }
+  }
+
+  const terminalFamilyStatuses = report.artifact_selection?.terminal_priority_family_statuses || [];
+  if (terminalFamilyStatuses.length > 0) {
+    lines.push(
+      '',
+      '| Terminal artifact family | Status | Candidates | Selected | Latest artifact |',
+      '|--------------------------|--------|------------|----------|-----------------|'
+    );
+    for (const familyStatus of terminalFamilyStatuses) {
+      const latest = familyStatus.selected_artifact?.name ||
+        familyStatus.latest_candidate?.name ||
+        'n/a';
+      lines.push(
+        `| ${familyStatus.family} | ${familyStatus.status} | ${familyStatus.candidate_count} | ${familyStatus.selected_count} | ${latest} |`
       );
     }
   }
@@ -544,6 +628,7 @@ module.exports = {
   normalizeEnforcementMode,
   normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
+  normalizeTerminalPriorityFamilyStatuses,
   readNdjsonFiles,
   readArtifactSelectionReport,
   summarizeTerminalDispositionCoverage,

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -66,6 +66,31 @@ function policyBlockers(report = {}) {
     : [];
 }
 
+function normalizeMonitorArtifactSelection(selection = null) {
+  if (!selection || typeof selection !== 'object' || Array.isArray(selection)) return null;
+  const familyStatuses = Array.isArray(selection.terminal_priority_family_statuses)
+    ? selection.terminal_priority_family_statuses
+      .filter((status) => status && typeof status === 'object' && !Array.isArray(status))
+      .map((status) => ({
+        family: cleanString(status.family),
+        status: cleanString(status.status),
+        candidate_count: Number(status.candidate_count) || 0,
+        selected_count: Number(status.selected_count) || 0,
+      }))
+      .filter((status) => status.family)
+    : [];
+  const missingFamilies = Array.isArray(selection.missing_terminal_priority_families)
+    ? selection.missing_terminal_priority_families.map(cleanString).filter(Boolean)
+    : [];
+  return {
+    status: cleanString(selection.status),
+    candidate_terminal_artifact_count: Number(selection.candidate_terminal_artifact_count) || 0,
+    selected_terminal_artifact_count: Number(selection.selected_terminal_artifact_count) || 0,
+    missing_terminal_priority_families: missingFamilies,
+    terminal_priority_family_statuses: familyStatuses,
+  };
+}
+
 function summarizeReport(readResult) {
   const report = readResult.report || {};
   const enforcement = report.enforcement || {};
@@ -86,6 +111,7 @@ function summarizeReport(readResult) {
     should_fail: Boolean(enforcement.should_fail || status === 'fail'),
     blockers: reportBlockers(report),
     policy_blockers: policyBlockers(report),
+    artifact_selection: normalizeMonitorArtifactSelection(report.artifact_selection),
     read_status: readResult.status,
     error_message: cleanString(readResult.error_message),
   };
@@ -169,6 +195,13 @@ function formatMonitorMarkdown(summary) {
     );
   }
 
+  for (const monitor of summary.monitors) {
+    const missingFamilies = monitor.artifact_selection?.missing_terminal_priority_families || [];
+    if (missingFamilies.length > 0) {
+      lines.push(`- ${monitor.label} missing artifact families: ${missingFamilies.join(', ')}`);
+    }
+  }
+
   return `${lines.join('\n')}\n`;
 }
 
@@ -222,6 +255,7 @@ module.exports = {
   SUMMARY_SCHEMA,
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
+  normalizeMonitorArtifactSelection,
   parseArgs,
   readJsonReport,
 };

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -246,6 +246,59 @@ function terminalFamilyCount(counts = {}) {
   );
 }
 
+function normalizeSelectionArtifact(artifact = {}) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) return null;
+  const name = cleanString(artifact.name);
+  const normalized = {
+    id: artifact.id ?? artifact.artifact_id ?? artifact.artifactId ?? null,
+    name,
+  };
+  const createdAt = cleanString(artifact.created_at ?? artifact.createdAt);
+  const updatedAt = cleanString(artifact.updated_at ?? artifact.updatedAt);
+  if (createdAt) normalized.created_at = createdAt;
+  if (updatedAt) normalized.updated_at = updatedAt;
+  return normalized;
+}
+
+function normalizeTerminalPriorityFamilyStatuses(report = {}, selectedArtifacts = []) {
+  const rawStatuses = Array.isArray(report.priority_family_statuses)
+    ? report.priority_family_statuses
+    : [];
+  const byFamily = new Map();
+
+  for (const status of rawStatuses) {
+    if (!status || typeof status !== 'object' || Array.isArray(status)) continue;
+    const family = cleanString(status.family);
+    if (!TERMINAL_ARTIFACT_FAMILIES.has(family)) continue;
+    byFamily.set(family, {
+      family,
+      status: cleanString(status.status) || 'missing',
+      candidate_count: Number(status.candidate_count) || 0,
+      selected_count: Number(status.selected_count) || 0,
+      latest_candidate: normalizeSelectionArtifact(status.latest_candidate),
+      selected_artifact: normalizeSelectionArtifact(status.selected_artifact),
+    });
+  }
+
+  for (const family of TERMINAL_ARTIFACT_FAMILIES) {
+    if (byFamily.has(family)) continue;
+    const candidateCount = Number(report.candidate_family_counts?.[family]) || 0;
+    const selectedCount = Number(report.selected_family_counts?.[family]) ||
+      selectedArtifacts.filter((artifact) => artifact.family === family).length;
+    const selectedArtifact = selectedArtifacts.find((artifact) => artifact.family === family) || null;
+    byFamily.set(family, {
+      family,
+      status: selectedCount > 0 ? 'selected' : (candidateCount > 0 ? 'available' : 'missing'),
+      candidate_count: candidateCount,
+      selected_count: selectedCount,
+      latest_candidate: selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null,
+      selected_artifact: selectedArtifact ? normalizeSelectionArtifact(selectedArtifact) : null,
+    });
+  }
+
+  return [...byFamily.values()].sort((a, b) => a.family.localeCompare(b.family));
+}
+
 function normalizeArtifactSelectionSummary(report) {
   if (!report) return null;
   if (report.status === 'missing' || report.status === 'parse-error') {
@@ -256,6 +309,8 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
   if (typeof report !== 'object' || Array.isArray(report)) {
@@ -266,6 +321,8 @@ function normalizeArtifactSelectionSummary(report) {
       candidate_terminal_artifact_count: 0,
       selected_terminal_artifact_count: 0,
       selected_terminal_artifacts: [],
+      terminal_priority_family_statuses: [],
+      missing_terminal_priority_families: [],
     };
   }
 
@@ -278,6 +335,7 @@ function normalizeArtifactSelectionSummary(report) {
       }))
       .filter((artifact) => TERMINAL_ARTIFACT_FAMILIES.has(artifact.family))
     : [];
+  const terminalFamilyStatuses = normalizeTerminalPriorityFamilyStatuses(report, selectedArtifacts);
 
   return {
     schema: cleanString(report.schema) || 'workflows-weekly-metrics-artifact-selection/v1',
@@ -287,6 +345,10 @@ function normalizeArtifactSelectionSummary(report) {
     selected_terminal_artifact_count: terminalFamilyCount(report.selected_family_counts) ||
       selectedArtifacts.length,
     selected_terminal_artifacts: selectedArtifacts,
+    terminal_priority_family_statuses: terminalFamilyStatuses,
+    missing_terminal_priority_families: terminalFamilyStatuses
+      .filter((status) => status.status === 'missing')
+      .map((status) => status.family),
   };
 }
 
@@ -329,6 +391,11 @@ function formatTerminalDispositionCoverageMarkdown(report) {
     if (selection.error_message) {
       lines.push(`- Artifact selector error: ${selection.error_message}`);
     }
+    if (selection.missing_terminal_priority_families?.length > 0) {
+      lines.push(
+        `- Missing terminal artifact families: ${selection.missing_terminal_priority_families.join(', ')}`
+      );
+    }
   }
 
   if (report.terminal_artifact_input_mismatch) {
@@ -355,6 +422,23 @@ function formatTerminalDispositionCoverageMarkdown(report) {
       const prs = source.pr_numbers.length ? source.pr_numbers.map((value) => `#${value}`).join(', ') : 'n/a';
       lines.push(
         `| ${source.source_key} | ${source.count} | ${formatDispositions(source.dispositions)} | ${prs} |`
+      );
+    }
+  }
+
+  const terminalFamilyStatuses = report.artifact_selection?.terminal_priority_family_statuses || [];
+  if (terminalFamilyStatuses.length > 0) {
+    lines.push(
+      '',
+      '| Terminal artifact family | Status | Candidates | Selected | Latest artifact |',
+      '|--------------------------|--------|------------|----------|-----------------|'
+    );
+    for (const familyStatus of terminalFamilyStatuses) {
+      const latest = familyStatus.selected_artifact?.name ||
+        familyStatus.latest_candidate?.name ||
+        'n/a';
+      lines.push(
+        `| ${familyStatus.family} | ${familyStatus.status} | ${familyStatus.candidate_count} | ${familyStatus.selected_count} | ${latest} |`
       );
     }
   }
@@ -544,6 +628,7 @@ module.exports = {
   normalizeEnforcementMode,
   normalizeEnforcementPolicy,
   normalizeArtifactSelectionSummary,
+  normalizeTerminalPriorityFamilyStatuses,
   readNdjsonFiles,
   readArtifactSelectionReport,
   summarizeTerminalDispositionCoverage,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#899](https://github.com/stranske/Travel-Plan-Permission/issues/899)
- [stranske/Travel-Plan-Permission#900](https://github.com/stranske/Travel-Plan-Permission/issues/900)
- [stranske/Travel-Plan-Permission#902](https://github.com/stranske/Travel-Plan-Permission/issues/902)
- [stranske/Travel-Plan-Permission#893](https://github.com/stranske/Travel-Plan-Permission/issues/893)
- [stranske/Travel-Plan-Permission#894](https://github.com/stranske/Travel-Plan-Permission/issues/894)
- [stranske/Travel-Plan-Permission#895](https://github.com/stranske/Travel-Plan-Permission/issues/895)
- [stranske/Travel-Plan-Permission#896](https://github.com/stranske/Travel-Plan-Permission/issues/896)
- [stranske/Template#582](https://github.com/stranske/Template/issues/582)
- [stranske/Travel-Plan-Permission#892](https://github.com/stranske/Travel-Plan-Permission/issues/892)
- [stranske/Travel-Plan-Permission#886](https://github.com/stranske/Travel-Plan-Permission/issues/886)
- [stranske/Travel-Plan-Permission#885](https://github.com/stranske/Travel-Plan-Permission/issues/885)
- [stranske/Template#588](https://github.com/stranske/Template/issues/588)
- [stranske/Template#586](https://github.com/stranske/Template/issues/586)
- [stranske/Template#585](https://github.com/stranske/Template/issues/585)
- [stranske/Template#580](https://github.com/stranske/Template/issues/580)
- [stranske/Template#579](https://github.com/stranske/Template/issues/579)
- [stranske/Template#577](https://github.com/stranske/Template/issues/577)
- [stranske/Counter_Risk#430](https://github.com/stranske/Counter_Risk/issues/430)
- [stranske/Counter_Risk#429](https://github.com/stranske/Counter_Risk/issues/429)
- [stranske/Counter_Risk#426](https://github.com/stranske/Counter_Risk/issues/426)
- [stranske/Counter_Risk#425](https://github.com/stranske/Counter_Risk/issues/425)
- [stranske/Counter_Risk#413](https://github.com/stranske/Counter_Risk/issues/413)
- [stranske/Counter_Risk#412](https://github.com/stranske/Counter_Risk/issues/412)
- [stranske/Counter_Risk#409](https://github.com/stranske/Counter_Risk/issues/409)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Pension-Data#284](https://github.com/stranske/Pension-Data/issues/284)
- [stranske/Pension-Data#280](https://github.com/stranske/Pension-Data/issues/280)
- [stranske/Pension-Data#279](https://github.com/stranske/Pension-Data/issues/279)
- [stranske/Pension-Data#278](https://github.com/stranske/Pension-Data/issues/278)
- [stranske/Pension-Data#276](https://github.com/stranske/Pension-Data/issues/276)
- [stranske/Pension-Data#275](https://github.com/stranske/Pension-Data/issues/275)
- [stranske/Pension-Data#274](https://github.com/stranske/Pension-Data/issues/274)
- [stranske/Pension-Data#273](https://github.com/stranske/Pension-Data/issues/273)
- [stranske/Pension-Data#272](https://github.com/stranske/Pension-Data/issues/272)
- [stranske/Pension-Data#270](https://github.com/stranske/Pension-Data/issues/270)
- [stranske/Pension-Data#268](https://github.com/stranske/Pension-Data/issues/268)
- [stranske/Pension-Data#266](https://github.com/stranske/Pension-Data/issues/266)
- [stranske/Pension-Data#265](https://github.com/stranske/Pension-Data/issues/265)
- [stranske/Pension-Data#263](https://github.com/stranske/Pension-Data/issues/263)
- [stranske/Pension-Data#262](https://github.com/stranske/Pension-Data/issues/262)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#272](https://github.com/stranske/Inv-Man-Intake/issues/272)
- [stranske/Inv-Man-Intake#267](https://github.com/stranske/Inv-Man-Intake/issues/267)
- [stranske/Inv-Man-Intake#266](https://github.com/stranske/Inv-Man-Intake/issues/266)
- [stranske/Inv-Man-Intake#263](https://github.com/stranske/Inv-Man-Intake/issues/263)
- [stranske/Inv-Man-Intake#260](https://github.com/stranske/Inv-Man-Intake/issues/260)
- [stranske/Inv-Man-Intake#254](https://github.com/stranske/Inv-Man-Intake/issues/254)
- [stranske/Inv-Man-Intake#252](https://github.com/stranske/Inv-Man-Intake/issues/252)
- [stranske/Inv-Man-Intake#251](https://github.com/stranske/Inv-Man-Intake/issues/251)
- [stranske/Inv-Man-Intake#250](https://github.com/stranske/Inv-Man-Intake/issues/250)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [stranske/Inv-Man-Intake#245](https://github.com/stranske/Inv-Man-Intake/issues/245)
- [stranske/Inv-Man-Intake#244](https://github.com/stranske/Inv-Man-Intake/issues/244)
- [stranske/Inv-Man-Intake#243](https://github.com/stranske/Inv-Man-Intake/issues/243)
- [stranske/Inv-Man-Intake#242](https://github.com/stranske/Inv-Man-Intake/issues/242)
- [stranske/Ready#111](https://github.com/stranske/Ready/issues/111)
- [stranske/Ready#108](https://github.com/stranske/Ready/issues/108)
- [stranske/Ready#107](https://github.com/stranske/Ready/issues/107)
- [stranske/Ready#106](https://github.com/stranske/Ready/issues/106)
- [stranske/Ready#101](https://github.com/stranske/Ready/issues/101)
- [stranske/Ready#99](https://github.com/stranske/Ready/issues/99)
- [stranske/Ready#96](https://github.com/stranske/Ready/issues/96)
- [stranske/Ready#95](https://github.com/stranske/Ready/issues/95)
- [stranske/Ready#94](https://github.com/stranske/Ready/issues/94)
- [stranske/Ready#93](https://github.com/stranske/Ready/issues/93)
- [stranske/Ready#92](https://github.com/stranske/Ready/issues/92)
- [stranske/Ready#90](https://github.com/stranske/Ready/issues/90)
- [stranske/Ready#89](https://github.com/stranske/Ready/issues/89)
- [stranske/Ready#88](https://github.com/stranske/Ready/issues/88)
- [stranske/Ready#87](https://github.com/stranske/Ready/issues/87)
- [stranske/Ready#84](https://github.com/stranske/Ready/issues/84)
- [stranske/Ready#83](https://github.com/stranske/Ready/issues/83)
- [stranske/Ready#82](https://github.com/stranske/Ready/issues/82)
- [stranske/trip-planner#920](https://github.com/stranske/trip-planner/issues/920)
- [stranske/trip-planner#916](https://github.com/stranske/trip-planner/issues/916)
- [stranske/trip-planner#915](https://github.com/stranske/trip-planner/issues/915)
- [stranske/trip-planner#914](https://github.com/stranske/trip-planner/issues/914)
- [stranske/Manager-Database#866](https://github.com/stranske/Manager-Database/issues/866)
- [stranske/Manager-Database#864](https://github.com/stranske/Manager-Database/issues/864)
- [stranske/Manager-Database#862](https://github.com/stranske/Manager-Database/issues/862)
- [stranske/Manager-Database#861](https://github.com/stranske/Manager-Database/issues/861)
- [stranske/Manager-Database#854](https://github.com/stranske/Manager-Database/issues/854)
- [stranske/Manager-Database#848](https://github.com/stranske/Manager-Database/issues/848)
- [stranske/Manager-Database#847](https://github.com/stranske/Manager-Database/issues/847)
- [stranske/Manager-Database#845](https://github.com/stranske/Manager-Database/issues/845)
- [stranske/Manager-Database#844](https://github.com/stranske/Manager-Database/issues/844)
- [stranske/Manager-Database#843](https://github.com/stranske/Manager-Database/issues/843)
- [stranske/Manager-Database#842](https://github.com/stranske/Manager-Database/issues/842)
- [stranske/Manager-Database#841](https://github.com/stranske/Manager-Database/issues/841)
- [stranske/Manager-Database#840](https://github.com/stranske/Manager-Database/issues/840)
- [stranske/Manager-Database#839](https://github.com/stranske/Manager-Database/issues/839)
- [stranske/Manager-Database#838](https://github.com/stranske/Manager-Database/issues/838)
- [stranske/Manager-Database#837](https://github.com/stranske/Manager-Database/issues/837)
- [stranske/Portable-Alpha-Extension-Model#1644](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1644)
- [stranske/Portable-Alpha-Extension-Model#1643](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1643)
- [stranske/Portable-Alpha-Extension-Model#1640](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1640)
- [stranske/Portable-Alpha-Extension-Model#1639](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1639)
- [stranske/Portable-Alpha-Extension-Model#1632](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1632)
- [stranske/Portable-Alpha-Extension-Model#1630](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1630)
- [stranske/Portable-Alpha-Extension-Model#1628](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1628)
- [stranske/Portable-Alpha-Extension-Model#1625](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1625)
- [stranske/Portable-Alpha-Extension-Model#1624](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1624)
- [stranske/Portable-Alpha-Extension-Model#1622](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1622)
- [stranske/Portable-Alpha-Extension-Model#1620](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1620)
- [stranske/Portable-Alpha-Extension-Model#1619](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1619)
- [stranske/Portable-Alpha-Extension-Model#1618](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1618)
- [stranske/Portable-Alpha-Extension-Model#1617](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1617)
- [stranske/Portable-Alpha-Extension-Model#1616](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1616)
- [stranske/Portable-Alpha-Extension-Model#1615](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1615)
- [#900](https://github.com/stranske/Workflows/issues/900)
- [#902](https://github.com/stranske/Workflows/issues/902)
- [#1855](https://github.com/stranske/Workflows/issues/1855)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T01:43:26.407Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 298
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 296
- [ ] Items needing local Codex: 0
- [ ] Actionable local Codex items: 0
- [ ] Claimable local Codex items: 0
- [ ] Source-fixed candidates: 5
- [ ] Superseded sync candidates: 115
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 0
- [ ] Next claim lease expires: -

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** 48c429142b6c8e6c8998d8746bf691ee01667218
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24947490963) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947491033) |
| Agents Keepalive Loop | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24947491013) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490996) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24947490911) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490994) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947491406) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24947490958) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24947490759) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24947490982) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490984) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490932) |
| Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24947490933) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490934) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490926) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490939) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490941) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490946) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24947490935) |
<!-- auto-status-summary:end -->