### PR TITLE
Scope verifier model aggregate counts

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -131,6 +131,19 @@ def _unsupported_verifier_models() -> set[str]:
     return {item.strip().lower() for item in raw.split(",") if item.strip()}
 
 
+def _is_verifier_terminal_entry(entry: dict[str, Any]) -> bool:
+    if entry.get("schema") != "workflows-terminal-disposition/v1":
+        return False
+    artifact_family = str(entry.get("artifact_family") or "").strip().lower()
+    workflow = str(entry.get("workflow") or "").strip().lower()
+    verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+    return (
+        artifact_family == "verifier-terminal-disposition"
+        or bool(verifier_mode)
+        or "verifier" in workflow
+    )
+
+
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
     stop_reasons = Counter()
     actions = Counter()
@@ -220,6 +233,7 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
     terminal_records = 0
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
+        is_verifier_terminal = _is_verifier_terminal_entry(entry)
         if not is_terminal_disposition:
             run_id = entry.get("run_id") or entry.get("workflow_run_id")
             run_attempt = entry.get("run_attempt")
@@ -249,7 +263,7 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
                 unsupported_verifier_models[model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
-        elif is_terminal_disposition:
+        elif is_verifier_terminal:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
             if verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -131,6 +131,19 @@ def _unsupported_verifier_models() -> set[str]:
     return {item.strip().lower() for item in raw.split(",") if item.strip()}
 
 
+def _is_verifier_terminal_entry(entry: dict[str, Any]) -> bool:
+    if entry.get("schema") != "workflows-terminal-disposition/v1":
+        return False
+    artifact_family = str(entry.get("artifact_family") or "").strip().lower()
+    workflow = str(entry.get("workflow") or "").strip().lower()
+    verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+    return (
+        artifact_family == "verifier-terminal-disposition"
+        or bool(verifier_mode)
+        or "verifier" in workflow
+    )
+
+
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
     stop_reasons = Counter()
     actions = Counter()
@@ -220,6 +233,7 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
     terminal_records = 0
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
+        is_verifier_terminal = _is_verifier_terminal_entry(entry)
         if not is_terminal_disposition:
             run_id = entry.get("run_id") or entry.get("workflow_run_id")
             run_attempt = entry.get("run_attempt")
@@ -249,7 +263,7 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
                 unsupported_verifier_models[model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
-        elif is_terminal_disposition:
+        elif is_verifier_terminal:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
             if verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -345,6 +345,7 @@ def test_verifier_summary_counts_unsupported_models(
         [
             {
                 "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
                 "run_id": "24948023778",
                 "pr_number": 1872,
                 "disposition": "verifier-error",
@@ -367,6 +368,7 @@ def test_verifier_summary_counts_unsupported_models(
         [
             {
                 "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
                 "run_id": "24948023778",
                 "pr_number": 1872,
                 "disposition": "verifier-error",
@@ -385,6 +387,7 @@ def test_verifier_summary_counts_missing_model_metadata() -> None:
         [
             {
                 "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
                 "run_id": "24948023778",
                 "pr_number": 1872,
                 "disposition": "verifier-error",
@@ -401,6 +404,36 @@ def test_verifier_summary_counts_missing_model_metadata() -> None:
     )
 
     assert "Missing verifier model metadata: verifier-error (1)" in summary
+
+
+def test_verifier_summary_ignores_review_thread_terminal_model_metadata() -> None:
+    summary = aggregate_agent_metrics.build_summary(
+        [
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "review-thread-terminal-disposition",
+                "source_type": "review-thread",
+                "source_id": "1875",
+                "pr_number": 1875,
+                "disposition": "wrapper-skipped",
+            },
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "source_type": "pull-request",
+                "source_id": "1872",
+                "pr_number": 1872,
+                "disposition": "verifier-error",
+            },
+        ],
+        errors=0,
+    )
+
+    assert "Terminal disposition records: 2" in summary
+    assert "verifier-error (1)" in summary
+    assert "wrapper-skipped (1)" in summary
+    assert "Missing verifier model metadata: verifier-error (1)" in summary
+    assert "wrapper-skipped" not in summary.split("Missing verifier model metadata: ", 1)[1]
 
 
 def test_format_helpers_and_summary_range() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#899](https://github.com/stranske/Travel-Plan-Permission/issues/899)
- [stranske/Travel-Plan-Permission#900](https://github.com/stranske/Travel-Plan-Permission/issues/900)
- [stranske/Travel-Plan-Permission#902](https://github.com/stranske/Travel-Plan-Permission/issues/902)
- [stranske/Travel-Plan-Permission#893](https://github.com/stranske/Travel-Plan-Permission/issues/893)
- [stranske/Travel-Plan-Permission#894](https://github.com/stranske/Travel-Plan-Permission/issues/894)
- [stranske/Travel-Plan-Permission#895](https://github.com/stranske/Travel-Plan-Permission/issues/895)
- [stranske/Travel-Plan-Permission#896](https://github.com/stranske/Travel-Plan-Permission/issues/896)
- [stranske/Template#582](https://github.com/stranske/Template/issues/582)
- [stranske/Travel-Plan-Permission#892](https://github.com/stranske/Travel-Plan-Permission/issues/892)
- [stranske/Travel-Plan-Permission#886](https://github.com/stranske/Travel-Plan-Permission/issues/886)
- [stranske/Travel-Plan-Permission#885](https://github.com/stranske/Travel-Plan-Permission/issues/885)
- [stranske/Template#588](https://github.com/stranske/Template/issues/588)
- [stranske/Template#586](https://github.com/stranske/Template/issues/586)
- [stranske/Template#585](https://github.com/stranske/Template/issues/585)
- [stranske/Template#580](https://github.com/stranske/Template/issues/580)
- [stranske/Template#579](https://github.com/stranske/Template/issues/579)
- [stranske/Template#577](https://github.com/stranske/Template/issues/577)
- [stranske/Counter_Risk#430](https://github.com/stranske/Counter_Risk/issues/430)
- [stranske/Counter_Risk#429](https://github.com/stranske/Counter_Risk/issues/429)
- [stranske/Counter_Risk#426](https://github.com/stranske/Counter_Risk/issues/426)
- [stranske/Counter_Risk#425](https://github.com/stranske/Counter_Risk/issues/425)
- [stranske/Counter_Risk#413](https://github.com/stranske/Counter_Risk/issues/413)
- [stranske/Counter_Risk#412](https://github.com/stranske/Counter_Risk/issues/412)
- [stranske/Counter_Risk#409](https://github.com/stranske/Counter_Risk/issues/409)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Pension-Data#284](https://github.com/stranske/Pension-Data/issues/284)
- [stranske/Pension-Data#280](https://github.com/stranske/Pension-Data/issues/280)
- [stranske/Pension-Data#279](https://github.com/stranske/Pension-Data/issues/279)
- [stranske/Pension-Data#278](https://github.com/stranske/Pension-Data/issues/278)
- [stranske/Pension-Data#276](https://github.com/stranske/Pension-Data/issues/276)
- [stranske/Pension-Data#275](https://github.com/stranske/Pension-Data/issues/275)
- [stranske/Pension-Data#274](https://github.com/stranske/Pension-Data/issues/274)
- [stranske/Pension-Data#273](https://github.com/stranske/Pension-Data/issues/273)
- [stranske/Pension-Data#272](https://github.com/stranske/Pension-Data/issues/272)
- [stranske/Pension-Data#270](https://github.com/stranske/Pension-Data/issues/270)
- [stranske/Pension-Data#268](https://github.com/stranske/Pension-Data/issues/268)
- [stranske/Pension-Data#266](https://github.com/stranske/Pension-Data/issues/266)
- [stranske/Pension-Data#265](https://github.com/stranske/Pension-Data/issues/265)
- [stranske/Pension-Data#263](https://github.com/stranske/Pension-Data/issues/263)
- [stranske/Pension-Data#262](https://github.com/stranske/Pension-Data/issues/262)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#272](https://github.com/stranske/Inv-Man-Intake/issues/272)
- [stranske/Inv-Man-Intake#267](https://github.com/stranske/Inv-Man-Intake/issues/267)
- [stranske/Inv-Man-Intake#266](https://github.com/stranske/Inv-Man-Intake/issues/266)
- [stranske/Inv-Man-Intake#263](https://github.com/stranske/Inv-Man-Intake/issues/263)
- [stranske/Inv-Man-Intake#260](https://github.com/stranske/Inv-Man-Intake/issues/260)
- [stranske/Inv-Man-Intake#254](https://github.com/stranske/Inv-Man-Intake/issues/254)
- [stranske/Inv-Man-Intake#252](https://github.com/stranske/Inv-Man-Intake/issues/252)
- [stranske/Inv-Man-Intake#251](https://github.com/stranske/Inv-Man-Intake/issues/251)
- [stranske/Inv-Man-Intake#250](https://github.com/stranske/Inv-Man-Intake/issues/250)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [stranske/Inv-Man-Intake#245](https://github.com/stranske/Inv-Man-Intake/issues/245)
- [stranske/Inv-Man-Intake#244](https://github.com/stranske/Inv-Man-Intake/issues/244)
- [stranske/Inv-Man-Intake#243](https://github.com/stranske/Inv-Man-Intake/issues/243)
- [stranske/Inv-Man-Intake#242](https://github.com/stranske/Inv-Man-Intake/issues/242)
- [stranske/Ready#111](https://github.com/stranske/Ready/issues/111)
- [stranske/Ready#108](https://github.com/stranske/Ready/issues/108)
- [stranske/Ready#107](https://github.com/stranske/Ready/issues/107)
- [stranske/Ready#106](https://github.com/stranske/Ready/issues/106)
- [stranske/Ready#101](https://github.com/stranske/Ready/issues/101)
- [stranske/Ready#99](https://github.com/stranske/Ready/issues/99)
- [stranske/Ready#96](https://github.com/stranske/Ready/issues/96)
- [stranske/Ready#95](https://github.com/stranske/Ready/issues/95)
- [stranske/Ready#94](https://github.com/stranske/Ready/issues/94)
- [stranske/Ready#93](https://github.com/stranske/Ready/issues/93)
- [stranske/Ready#92](https://github.com/stranske/Ready/issues/92)
- [stranske/Ready#90](https://github.com/stranske/Ready/issues/90)
- [stranske/Ready#89](https://github.com/stranske/Ready/issues/89)
- [stranske/Ready#88](https://github.com/stranske/Ready/issues/88)
- [stranske/Ready#87](https://github.com/stranske/Ready/issues/87)
- [stranske/Ready#84](https://github.com/stranske/Ready/issues/84)
- [stranske/Ready#83](https://github.com/stranske/Ready/issues/83)
- [stranske/Ready#82](https://github.com/stranske/Ready/issues/82)
- [stranske/trip-planner#920](https://github.com/stranske/trip-planner/issues/920)
- [stranske/trip-planner#916](https://github.com/stranske/trip-planner/issues/916)
- [stranske/trip-planner#915](https://github.com/stranske/trip-planner/issues/915)
- [stranske/trip-planner#914](https://github.com/stranske/trip-planner/issues/914)
- [stranske/Manager-Database#866](https://github.com/stranske/Manager-Database/issues/866)
- [stranske/Manager-Database#864](https://github.com/stranske/Manager-Database/issues/864)
- [stranske/Manager-Database#862](https://github.com/stranske/Manager-Database/issues/862)
- [stranske/Manager-Database#861](https://github.com/stranske/Manager-Database/issues/861)
- [stranske/Manager-Database#854](https://github.com/stranske/Manager-Database/issues/854)
- [stranske/Manager-Database#848](https://github.com/stranske/Manager-Database/issues/848)
- [stranske/Manager-Database#847](https://github.com/stranske/Manager-Database/issues/847)
- [stranske/Manager-Database#845](https://github.com/stranske/Manager-Database/issues/845)
- [stranske/Manager-Database#844](https://github.com/stranske/Manager-Database/issues/844)
- [stranske/Manager-Database#843](https://github.com/stranske/Manager-Database/issues/843)
- [stranske/Manager-Database#842](https://github.com/stranske/Manager-Database/issues/842)
- [stranske/Manager-Database#841](https://github.com/stranske/Manager-Database/issues/841)
- [stranske/Manager-Database#840](https://github.com/stranske/Manager-Database/issues/840)
- [stranske/Manager-Database#839](https://github.com/stranske/Manager-Database/issues/839)
- [stranske/Manager-Database#838](https://github.com/stranske/Manager-Database/issues/838)
- [stranske/Manager-Database#837](https://github.com/stranske/Manager-Database/issues/837)
- [stranske/Portable-Alpha-Extension-Model#1644](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1644)
- [stranske/Portable-Alpha-Extension-Model#1643](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1643)
- [stranske/Portable-Alpha-Extension-Model#1640](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1640)
- [stranske/Portable-Alpha-Extension-Model#1639](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1639)
- [stranske/Portable-Alpha-Extension-Model#1632](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1632)
- [stranske/Portable-Alpha-Extension-Model#1630](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1630)
- [stranske/Portable-Alpha-Extension-Model#1628](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1628)
- [stranske/Portable-Alpha-Extension-Model#1625](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1625)
- [stranske/Portable-Alpha-Extension-Model#1624](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1624)
- [stranske/Portable-Alpha-Extension-Model#1622](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1622)
- [stranske/Portable-Alpha-Extension-Model#1620](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1620)
- [stranske/Portable-Alpha-Extension-Model#1619](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1619)
- [stranske/Portable-Alpha-Extension-Model#1618](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1618)
- [stranske/Portable-Alpha-Extension-Model#1617](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1617)
- [stranske/Portable-Alpha-Extension-Model#1616](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1616)
- [stranske/Portable-Alpha-Extension-Model#1615](https://github.com/stranske/Portable-Alpha-Extension-Model/issues/1615)
- [#900](https://github.com/stranske/Workflows/issues/900)
- [#902](https://github.com/stranske/Workflows/issues/902)
- [#1855](https://github.com/stranske/Workflows/issues/1855)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T01:43:26.407Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 298
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 296
- [ ] Items needing local Codex: 0
- [ ] Actionable local Codex items: 0
- [ ] Claimable local Codex items: 0
- [ ] Source-fixed candidates: 5
- [ ] Superseded sync candidates: 115
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 0
- [ ] Next claim lease expires: -

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

**Head SHA:** a882a3287cbe007ba47b2e92b7fa1e242985d0c3
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24948995911) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995946) |
| Agents Keepalive Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995945) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995597) |
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24948995810) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995593) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948996403) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24948995588) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24948995598) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Workflows/actions/runs/24948995878) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995888) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995839) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995828) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995823) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995821) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995825) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995819) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24948995849) |
<!-- auto-status-summary:end -->