### PR TITLE
Preserve weekly artifact identity during aggregation

### DIFF
--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -72,11 +72,12 @@ jobs:
           fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            mkdir -p "artifacts/$name"
+            artifact_dir="artifacts/$name/$id"
+            mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
             export ARTIFACT_ID="$id"
-            export ARTIFACT_DIR="artifacts/$name"
-            export ARTIFACT_ZIP="artifacts/$name/$id.zip"
+            export ARTIFACT_DIR="$artifact_dir"
+            export ARTIFACT_ZIP="$artifact_dir/$id.zip"
             if ! node - <<'NODE'
           const fs = require('fs');
           const { Octokit } = require('@octokit/rest');
@@ -116,7 +117,7 @@ jobs:
               echo "Warning: Could not download artifact $id ($name)"
               continue
             fi
-            unzip -o "artifacts/$name/$id.zip" -d "artifacts/$name" >/dev/null || \
+            unzip -o "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR" >/dev/null || \
               echo "Warning: Could not unzip artifact $id ($name)"
           done < "$artifact_list"
 

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -63,6 +63,13 @@ class ParseErrorDetail:
         }
 
 
+@dataclass(frozen=True)
+class MetricSource:
+    path: str
+    artifact: str
+    artifact_family: str
+
+
 def _parse_timestamp(value: Any) -> _dt.datetime | None:
     if value is None:
         return None
@@ -109,22 +116,52 @@ def _artifact_family(artifact: str) -> str:
     return "unknown"
 
 
+def _is_artifact_id_segment(value: str) -> bool:
+    return bool(value) and value.isdigit()
+
+
 def _infer_artifact_name(path: Path) -> str:
     parts = path.parts
     for index, part in enumerate(parts):
         if part == "agent-metrics" and index > 0:
-            return parts[index - 1]
+            candidate = parts[index - 1]
+            if _is_artifact_id_segment(candidate) and index > 1:
+                return parts[index - 2]
+            return candidate
+    parent = path.parent.name
+    if _is_artifact_id_segment(parent) and path.parent.parent.name:
+        return path.parent.parent.name
     if path.parent.name:
         return path.parent.name
     return "unknown"
 
 
-def _parse_error_detail(path: Path, line: int | None, reason: str) -> ParseErrorDetail:
+def _metric_source(path: Path) -> MetricSource:
     artifact = _infer_artifact_name(path)
-    return ParseErrorDetail(
+    return MetricSource(
         path=path.as_posix(),
         artifact=artifact,
         artifact_family=_artifact_family(artifact),
+    )
+
+
+def _attach_metric_source(entry: dict[str, Any], path: Path) -> dict[str, Any]:
+    source = _metric_source(path)
+    enriched = dict(entry)
+    enriched.setdefault("artifact_name", source.artifact)
+    enriched.setdefault("artifact_family", source.artifact_family)
+    enriched.setdefault("metric_artifact", source.artifact)
+    enriched.setdefault("metric_artifact_family", source.artifact_family)
+    enriched.setdefault("metric_path", source.path)
+    return enriched
+
+
+def _parse_error_detail(path: Path, line: int | None, reason: str) -> ParseErrorDetail:
+    source = _metric_source(path)
+    return ParseErrorDetail(
+        path=source.path,
+        artifact=source.artifact,
+        artifact_family=source.artifact_family,
         line=line,
         reason=reason,
     )
@@ -154,7 +191,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    file_entries.append(parsed)
+                    file_entries.append(_attach_metric_source(parsed, path))
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
         if file_errors and not file_entries and raw_lines:
@@ -164,12 +201,12 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                 pass
             else:
                 if isinstance(parsed_file, dict):
-                    file_entries.append(parsed_file)
+                    file_entries.append(_attach_metric_source(parsed_file, path))
                     file_errors = []
                 elif isinstance(parsed_file, list) and all(
                     isinstance(item, dict) for item in parsed_file
                 ):
-                    file_entries.extend(parsed_file)
+                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
                     file_errors = []
         entries.extend(file_entries)
         errors.extend(file_errors)
@@ -572,6 +609,23 @@ def _parse_error_contract(parse_error_details: list[ParseErrorDetail]) -> dict[s
     }
 
 
+def _metric_source_contract(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    family_counts = Counter(
+        str(entry.get("metric_artifact_family") or entry.get("artifact_family") or "unknown")
+        for entry in entries
+    )
+    artifact_counts = Counter(
+        str(entry.get("metric_artifact") or entry.get("artifact_name") or "unknown")
+        for entry in entries
+    )
+    file_counts = Counter(str(entry.get("metric_path") or "unknown") for entry in entries)
+    return {
+        "by_artifact_family": dict(sorted(family_counts.items())),
+        "by_artifact": dict(sorted(artifact_counts.items())),
+        "by_file": dict(sorted(file_counts.items())),
+    }
+
+
 def build_summary(
     entries: list[dict[str, Any]],
     errors: int,
@@ -728,6 +782,7 @@ def build_summary_contract(
         "generated_at": generated_at,
         "record_count": len(entries),
         "record_buckets": dict(sorted(buckets.items())),
+        "metric_sources": _metric_source_contract(entries),
         "parse_errors": _parse_error_contract(parse_error_details),
     }
     if timestamps:

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -83,11 +83,12 @@ jobs:
           fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            mkdir -p "artifacts/$name"
+            artifact_dir="artifacts/$name/$id"
+            mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
             export ARTIFACT_ID="$id"
-            export ARTIFACT_DIR="artifacts/$name"
-            export ARTIFACT_ZIP="artifacts/$name/$id.zip"
+            export ARTIFACT_DIR="$artifact_dir"
+            export ARTIFACT_ZIP="$artifact_dir/$id.zip"
             if ! node - <<'NODE'
           const fs = require('fs');
           const { Octokit } = require('@octokit/rest');
@@ -127,7 +128,7 @@ jobs:
               echo "Warning: Could not download artifact $id ($name)"
               continue
             fi
-            unzip -o "artifacts/$name/$id.zip" -d "artifacts/$name" >/dev/null || \
+            unzip -o "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR" >/dev/null || \
               echo "Warning: Could not unzip artifact $id ($name)"
           done < "$artifact_list"
 

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -63,6 +63,13 @@ class ParseErrorDetail:
         }
 
 
+@dataclass(frozen=True)
+class MetricSource:
+    path: str
+    artifact: str
+    artifact_family: str
+
+
 def _parse_timestamp(value: Any) -> _dt.datetime | None:
     if value is None:
         return None
@@ -109,22 +116,52 @@ def _artifact_family(artifact: str) -> str:
     return "unknown"
 
 
+def _is_artifact_id_segment(value: str) -> bool:
+    return bool(value) and value.isdigit()
+
+
 def _infer_artifact_name(path: Path) -> str:
     parts = path.parts
     for index, part in enumerate(parts):
         if part == "agent-metrics" and index > 0:
-            return parts[index - 1]
+            candidate = parts[index - 1]
+            if _is_artifact_id_segment(candidate) and index > 1:
+                return parts[index - 2]
+            return candidate
+    parent = path.parent.name
+    if _is_artifact_id_segment(parent) and path.parent.parent.name:
+        return path.parent.parent.name
     if path.parent.name:
         return path.parent.name
     return "unknown"
 
 
-def _parse_error_detail(path: Path, line: int | None, reason: str) -> ParseErrorDetail:
+def _metric_source(path: Path) -> MetricSource:
     artifact = _infer_artifact_name(path)
-    return ParseErrorDetail(
+    return MetricSource(
         path=path.as_posix(),
         artifact=artifact,
         artifact_family=_artifact_family(artifact),
+    )
+
+
+def _attach_metric_source(entry: dict[str, Any], path: Path) -> dict[str, Any]:
+    source = _metric_source(path)
+    enriched = dict(entry)
+    enriched.setdefault("artifact_name", source.artifact)
+    enriched.setdefault("artifact_family", source.artifact_family)
+    enriched.setdefault("metric_artifact", source.artifact)
+    enriched.setdefault("metric_artifact_family", source.artifact_family)
+    enriched.setdefault("metric_path", source.path)
+    return enriched
+
+
+def _parse_error_detail(path: Path, line: int | None, reason: str) -> ParseErrorDetail:
+    source = _metric_source(path)
+    return ParseErrorDetail(
+        path=source.path,
+        artifact=source.artifact,
+        artifact_family=source.artifact_family,
         line=line,
         reason=reason,
     )
@@ -154,7 +191,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    file_entries.append(parsed)
+                    file_entries.append(_attach_metric_source(parsed, path))
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
         if file_errors and not file_entries and raw_lines:
@@ -164,12 +201,12 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                 pass
             else:
                 if isinstance(parsed_file, dict):
-                    file_entries.append(parsed_file)
+                    file_entries.append(_attach_metric_source(parsed_file, path))
                     file_errors = []
                 elif isinstance(parsed_file, list) and all(
                     isinstance(item, dict) for item in parsed_file
                 ):
-                    file_entries.extend(parsed_file)
+                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
                     file_errors = []
         entries.extend(file_entries)
         errors.extend(file_errors)
@@ -572,6 +609,23 @@ def _parse_error_contract(parse_error_details: list[ParseErrorDetail]) -> dict[s
     }
 
 
+def _metric_source_contract(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    family_counts = Counter(
+        str(entry.get("metric_artifact_family") or entry.get("artifact_family") or "unknown")
+        for entry in entries
+    )
+    artifact_counts = Counter(
+        str(entry.get("metric_artifact") or entry.get("artifact_name") or "unknown")
+        for entry in entries
+    )
+    file_counts = Counter(str(entry.get("metric_path") or "unknown") for entry in entries)
+    return {
+        "by_artifact_family": dict(sorted(family_counts.items())),
+        "by_artifact": dict(sorted(artifact_counts.items())),
+        "by_file": dict(sorted(file_counts.items())),
+    }
+
+
 def build_summary(
     entries: list[dict[str, Any]],
     errors: int,
@@ -728,6 +782,7 @@ def build_summary_contract(
         "generated_at": generated_at,
         "record_count": len(entries),
         "record_buckets": dict(sorted(buckets.items())),
+        "metric_sources": _metric_source_contract(entries),
         "parse_errors": _parse_error_contract(parse_error_details),
     }
     if timestamps:

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -211,7 +211,9 @@ def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
 
     entries, errors = aggregate_agent_metrics._read_ndjson([path])
 
-    assert entries == [{"key": "value"}]
+    assert len(entries) == 1
+    assert entries[0]["key"] == "value"
+    assert entries[0]["metric_path"] == path.as_posix()
     assert len(errors) == 2
     assert [error.reason for error in errors] == ["invalid-json", "non-object-json"]
     assert errors[0].line == 2
@@ -228,7 +230,8 @@ def test_read_ndjson_streams_file_lines(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     entries, errors = aggregate_agent_metrics._read_ndjson([path])
 
-    assert entries == [{"key": "value"}]
+    assert len(entries) == 1
+    assert entries[0]["key"] == "value"
     assert errors == []
 
 
@@ -250,7 +253,12 @@ def test_read_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) 
 
     entries, errors = aggregate_agent_metrics._read_ndjson([path])
 
-    assert entries == [{"ok": True}]
+    assert len(entries) == 1
+    assert entries[0]["ok"] is True
+    assert entries[0]["artifact_name"] == "review-thread-terminal-disposition-123"
+    assert entries[0]["artifact_family"] == "review-thread-terminal-disposition"
+    assert entries[0]["metric_artifact"] == "review-thread-terminal-disposition-123"
+    assert entries[0]["metric_artifact_family"] == "review-thread-terminal-disposition"
     assert len(errors) == 1
     assert errors[0].artifact == "review-thread-terminal-disposition-123"
     assert errors[0].artifact_family == "review-thread-terminal-disposition"
@@ -266,7 +274,32 @@ def test_read_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) 
     assert contract["parse_errors"]["by_artifact_family"] == {
         "review-thread-terminal-disposition": 1
     }
+    assert contract["metric_sources"]["by_artifact_family"] == {
+        "review-thread-terminal-disposition": 1
+    }
     assert contract["parse_errors"]["details"][0]["reason"] == "invalid-json"
+
+
+def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Path) -> None:
+    metrics_dir = (
+        tmp_path
+        / "artifacts"
+        / "review-thread-terminal-disposition-123"
+        / "987654321"
+        / "agent-metrics"
+    )
+    metrics_dir.mkdir(parents=True)
+    path = metrics_dir / "terminal.ndjson"
+    path.write_text('{"schema":"workflows-terminal-disposition/v1"}\n', encoding="utf-8")
+
+    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+
+    assert errors == []
+    assert len(entries) == 1
+    assert entries[0]["artifact_name"] == "review-thread-terminal-disposition-123"
+    assert entries[0]["artifact_family"] == "review-thread-terminal-disposition"
+    assert entries[0]["metric_artifact"] == "review-thread-terminal-disposition-123"
+    assert entries[0]["metric_artifact_family"] == "review-thread-terminal-disposition"
 
 
 def test_read_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
@@ -289,13 +322,11 @@ def test_read_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
     entries, errors = aggregate_agent_metrics._read_ndjson([path])
 
     assert errors == []
-    assert entries == [
-        {
-            "schema": "workflows-keepalive-metrics/v1",
-            "pr_number": 1872,
-            "iteration_count": 0,
-        }
-    ]
+    assert len(entries) == 1
+    assert entries[0]["schema"] == "workflows-keepalive-metrics/v1"
+    assert entries[0]["pr_number"] == 1872
+    assert entries[0]["iteration_count"] == 0
+    assert entries[0]["artifact_name"] == "keepalive-metrics"
 
 
 def test_classify_entry_prefers_explicit_type() -> None:

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -280,6 +280,13 @@ def test_weekly_metrics_uploads_selector_report_on_failure():
             and "agent-weekly-metrics.json" in text
         ), "Weekly metrics must upload a machine-readable aggregate summary"
         assert (
+            'artifact_dir="artifacts/$name/$id"' in text
+        ), "Weekly metrics must isolate same-name artifact downloads by artifact ID"
+        assert (
+            'export ARTIFACT_ZIP="$artifact_dir/$id.zip"' in text
+            and 'unzip -o "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR"' in text
+        ), "Weekly metrics must unzip each artifact inside its unique extraction directory"
+        assert (
             "uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6" in text
         ), "Weekly metrics must pin the Node runtime setup action to the v6 commit SHA"
         assert (


### PR DESCRIPTION
## Summary
- download weekly metric artifacts into artifact-name/artifact-id directories to prevent same-name overwrites
- infer metric artifact/source metadata from both legacy and id-scoped extraction paths
- add metric_sources to the weekly aggregate JSON contract and cover the live/template workflows

## Verification
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_workflow_agents_consolidation.py -q
- python -m black --check --line-length 100 scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_workflow_agents_consolidation.py
- python -m ruff check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_workflow_agents_consolidation.py
- python scripts/validate_template_completeness.py --strict
- python scripts/validate_template_sync.py
- git diff --check
- local duplicate keepalive-metrics replay counted both artifact IDs in agent-weekly-metrics JSON

Generated by workflows-system-review-2 automation.