### PR TITLE
fix: address sync review feedback

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -215,6 +215,7 @@ scripts:
   # Scripts directory - CI helpers used by reusable-10-ci-python.yml
   - source: scripts/aggregate_agent_metrics.py
     description: "Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml"
+    template_sync: exact
 
   - source: scripts/coverage_history_append.py
     description: "Appends coverage data to history file - required by reusable CI workflow"

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload wrapper terminal disposition
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: review-thread-terminal-disposition-${{ github.run_id }}
           path: |

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -418,11 +418,12 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
             source_id = entry.get("source_id") or "unknown"
             terminal_sources[f"{source_type}:{source_id}"] += 1
         model = entry.get("codex_model") or entry.get("llm_model") or entry.get("model")
-        if model:
-            model_text = str(model)
-            verifier_models[model_text] += 1
-            if model_text.lower() in unsupported_models:
-                unsupported_verifier_models[model_text] += 1
+        model_text = str(model).strip() if model is not None else ""
+        if model_text:
+            normalized_model_text = model_text.lower()
+            verifier_models[normalized_model_text] += 1
+            if normalized_model_text in unsupported_models:
+                unsupported_verifier_models[normalized_model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal:

--- a/scripts/sync_templates.sh
+++ b/scripts/sync_templates.sh
@@ -2,8 +2,7 @@
 # Sync source scripts to template directory
 set -e
 
-SOURCE_DIR=".github/scripts"
-TEMPLATE_DIR="templates/consumer-repo/.github/scripts"
+TEMPLATE_ROOT="templates/consumer-repo"
 
 echo "🔄 Syncing scripts to template directory..."
 
@@ -28,7 +27,10 @@ scripts = []
 for entry in manifest.get("scripts", []) or []:
     source = entry.get("source", "")
     if source.startswith(".github/scripts/"):
-        scripts.append(source.replace(".github/scripts/", "", 1))
+        scripts.append(source)
+        continue
+    if entry.get("template_sync") == "exact":
+        scripts.append(source)
 
 print("\n".join(sorted(set(scripts))))
 PY
@@ -36,8 +38,8 @@ PY
 
 synced=0
 for file in $FILES; do
-    source_file="$SOURCE_DIR/$file"
-    template_file="$TEMPLATE_DIR/$file"
+    source_file="$file"
+    template_file="$TEMPLATE_ROOT/$file"
 
     # Create parent directory if it doesn't exist
     mkdir -p "$(dirname "$template_file")"

--- a/scripts/validate_template_sync.py
+++ b/scripts/validate_template_sync.py
@@ -30,10 +30,23 @@ def hash_directory(path: Path) -> str:
     return h.hexdigest()
 
 
+def _manifest_template_sync_sources(manifest: dict) -> list[str]:
+    sources: list[str] = []
+    for entry in manifest.get("scripts", []) or []:
+        source = entry.get("source", "")
+        if source.startswith(".github/scripts/"):
+            sources.append(source)
+            continue
+        if entry.get("template_sync") == "exact":
+            sources.append(source)
+    return sorted(set(sources))
+
+
 def main() -> int:
     repo_root = Path(__file__).parent.parent
+    template_root = repo_root / "templates" / "consumer-repo"
     source_dir = repo_root / ".github" / "scripts"
-    template_dir = repo_root / "templates" / "consumer-repo" / ".github" / "scripts"
+    template_dir = template_root / ".github" / "scripts"
 
     if not source_dir.exists():
         print(f"❌ Source directory not found: {source_dir}")
@@ -49,18 +62,13 @@ def main() -> int:
         return 1
 
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-    manifest_scripts = []
-    for entry in manifest.get("scripts", []) or []:
-        source = entry.get("source", "")
-        if source.startswith(".github/scripts/"):
-            manifest_scripts.append(source.replace(".github/scripts/", "", 1))
+    manifest_sources = _manifest_template_sync_sources(manifest)
 
     mismatches = []
-    source_files = [source_dir / rel_path for rel_path in manifest_scripts]
-
-    for source_file in source_files:
-        relative_path = source_file.relative_to(source_dir)
-        template_file = template_dir / relative_path
+    for source in manifest_sources:
+        source_file = repo_root / source
+        template_file = template_root / source
+        relative_path = Path(source)
 
         if not source_file.exists():
             mismatches.append(relative_path)
@@ -83,7 +91,7 @@ def main() -> int:
     if mismatches:
         print("❌ Template files out of sync with source files:\n")
         for path in mismatches:
-            template_file = template_dir / path
+            template_file = template_root / path
             if not template_file.exists():
                 print(f"  • {path} (MISSING - needs to be created)")
             else:

--- a/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
+++ b/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload wrapper terminal disposition
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: review-thread-terminal-disposition-${{ github.run_id }}
           path: |

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -418,11 +418,12 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
             source_id = entry.get("source_id") or "unknown"
             terminal_sources[f"{source_type}:{source_id}"] += 1
         model = entry.get("codex_model") or entry.get("llm_model") or entry.get("model")
-        if model:
-            model_text = str(model)
-            verifier_models[model_text] += 1
-            if model_text.lower() in unsupported_models:
-                unsupported_verifier_models[model_text] += 1
+        model_text = str(model).strip() if model is not None else ""
+        if model_text:
+            normalized_model_text = model_text.lower()
+            verifier_models[normalized_model_text] += 1
+            if normalized_model_text in unsupported_models:
+                unsupported_verifier_models[normalized_model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal:

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -448,20 +448,30 @@ def test_verifier_summary_counts_unsupported_models(
                 "run_id": "24948023778",
                 "pr_number": 1872,
                 "disposition": "verifier-error",
-                "llm_model": "gpt-5.2-codex",
+                "llm_model": "GPT-5.2-Codex",
+            },
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "run_id": "24948023778",
+                "pr_number": 1872,
+                "disposition": "verifier-error",
+                "llm_model": " gpt-5.2-codex ",
             },
             {
                 "schema": "workflows-terminal-disposition/v1",
                 "run_id": "24948023779",
                 "pr_number": 1873,
                 "disposition": "verified-pass",
-                "llm_model": "gpt-5.3-codex",
+                "llm_model": "GPT-5.3-Codex",
             },
         ]
     )
 
-    assert verifier["unsupported_verifier_models"]["gpt-5.2-codex"] == 1
-    assert verifier["unsupported_model_dispositions"]["verifier-error"] == 1
+    assert verifier["verifier_models"]["gpt-5.2-codex"] == 2
+    assert verifier["verifier_models"]["gpt-5.3-codex"] == 1
+    assert verifier["unsupported_verifier_models"]["gpt-5.2-codex"] == 2
+    assert verifier["unsupported_model_dispositions"]["verifier-error"] == 2
 
     summary = aggregate_agent_metrics.build_summary(
         [

--- a/tests/scripts/test_validate_template_sync.py
+++ b/tests/scripts/test_validate_template_sync.py
@@ -33,6 +33,12 @@ def write_manifest(tmp_path: Path, script_names: list[str]) -> None:
     (manifest_dir / "sync-manifest.yml").write_text(manifest, encoding="utf-8")
 
 
+def write_raw_manifest(tmp_path: Path, manifest: str) -> None:
+    manifest_dir = tmp_path / ".github"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "sync-manifest.yml").write_text(manifest, encoding="utf-8")
+
+
 def test_validator_passes_when_files_match(tmp_path):
     """Validator should exit 0 when source and template files match."""
     source, template = create_test_structure(tmp_path)
@@ -188,3 +194,38 @@ def test_validator_ignores_non_js_files(tmp_path):
     # Should pass because only .js files are checked
     assert result.returncode == 0
     assert "✅ All template files in sync" in result.stdout
+
+
+def test_validator_checks_exact_template_sync_script_entries(tmp_path):
+    """Validator should check non-.github scripts marked for exact template sync."""
+    create_test_structure(tmp_path)
+    source = tmp_path / "scripts"
+    template = tmp_path / "templates" / "consumer-repo" / "scripts"
+    source.mkdir(parents=True, exist_ok=True)
+    template.mkdir(parents=True, exist_ok=True)
+
+    (source / "aggregate_agent_metrics.py").write_text("SOURCE = True\n", encoding="utf-8")
+    (template / "aggregate_agent_metrics.py").write_text("SOURCE = False\n", encoding="utf-8")
+    write_raw_manifest(
+        tmp_path,
+        "\n".join(
+            [
+                "version: 1",
+                "scripts:",
+                "  - source: scripts/aggregate_agent_metrics.py",
+                "    description: test",
+                "    template_sync: exact",
+                "",
+            ]
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_template_sync.py"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "scripts/aggregate_agent_metrics.py" in result.stdout

--- a/tests/workflows/test_bot_comment_handler.py
+++ b/tests/workflows/test_bot_comment_handler.py
@@ -288,7 +288,9 @@ def test_bot_comment_handler_wrappers_emit_terminal_disposition_artifact() -> No
         assert "review-thread-terminal-disposition" in write_step["run"]
         assert "wrapper-skipped" in write_step["run"]
         assert upload_step.get("if") == "always()"
-        assert upload_step.get("uses") == "actions/upload-artifact@v7"
+        assert upload_step.get("uses") == (
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+        )
         assert (
             upload_step["with"]["name"] == "review-thread-terminal-disposition-${{ github.run_id }}"
         )


### PR DESCRIPTION
## Summary
- Pin the bot-comment handler wrapper terminal-disposition artifact upload to the current actions/upload-artifact v7 commit in both source and consumer template workflows.
- Normalize verifier model counter keys by trimming and lowercasing model names before counting unsupported verifier usage.
- Add regression coverage for mixed-case verifier model records and the pinned workflow action.

## Validation
- pytest tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_bot_comment_handler.py tests/scripts/test_validate_template_sync.py -q
- python scripts/validate_template_sync.py
- git diff --check

Addresses consumer sync review feedback from stranske/Inv-Man-Intake#285.