### PR TITLE
fix: align weekly metrics review contracts

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -297,6 +297,7 @@ test('warns when Codex verifier terminal records omit model metadata', () => {
       pr_number: 1872,
       run_id: '24948023778',
       disposition: 'verifier-error',
+      verifier_mode: 'compare',
     },
     {
       schema: 'workflows-terminal-disposition/v1',
@@ -322,6 +323,26 @@ test('warns when Codex verifier terminal records omit model metadata', () => {
   assert.doesNotMatch(markdown, /\| pull-request:1873 \| verified-pass \| evaluate/);
 });
 
+test('does not require verifier model metadata when verifier mode is unknown', () => {
+  const report = summarizeTerminalDispositionCoverage([
+    {
+      schema: 'workflows-terminal-disposition/v1',
+      artifact_family: 'verifier-terminal-disposition',
+      source_type: 'pull-request',
+      source_id: '1874',
+      pr_number: 1874,
+      run_id: '24948023779',
+      disposition: 'verifier-error',
+      verifier_mode: '',
+    },
+  ]);
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.verifier_model_compatibility.status, 'pass');
+  assert.equal(report.verifier_model_compatibility.missing_model_record_count, 0);
+  assert.deepEqual(report.enforcement.blockers, []);
+});
+
 test('suppresses pre-contract verifier terminal records missing model metadata', () => {
   const report = summarizeTerminalDispositionCoverage(
     [
@@ -333,6 +354,7 @@ test('suppresses pre-contract verifier terminal records missing model metadata',
         pr_number: 1872,
         run_id: '24948023778',
         disposition: 'verifier-error',
+        verifier_mode: 'compare',
       },
     ],
     {
@@ -373,6 +395,7 @@ test('still warns for post-contract verifier terminal records missing model meta
         pr_number: 1877,
         run_id: '24950000000',
         disposition: 'verifier-error',
+        verifier_mode: 'compare',
       },
     ],
     {

--- a/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
@@ -51,7 +51,7 @@ test('builds initial download manifest from selected artifacts', () => {
     download_failed_count: 0,
     unzip_pass_count: 0,
     unzip_failed_count: 0,
-    unzip_skipped_count: 2,
+    unzip_skipped_count: 0,
   });
   assert.equal(manifest.artifacts[0].artifact_dir, 'artifacts/keepalive-metrics/42');
   assert.equal(manifest.artifacts[0].zip_path, 'artifacts/keepalive-metrics/42/42.zip');

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -172,7 +172,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = verifierMode !== 'evaluate';
+    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel) {

--- a/.github/scripts/weekly_metrics_download_manifest.js
+++ b/.github/scripts/weekly_metrics_download_manifest.js
@@ -59,7 +59,7 @@ function buildInitialManifest(selection = {}, options = {}) {
       download_failed_count: 0,
       unzip_pass_count: 0,
       unzip_failed_count: 0,
-      unzip_skipped_count: selected.length,
+      unzip_skipped_count: 0,
     },
     artifacts: selected.map((artifact, index) => ({
       id: artifact.id,

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -439,9 +439,9 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         )
         if model_selection_reason:
             model_selection_reasons[str(model_selection_reason)] += 1
-        verifier_mode = entry.get("verifier_mode")
+        verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
         if verifier_mode:
-            verifier_modes[str(verifier_mode)] += 1
+            verifier_modes[verifier_mode] += 1
         pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
         if pr_number is not None:
             prs.add(pr_number)

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -172,7 +172,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = verifierMode !== 'evaluate';
+    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel) {

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
@@ -59,7 +59,7 @@ function buildInitialManifest(selection = {}, options = {}) {
       download_failed_count: 0,
       unzip_pass_count: 0,
       unzip_failed_count: 0,
-      unzip_skipped_count: selected.length,
+      unzip_skipped_count: 0,
     },
     artifacts: selected.map((artifact, index) => ({
       id: artifact.id,

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -439,9 +439,9 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         )
         if model_selection_reason:
             model_selection_reasons[str(model_selection_reason)] += 1
-        verifier_mode = entry.get("verifier_mode")
+        verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
         if verifier_mode:
-            verifier_modes[str(verifier_mode)] += 1
+            verifier_modes[verifier_mode] += 1
         pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
         if pr_number is not None:
             prs.add(pr_number)

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -417,12 +417,20 @@ def test_summary_helpers_cover_branches() -> None:
                 "disposition": "follow-up-created",
                 "llm_model": "gpt-5.3-codex",
                 "model_selection_reason": "fallback-unsupported-chatgpt-codex-model",
+                "verifier_mode": " Checkbox ",
+            },
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "run_id": "124",
+                "pr_number": 304,
+                "disposition": "verified-pass",
+                "llm_model": "gpt-5.4",
                 "verifier_mode": "checkbox",
             },
         ]
     )
     assert verifier_with_terminal["runs"] == 1
-    assert verifier_with_terminal["terminal_records"] == 1
+    assert verifier_with_terminal["terminal_records"] == 2
     assert verifier_with_terminal["verifier_models"]["gpt-5.3-codex"] == 1
     assert verifier_with_terminal["unsupported_verifier_models"] == Counter()
     assert verifier_with_terminal["missing_verifier_model_metadata"] == Counter()
@@ -432,7 +440,7 @@ def test_summary_helpers_cover_branches() -> None:
         ]
         == 1
     )
-    assert verifier_with_terminal["verifier_modes"]["checkbox"] == 1
+    assert verifier_with_terminal["verifier_modes"]["checkbox"] == 2
 
 
 def test_verifier_summary_counts_unsupported_models(


### PR DESCRIPTION
## Summary
- Align weekly metrics download manifest initial unzip skipped stats with pending artifact unzip statuses.
- Normalize verifier mode aggregation keys before counting weekly metrics.
- Treat empty verifier mode as unknown in terminal disposition compatibility checks instead of requiring model metadata.
- Sync updated scripts into the consumer template so downstream sync PRs pick up the fix.

## Validation
- node --test .github/scripts/__tests__/weekly-metrics-download-manifest.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js
- pytest -q tests/scripts/test_aggregate_agent_metrics.py
- python scripts/validate_template_sync.py

Unblocks Copilot review threads on stranske/Travel-Plan-Permission#920.