### PR TITLE
Harden sync campaign metric contracts

### DIFF
--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -214,6 +214,21 @@ test('reports missing and parse-error inputs as repairable monitor warnings', ()
   assert.equal(summary.monitors[1].status, 'parse-error');
 });
 
+test('treats unknown monitor status as a warning', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
+  const terminal = writeJson(dir, 'terminal.json', report('mystery'));
+  const botAuth = writeJson(dir, 'bot-auth.json', report('pass'));
+
+  const summary = buildCoverageMonitorSummary({
+    terminal_report: terminal,
+    bot_auth_report: botAuth,
+  });
+
+  assert.equal(summary.status, 'warning');
+  assert.equal(summary.monitors[0].status, 'unknown');
+  assert.equal(summary.next_action, 'inspect-monitor-warnings');
+});
+
 test('parses CLI paths and writes summary artifacts without failing warning states', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-cli-'));
   const terminal = writeJson(dir, 'terminal.json', report('warning'));

--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -323,7 +323,7 @@ test('warns when Codex verifier terminal records omit model metadata', () => {
   assert.doesNotMatch(markdown, /\| pull-request:1873 \| verified-pass \| evaluate/);
 });
 
-test('does not require verifier model metadata when verifier mode is unknown', () => {
+test('warns when verifier terminal model metadata is missing with unknown mode', () => {
   const report = summarizeTerminalDispositionCoverage([
     {
       schema: 'workflows-terminal-disposition/v1',
@@ -337,10 +337,11 @@ test('does not require verifier model metadata when verifier mode is unknown', (
     },
   ]);
 
-  assert.equal(report.status, 'pass');
-  assert.equal(report.verifier_model_compatibility.status, 'pass');
-  assert.equal(report.verifier_model_compatibility.missing_model_record_count, 0);
-  assert.deepEqual(report.enforcement.blockers, []);
+  assert.equal(report.status, 'warning');
+  assert.equal(report.verifier_model_compatibility.status, 'warning');
+  assert.equal(report.verifier_model_compatibility.missing_model_record_count, 1);
+  assert.equal(report.verifier_model_compatibility.missing_model_records[0].verifier_mode, 'unknown');
+  assert.deepEqual(report.enforcement.blockers, ['unsupported-verifier-model']);
 });
 
 test('suppresses pre-contract verifier terminal records missing model metadata', () => {

--- a/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
@@ -112,6 +112,19 @@ test('finalizes pass when every selected artifact downloads and extracts', () =>
   assert.equal(manifest.stats.unzip_pass_count, 2);
 });
 
+test('does not fall back to name when artifact id mismatches', () => {
+  const manifest = buildInitialManifest(selection);
+
+  assert.throws(
+    () => updateArtifactResult(manifest, {
+      id: 'missing-id',
+      name: 'keepalive-metrics',
+      download_status: 'pass',
+    }),
+    /Artifact is not present in manifest: missing-id/
+  );
+});
+
 test('formats human-visible markdown without replacing the JSON contract', () => {
   const manifest = buildInitialManifest(selection);
   updateArtifactResult(manifest, {

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -119,7 +119,7 @@ function summarizeReport(readResult) {
 
 function overallStatus(monitors) {
   if (monitors.some((monitor) => monitor.should_fail || monitor.status === 'fail')) return 'fail';
-  if (monitors.some((monitor) => ['missing', 'parse-error', 'warning'].includes(monitor.status))) {
+  if (monitors.some((monitor) => ['missing', 'parse-error', 'warning', 'unknown'].includes(monitor.status))) {
     return 'warning';
   }
   if (monitors.length > 0 && monitors.every((monitor) => monitor.status === 'no-data')) return 'no-data';

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -172,7 +172,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
+    const requiresCodexModel = verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel) {

--- a/.github/scripts/weekly_metrics_download_manifest.js
+++ b/.github/scripts/weekly_metrics_download_manifest.js
@@ -87,8 +87,10 @@ function buildInitialManifest(selection = {}, options = {}) {
 function findArtifact(manifest, id, name) {
   const cleanId = cleanString(id);
   const cleanName = cleanString(name);
+  if (cleanId) {
+    return (manifest.artifacts || []).find((artifact) => cleanString(artifact.id) === cleanId);
+  }
   return (manifest.artifacts || []).find((artifact) => {
-    if (cleanId && cleanString(artifact.id) === cleanId) return true;
     return cleanName && cleanString(artifact.name) === cleanName;
   });
 }

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -254,6 +254,7 @@ jobs:
                 const errorMessage = error.message || error;
                 console.log(`Failed to fetch PR #${prNumber} details; skipping.`);
                 console.log(`Error: ${errorMessage}`);
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'pr-fetch-failed');
                 core.setOutput('should_run', 'false');
                 return;
@@ -262,6 +263,7 @@ jobs:
               const hasAgentLabel = pr.labels.some(l => /^agent:/.test(l.name));
               if (!hasAgentLabel) {
                 console.log(`PR #${prNumber} has no agent label, skipping`);
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'missing-agent-label');
                 core.setOutput('should_run', 'false');
                 return;
@@ -271,6 +273,7 @@ jobs:
               const hasAutoPilot = pr.labels.some(l => l.name === 'agents:auto-pilot');
               if (hasAutoPilot) {
                 console.log(`PR #${prNumber} is auto-pilot managed, skipping bot-comment handler`);
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'auto-pilot-managed');
                 core.setOutput('should_run', 'false');
                 return;

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -172,6 +172,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
+        source = _metric_source(path)
         try:
             handle = path.open("r", encoding="utf-8")
         except OSError:
@@ -179,25 +180,33 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
             continue
         file_entries: list[dict[str, Any]] = []
         file_errors: list[ParseErrorDetail] = []
-        raw_lines: list[str] = []
+        raw_lines_for_fallback: list[str] = []
         with handle:
             for line_number, line in enumerate(handle, start=1):
                 raw = line.strip()
                 if not raw:
                     continue
-                raw_lines.append(raw)
+                if not file_entries:
+                    raw_lines_for_fallback.append(raw)
                 try:
                     parsed = json.loads(raw)
                 except json.JSONDecodeError:
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    file_entries.append(_attach_metric_source(parsed, path))
+                    enriched = dict(parsed)
+                    enriched.setdefault("artifact_name", source.artifact)
+                    enriched.setdefault("artifact_family", source.artifact_family)
+                    enriched.setdefault("metric_artifact", source.artifact)
+                    enriched.setdefault("metric_artifact_family", source.artifact_family)
+                    enriched.setdefault("metric_path", source.path)
+                    file_entries.append(enriched)
+                    raw_lines_for_fallback = []
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
-        if file_errors and not file_entries and raw_lines:
+        if file_errors and not file_entries and raw_lines_for_fallback:
             try:
-                parsed_file = json.loads("\n".join(raw_lines))
+                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
             except json.JSONDecodeError:
                 pass
             else:
@@ -563,6 +572,12 @@ def _format_counter(counter: Counter[str]) -> str:
     return ", ".join(parts)
 
 
+def _markdown_table_cell(value: Any) -> str:
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(part.strip() for part in text.split("\n"))
+    return text.replace("|", "\\|")
+
+
 def _format_rate(numerator: int, denominator: int) -> str:
     if denominator <= 0:
         return "n/a"
@@ -588,8 +603,11 @@ def _format_parse_error_details(parse_error_details: list[ParseErrorDetail]) -> 
         line = str(detail.line) if detail.line is not None else "n/a"
         lines.append(
             "| "
-            f"{detail.artifact_family} | {detail.artifact} | {detail.path} | {line} | "
-            f"{detail.reason} |"
+            f"{_markdown_table_cell(detail.artifact_family)} | "
+            f"{_markdown_table_cell(detail.artifact)} | "
+            f"{_markdown_table_cell(detail.path)} | "
+            f"{_markdown_table_cell(line)} | "
+            f"{_markdown_table_cell(detail.reason)} |"
         )
     remaining = len(parse_error_details) - _MAX_PARSE_ERROR_ROWS
     if remaining > 0:
@@ -602,12 +620,16 @@ def _parse_error_contract(parse_error_details: list[ParseErrorDetail]) -> dict[s
     family_counts = Counter(detail.artifact_family for detail in parse_error_details)
     artifact_counts = Counter(detail.artifact for detail in parse_error_details)
     reason_counts = Counter(detail.reason for detail in parse_error_details)
+    details = [detail.as_dict() for detail in parse_error_details[:_MAX_PARSE_ERROR_ROWS]]
+    omitted_count = max(0, len(parse_error_details) - len(details))
     return {
         "count": len(parse_error_details),
         "by_artifact_family": dict(sorted(family_counts.items())),
         "by_artifact": dict(sorted(artifact_counts.items())),
         "by_reason": dict(sorted(reason_counts.items())),
-        "details": [detail.as_dict() for detail in parse_error_details],
+        "details": details,
+        "details_truncated": omitted_count > 0,
+        "omitted_count": omitted_count,
     }
 
 

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -119,7 +119,7 @@ function summarizeReport(readResult) {
 
 function overallStatus(monitors) {
   if (monitors.some((monitor) => monitor.should_fail || monitor.status === 'fail')) return 'fail';
-  if (monitors.some((monitor) => ['missing', 'parse-error', 'warning'].includes(monitor.status))) {
+  if (monitors.some((monitor) => ['missing', 'parse-error', 'warning', 'unknown'].includes(monitor.status))) {
     return 'warning';
   }
   if (monitors.length > 0 && monitors.every((monitor) => monitor.status === 'no-data')) return 'no-data';

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -172,7 +172,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
+    const requiresCodexModel = verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel) {

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
@@ -87,8 +87,10 @@ function buildInitialManifest(selection = {}, options = {}) {
 function findArtifact(manifest, id, name) {
   const cleanId = cleanString(id);
   const cleanName = cleanString(name);
+  if (cleanId) {
+    return (manifest.artifacts || []).find((artifact) => cleanString(artifact.id) === cleanId);
+  }
   return (manifest.artifacts || []).find((artifact) => {
-    if (cleanId && cleanString(artifact.id) === cleanId) return true;
     return cleanName && cleanString(artifact.name) === cleanName;
   });
 }

--- a/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
+++ b/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
@@ -172,6 +172,7 @@ jobs:
                   `Failed to fetch PR #${prNumber} details, skipping. ` +
                     `Error: ${error.message || error}`
                 );
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'pr-fetch-failed');
                 core.setOutput('should_run', 'false');
                 return;
@@ -180,6 +181,7 @@ jobs:
               const hasAgentLabel = pr.labels.some(l => /^agent:/.test(l.name));
               if (!hasAgentLabel) {
                 console.log(`PR #${prNumber} has no agent label, skipping`);
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'missing-agent-label');
                 core.setOutput('should_run', 'false');
                 return;
@@ -189,6 +191,7 @@ jobs:
               const hasAutoPilot = pr.labels.some(l => l.name === 'agents:auto-pilot');
               if (hasAutoPilot) {
                 console.log(`PR #${prNumber} is auto-pilot managed, skipping bot-comment handler`);
+                core.setOutput('pr_number', prNumber || '');
                 core.setOutput('skip_reason', 'auto-pilot-managed');
                 core.setOutput('should_run', 'false');
                 return;

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -172,6 +172,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
+        source = _metric_source(path)
         try:
             handle = path.open("r", encoding="utf-8")
         except OSError:
@@ -179,25 +180,33 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
             continue
         file_entries: list[dict[str, Any]] = []
         file_errors: list[ParseErrorDetail] = []
-        raw_lines: list[str] = []
+        raw_lines_for_fallback: list[str] = []
         with handle:
             for line_number, line in enumerate(handle, start=1):
                 raw = line.strip()
                 if not raw:
                     continue
-                raw_lines.append(raw)
+                if not file_entries:
+                    raw_lines_for_fallback.append(raw)
                 try:
                     parsed = json.loads(raw)
                 except json.JSONDecodeError:
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    file_entries.append(_attach_metric_source(parsed, path))
+                    enriched = dict(parsed)
+                    enriched.setdefault("artifact_name", source.artifact)
+                    enriched.setdefault("artifact_family", source.artifact_family)
+                    enriched.setdefault("metric_artifact", source.artifact)
+                    enriched.setdefault("metric_artifact_family", source.artifact_family)
+                    enriched.setdefault("metric_path", source.path)
+                    file_entries.append(enriched)
+                    raw_lines_for_fallback = []
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
-        if file_errors and not file_entries and raw_lines:
+        if file_errors and not file_entries and raw_lines_for_fallback:
             try:
-                parsed_file = json.loads("\n".join(raw_lines))
+                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
             except json.JSONDecodeError:
                 pass
             else:
@@ -563,6 +572,12 @@ def _format_counter(counter: Counter[str]) -> str:
     return ", ".join(parts)
 
 
+def _markdown_table_cell(value: Any) -> str:
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    text = " ".join(part.strip() for part in text.split("\n"))
+    return text.replace("|", "\\|")
+
+
 def _format_rate(numerator: int, denominator: int) -> str:
     if denominator <= 0:
         return "n/a"
@@ -588,8 +603,11 @@ def _format_parse_error_details(parse_error_details: list[ParseErrorDetail]) -> 
         line = str(detail.line) if detail.line is not None else "n/a"
         lines.append(
             "| "
-            f"{detail.artifact_family} | {detail.artifact} | {detail.path} | {line} | "
-            f"{detail.reason} |"
+            f"{_markdown_table_cell(detail.artifact_family)} | "
+            f"{_markdown_table_cell(detail.artifact)} | "
+            f"{_markdown_table_cell(detail.path)} | "
+            f"{_markdown_table_cell(line)} | "
+            f"{_markdown_table_cell(detail.reason)} |"
         )
     remaining = len(parse_error_details) - _MAX_PARSE_ERROR_ROWS
     if remaining > 0:
@@ -602,12 +620,16 @@ def _parse_error_contract(parse_error_details: list[ParseErrorDetail]) -> dict[s
     family_counts = Counter(detail.artifact_family for detail in parse_error_details)
     artifact_counts = Counter(detail.artifact for detail in parse_error_details)
     reason_counts = Counter(detail.reason for detail in parse_error_details)
+    details = [detail.as_dict() for detail in parse_error_details[:_MAX_PARSE_ERROR_ROWS]]
+    omitted_count = max(0, len(parse_error_details) - len(details))
     return {
         "count": len(parse_error_details),
         "by_artifact_family": dict(sorted(family_counts.items())),
         "by_artifact": dict(sorted(artifact_counts.items())),
         "by_reason": dict(sorted(reason_counts.items())),
-        "details": [detail.as_dict() for detail in parse_error_details],
+        "details": details,
+        "details_truncated": omitted_count > 0,
+        "omitted_count": omitted_count,
     }
 
 

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -219,6 +219,29 @@ def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
     assert errors[0].line == 2
 
 
+def test_read_ndjson_does_not_buffer_valid_ndjson_for_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "metrics.ndjson"
+    path.write_text('{"key": "value"}\n{"other": true}\n', encoding="utf-8")
+
+    calls = 0
+    original_loads = aggregate_agent_metrics.json.loads
+
+    def counting_loads(raw: str) -> object:
+        nonlocal calls
+        calls += 1
+        return original_loads(raw)
+
+    monkeypatch.setattr(aggregate_agent_metrics.json, "loads", counting_loads)
+
+    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+
+    assert len(entries) == 2
+    assert errors == []
+    assert calls == 2
+
+
 def test_read_ndjson_streams_file_lines(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     path = tmp_path / "metrics.ndjson"
     path.write_text('{"key": "value"}\n', encoding="utf-8")
@@ -278,6 +301,47 @@ def test_read_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) 
         "review-thread-terminal-disposition": 1
     }
     assert contract["parse_errors"]["details"][0]["reason"] == "invalid-json"
+    assert contract["parse_errors"]["details_truncated"] is False
+    assert contract["parse_errors"]["omitted_count"] == 0
+
+
+def test_parse_error_details_escape_markdown_table_cells() -> None:
+    details = [
+        aggregate_agent_metrics.ParseErrorDetail(
+            path="artifact|path\nmetrics.ndjson",
+            artifact="artifact|name",
+            artifact_family="family\nname",
+            line=1,
+            reason="invalid|json\npayload",
+        )
+    ]
+
+    lines = aggregate_agent_metrics._format_parse_error_details(details)
+
+    assert (
+        "| family name | artifact\\|name | artifact\\|path metrics.ndjson | 1 | invalid\\|json payload |"
+        in lines
+    )
+
+
+def test_parse_error_contract_truncates_details() -> None:
+    details = [
+        aggregate_agent_metrics.ParseErrorDetail(
+            path=f"metrics-{index}.ndjson",
+            artifact="artifact",
+            artifact_family="artifact",
+            line=index,
+            reason="invalid-json",
+        )
+        for index in range(aggregate_agent_metrics._MAX_PARSE_ERROR_ROWS + 2)
+    ]
+
+    contract = aggregate_agent_metrics._parse_error_contract(details)
+
+    assert contract["count"] == aggregate_agent_metrics._MAX_PARSE_ERROR_ROWS + 2
+    assert len(contract["details"]) == aggregate_agent_metrics._MAX_PARSE_ERROR_ROWS
+    assert contract["details_truncated"] is True
+    assert contract["omitted_count"] == 2
 
 
 def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Path) -> None:

--- a/tests/workflows/test_bot_comment_handler.py
+++ b/tests/workflows/test_bot_comment_handler.py
@@ -118,6 +118,28 @@ def test_reusable_bot_comment_handler_prefers_app_client_id() -> None:
     )
 
 
+def test_bot_comment_handler_preserves_pr_number_on_known_pr_skips() -> None:
+    for workflow_path in (
+        ROOT / ".github/workflows/agents-bot-comment-handler.yml",
+        ROOT / "templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml",
+    ):
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        for skip_reason in (
+            "pr-fetch-failed",
+            "missing-agent-label",
+            "auto-pilot-managed",
+        ):
+            skip_index = workflow_text.index(f"core.setOutput('skip_reason', '{skip_reason}')")
+            pr_output_index = workflow_text.rfind(
+                "core.setOutput('pr_number', prNumber || '');",
+                0,
+                skip_index,
+            )
+            assert (
+                pr_output_index != -1
+            ), f"{workflow_path} must preserve pr_number for {skip_reason}"
+
+
 def test_reusable_bot_comment_handler_uploads_auth_coverage_artifact() -> None:
     workflow = _load_yaml(ROOT / ".github/workflows/reusable-bot-comment-handler.yml")
     collect_steps = workflow["jobs"]["collect"]["steps"]


### PR DESCRIPTION
## Summary
- Bound aggregate parse-error detail contracts, escape parse-error markdown table cells, and avoid buffering valid NDJSON for fallback parsing.
- Treat verifier terminal records with unknown mode as post-contract missing model metadata warnings unless they are pre-contract records.
- Tighten weekly artifact manifest updates to require ID matches when an ID is supplied, classify unknown monitor statuses as warnings, and preserve resolved PR numbers on known bot-comment-handler skip paths.
- Mirror source changes into the consumer template copies.

## Campaign context
- Campaign queue: https://github.com/stranske/Workflows/issues/1836
- Refresh run: https://github.com/stranske/Workflows/actions/runs/24953940908
- This PR intentionally does not close the active campaign issue.

## Validation
- node --test .github/scripts/__tests__/weekly-metrics-download-manifest.test.js .github/scripts/__tests__/coverage-monitor-summary.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js
- pytest -q tests/scripts/test_aggregate_agent_metrics.py tests/scripts/test_validate_template_sync.py tests/workflows/test_bot_comment_handler.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py --strict
- git diff --check
- python -m black --check --line-length 100 tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_bot_comment_handler.py
- python -m ruff check tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_bot_comment_handler.py