### PR TITLE
fix: harden weekly metrics artifact handling

### DIFF
--- a/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
@@ -6,6 +6,7 @@ const {
   buildInitialManifest,
   finalizeManifest,
   formatMarkdown,
+  safeArtifactPathComponent,
   updateArtifactResult,
 } = require('../weekly_metrics_download_manifest.js');
 
@@ -57,6 +58,30 @@ test('builds initial download manifest from selected artifacts', () => {
   assert.equal(manifest.artifacts[0].zip_path, 'artifacts/keepalive-metrics/42/42.zip');
   assert.equal(manifest.artifacts[0].download.status, 'pending');
   assert.equal(manifest.artifacts[0].unzip.status, 'pending');
+});
+
+test('sanitizes artifact filesystem paths while preserving original names', () => {
+  const manifest = buildInitialManifest({
+    ...selection,
+    selected_artifacts: [
+      {
+        id: '../44|45',
+        name: '../../keepalive\\metrics/latest',
+        family: 'keepalive-metrics',
+      },
+    ],
+  });
+
+  assert.equal(manifest.artifacts[0].name, '../../keepalive\\metrics/latest');
+  assert.equal(manifest.artifacts[0].id, '../44|45');
+  assert.equal(manifest.artifacts[0].artifact_dir, 'artifacts/keepalive_metrics_latest/44_45');
+  assert.equal(manifest.artifacts[0].zip_path, 'artifacts/keepalive_metrics_latest/44_45/44_45.zip');
+});
+
+test('normalizes unsafe artifact path components', () => {
+  assert.equal(safeArtifactPathComponent('../../bad\\name'), 'bad_name');
+  assert.equal(safeArtifactPathComponent('..'), 'unknown');
+  assert.equal(safeArtifactPathComponent('', 'fallback'), 'fallback');
 });
 
 test('records download and unzip outcomes and finalizes warning status', () => {
@@ -156,7 +181,7 @@ test('escapes markdown table cells in human-visible manifest', () => {
   });
   updateArtifactResult(manifest, {
     id: '44|45',
-    artifact_dir: 'artifacts/keepalive|metrics\nlatest/44|45',
+    artifact_dir: 'artifacts/keepalive_metrics_latest/44_45',
     download_status: 'failed',
     download_error: 'bad|download\nreason',
     unzip_status: 'skipped',
@@ -169,5 +194,5 @@ test('escapes markdown table cells in human-visible manifest', () => {
   assert.match(markdown, /keepalive\\\|metrics latest/);
   assert.match(markdown, /44\\\|45/);
   assert.match(markdown, /bad\\\|download reason/);
-  assert.match(markdown, /artifacts\/keepalive\\\|metrics latest\/44\\\|45/);
+  assert.match(markdown, /artifacts\/keepalive_metrics_latest\/44_45/);
 });

--- a/.github/scripts/weekly_metrics_download_manifest.js
+++ b/.github/scripts/weekly_metrics_download_manifest.js
@@ -30,12 +30,24 @@ function selectedArtifactsFromSelection(selection = {}) {
   return Array.isArray(selection.selected_artifacts) ? selection.selected_artifacts : [];
 }
 
+function safeArtifactPathComponent(value, fallback = 'unknown') {
+  const safe = cleanString(value)
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/\.\.+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!safe || safe === '.' || safe === '..') return fallback;
+  return safe;
+}
+
 function defaultArtifactDir(root, artifact) {
-  return path.posix.join(root, cleanString(artifact.name) || 'unknown', String(artifact.id || ''));
+  const artifactName = safeArtifactPathComponent(artifact.name, 'unknown');
+  const artifactId = safeArtifactPathComponent(artifact.id, 'unknown-id');
+  return path.posix.join(root, artifactName, artifactId);
 }
 
 function defaultZipPath(root, artifact) {
-  return path.posix.join(defaultArtifactDir(root, artifact), `${artifact.id}.zip`);
+  const artifactId = safeArtifactPathComponent(artifact.id, 'unknown-id');
+  return path.posix.join(defaultArtifactDir(root, artifact), `${artifactId}.zip`);
 }
 
 function buildInitialManifest(selection = {}, options = {}) {
@@ -306,5 +318,6 @@ module.exports = {
   buildInitialManifest,
   finalizeManifest,
   formatMarkdown,
+  safeArtifactPathComponent,
   updateArtifactResult,
 };

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -86,14 +86,22 @@ jobs:
           if [ ! -s "$artifact_list" ]; then
             echo "No metrics artifacts found"
           fi
+          sanitize_component() {
+            printf '%s' "$1" |
+              sed -E 's/[^A-Za-z0-9._-]+/_/g; s/[.][.]+/_/g; s/^_+//; s/_+$//'
+          }
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            artifact_dir="artifacts/$name/$id"
+            safe_name="$(sanitize_component "$name")"
+            safe_id="$(sanitize_component "$id")"
+            safe_name="${safe_name:-unknown}"
+            safe_id="${safe_id:-unknown-id}"
+            artifact_dir="artifacts/$safe_name/$safe_id"
             mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
             export ARTIFACT_ID="$id"
             export ARTIFACT_DIR="$artifact_dir"
-            export ARTIFACT_ZIP="$artifact_dir/$id.zip"
+            export ARTIFACT_ZIP="$artifact_dir/$safe_id.zip"
             if ! node - <<'NODE'
           const fs = require('fs');
           const { Octokit } = require('@octokit/rest');

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -172,7 +172,6 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        source = _metric_source(path)
         try:
             handle = path.open("r", encoding="utf-8")
         except OSError:
@@ -194,13 +193,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    enriched = dict(parsed)
-                    enriched.setdefault("artifact_name", source.artifact)
-                    enriched.setdefault("artifact_family", source.artifact_family)
-                    enriched.setdefault("metric_artifact", source.artifact)
-                    enriched.setdefault("metric_artifact_family", source.artifact_family)
-                    enriched.setdefault("metric_path", source.path)
-                    file_entries.append(enriched)
+                    file_entries.append(_attach_metric_source(parsed, path))
                     raw_lines_for_fallback = []
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
@@ -271,7 +264,11 @@ def _safe_int(value: Any) -> int | None:
 
 
 def _unsupported_verifier_models() -> set[str]:
-    raw = os.environ.get("UNSUPPORTED_VERIFIER_MODELS", "")
+    raw = (
+        os.environ.get("UNSUPPORTED_VERIFIER_MODELS")
+        or os.environ.get("TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS")
+        or ""
+    )
     if not raw.strip():
         return set(_DEFAULT_UNSUPPORTED_VERIFIER_MODELS)
     return {item.strip().lower() for item in raw.split(",") if item.strip()}

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
@@ -30,12 +30,24 @@ function selectedArtifactsFromSelection(selection = {}) {
   return Array.isArray(selection.selected_artifacts) ? selection.selected_artifacts : [];
 }
 
+function safeArtifactPathComponent(value, fallback = 'unknown') {
+  const safe = cleanString(value)
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/\.\.+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!safe || safe === '.' || safe === '..') return fallback;
+  return safe;
+}
+
 function defaultArtifactDir(root, artifact) {
-  return path.posix.join(root, cleanString(artifact.name) || 'unknown', String(artifact.id || ''));
+  const artifactName = safeArtifactPathComponent(artifact.name, 'unknown');
+  const artifactId = safeArtifactPathComponent(artifact.id, 'unknown-id');
+  return path.posix.join(root, artifactName, artifactId);
 }
 
 function defaultZipPath(root, artifact) {
-  return path.posix.join(defaultArtifactDir(root, artifact), `${artifact.id}.zip`);
+  const artifactId = safeArtifactPathComponent(artifact.id, 'unknown-id');
+  return path.posix.join(defaultArtifactDir(root, artifact), `${artifactId}.zip`);
 }
 
 function buildInitialManifest(selection = {}, options = {}) {
@@ -306,5 +318,6 @@ module.exports = {
   buildInitialManifest,
   finalizeManifest,
   formatMarkdown,
+  safeArtifactPathComponent,
   updateArtifactResult,
 };

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -97,14 +97,22 @@ jobs:
           if [ ! -s "$artifact_list" ]; then
             echo "No metrics artifacts found"
           fi
+          sanitize_component() {
+            printf '%s' "$1" |
+              sed -E 's/[^A-Za-z0-9._-]+/_/g; s/[.][.]+/_/g; s/^_+//; s/_+$//'
+          }
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            artifact_dir="artifacts/$name/$id"
+            safe_name="$(sanitize_component "$name")"
+            safe_id="$(sanitize_component "$id")"
+            safe_name="${safe_name:-unknown}"
+            safe_id="${safe_id:-unknown-id}"
+            artifact_dir="artifacts/$safe_name/$safe_id"
             mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
             export ARTIFACT_ID="$id"
             export ARTIFACT_DIR="$artifact_dir"
-            export ARTIFACT_ZIP="$artifact_dir/$id.zip"
+            export ARTIFACT_ZIP="$artifact_dir/$safe_id.zip"
             if ! node - <<'NODE'
           const fs = require('fs');
           const { Octokit } = require('@octokit/rest');

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -172,7 +172,6 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        source = _metric_source(path)
         try:
             handle = path.open("r", encoding="utf-8")
         except OSError:
@@ -194,13 +193,7 @@ def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[Pars
                     file_errors.append(_parse_error_detail(path, line_number, "invalid-json"))
                     continue
                 if isinstance(parsed, dict):
-                    enriched = dict(parsed)
-                    enriched.setdefault("artifact_name", source.artifact)
-                    enriched.setdefault("artifact_family", source.artifact_family)
-                    enriched.setdefault("metric_artifact", source.artifact)
-                    enriched.setdefault("metric_artifact_family", source.artifact_family)
-                    enriched.setdefault("metric_path", source.path)
-                    file_entries.append(enriched)
+                    file_entries.append(_attach_metric_source(parsed, path))
                     raw_lines_for_fallback = []
                 else:
                     file_errors.append(_parse_error_detail(path, line_number, "non-object-json"))
@@ -271,7 +264,11 @@ def _safe_int(value: Any) -> int | None:
 
 
 def _unsupported_verifier_models() -> set[str]:
-    raw = os.environ.get("UNSUPPORTED_VERIFIER_MODELS", "")
+    raw = (
+        os.environ.get("UNSUPPORTED_VERIFIER_MODELS")
+        or os.environ.get("TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS")
+        or ""
+    )
     if not raw.strip():
         return set(_DEFAULT_UNSUPPORTED_VERIFIER_MODELS)
     return {item.strip().lower() for item in raw.split(",") if item.strip()}

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -563,6 +563,29 @@ def test_verifier_summary_counts_unsupported_models(
     assert "Unsupported model dispositions: verifier-error (1)" in summary
 
 
+def test_verifier_summary_supports_terminal_disposition_unsupported_model_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNSUPPORTED_VERIFIER_MODELS", raising=False)
+    monkeypatch.setenv("TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS", "gpt-5.4")
+
+    verifier = aggregate_agent_metrics._summarise_verifier(
+        [
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "run_id": "24948023780",
+                "pr_number": 1874,
+                "disposition": "verifier-error",
+                "llm_model": "GPT-5.4",
+            }
+        ]
+    )
+
+    assert verifier["unsupported_verifier_models"]["gpt-5.4"] == 1
+    assert verifier["unsupported_model_dispositions"]["verifier-error"] == 1
+
+
 def test_verifier_summary_counts_missing_model_metadata() -> None:
     summary = aggregate_agent_metrics.build_summary(
         [

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -295,10 +295,13 @@ def test_weekly_metrics_uploads_selector_report_on_failure():
             and "agent-weekly-metrics.json" in text
         ), "Weekly metrics must upload a machine-readable aggregate summary"
         assert (
-            'artifact_dir="artifacts/$name/$id"' in text
-        ), "Weekly metrics must isolate same-name artifact downloads by artifact ID"
+            "sanitize_component()" in text
+            and 'safe_name="$(sanitize_component "$name")"' in text
+            and 'safe_id="$(sanitize_component "$id")"' in text
+            and 'artifact_dir="artifacts/$safe_name/$safe_id"' in text
+        ), "Weekly metrics must isolate same-name artifact downloads with sanitized name and ID components"
         assert (
-            'export ARTIFACT_ZIP="$artifact_dir/$id.zip"' in text
+            'export ARTIFACT_ZIP="$artifact_dir/$safe_id.zip"' in text
             and 'unzip -o "$ARTIFACT_ZIP" -d "$ARTIFACT_DIR"' in text
         ), "Weekly metrics must unzip each artifact inside its unique extraction directory"
         assert (


### PR DESCRIPTION
## Summary
- sanitize weekly metrics artifact name/id components before using them in download paths
- mirror the sanitized path handling into the consumer template and manifest helper
- reuse aggregate metric source enrichment and accept the terminal-disposition unsupported-model env alias

## Validation
- node --test .github/scripts/__tests__/weekly-metrics-download-manifest.test.js
- pytest -q tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_workflow_agents_consolidation.py
- python scripts/validate_template_sync.py
- python scripts/validate_workflow_yaml.py .github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml

Addresses actionable review feedback from stranske/Pension-Data#301.