### PR TITLE
Fix sync campaign issue reuse and marker size

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -192,7 +192,7 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
     { reposRequested: 1, reposChecked: 1 },
   );
   const body = formatCampaignBody(state);
-  const markerItem = parseCampaignMarker(formatCampaignMarker(state)).items[0];
+  const marker = parseCampaignMarker(formatCampaignMarker(state));
 
   assert.equal(item.source_sync.status, 'superseded');
   assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
@@ -208,11 +208,10 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
   assert.deepEqual(state.stats.local_codex_queue_state_counts, {
     'superseded-sync-candidate': 1,
   });
-  assert.equal(markerItem.status, 'local-codex-superseded-sync-candidate');
-  assert.equal(markerItem.source_sync.status, 'superseded');
-  assert.equal(markerItem.local_codex_queue_state, 'superseded-sync-candidate');
-  assert.equal(markerItem.local_codex_actionable, false);
-  assert.equal(markerItem.local_codex_claimable, false);
+  assert.equal(marker.stats.items_superseded_sync_candidates, 1);
+  assert.equal(marker.stats.marker_items_retained, 0);
+  assert.equal(marker.stats.marker_items_omitted, 1);
+  assert.deepEqual(marker.items, []);
   assert.match(body, /No local Codex work is queued/);
   assert.match(body, /Superseded sync candidates: 1/);
   assert.match(body, /Source sync state: superseded/);
@@ -398,11 +397,10 @@ test('mergeCampaignState flags repeated source-fixed review signatures without h
     'source-fixed-candidate': 1,
     finished: 1,
   });
-  assert.equal(markerItem.status, 'local-codex-source-fixed-candidate');
-  assert.equal(markerItem.source_fixed_candidate.matching_item_id, finished.id);
-  assert.equal(markerItem.local_codex_queue_state, 'source-fixed-candidate');
-  assert.equal(markerItem.local_codex_actionable, false);
-  assert.equal(markerItem.local_codex_claimable, false);
+  assert.equal(markerItem, undefined);
+  assert.equal(marker.stats.items_source_fixed_candidates, 1);
+  assert.equal(marker.stats.marker_items_retained, 0);
+  assert.equal(marker.stats.marker_items_omitted, 2);
   assert.equal(marker.source_review_history[0].matching_item_id, finished.id);
   assert.match(body, /No local Codex work is queued/);
   assert.match(body, /Source-fixed candidates: 1/);
@@ -821,6 +819,48 @@ test('findCampaignIssue does not fall back to unmarked title matches', async () 
   assert.equal(issue, null);
 });
 
+test('findCampaignIssue falls back to active campaign labels', async () => {
+  const markerBody = formatCampaignBody(mergeCampaignState({}, [], '2026-04-21T05:52:00Z'));
+  const github = {
+    rest: {
+      issues: {
+        listForRepo: function issueList() {},
+        get: async ({ issue_number: issueNumber }) => ({
+          data: {
+            number: issueNumber,
+            title: 'Sync/Dependabot campaign queue',
+            body: markerBody,
+            labels: [
+              { name: 'campaign:sync-dependabot' },
+              { name: 'campaign:active' },
+            ],
+          },
+        }),
+      },
+    },
+    paginate: async (method, params) => {
+      if (params.labels === 'campaign:sync-dependabot,campaign:active') {
+        return [
+          {
+            number: 1836,
+            title: 'Sync/Dependabot campaign queue',
+            pull_request: null,
+            labels: [
+              { name: 'campaign:sync-dependabot' },
+              { name: 'campaign:active' },
+            ],
+          },
+        ];
+      }
+      return [];
+    },
+  };
+
+  const issue = await findCampaignIssue(github, 'stranske', 'Workflows', console);
+
+  assert.equal(issue.number, 1836);
+});
+
 test('dry-run summary avoids logging generated issue body by default', () => {
   const state = mergeCampaignState({}, [], '2026-04-21T05:52:00Z', {
     reposRequested: 2,
@@ -959,4 +999,49 @@ test('formatCampaignBody remains below GitHub issue body limit for large queues'
 
   assert.ok(body.length <= 60000, `body length ${body.length} should fit GitHub issue limit`);
   assert.equal(parseCampaignMarker(body).items.length, 60);
+});
+
+test('formatCampaignBody omits inactive superseded details from issue marker', () => {
+  const items = Array.from({ length: 150 }, (_, index) => ({
+    id: `sync-review-comments:stranske/App#${index + 1}:abc${index}`,
+    status: 'needs-local-codex',
+    kind: 'sync-review-comments',
+    classification: 'sync',
+    repo: 'stranske/App',
+    pr_number: index + 1,
+    pr_title: 'chore: sync workflow templates',
+    pr_url: `https://github.com/stranske/App/pull/${index + 1}`,
+    source_repo: 'stranske/Workflows',
+    preferred_workdir: 'Workflows',
+    source_sync: {
+      schema: 'sync-dependabot-campaign-source-sync/v1',
+      current_sync_hash: 'new-sync-hash',
+      pr_sync_hash: 'old-sync-hash',
+      status: 'superseded',
+    },
+    review_thread_count: 4,
+    review_threads: Array.from({ length: 4 }, (_, threadIndex) => ({
+      id: `thread-${index}-${threadIndex}`,
+      path: '.github/scripts/example.js',
+      line: 100 + threadIndex,
+      url: `https://github.test/thread-${index}-${threadIndex}`,
+      author: 'copilot-pull-request-reviewer',
+      body_preview: 'A'.repeat(400),
+    })),
+  }));
+  const state = mergeCampaignState(
+    {},
+    items,
+    '2026-04-21T05:52:00Z',
+    { reposRequested: 11, reposChecked: 11, syncPrsOpen: 150 },
+  );
+
+  const body = formatCampaignBody(state);
+  const marker = parseCampaignMarker(body);
+
+  assert.ok(body.length <= 60000, `body length ${body.length} should fit GitHub issue limit`);
+  assert.equal(marker.stats.items_superseded_sync_candidates, 120);
+  assert.equal(marker.stats.marker_items_retained, 0);
+  assert.equal(marker.stats.marker_items_omitted, 120);
+  assert.deepEqual(marker.items, []);
 });

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -13,6 +13,7 @@ const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_MAX_RETAINED_ITEMS = 120;
 const DEFAULT_MAX_SOURCE_REVIEW_HISTORY = 80;
 const MAX_ISSUE_BODY_LENGTH = 60000;
+const MAX_MARKER_ITEMS = 80;
 const MAX_QUEUE_ROWS = 15;
 const MAX_DETAIL_ITEMS = 10;
 const MAX_THREADS_PER_ITEM = 4;
@@ -729,6 +730,10 @@ function formatCampaignMarker(state) {
 
 function compactStateForMarker(state = {}) {
   const stats = state.stats || {};
+  const stateItems = cleanArray(state.items);
+  const markerItems = stateItems
+    .filter(isMarkerQueueItem)
+    .slice(0, MAX_MARKER_ITEMS);
   return {
     schema: state.schema || CAMPAIGN_SCHEMA,
     updated_at: cleanString(state.updated_at),
@@ -740,13 +745,23 @@ function compactStateForMarker(state = {}) {
         stats.local_codex_queue_state_counts || localCodexQueueStateCounts(state.items),
       local_codex_claims:
         stats.local_codex_claims || localCodexClaimSummary(state.items),
+      marker_items_retained: markerItems.length,
+      marker_items_omitted: Math.max(0, stateItems.length - markerItems.length),
     },
     validation: state.validation || null,
     source_review_history: cleanArray(state.source_review_history)
       .map(compactSourceReviewHistoryEntry)
       .filter(Boolean),
-    items: cleanArray(state.items).map(compactQueueItemForMarker),
+    marker_item_filter: 'actionable-claimed-blocked-unpublished',
+    items: markerItems.map(compactQueueItemForMarker),
   };
+}
+
+function isMarkerQueueItem(item = {}) {
+  return isVisibleQueueItem(item) ||
+    item.status === 'retryable-error' ||
+    item.status === 'blocked' ||
+    hasUnpublishedSourceResult(item);
 }
 
 function compactQueueItemForMarker(item = {}) {
@@ -1263,19 +1278,43 @@ async function discoverRepoWork({
 }
 
 async function findCampaignIssue(github, owner, repo, core, withRetry = null) {
-  const issues = cleanArray(await paginateWithRetry({
+  const listIssues = async (params, label) => cleanArray(await paginateWithRetry({
     github,
     core,
     withRetry,
     method: (client) => client.rest.issues.listForRepo,
-    params: { owner, repo, state: 'open', per_page: 100 },
-    label: `${owner}/${repo} campaign issue list`,
+    params,
+    label,
   }));
-  const candidates = issues.filter((issue) =>
-    !issue.pull_request && cleanString(issue.title).startsWith(CAMPAIGN_TITLE)
+  const titleIssues = await listIssues(
+    { owner, repo, state: 'open', per_page: 100 },
+    `${owner}/${repo} campaign issue list`,
   );
+  const labeledIssues = await listIssues(
+    {
+      owner,
+      repo,
+      state: 'open',
+      labels: `${LABEL_CAMPAIGN},${LABEL_ACTIVE}`,
+      per_page: 100,
+    },
+    `${owner}/${repo} active campaign issue list`,
+  );
+  const candidatesByNumber = new Map();
+  for (const issue of [...titleIssues, ...labeledIssues]) {
+    if (issue.pull_request) {
+      continue;
+    }
+    const labelNames = labelsForPullRequest(issue);
+    const hasCampaignLabels =
+      labelNames.includes(LABEL_CAMPAIGN) && labelNames.includes(LABEL_ACTIVE);
+    const hasCampaignTitle = cleanString(issue.title).startsWith(CAMPAIGN_TITLE);
+    if (hasCampaignTitle || hasCampaignLabels) {
+      candidatesByNumber.set(issue.number, issue);
+    }
+  }
 
-  for (const issue of candidates) {
+  for (const issue of candidatesByNumber.values()) {
     const fullIssue = await callWithRetry(
       (client) => client.rest.issues.get({ owner, repo, issue_number: issue.number }),
       `${owner}/${repo}#${issue.number}`,
@@ -1284,7 +1323,10 @@ async function findCampaignIssue(github, owner, repo, core, withRetry = null) {
       withRetry,
       github,
     );
-    if (parseCampaignMarker(fullIssue.data.body)) {
+    const labelNames = labelsForPullRequest(fullIssue.data);
+    const hasCampaignLabels =
+      labelNames.includes(LABEL_CAMPAIGN) && labelNames.includes(LABEL_ACTIVE);
+    if (parseCampaignMarker(fullIssue.data.body) || hasCampaignLabels) {
       return fullIssue.data;
     }
   }


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1836 -->
> **Source:** Issue #1836

Closes #1836

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#922](https://github.com/stranske/Travel-Plan-Permission/issues/922)
- [stranske/Template#608](https://github.com/stranske/Template/issues/608)
- [stranske/Counter_Risk#448](https://github.com/stranske/Counter_Risk/issues/448)
- [stranske/Pension-Data#301](https://github.com/stranske/Pension-Data/issues/301)
- [stranske/Inv-Man-Intake#289](https://github.com/stranske/Inv-Man-Intake/issues/289)
- [stranske/Template#607](https://github.com/stranske/Template/issues/607)
- [stranske/Travel-Plan-Permission#921](https://github.com/stranske/Travel-Plan-Permission/issues/921)
- [stranske/Inv-Man-Intake#285](https://github.com/stranske/Inv-Man-Intake/issues/285)
- [stranske/Workflows#1882](https://github.com/stranske/Workflows/issues/1882)
- [stranske/Pension-Data#297](https://github.com/stranske/Pension-Data/issues/297)
- [stranske/Counter_Risk#444](https://github.com/stranske/Counter_Risk/issues/444)
- [stranske/Template#604](https://github.com/stranske/Template/issues/604)
- [stranske/Travel-Plan-Permission#918](https://github.com/stranske/Travel-Plan-Permission/issues/918)
- [stranske/Travel-Plan-Permission#899](https://github.com/stranske/Travel-Plan-Permission/issues/899)
- [stranske/Travel-Plan-Permission#900](https://github.com/stranske/Travel-Plan-Permission/issues/900)
- [stranske/Travel-Plan-Permission#902](https://github.com/stranske/Travel-Plan-Permission/issues/902)
- [stranske/Travel-Plan-Permission#893](https://github.com/stranske/Travel-Plan-Permission/issues/893)
- [stranske/Travel-Plan-Permission#894](https://github.com/stranske/Travel-Plan-Permission/issues/894)
- [stranske/Travel-Plan-Permission#895](https://github.com/stranske/Travel-Plan-Permission/issues/895)
- [stranske/Travel-Plan-Permission#896](https://github.com/stranske/Travel-Plan-Permission/issues/896)
- [stranske/Template#582](https://github.com/stranske/Template/issues/582)
- [stranske/Workflows#1893](https://github.com/stranske/Workflows/issues/1893)
- [stranske/Travel-Plan-Permission#920](https://github.com/stranske/Travel-Plan-Permission/issues/920)
- [stranske/Workflows#1894](https://github.com/stranske/Workflows/issues/1894)
- [stranske/Template#606](https://github.com/stranske/Template/issues/606)
- [stranske/Template#605](https://github.com/stranske/Template/issues/605)
- [stranske/Template#603](https://github.com/stranske/Template/issues/603)
- [stranske/Template#602](https://github.com/stranske/Template/issues/602)
- [stranske/Template#601](https://github.com/stranske/Template/issues/601)
- [stranske/Template#600](https://github.com/stranske/Template/issues/600)
- [stranske/Template#599](https://github.com/stranske/Template/issues/599)
- [stranske/Template#598](https://github.com/stranske/Template/issues/598)
- [stranske/Template#597](https://github.com/stranske/Template/issues/597)
- [stranske/Template#596](https://github.com/stranske/Template/issues/596)
- [stranske/Template#595](https://github.com/stranske/Template/issues/595)
- [stranske/Template#594](https://github.com/stranske/Template/issues/594)
- [stranske/Template#593](https://github.com/stranske/Template/issues/593)
- [stranske/Template#588](https://github.com/stranske/Template/issues/588)
- [stranske/Template#586](https://github.com/stranske/Template/issues/586)
- [stranske/Template#585](https://github.com/stranske/Template/issues/585)
- [stranske/Template#580](https://github.com/stranske/Template/issues/580)
- [stranske/Template#579](https://github.com/stranske/Template/issues/579)
- [stranske/Template#577](https://github.com/stranske/Template/issues/577)
- [stranske/Counter_Risk#447](https://github.com/stranske/Counter_Risk/issues/447)
- [stranske/Counter_Risk#446](https://github.com/stranske/Counter_Risk/issues/446)
- [stranske/Counter_Risk#443](https://github.com/stranske/Counter_Risk/issues/443)
- [stranske/Counter_Risk#442](https://github.com/stranske/Counter_Risk/issues/442)
- [stranske/Counter_Risk#441](https://github.com/stranske/Counter_Risk/issues/441)
- [stranske/Counter_Risk#440](https://github.com/stranske/Counter_Risk/issues/440)
- [stranske/Counter_Risk#439](https://github.com/stranske/Counter_Risk/issues/439)
- [stranske/Counter_Risk#438](https://github.com/stranske/Counter_Risk/issues/438)
- [stranske/Counter_Risk#437](https://github.com/stranske/Counter_Risk/issues/437)
- [stranske/Counter_Risk#436](https://github.com/stranske/Counter_Risk/issues/436)
- [stranske/Counter_Risk#435](https://github.com/stranske/Counter_Risk/issues/435)
- [stranske/Counter_Risk#434](https://github.com/stranske/Counter_Risk/issues/434)
- [stranske/Counter_Risk#433](https://github.com/stranske/Counter_Risk/issues/433)
- [stranske/Counter_Risk#430](https://github.com/stranske/Counter_Risk/issues/430)
- [stranske/Counter_Risk#429](https://github.com/stranske/Counter_Risk/issues/429)
- [stranske/Counter_Risk#426](https://github.com/stranske/Counter_Risk/issues/426)
- [stranske/Counter_Risk#425](https://github.com/stranske/Counter_Risk/issues/425)
- [stranske/Counter_Risk#413](https://github.com/stranske/Counter_Risk/issues/413)
- [stranske/Counter_Risk#412](https://github.com/stranske/Counter_Risk/issues/412)
- [stranske/Counter_Risk#409](https://github.com/stranske/Counter_Risk/issues/409)
- [stranske/Counter_Risk#408](https://github.com/stranske/Counter_Risk/issues/408)
- [stranske/Counter_Risk#407](https://github.com/stranske/Counter_Risk/issues/407)
- [stranske/Counter_Risk#406](https://github.com/stranske/Counter_Risk/issues/406)
- [stranske/Counter_Risk#405](https://github.com/stranske/Counter_Risk/issues/405)
- [stranske/Counter_Risk#404](https://github.com/stranske/Counter_Risk/issues/404)
- [stranske/Counter_Risk#403](https://github.com/stranske/Counter_Risk/issues/403)
- [stranske/Counter_Risk#402](https://github.com/stranske/Counter_Risk/issues/402)
- [stranske/Counter_Risk#401](https://github.com/stranske/Counter_Risk/issues/401)
- [stranske/Workflows#1895](https://github.com/stranske/Workflows/issues/1895)
- [stranske/Pension-Data#300](https://github.com/stranske/Pension-Data/issues/300)
- [stranske/Pension-Data#299](https://github.com/stranske/Pension-Data/issues/299)
- [stranske/Pension-Data#298](https://github.com/stranske/Pension-Data/issues/298)
- [stranske/Pension-Data#296](https://github.com/stranske/Pension-Data/issues/296)
- [stranske/Pension-Data#295](https://github.com/stranske/Pension-Data/issues/295)
- [stranske/Pension-Data#294](https://github.com/stranske/Pension-Data/issues/294)
- [stranske/Pension-Data#293](https://github.com/stranske/Pension-Data/issues/293)
- [stranske/Pension-Data#292](https://github.com/stranske/Pension-Data/issues/292)
- [stranske/Pension-Data#291](https://github.com/stranske/Pension-Data/issues/291)
- [stranske/Pension-Data#290](https://github.com/stranske/Pension-Data/issues/290)
- [stranske/Pension-Data#289](https://github.com/stranske/Pension-Data/issues/289)
- [stranske/Pension-Data#288](https://github.com/stranske/Pension-Data/issues/288)
- [stranske/Pension-Data#287](https://github.com/stranske/Pension-Data/issues/287)
- [stranske/Pension-Data#286](https://github.com/stranske/Pension-Data/issues/286)
- [stranske/Pension-Data#284](https://github.com/stranske/Pension-Data/issues/284)
- [stranske/Pension-Data#280](https://github.com/stranske/Pension-Data/issues/280)
- [stranske/Pension-Data#279](https://github.com/stranske/Pension-Data/issues/279)
- [stranske/Pension-Data#278](https://github.com/stranske/Pension-Data/issues/278)
- [stranske/Pension-Data#276](https://github.com/stranske/Pension-Data/issues/276)
- [stranske/Pension-Data#275](https://github.com/stranske/Pension-Data/issues/275)
- [stranske/Pension-Data#274](https://github.com/stranske/Pension-Data/issues/274)
- [stranske/Pension-Data#273](https://github.com/stranske/Pension-Data/issues/273)
- [stranske/Pension-Data#272](https://github.com/stranske/Pension-Data/issues/272)
- [stranske/Pension-Data#270](https://github.com/stranske/Pension-Data/issues/270)
- [stranske/Pension-Data#268](https://github.com/stranske/Pension-Data/issues/268)
- [stranske/Pension-Data#266](https://github.com/stranske/Pension-Data/issues/266)
- [stranske/Pension-Data#265](https://github.com/stranske/Pension-Data/issues/265)
- [stranske/Pension-Data#263](https://github.com/stranske/Pension-Data/issues/263)
- [stranske/Pension-Data#262](https://github.com/stranske/Pension-Data/issues/262)
- [stranske/Pension-Data#259](https://github.com/stranske/Pension-Data/issues/259)
- [stranske/Pension-Data#258](https://github.com/stranske/Pension-Data/issues/258)
- [stranske/Pension-Data#257](https://github.com/stranske/Pension-Data/issues/257)
- [stranske/Pension-Data#256](https://github.com/stranske/Pension-Data/issues/256)
- [stranske/Pension-Data#254](https://github.com/stranske/Pension-Data/issues/254)
- [stranske/Inv-Man-Intake#288](https://github.com/stranske/Inv-Man-Intake/issues/288)
- [stranske/Inv-Man-Intake#287](https://github.com/stranske/Inv-Man-Intake/issues/287)
- [stranske/Inv-Man-Intake#286](https://github.com/stranske/Inv-Man-Intake/issues/286)
- [stranske/Inv-Man-Intake#284](https://github.com/stranske/Inv-Man-Intake/issues/284)
- [stranske/Inv-Man-Intake#283](https://github.com/stranske/Inv-Man-Intake/issues/283)
- [stranske/Inv-Man-Intake#282](https://github.com/stranske/Inv-Man-Intake/issues/282)
- [stranske/Inv-Man-Intake#281](https://github.com/stranske/Inv-Man-Intake/issues/281)
- [stranske/Inv-Man-Intake#280](https://github.com/stranske/Inv-Man-Intake/issues/280)
- [stranske/Inv-Man-Intake#279](https://github.com/stranske/Inv-Man-Intake/issues/279)
- [stranske/Inv-Man-Intake#278](https://github.com/stranske/Inv-Man-Intake/issues/278)
- [stranske/Inv-Man-Intake#277](https://github.com/stranske/Inv-Man-Intake/issues/277)
- [stranske/Inv-Man-Intake#275](https://github.com/stranske/Inv-Man-Intake/issues/275)
- [stranske/Inv-Man-Intake#274](https://github.com/stranske/Inv-Man-Intake/issues/274)
- [stranske/Inv-Man-Intake#272](https://github.com/stranske/Inv-Man-Intake/issues/272)
- [stranske/Inv-Man-Intake#267](https://github.com/stranske/Inv-Man-Intake/issues/267)
- [stranske/Inv-Man-Intake#266](https://github.com/stranske/Inv-Man-Intake/issues/266)
- [stranske/Inv-Man-Intake#263](https://github.com/stranske/Inv-Man-Intake/issues/263)
- [stranske/Inv-Man-Intake#260](https://github.com/stranske/Inv-Man-Intake/issues/260)
- [stranske/Inv-Man-Intake#254](https://github.com/stranske/Inv-Man-Intake/issues/254)
- [stranske/Inv-Man-Intake#252](https://github.com/stranske/Inv-Man-Intake/issues/252)
- [stranske/Inv-Man-Intake#251](https://github.com/stranske/Inv-Man-Intake/issues/251)
- [stranske/Inv-Man-Intake#250](https://github.com/stranske/Inv-Man-Intake/issues/250)
- [stranske/Inv-Man-Intake#249](https://github.com/stranske/Inv-Man-Intake/issues/249)
- [stranske/Inv-Man-Intake#248](https://github.com/stranske/Inv-Man-Intake/issues/248)
- [stranske/Inv-Man-Intake#247](https://github.com/stranske/Inv-Man-Intake/issues/247)
- [stranske/Inv-Man-Intake#246](https://github.com/stranske/Inv-Man-Intake/issues/246)
- [#900](https://github.com/stranske/Workflows/issues/900)
- [#902](https://github.com/stranske/Workflows/issues/902)
- [#1855](https://github.com/stranske/Workflows/issues/1855)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T12:33:27.204Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 439
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 693
- [ ] Items needing local Codex: 5
- [ ] Actionable local Codex items: 5
- [ ] Claimable local Codex items: 5
- [ ] Source-fixed candidates: 7
- [ ] Superseded sync candidates: 108
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 0
- [ ] Next claim lease expires: -

#### Acceptance criteria
- [ ] Acceptance criteria section missing from source issue.

<!-- auto-status-summary:end -->