### PR TITLE
Add verifier ledger and setup preflight contracts

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -69,6 +69,9 @@ outputs:
   available_tokens:
     description: 'Comma-separated list of available token names'
     value: ${{ steps.export-tokens.outputs.available_tokens }}
+  setup_contract:
+    description: 'Redacted machine-readable setup/auth/dependency contract JSON'
+    value: ${{ steps.export-tokens.outputs.setup_contract }}
 
 runs:
   using: composite
@@ -360,6 +363,7 @@ runs:
         INPUT_APP_1_PRIVATE_KEY: ${{ inputs.app_1_private_key }}
         INPUT_APP_2_ID: ${{ inputs.app_2_id }}
         INPUT_APP_2_PRIVATE_KEY: ${{ inputs.app_2_private_key }}
+        INPUT_INSTALL_DIR: ${{ inputs.install_dir }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
         set -euo pipefail
@@ -489,11 +493,76 @@ runs:
         echo "token_count=${token_count}" >> "$GITHUB_OUTPUT"
         echo "available_tokens=${available_tokens}" >> "$GITHUB_OUTPUT"
 
+        install_dir="${INPUT_INSTALL_DIR:-}"
+        if [ -z "$install_dir" ]; then
+          install_dir="${GITHUB_WORKSPACE}/.github/scripts"
+        fi
+        setup_contract="$(
+          AVAILABLE_TOKENS="${available_tokens}" \
+          TOKEN_COUNT="${token_count}" \
+          INSTALL_DIR="${install_dir}" \
+          node <<'NODE'
+        const fs = require('node:fs');
+        const path = require('node:path');
+
+        const installDir = process.env.INSTALL_DIR || '';
+        const tokenNames = (process.env.AVAILABLE_TOKENS || '')
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean);
+        const tokenSet = new Set(tokenNames);
+        const appPairs = [
+          ['WORKFLOWS_APP', 'WORKFLOWS_APP_ID', 'WORKFLOWS_APP_PRIVATE_KEY'],
+          ['KEEPALIVE_APP', 'KEEPALIVE_APP_ID', 'KEEPALIVE_APP_PRIVATE_KEY'],
+          ['GH_APP', 'GH_APP_ID', 'GH_APP_PRIVATE_KEY'],
+          ['APP_1', 'APP_1_ID', 'APP_1_PRIVATE_KEY'],
+          ['APP_2', 'APP_2_ID', 'APP_2_PRIVATE_KEY'],
+        ];
+        const authModes = [];
+        if (tokenSet.has('GITHUB_TOKEN')) {
+          authModes.push({ source: 'GITHUB_TOKEN', mode: 'github-token' });
+        }
+        for (const name of tokenNames) {
+          if (name.endsWith('_PAT')) {
+            authModes.push({ source: name, mode: 'pat' });
+          }
+        }
+        for (const [source, idName, keyName] of appPairs) {
+          if (tokenSet.has(idName) && tokenSet.has(keyName)) {
+            authModes.push({
+              source,
+              mode: 'github-app',
+              credential_names: [idName, keyName],
+            });
+          }
+        }
+
+        const moduleDir = path.join(installDir, 'node_modules');
+        const hasModule = (name) => fs.existsSync(path.join(moduleDir, ...name.split('/')));
+        const contract = {
+          schema: 'workflows-api-client-setup/v1',
+          token_count: Number.parseInt(process.env.TOKEN_COUNT || '0', 10) || 0,
+          available_token_names: tokenNames,
+          auth_modes: authModes,
+          dependency_state: {
+            node_path_ready: fs.existsSync(moduleDir),
+            octokit_rest_ready: hasModule('@octokit/rest'),
+            octokit_auth_app_ready: hasModule('@octokit/auth-app'),
+            lru_cache_ready: hasModule('lru-cache'),
+          },
+        };
+        process.stdout.write(JSON.stringify(contract));
+        NODE
+        )"
+        printf 'setup_contract=%s\n' "$setup_contract" >> "$GITHUB_OUTPUT"
+
         echo ""
         echo "📊 Token Setup Summary:"
         echo "  Total tokens exported: ${token_count}"
+        echo "  Setup contract schema: workflows-api-client-setup/v1"
         if [ "${INPUT_VERBOSE}" = "true" ]; then
           echo "  Available: ${available_tokens}"
+          echo "  Setup contract: ${setup_contract}"
         fi
 
         # Warn if no tokens were exported

--- a/.github/scripts/__tests__/terminal-disposition.test.js
+++ b/.github/scripts/__tests__/terminal-disposition.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert/strict');
 
 const {
   normalizeTerminalDisposition,
+  normalizeVerifierFollowupLedger,
+  normalizeLedgerDisposition,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,
@@ -47,6 +49,50 @@ test('normalizes terminal disposition records with stable source keys', () => {
 
 test('sourceKey falls back to unknown for blank values', () => {
   assert.equal(sourceKey('', ''), 'unknown:unknown');
+});
+
+test('normalizes verifier follow-up ledger records with stable PR/run key', () => {
+  const record = normalizeVerifierFollowupLedger({
+    prNumber: '101',
+    verificationRunId: '24950000001',
+    runAttempt: '2',
+    verdict: 'CONCERNS',
+    terminalState: 'follow-up-created',
+    concernsHash: 'abc123',
+    followupIssueNumber: '105',
+    followupIssueUrl: 'https://github.example/issues/105',
+    sourceIssueNumbers: ['42', '42', 43],
+    chainDepth: '1',
+    workflow: 'Reusable Agents Verifier',
+    actor: 'github-actions[bot]',
+    terminalDispositionArtifact: 'verifier-terminal-disposition-24950000001',
+    dispatchOutcome: 'success',
+    needsHuman: false,
+    timestamp: '2026-04-25T00:00:00Z',
+  });
+
+  assert.equal(record.schema, 'workflows-verifier-followup-ledger/v1');
+  assert.equal(record.metric_type, 'verifier_followup_ledger');
+  assert.equal(record.state_key, 'pr:101:run:24950000001');
+  assert.equal(record.pr_number, 101);
+  assert.equal(record.verification_run_id, '24950000001');
+  assert.equal(record.verification_run_attempt, 2);
+  assert.equal(record.verdict, 'CONCERNS');
+  assert.equal(record.disposition, 'follow-up');
+  assert.equal(record.concerns_hash, 'abc123');
+  assert.equal(record.followup_issue_number, 105);
+  assert.deepEqual(record.source_issue_numbers, [42, 43]);
+  assert.equal(record.chain_depth, 1);
+  assert.equal(record.terminal_disposition_artifact, 'verifier-terminal-disposition-24950000001');
+  assert.equal(record.needs_human, false);
+});
+
+test('maps verifier terminal states to ledger disposition contract values', () => {
+  assert.equal(normalizeLedgerDisposition({ terminalState: 'verified-pass' }), 'merge');
+  assert.equal(normalizeLedgerDisposition({ terminalState: 'follow-up-created' }), 'follow-up');
+  assert.equal(normalizeLedgerDisposition({ terminalState: 'needs-human-depth-limit' }), 'needs-human');
+  assert.equal(normalizeLedgerDisposition({ disposition: 'accept_risk' }), 'accept-risk');
+  assert.equal(normalizeLedgerDisposition({ verdict: 'fail' }), 'needs-human');
 });
 
 test('summarizes terminal dispositions by source', () => {

--- a/.github/scripts/terminal_disposition.js
+++ b/.github/scripts/terminal_disposition.js
@@ -27,6 +27,43 @@ function sourceKey(sourceType, sourceId) {
   return `${normalizeSourceType(sourceType)}:${normalizeSourceId(sourceId)}`;
 }
 
+function cleanIntArray(value) {
+  const rawItems = Array.isArray(value) ? value : [value];
+  return [...new Set(
+    rawItems
+      .flatMap((item) => {
+        if (Array.isArray(item)) return item;
+        if (typeof item === 'string') return item.split(',');
+        return [item];
+      })
+      .map((item) => cleanInt(item))
+      .filter((item) => item !== null && item > 0)
+  )].sort((a, b) => a - b);
+}
+
+function normalizeLedgerDisposition(input = {}) {
+  const explicit = cleanString(input.disposition ?? input.terminal_disposition);
+  const normalized = explicit.toLowerCase().replace(/_/g, '-');
+  const allowed = new Set(['merge', 'supersede', 'follow-up', 'accept-risk', 'needs-human']);
+  if (allowed.has(normalized)) return normalized;
+
+  const terminalDisposition = cleanString(input.terminal_state ?? input.terminalState).toLowerCase();
+  if (terminalDisposition.includes('follow-up')) return 'follow-up';
+  if (terminalDisposition.includes('needs-human') || terminalDisposition.includes('verifier-error')) {
+    return 'needs-human';
+  }
+  if (terminalDisposition.includes('verified-pass')) return 'merge';
+
+  const verdict = cleanString(input.verdict).toLowerCase();
+  const hasFollowup = cleanInt(input.followup_issue_number ?? input.followupIssueNumber) !== null ||
+    cleanInt(input.followup_pr_number ?? input.followupPrNumber) !== null;
+  if (hasFollowup) return 'follow-up';
+  if (input.needs_human === true || input.needsHuman === true) return 'needs-human';
+  if (['pass', 'passed'].includes(verdict)) return 'merge';
+  if (['fail', 'failed', 'concerns', 'error'].includes(verdict)) return 'needs-human';
+  return 'needs-human';
+}
+
 function normalizeTerminalDisposition(input = {}) {
   const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
   const issueNumber = cleanInt(input.issue_number ?? input.issueNumber ?? input.issue);
@@ -76,6 +113,68 @@ function normalizeTerminalDisposition(input = {}) {
 
   for (const [key, value] of Object.entries(optional)) {
     if (value === null || value === undefined) continue;
+    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
+    if (cleaned === '') continue;
+    record[key] = typeof value === 'string' ? cleaned : value;
+  }
+
+  return record;
+}
+
+function normalizeVerifierFollowupLedger(input = {}) {
+  const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
+  const verificationRunId = normalizeSourceId(
+    input.verification_run_id ?? input.verificationRunId ?? input.run_id ?? input.runId,
+    prNumber ?? input.timestamp
+  );
+  const timestamp = cleanString(input.timestamp) || new Date().toISOString();
+  const sourceIssueNumbers = cleanIntArray(
+    input.source_issue_numbers ?? input.sourceIssueNumbers ?? input.issue_numbers ?? input.issueNumbers
+  );
+  const disposition = normalizeLedgerDisposition(input);
+  const stateKey = `pr:${prNumber || 'unknown'}:run:${verificationRunId}`;
+
+  const record = {
+    schema: 'workflows-verifier-followup-ledger/v1',
+    metric_type: 'verifier_followup_ledger',
+    timestamp,
+    state_key: stateKey,
+    pr_number: prNumber,
+    verification_run_id: verificationRunId,
+    verdict: cleanString(input.verdict) || 'unknown',
+    disposition,
+    source_issue_numbers: sourceIssueNumbers,
+  };
+
+  const optional = {
+    verification_run_attempt:
+      input.verification_run_attempt ??
+      input.verificationRunAttempt ??
+      input.run_attempt ??
+      input.runAttempt,
+    concerns_hash: input.concerns_hash ?? input.concernsHash,
+    followup_issue_number:
+      input.followup_issue_number ?? input.followupIssueNumber ?? input.created_issue_number,
+    followup_issue_url:
+      input.followup_issue_url ?? input.followupIssueUrl ?? input.created_issue_url,
+    followup_pr_number: input.followup_pr_number ?? input.followupPrNumber,
+    followup_pr_url: input.followup_pr_url ?? input.followupPrUrl,
+    chain_depth: input.chain_depth ?? input.chainDepth,
+    workflow: input.workflow,
+    actor: input.actor,
+    terminal_disposition_artifact:
+      input.terminal_disposition_artifact ?? input.terminalDispositionArtifact,
+    dispatch_outcome: input.dispatch_outcome ?? input.dispatchOutcome,
+    needs_human: input.needs_human ?? input.needsHuman,
+  };
+
+  for (const [key, value] of Object.entries(optional)) {
+    if (value === null || value === undefined) continue;
+    if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
+      const parsed = cleanInt(value);
+      if (parsed !== null) record[key] = parsed;
+      continue;
+    }
     const cleaned = typeof value === 'boolean' ? value : cleanString(value);
     if (cleaned === '') continue;
     record[key] = typeof value === 'string' ? cleaned : value;
@@ -155,6 +254,8 @@ function formatTerminalDispositionMarkdown(records = []) {
 
 module.exports = {
   normalizeTerminalDisposition,
+  normalizeVerifierFollowupLedger,
+  normalizeLedgerDisposition,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -861,6 +861,7 @@ jobs:
         env:
           ORIGINAL_ISSUE_NUMBER: ${{ steps.collect.outputs.original_issue_number }}
           ORIGINAL_ISSUE_TITLE: ${{ steps.collect.outputs.original_issue_title }}
+          CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
           CHAIN_EXCEEDED: ${{ steps.chain-check.outputs.exceeded }}
           NEEDS_HUMAN: ${{ steps.extract-verdict.outputs.needs_human }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -873,8 +874,10 @@ jobs:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
             const fs = require('fs');
+            const crypto = require('crypto');
             const {
               normalizeTerminalDisposition,
+              normalizeVerifierFollowupLedger,
               formatTerminalDispositionMarkdown,
             } = require('./.github/scripts/terminal_disposition.js');
 
@@ -937,6 +940,35 @@ jobs:
               'agent-metrics/verifier-terminal-disposition.ndjson',
               `${JSON.stringify(record)}\n`
             );
+
+            let concernsHash = '';
+            try {
+              const raw = fs.readFileSync('verification_data.txt', 'utf8');
+              if (raw.trim()) {
+                concernsHash = crypto.createHash('sha256').update(raw).digest('hex');
+              }
+            } catch (_) { /* best effort */ }
+            const ledgerRecord = normalizeVerifierFollowupLedger({
+              pr_number: prNumber,
+              verification_run_id: context.runId,
+              verification_run_attempt: context.runAttempt,
+              verdict: process.env.VERDICT || undefined,
+              terminal_state: disposition,
+              concerns_hash: concernsHash || undefined,
+              followup_issue_number: followupIssue || undefined,
+              followup_issue_url: process.env.FOLLOWUP_ISSUE_URL || undefined,
+              source_issue_numbers: sourceIssue ? [sourceIssue] : [],
+              chain_depth: process.env.CHAIN_DEPTH || undefined,
+              workflow: context.workflow,
+              actor: context.actor,
+              terminal_disposition_artifact: `verifier-terminal-disposition-${context.runId}`,
+              dispatch_outcome: dispatchOutcome || undefined,
+              needs_human: needsHuman,
+            });
+            fs.writeFileSync(
+              'agent-metrics/verifier-followup-ledger.ndjson',
+              `${JSON.stringify(ledgerRecord)}\n`
+            );
             const markdown = formatTerminalDispositionMarkdown([record]);
             fs.writeFileSync('terminal-disposition-summary.md', `${markdown}\n`);
             await core.summary
@@ -951,6 +983,7 @@ jobs:
           name: verifier-terminal-disposition-${{ github.run_id }}
           path: |
             agent-metrics/verifier-terminal-disposition.ndjson
+            agent-metrics/verifier-followup-ledger.ndjson
             terminal-disposition-summary.md
           retention-days: 14
 

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -1322,6 +1322,7 @@ jobs:
           CODEX_MODEL: ${{ steps.codex.outputs.model || steps.codex_model.outputs.model }}
           CODEX_MODEL_SELECTION_REASON: ${{ steps.codex.outputs.selection_reason || steps.codex_model.outputs.selection_reason }}
           VERIFIER_MODE: ${{ inputs.mode }}
+          CHAIN_DEPTH: ${{ steps.context.outputs.chain_depth || '0' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -1341,6 +1342,7 @@ jobs:
           codex_model = os.environ.get("CODEX_MODEL") or ""
           codex_model_selection_reason = os.environ.get("CODEX_MODEL_SELECTION_REASON") or ""
           verifier_mode = os.environ.get("VERIFIER_MODE") or ""
+          chain_depth = int(os.environ.get("CHAIN_DEPTH") or 0)
 
           if not should_run:
               verdict = "skipped"
@@ -1372,6 +1374,7 @@ jobs:
               "codex_model": codex_model,
               "codex_model_selection_reason": codex_model_selection_reason,
               "verifier_mode": verifier_mode,
+              "chain_depth": chain_depth,
               "recorded_at": datetime.now(timezone.utc).isoformat(),
           }
 
@@ -1393,6 +1396,7 @@ jobs:
           CODEX_MODEL: ${{ steps.codex.outputs.model || steps.codex_model.outputs.model }}
           CODEX_MODEL_SELECTION_REASON: ${{ steps.codex.outputs.selection_reason || steps.codex_model.outputs.selection_reason }}
           VERIFIER_MODE: ${{ inputs.mode }}
+          CHAIN_DEPTH: ${{ steps.context.outputs.chain_depth || '0' }}
           FINAL_VERDICT: >-
             ${{
               steps.unified_verdict.outputs.verdict ||
@@ -1405,14 +1409,17 @@ jobs:
           mkdir -p agent-metrics
           node <<'NODE'
           const fs = require('fs');
+          const crypto = require('crypto');
           const helperPath = './.workflows-lib/.github/scripts/terminal_disposition.js';
           const fallback = {
             normalizeTerminalDisposition: (value) => value,
+            normalizeVerifierFollowupLedger: (value) => value,
             formatTerminalDispositionMarkdown: (records) =>
               records.map((record) => `- ${record.source_type}:${record.source_id} ${record.disposition}`).join('\n'),
           };
           const {
             normalizeTerminalDisposition,
+            normalizeVerifierFollowupLedger,
             formatTerminalDispositionMarkdown,
           } = fs.existsSync(helperPath) ? require(helperPath) : fallback;
 
@@ -1443,6 +1450,8 @@ jobs:
           const codexModelSelectionReason =
             process.env.CODEX_MODEL_SELECTION_REASON || metrics.codex_model_selection_reason || '';
           const verifierMode = process.env.VERIFIER_MODE || metrics.verifier_mode || '';
+          const chainDepth =
+            Number.parseInt(process.env.CHAIN_DEPTH || metrics.chain_depth || '0', 10) || 0;
 
           let disposition = 'unknown';
           let reason = 'Verifier terminal state captured for coverage monitoring.';
@@ -1496,6 +1505,40 @@ jobs:
             'agent-metrics/verifier-terminal-disposition.ndjson',
             `${records.map((record) => JSON.stringify(record)).join('\n')}\n`
           );
+
+          const concernInputs = [
+            'codex-output.md',
+            'evaluation.json',
+            'comparison.json',
+            'comparison-comment.md',
+          ]
+            .filter((file) => fs.existsSync(file))
+            .map((file) => fs.readFileSync(file, 'utf8'))
+            .filter((value) => value.trim());
+          const concernsHash = concernInputs.length
+            ? crypto.createHash('sha256').update(concernInputs.join('\n---\n')).digest('hex')
+            : '';
+          const ledgerRecord = normalizeVerifierFollowupLedger({
+            pr_number: prNumber,
+            verification_run_id: process.env.GITHUB_RUN_ID || '',
+            verification_run_attempt: process.env.GITHUB_RUN_ATTEMPT || '',
+            verdict: verdict || metrics.verdict || 'unknown',
+            terminal_state: disposition,
+            concerns_hash: concernsHash || undefined,
+            followup_issue_number: followupIssueNumber || undefined,
+            source_issue_numbers: sourceIssueNumbers,
+            chain_depth: chainDepth,
+            workflow: process.env.GITHUB_WORKFLOW || '',
+            actor: process.env.GITHUB_ACTOR || '',
+            terminal_disposition_artifact:
+              `verifier-terminal-disposition-${process.env.GITHUB_RUN_ID || ''}`,
+            dispatch_outcome: shouldRun ? 'verifier-ran' : 'verifier-skipped',
+            needs_human: disposition === 'needs-human' || disposition === 'verifier-error',
+          });
+          fs.writeFileSync(
+            'agent-metrics/verifier-followup-ledger.ndjson',
+            `${JSON.stringify(ledgerRecord)}\n`
+          );
           fs.writeFileSync(
             'terminal-disposition-summary.md',
             `${formatTerminalDispositionMarkdown(records)}\n`
@@ -1519,6 +1562,7 @@ jobs:
           name: verifier-terminal-disposition-${{ github.run_id }}
           path: |
             agent-metrics/verifier-terminal-disposition.ndjson
+            agent-metrics/verifier-followup-ledger.ndjson
             terminal-disposition-summary.md
           if-no-files-found: error
           retention-days: 14
@@ -1547,6 +1591,7 @@ jobs:
             "codex_model",
             "codex_model_selection_reason",
             "verifier_mode",
+            "chain_depth",
           ]
           for key in keys:
             lines.append(f"| {key} | `{metrics.get(key, '')}` |")

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -220,6 +220,8 @@ def _classify_entry(entry: dict[str, Any]) -> str:
     schema = entry.get("schema")
     if schema == "workflows-terminal-disposition/v1":
         return "terminal_disposition"
+    if schema == "workflows-verifier-followup-ledger/v1":
+        return "verifier_followup_ledger"
     explicit = entry.get("metric_type") or entry.get("type") or entry.get("workflow")
     if isinstance(explicit, str):
         lowered = explicit.lower()
@@ -394,7 +396,10 @@ def _summarise_autofix(entries: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
+def _summarise_verifier(
+    entries: list[dict[str, Any]],
+    ledger_entries: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     verdicts = Counter()
     terminal_dispositions = Counter()
     terminal_sources = Counter()
@@ -408,6 +413,10 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
     model_metadata_required_after = _verifier_model_metadata_required_after()
     legacy_missing_verifier_model_metadata = Counter()
     verifier_modes = Counter()
+    ledger_dispositions = Counter()
+    ledger_followup_issues: set[int] = set()
+    ledger_prs: set[int] = set()
+    ledger_needs_human = 0
     verifier_run_keys: set[str] = set()
     prs: set[int] = set()
     issues_created = 0
@@ -471,6 +480,17 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+    for entry in ledger_entries or []:
+        disposition = str(entry.get("disposition") or "unknown")
+        ledger_dispositions[disposition] += 1
+        pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
+        if pr_number is not None:
+            ledger_prs.add(pr_number)
+        followup_issue = _safe_int(entry.get("followup_issue_number"))
+        if followup_issue is not None:
+            ledger_followup_issues.add(followup_issue)
+        if bool(entry.get("needs_human")) or disposition == "needs-human":
+            ledger_needs_human += 1
     avg_acceptance = sum(acceptance_counts) / len(acceptance_counts) if acceptance_counts else 0.0
     return {
         "runs": len(verifier_run_keys),
@@ -488,6 +508,11 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "legacy_missing_verifier_model_metadata": legacy_missing_verifier_model_metadata,
         "model_selection_reasons": model_selection_reasons,
         "verifier_modes": verifier_modes,
+        "ledger_records": len(ledger_entries or []),
+        "ledger_dispositions": ledger_dispositions,
+        "ledger_prs": len(ledger_prs),
+        "ledger_followup_issues": len(ledger_followup_issues),
+        "ledger_needs_human": ledger_needs_human,
     }
 
 
@@ -736,6 +761,7 @@ def build_summary(
         "autofix": [],
         "verifier": [],
         "terminal_disposition": [],
+        "verifier_followup_ledger": [],
         "autopilot": [],
         "unknown": [],
     }
@@ -752,7 +778,10 @@ def build_summary(
 
     keepalive = _summarise_keepalive(buckets["keepalive"])
     autofix = _summarise_autofix(buckets["autofix"])
-    verifier = _summarise_verifier(buckets["verifier"] + buckets["terminal_disposition"])
+    verifier = _summarise_verifier(
+        buckets["verifier"] + buckets["terminal_disposition"],
+        buckets["verifier_followup_ledger"],
+    )
     autopilot = _summarise_autopilot(buckets["autopilot"])
 
     now = _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -765,6 +794,7 @@ def build_summary(
             f"(keepalive {keepalive['runs']}, autofix {autofix['attempts']}, "
             f"verifier {verifier['runs']}, "
             f"terminal dispositions {verifier['terminal_records']}, "
+            f"verifier follow-up ledgers {verifier['ledger_records']}, "
             f"autopilot {autopilot['records']}, "
             f"unknown {len(buckets['unknown'])})"
         ),
@@ -807,6 +837,11 @@ def build_summary(
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
+            f"- Verifier follow-up ledger records: {verifier['ledger_records']}",
+            f"- Verifier follow-up ledger dispositions: {_format_counter(verifier['ledger_dispositions'])}",
+            f"- Verifier follow-up ledger PRs: {verifier['ledger_prs']}",
+            f"- Verifier follow-up issues linked: {verifier['ledger_followup_issues']}",
+            f"- Verifier follow-up needs-human records: {verifier['ledger_needs_human']}",
             f"- Verifier models: {_format_counter(verifier['verifier_models'])}",
             f"- Unsupported verifier models: {_format_counter(verifier['unsupported_verifier_models'])}",
             (

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -972,11 +972,7 @@ def write_packet(output_dir: Path, states: list[dict[str, Any]], generated_on: s
     review_pending = [
         state for state in active if state["review_status"] == "pending standardized review"
     ]
-    blocked = [
-        state
-        for state in active
-        if state["review_status"] != "pending standardized review"
-    ]
+    blocked = [state for state in active if state["review_status"] != "pending standardized review"]
     issue_candidate_repos = [
         state for state in active if state["issue_queue_status"] == "draft candidates present"
     ]

--- a/templates/consumer-repo/.github/actions/setup-api-client/action.yml
+++ b/templates/consumer-repo/.github/actions/setup-api-client/action.yml
@@ -69,6 +69,9 @@ outputs:
   available_tokens:
     description: 'Comma-separated list of available token names'
     value: ${{ steps.export-tokens.outputs.available_tokens }}
+  setup_contract:
+    description: 'Redacted machine-readable setup/auth/dependency contract JSON'
+    value: ${{ steps.export-tokens.outputs.setup_contract }}
 
 runs:
   using: composite
@@ -214,8 +217,8 @@ runs:
           CREATED_PACKAGE_JSON=true
         fi
 
-        # Check if already installed (including lru-cache, a required transitive dep
-        # of @octokit/auth-app used for GitHub App token minting).
+        # Check if already installed (including lru-cache@10.4.3, a required
+        # transitive dep of @octokit/auth-app used for GitHub App token minting).
         if [ -d "node_modules/@octokit/rest" ] && [ -d "node_modules/lru-cache" ]; then
           echo "✅ @octokit/rest already installed"
         else
@@ -360,6 +363,7 @@ runs:
         INPUT_APP_1_PRIVATE_KEY: ${{ inputs.app_1_private_key }}
         INPUT_APP_2_ID: ${{ inputs.app_2_id }}
         INPUT_APP_2_PRIVATE_KEY: ${{ inputs.app_2_private_key }}
+        INPUT_INSTALL_DIR: ${{ inputs.install_dir }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
         set -euo pipefail
@@ -489,11 +493,76 @@ runs:
         echo "token_count=${token_count}" >> "$GITHUB_OUTPUT"
         echo "available_tokens=${available_tokens}" >> "$GITHUB_OUTPUT"
 
+        install_dir="${INPUT_INSTALL_DIR:-}"
+        if [ -z "$install_dir" ]; then
+          install_dir="${GITHUB_WORKSPACE}/.github/scripts"
+        fi
+        setup_contract="$(
+          AVAILABLE_TOKENS="${available_tokens}" \
+          TOKEN_COUNT="${token_count}" \
+          INSTALL_DIR="${install_dir}" \
+          node <<'NODE'
+        const fs = require('node:fs');
+        const path = require('node:path');
+
+        const installDir = process.env.INSTALL_DIR || '';
+        const tokenNames = (process.env.AVAILABLE_TOKENS || '')
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean);
+        const tokenSet = new Set(tokenNames);
+        const appPairs = [
+          ['WORKFLOWS_APP', 'WORKFLOWS_APP_ID', 'WORKFLOWS_APP_PRIVATE_KEY'],
+          ['KEEPALIVE_APP', 'KEEPALIVE_APP_ID', 'KEEPALIVE_APP_PRIVATE_KEY'],
+          ['GH_APP', 'GH_APP_ID', 'GH_APP_PRIVATE_KEY'],
+          ['APP_1', 'APP_1_ID', 'APP_1_PRIVATE_KEY'],
+          ['APP_2', 'APP_2_ID', 'APP_2_PRIVATE_KEY'],
+        ];
+        const authModes = [];
+        if (tokenSet.has('GITHUB_TOKEN')) {
+          authModes.push({ source: 'GITHUB_TOKEN', mode: 'github-token' });
+        }
+        for (const name of tokenNames) {
+          if (name.endsWith('_PAT')) {
+            authModes.push({ source: name, mode: 'pat' });
+          }
+        }
+        for (const [source, idName, keyName] of appPairs) {
+          if (tokenSet.has(idName) && tokenSet.has(keyName)) {
+            authModes.push({
+              source,
+              mode: 'github-app',
+              credential_names: [idName, keyName],
+            });
+          }
+        }
+
+        const moduleDir = path.join(installDir, 'node_modules');
+        const hasModule = (name) => fs.existsSync(path.join(moduleDir, ...name.split('/')));
+        const contract = {
+          schema: 'workflows-api-client-setup/v1',
+          token_count: Number.parseInt(process.env.TOKEN_COUNT || '0', 10) || 0,
+          available_token_names: tokenNames,
+          auth_modes: authModes,
+          dependency_state: {
+            node_path_ready: fs.existsSync(moduleDir),
+            octokit_rest_ready: hasModule('@octokit/rest'),
+            octokit_auth_app_ready: hasModule('@octokit/auth-app'),
+            lru_cache_ready: hasModule('lru-cache'),
+          },
+        };
+        process.stdout.write(JSON.stringify(contract));
+        NODE
+        )"
+        printf 'setup_contract=%s\n' "$setup_contract" >> "$GITHUB_OUTPUT"
+
         echo ""
         echo "📊 Token Setup Summary:"
         echo "  Total tokens exported: ${token_count}"
+        echo "  Setup contract schema: workflows-api-client-setup/v1"
         if [ "${INPUT_VERBOSE}" = "true" ]; then
           echo "  Available: ${available_tokens}"
+          echo "  Setup contract: ${setup_contract}"
         fi
 
         # Warn if no tokens were exported

--- a/templates/consumer-repo/.github/scripts/terminal_disposition.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition.js
@@ -27,6 +27,43 @@ function sourceKey(sourceType, sourceId) {
   return `${normalizeSourceType(sourceType)}:${normalizeSourceId(sourceId)}`;
 }
 
+function cleanIntArray(value) {
+  const rawItems = Array.isArray(value) ? value : [value];
+  return [...new Set(
+    rawItems
+      .flatMap((item) => {
+        if (Array.isArray(item)) return item;
+        if (typeof item === 'string') return item.split(',');
+        return [item];
+      })
+      .map((item) => cleanInt(item))
+      .filter((item) => item !== null && item > 0)
+  )].sort((a, b) => a - b);
+}
+
+function normalizeLedgerDisposition(input = {}) {
+  const explicit = cleanString(input.disposition ?? input.terminal_disposition);
+  const normalized = explicit.toLowerCase().replace(/_/g, '-');
+  const allowed = new Set(['merge', 'supersede', 'follow-up', 'accept-risk', 'needs-human']);
+  if (allowed.has(normalized)) return normalized;
+
+  const terminalDisposition = cleanString(input.terminal_state ?? input.terminalState).toLowerCase();
+  if (terminalDisposition.includes('follow-up')) return 'follow-up';
+  if (terminalDisposition.includes('needs-human') || terminalDisposition.includes('verifier-error')) {
+    return 'needs-human';
+  }
+  if (terminalDisposition.includes('verified-pass')) return 'merge';
+
+  const verdict = cleanString(input.verdict).toLowerCase();
+  const hasFollowup = cleanInt(input.followup_issue_number ?? input.followupIssueNumber) !== null ||
+    cleanInt(input.followup_pr_number ?? input.followupPrNumber) !== null;
+  if (hasFollowup) return 'follow-up';
+  if (input.needs_human === true || input.needsHuman === true) return 'needs-human';
+  if (['pass', 'passed'].includes(verdict)) return 'merge';
+  if (['fail', 'failed', 'concerns', 'error'].includes(verdict)) return 'needs-human';
+  return 'needs-human';
+}
+
 function normalizeTerminalDisposition(input = {}) {
   const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
   const issueNumber = cleanInt(input.issue_number ?? input.issueNumber ?? input.issue);
@@ -76,6 +113,68 @@ function normalizeTerminalDisposition(input = {}) {
 
   for (const [key, value] of Object.entries(optional)) {
     if (value === null || value === undefined) continue;
+    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
+    if (cleaned === '') continue;
+    record[key] = typeof value === 'string' ? cleaned : value;
+  }
+
+  return record;
+}
+
+function normalizeVerifierFollowupLedger(input = {}) {
+  const prNumber = cleanInt(input.pr_number ?? input.prNumber ?? input.pr);
+  const verificationRunId = normalizeSourceId(
+    input.verification_run_id ?? input.verificationRunId ?? input.run_id ?? input.runId,
+    prNumber ?? input.timestamp
+  );
+  const timestamp = cleanString(input.timestamp) || new Date().toISOString();
+  const sourceIssueNumbers = cleanIntArray(
+    input.source_issue_numbers ?? input.sourceIssueNumbers ?? input.issue_numbers ?? input.issueNumbers
+  );
+  const disposition = normalizeLedgerDisposition(input);
+  const stateKey = `pr:${prNumber || 'unknown'}:run:${verificationRunId}`;
+
+  const record = {
+    schema: 'workflows-verifier-followup-ledger/v1',
+    metric_type: 'verifier_followup_ledger',
+    timestamp,
+    state_key: stateKey,
+    pr_number: prNumber,
+    verification_run_id: verificationRunId,
+    verdict: cleanString(input.verdict) || 'unknown',
+    disposition,
+    source_issue_numbers: sourceIssueNumbers,
+  };
+
+  const optional = {
+    verification_run_attempt:
+      input.verification_run_attempt ??
+      input.verificationRunAttempt ??
+      input.run_attempt ??
+      input.runAttempt,
+    concerns_hash: input.concerns_hash ?? input.concernsHash,
+    followup_issue_number:
+      input.followup_issue_number ?? input.followupIssueNumber ?? input.created_issue_number,
+    followup_issue_url:
+      input.followup_issue_url ?? input.followupIssueUrl ?? input.created_issue_url,
+    followup_pr_number: input.followup_pr_number ?? input.followupPrNumber,
+    followup_pr_url: input.followup_pr_url ?? input.followupPrUrl,
+    chain_depth: input.chain_depth ?? input.chainDepth,
+    workflow: input.workflow,
+    actor: input.actor,
+    terminal_disposition_artifact:
+      input.terminal_disposition_artifact ?? input.terminalDispositionArtifact,
+    dispatch_outcome: input.dispatch_outcome ?? input.dispatchOutcome,
+    needs_human: input.needs_human ?? input.needsHuman,
+  };
+
+  for (const [key, value] of Object.entries(optional)) {
+    if (value === null || value === undefined) continue;
+    if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
+      const parsed = cleanInt(value);
+      if (parsed !== null) record[key] = parsed;
+      continue;
+    }
     const cleaned = typeof value === 'boolean' ? value : cleanString(value);
     if (cleaned === '') continue;
     record[key] = typeof value === 'string' ? cleaned : value;
@@ -155,6 +254,8 @@ function formatTerminalDispositionMarkdown(records = []) {
 
 module.exports = {
   normalizeTerminalDisposition,
+  normalizeVerifierFollowupLedger,
+  normalizeLedgerDisposition,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check PR is merged
         id: check-merged
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}
           script: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
           token: ${{ steps.select-token.outputs.token }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -103,7 +103,7 @@ jobs:
       - name: Collect verification and original issue data
         id: collect
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
@@ -248,7 +248,7 @@ jobs:
       - name: Check chain depth limit
         id: chain-check
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
           MAX_CHAIN_DEPTH: '2'
@@ -389,7 +389,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           LINKED_ISSUE: ${{ steps.collect.outputs.original_issue_number }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -505,7 +505,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
           EXTRACTED_VERDICT: ${{ steps.extract-verdict.outputs.verdict }}
@@ -677,7 +677,7 @@ jobs:
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_TITLE: >-
             ${{ steps.generate.outputs.issue_title ||
@@ -736,7 +736,13 @@ jobs:
               return;
             }
 
-            let agentKey = 'codex';
+            // Resolve agent from PR labels; fall back to registry default
+            let _defaultAgent = 'codex';
+            try {
+              const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
+              _defaultAgent = loadAgentRegistry('./.github/agents/registry.yml').default_agent || 'codex';
+            } catch (_) {}
+            let agentKey = _defaultAgent;
             try {
               const { resolveAgentFromLabels } = require('./.github/scripts/agent_registry.js');
               const labels =
@@ -746,11 +752,11 @@ jobs:
               });
             } catch (err) {
               core.warning(
-                `Failed to resolve agent from PR labels; defaulting to codex: ${err.message}`
+                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ${err.message}`
               );
-              agentKey = 'codex';
+              agentKey = _defaultAgent;
             }
-            const normalized = String(agentKey || 'codex').trim().toLowerCase() || 'codex';
+            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             const agentLabel = `agent:${normalized}`;
             const fromLabel = `from:${normalized}`;
 
@@ -759,7 +765,7 @@ jobs:
               repo: context.repo.repo,
               title: title,
               body: body,
-              labels: ['follow-up', agentLabel, fromLabel, 'agents:auto-pilot']
+              labels: ['follow-up', agentLabel, fromLabel, `runner:${normalized}`, 'agents:auto-pilot']
             }));
 
             core.info(`Created issue #${issue.data.number}`);
@@ -773,7 +779,7 @@ jobs:
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true' &&
           steps.create-issue.outputs.issue_number != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -803,14 +809,14 @@ jobs:
                 force_step: 'optimize'
               }
             }));
-            core.info(`Dispatched agents-auto-pilot for follow-up issue #${issueNumber}.`);
+            core.info(`Dispatched agents-auto-pilot for follow-up issue #${issueNumber}.`)
 
       - name: Comment on original PR
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
@@ -855,6 +861,7 @@ jobs:
         env:
           ORIGINAL_ISSUE_NUMBER: ${{ steps.collect.outputs.original_issue_number }}
           ORIGINAL_ISSUE_TITLE: ${{ steps.collect.outputs.original_issue_title }}
+          CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
           CHAIN_EXCEEDED: ${{ steps.chain-check.outputs.exceeded }}
           NEEDS_HUMAN: ${{ steps.extract-verdict.outputs.needs_human }}
           NEEDS_HUMAN_REASON: ${{ steps.extract-verdict.outputs.needs_human_reason }}
@@ -862,13 +869,15 @@ jobs:
           FOLLOWUP_ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
           FOLLOWUP_ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
           DISPATCH_AUTOPILOT_OUTCOME: ${{ steps.dispatch-autopilot.outcome }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
             const fs = require('fs');
+            const crypto = require('crypto');
             const {
               normalizeTerminalDisposition,
+              normalizeVerifierFollowupLedger,
               formatTerminalDispositionMarkdown,
             } = require('./.github/scripts/terminal_disposition.js');
 
@@ -931,6 +940,35 @@ jobs:
               'agent-metrics/verifier-terminal-disposition.ndjson',
               `${JSON.stringify(record)}\n`
             );
+
+            let concernsHash = '';
+            try {
+              const raw = fs.readFileSync('verification_data.txt', 'utf8');
+              if (raw.trim()) {
+                concernsHash = crypto.createHash('sha256').update(raw).digest('hex');
+              }
+            } catch (_) { /* best effort */ }
+            const ledgerRecord = normalizeVerifierFollowupLedger({
+              pr_number: prNumber,
+              verification_run_id: context.runId,
+              verification_run_attempt: context.runAttempt,
+              verdict: process.env.VERDICT || undefined,
+              terminal_state: disposition,
+              concerns_hash: concernsHash || undefined,
+              followup_issue_number: followupIssue || undefined,
+              followup_issue_url: process.env.FOLLOWUP_ISSUE_URL || undefined,
+              source_issue_numbers: sourceIssue ? [sourceIssue] : [],
+              chain_depth: process.env.CHAIN_DEPTH || undefined,
+              workflow: context.workflow,
+              actor: context.actor,
+              terminal_disposition_artifact: `verifier-terminal-disposition-${context.runId}`,
+              dispatch_outcome: dispatchOutcome || undefined,
+              needs_human: needsHuman,
+            });
+            fs.writeFileSync(
+              'agent-metrics/verifier-followup-ledger.ndjson',
+              `${JSON.stringify(ledgerRecord)}\n`
+            );
             const markdown = formatTerminalDispositionMarkdown([record]);
             fs.writeFileSync('terminal-disposition-summary.md', `${markdown}\n`);
             await core.summary
@@ -940,17 +978,18 @@ jobs:
 
       - name: Upload terminal disposition artifact
         if: always() && steps.check-merged.outputs.merged == 'true'
-        uses: actions/upload-artifact@65ecb0ca2d3e252f7b82842cd0489c883189f7d0 # v7
+        uses: actions/upload-artifact@v7
         with:
           name: verifier-terminal-disposition-${{ github.run_id }}
           path: |
             agent-metrics/verifier-terminal-disposition.ndjson
+            agent-metrics/verifier-followup-ledger.ndjson
             terminal-disposition-summary.md
           retention-days: 14
 
       - name: Remove trigger label
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           github-token: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -220,6 +220,8 @@ def _classify_entry(entry: dict[str, Any]) -> str:
     schema = entry.get("schema")
     if schema == "workflows-terminal-disposition/v1":
         return "terminal_disposition"
+    if schema == "workflows-verifier-followup-ledger/v1":
+        return "verifier_followup_ledger"
     explicit = entry.get("metric_type") or entry.get("type") or entry.get("workflow")
     if isinstance(explicit, str):
         lowered = explicit.lower()
@@ -394,7 +396,10 @@ def _summarise_autofix(entries: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
+def _summarise_verifier(
+    entries: list[dict[str, Any]],
+    ledger_entries: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     verdicts = Counter()
     terminal_dispositions = Counter()
     terminal_sources = Counter()
@@ -408,6 +413,10 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
     model_metadata_required_after = _verifier_model_metadata_required_after()
     legacy_missing_verifier_model_metadata = Counter()
     verifier_modes = Counter()
+    ledger_dispositions = Counter()
+    ledger_followup_issues: set[int] = set()
+    ledger_prs: set[int] = set()
+    ledger_needs_human = 0
     verifier_run_keys: set[str] = set()
     prs: set[int] = set()
     issues_created = 0
@@ -471,6 +480,17 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+    for entry in ledger_entries or []:
+        disposition = str(entry.get("disposition") or "unknown")
+        ledger_dispositions[disposition] += 1
+        pr_number = _safe_int(entry.get("pr_number") or entry.get("pr"))
+        if pr_number is not None:
+            ledger_prs.add(pr_number)
+        followup_issue = _safe_int(entry.get("followup_issue_number"))
+        if followup_issue is not None:
+            ledger_followup_issues.add(followup_issue)
+        if bool(entry.get("needs_human")) or disposition == "needs-human":
+            ledger_needs_human += 1
     avg_acceptance = sum(acceptance_counts) / len(acceptance_counts) if acceptance_counts else 0.0
     return {
         "runs": len(verifier_run_keys),
@@ -488,6 +508,11 @@ def _summarise_verifier(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "legacy_missing_verifier_model_metadata": legacy_missing_verifier_model_metadata,
         "model_selection_reasons": model_selection_reasons,
         "verifier_modes": verifier_modes,
+        "ledger_records": len(ledger_entries or []),
+        "ledger_dispositions": ledger_dispositions,
+        "ledger_prs": len(ledger_prs),
+        "ledger_followup_issues": len(ledger_followup_issues),
+        "ledger_needs_human": ledger_needs_human,
     }
 
 
@@ -736,6 +761,7 @@ def build_summary(
         "autofix": [],
         "verifier": [],
         "terminal_disposition": [],
+        "verifier_followup_ledger": [],
         "autopilot": [],
         "unknown": [],
     }
@@ -752,7 +778,10 @@ def build_summary(
 
     keepalive = _summarise_keepalive(buckets["keepalive"])
     autofix = _summarise_autofix(buckets["autofix"])
-    verifier = _summarise_verifier(buckets["verifier"] + buckets["terminal_disposition"])
+    verifier = _summarise_verifier(
+        buckets["verifier"] + buckets["terminal_disposition"],
+        buckets["verifier_followup_ledger"],
+    )
     autopilot = _summarise_autopilot(buckets["autopilot"])
 
     now = _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -765,6 +794,7 @@ def build_summary(
             f"(keepalive {keepalive['runs']}, autofix {autofix['attempts']}, "
             f"verifier {verifier['runs']}, "
             f"terminal dispositions {verifier['terminal_records']}, "
+            f"verifier follow-up ledgers {verifier['ledger_records']}, "
             f"autopilot {autopilot['records']}, "
             f"unknown {len(buckets['unknown'])})"
         ),
@@ -807,6 +837,11 @@ def build_summary(
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
+            f"- Verifier follow-up ledger records: {verifier['ledger_records']}",
+            f"- Verifier follow-up ledger dispositions: {_format_counter(verifier['ledger_dispositions'])}",
+            f"- Verifier follow-up ledger PRs: {verifier['ledger_prs']}",
+            f"- Verifier follow-up issues linked: {verifier['ledger_followup_issues']}",
+            f"- Verifier follow-up needs-human records: {verifier['ledger_needs_human']}",
             f"- Verifier models: {_format_counter(verifier['verifier_models'])}",
             f"- Unsupported verifier models: {_format_counter(verifier['unsupported_verifier_models'])}",
             (

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -51,13 +51,23 @@ def test_build_summary_formats_sections() -> None:
             "model_selection_reason": "default",
             "verifier_mode": "checkbox",
         },
+        {
+            "schema": "workflows-verifier-followup-ledger/v1",
+            "metric_type": "verifier_followup_ledger",
+            "pr_number": 101,
+            "verification_run_id": "verify-101",
+            "verdict": "concerns",
+            "disposition": "follow-up",
+            "followup_issue_number": 303,
+            "needs_human": False,
+        },
     ]
 
     summary = aggregate_agent_metrics.build_summary(entries, errors=1)
 
     assert (
-        "Records: 5 (keepalive 2, autofix 1, verifier 1, terminal dispositions 1, "
-        "autopilot 0, unknown 0)"
+        "Records: 6 (keepalive 2, autofix 1, verifier 1, terminal dispositions 1, "
+        "verifier follow-up ledgers 1, autopilot 0, unknown 0)"
     ) in summary
     assert "Parse errors: 1" in summary
     assert "Avg iterations: 3.5" in summary
@@ -70,6 +80,11 @@ def test_build_summary_formats_sections() -> None:
     assert "Terminal disposition records: 1" in summary
     assert "Terminal dispositions: follow-up-created (1)" in summary
     assert "Terminal disposition sources: source-issue:99 (1)" in summary
+    assert "Verifier follow-up ledger records: 1" in summary
+    assert "Verifier follow-up ledger dispositions: follow-up (1)" in summary
+    assert "Verifier follow-up ledger PRs: 1" in summary
+    assert "Verifier follow-up issues linked: 1" in summary
+    assert "Verifier follow-up needs-human records: 0" in summary
     assert "Verifier models: gpt-5.3-codex (1)" in summary
     assert "Unsupported verifier models: n/a" in summary
     assert "Unsupported model dispositions: n/a" in summary
@@ -400,6 +415,10 @@ def test_classify_entry_prefers_explicit_type() -> None:
     assert (
         aggregate_agent_metrics._classify_entry({"schema": "workflows-terminal-disposition/v1"})
         == "terminal_disposition"
+    )
+    assert (
+        aggregate_agent_metrics._classify_entry({"schema": "workflows-verifier-followup-ledger/v1"})
+        == "verifier_followup_ledger"
     )
     assert aggregate_agent_metrics._classify_entry({"iteration_count": 1}) == "keepalive"
     assert aggregate_agent_metrics._classify_entry({"trigger_reason": "pytest"}) == "autofix"

--- a/tests/scripts/test_repo_review_evaluator.py
+++ b/tests/scripts/test_repo_review_evaluator.py
@@ -193,7 +193,9 @@ def test_collect_repo_state_marks_clean_active_repo_review_pending(tmp_path: Pat
     (repo_dir / "README.md").write_text("# Manager\n", encoding="utf-8")
     subprocess = evaluator.subprocess
     subprocess.run(["git", "-C", str(repo_dir), "init"], check=True, capture_output=True)
-    subprocess.run(["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"], check=True
+    )
     subprocess.run(["git", "-C", str(repo_dir), "config", "user.name", "Test User"], check=True)
     subprocess.run(["git", "-C", str(repo_dir), "add", "README.md"], check=True)
     subprocess.run(
@@ -223,7 +225,9 @@ def test_issues_txt_changes_are_helper_inputs_not_review_blockers(tmp_path: Path
     (repo_dir / "Issues.txt").write_text("# helper\n", encoding="utf-8")
     subprocess = evaluator.subprocess
     subprocess.run(["git", "-C", str(repo_dir), "init"], check=True, capture_output=True)
-    subprocess.run(["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"], check=True
+    )
     subprocess.run(["git", "-C", str(repo_dir), "config", "user.name", "Test User"], check=True)
     subprocess.run(["git", "-C", str(repo_dir), "add", "README.md", "Issues.txt"], check=True)
     subprocess.run(

--- a/tests/workflows/test_setup_api_client_contract.py
+++ b/tests/workflows/test_setup_api_client_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_setup_api_client_emits_redacted_contract_output() -> None:
+    action_path = Path(".github/actions/setup-api-client/action.yml")
+    action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
+
+    outputs = action.get("outputs") or {}
+    assert outputs["setup_contract"]["value"] == "${{ steps.export-tokens.outputs.setup_contract }}"
+
+    export_step = next(
+        step for step in action["runs"]["steps"] if step.get("id") == "export-tokens"
+    )
+    script = export_step["run"]
+
+    assert "workflows-api-client-setup/v1" in script
+    assert "available_token_names" in script
+    assert "auth_modes" in script
+    assert "dependency_state" in script
+    assert "octokit_rest_ready" in script
+    assert "octokit_auth_app_ready" in script
+    assert "lru_cache_ready" in script
+    assert "credential_names" in script
+    assert "printf 'setup_contract=%s\\n'" in script
+
+    template_text = Path(
+        "templates/consumer-repo/.github/actions/setup-api-client/action.yml"
+    ).read_text(encoding="utf-8")
+    assert "workflows-api-client-setup/v1" in template_text
+    assert "setup_contract" in template_text

--- a/tests/workflows/test_verifier_terminal_disposition.py
+++ b/tests/workflows/test_verifier_terminal_disposition.py
@@ -62,6 +62,10 @@ def test_reusable_verifier_uploads_terminal_disposition_artifact() -> None:
         "${{ steps.context.outputs.issue_numbers || '[]' }}"
     )
     assert "verifier-terminal-disposition" in write_step["run"]
+    assert "normalizeVerifierFollowupLedger" in write_step["run"]
+    assert "verifier-followup-ledger.ndjson" in write_step["run"]
+    assert "concernsHash" in write_step["run"]
+    assert "CHAIN_DEPTH" in write_step["env"]
     assert "llm_model" in write_step["run"]
     assert "model_selection_reason" in write_step["run"]
     assert "source-issue" in write_step["run"]
@@ -72,5 +76,6 @@ def test_reusable_verifier_uploads_terminal_disposition_artifact() -> None:
     assert upload_step.get("uses") == "actions/upload-artifact@v7"
     assert upload_step["with"]["name"] == "verifier-terminal-disposition-${{ github.run_id }}"
     assert "agent-metrics/verifier-terminal-disposition.ndjson" in upload_step["with"]["path"]
+    assert "agent-metrics/verifier-followup-ledger.ndjson" in upload_step["with"]["path"]
     assert upload_step["with"]["if-no-files-found"] == "error"
     assert upload_step["with"]["retention-days"] == 14

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -430,6 +430,20 @@ def test_terminal_disposition_records_include_artifact_identity():
         ), f"{path} must identify terminal disposition artifact families"
 
 
+def test_verify_to_new_pr_uploads_verifier_followup_ledger() -> None:
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-verify-to-new-pr.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml"),
+    ]
+    for path in workflow_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "normalizeVerifierFollowupLedger" in text
+        assert "verifier-followup-ledger.ndjson" in text
+        assert "workflows-verifier-followup-ledger/v1" in Path(
+            ".github/scripts/terminal_disposition.js"
+        ).read_text(encoding="utf-8")
+
+
 def test_issue_intake_handles_codex_events():
     intake = WORKFLOWS_DIR / "agents-63-issue-intake.yml"
     assert intake.exists(), "agents-63-issue-intake.yml must exist"


### PR DESCRIPTION
## Summary

- Add a redacted `workflows-api-client-setup/v1` setup contract output from `setup-api-client` so workflows can inspect auth modes and dependency readiness without exposing secret values.
- Add a `workflows-verifier-followup-ledger/v1` helper and emit `verifier-followup-ledger.ndjson` from verifier follow-up flows alongside existing terminal disposition artifacts.
- Teach weekly agent metrics aggregation to count verifier follow-up ledgers without treating them as extra verifier runs, and sync managed consumer template copies.

## Verification

- `node --test .github/scripts/__tests__/terminal-disposition.test.js`
- `pytest -q tests/scripts/test_aggregate_agent_metrics.py tests/workflows/test_verifier_terminal_disposition.py tests/workflows/test_setup_api_client_contract.py tests/workflows/test_workflow_agents_consolidation.py::test_verify_to_new_pr_uploads_verifier_followup_ledger tests/workflows/test_workflow_agents_consolidation.py::test_terminal_disposition_records_include_artifact_identity tests/scripts/test_validate_template_sync.py`
- `git diff --check`
- Runtime-style bash validation of the `setup-api-client` export-token step with fake redacted token inputs
