### PR TITLE
[codex] Add consumer sync remediation contracts

### DIFF
--- a/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
+++ b/.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js
@@ -24,6 +24,27 @@ const report = {
     all_repos_command: 'gh workflow run maint-68-sync-consumer-repos.yml --repo stranske/Workflows --ref main',
     targeted_repos_command: 'gh workflow run maint-68-sync-consumer-repos.yml --repo stranske/Workflows --ref main -f repos=owner/a,owner/b',
   },
+  sync_remediation: {
+    state: 'pending_sync_prs',
+    open_pr_count: 1,
+    repo_count: 1,
+    latest_open_pr: {
+      repo: 'owner/a',
+      number: 42,
+      branch: 'sync/workflows-abc123',
+      url: 'https://github.com/owner/a/pull/42',
+    },
+    stale_open_pr_count: 0,
+    open_prs: [
+      {
+        repo: 'owner/a',
+        number: 42,
+        branch: 'sync/workflows-abc123',
+        url: 'https://github.com/owner/a/pull/42',
+      },
+    ],
+    lookup_errors: [],
+  },
 };
 
 test('countsLine renders stable drift counts', () => {
@@ -42,6 +63,8 @@ test('formatIssueBody includes actionable repo, prefix, and command details', ()
   assert.match(body, /owner\/a: total=100, drift=27, missing=73/);
   assert.match(body, /\.github\/scripts=60/);
   assert.match(body, /Top repos first: `gh workflow run maint-68-sync-consumer-repos.yml/);
+  assert.match(body, /Open sync PRs/);
+  assert.match(body, /owner\/a#42: `sync\/workflows-abc123`/);
   assert.match(body, /consumer-sync-drift-report/);
   assert.match(body, /<!-- consumer-sync-drift:v1 /);
   assert.match(body, /"schema":"consumer-sync-drift-issue\/v1"/);
@@ -58,6 +81,7 @@ test('formatIssueComment stays compact for existing issue updates', () => {
   assert.match(body, /Drift still detected in \[run #124\]/);
   assert.match(body, /Counts: drift=27, missing=73, errors=0, obsolete=0/);
   assert.match(body, /Highest-impact repos:/);
+  assert.match(body, /Open sync PRs:/);
 });
 
 test('compactMarkerPayload exposes the current drift checkpoint', () => {
@@ -73,6 +97,11 @@ test('compactMarkerPayload exposes the current drift checkpoint', () => {
   assert.equal(payload.run_id, '1');
   assert.deepEqual(payload.counts, { drift: 27, missing: 73, errors: 0, obsolete: 0 });
   assert.equal(payload.top_repo_gaps.length, 2);
+  assert.equal(payload.sync_remediation.state, 'pending_sync_prs');
+  assert.equal(payload.sync_remediation.open_pr_count, 1);
+  assert.equal(payload.sync_remediation.latest_open_pr.number, 42);
+  assert.equal(payload.sync_remediation.stale_open_pr_count, 0);
+  assert.equal(payload.sync_remediation.open_prs[0].number, 42);
   assert.equal(payload.follow_up.workflow, 'maint-68-sync-consumer-repos.yml');
 });
 

--- a/.github/scripts/consumer_sync_drift_issue_body.js
+++ b/.github/scripts/consumer_sync_drift_issue_body.js
@@ -47,6 +47,22 @@ function followUpLines(report) {
   return lines.length ? lines : ['- Run Maint 68 Sync Consumer Repos from the Workflows repo.'];
 }
 
+function formatOpenSyncPrs(report, limit = 10) {
+  const remediation = report && report.sync_remediation ? report.sync_remediation : {};
+  const prs = Array.isArray(remediation.open_prs) ? remediation.open_prs : [];
+  if (prs.length === 0) {
+    return [];
+  }
+  return prs.slice(0, limit).map((item) => {
+    const repo = item.repo || 'unknown';
+    const number = item.number || '';
+    const branch = item.branch || '';
+    const url = item.url || '';
+    const prLabel = number ? `${repo}#${number}` : repo;
+    return `- ${prLabel}: \`${branch}\`${url ? ` (${url})` : ''}`;
+  });
+}
+
 function limitedArray(value, limit) {
   return Array.isArray(value) ? value.slice(0, limit) : [];
 }
@@ -71,6 +87,23 @@ function compactMarkerPayload(report, options = {}) {
     },
     top_repo_gaps: limitedArray(report && report.top_repo_gaps, 10),
     path_prefix_counts: report && report.path_prefix_counts ? report.path_prefix_counts : {},
+    sync_remediation: report && report.sync_remediation ? {
+      state: report.sync_remediation.state || 'unknown',
+      open_pr_count: report.sync_remediation.open_pr_count || 0,
+      repo_count: report.sync_remediation.repo_count || 0,
+      latest_open_pr: report.sync_remediation.latest_open_pr || null,
+      stale_open_pr_count: report.sync_remediation.stale_open_pr_count || 0,
+      open_prs: limitedArray(report.sync_remediation.open_prs, 10),
+      lookup_errors: limitedArray(report.sync_remediation.lookup_errors, 10),
+    } : {
+      state: 'unknown',
+      open_pr_count: 0,
+      repo_count: 0,
+      latest_open_pr: null,
+      stale_open_pr_count: 0,
+      open_prs: [],
+      lookup_errors: [],
+    },
     follow_up: {
       workflow: followUp.workflow || 'maint-68-sync-consumer-repos.yml',
       all_repos_command: followUp.all_repos_command || '',
@@ -87,8 +120,9 @@ function formatIssueBody(report, options = {}) {
   const runUrl = options.runUrl || '';
   const runNumber = options.runNumber || '';
   const runLink = runUrl && runNumber ? `[Run #${runNumber}](${runUrl})` : runUrl || 'current run';
+  const openSyncPrs = formatOpenSyncPrs(report);
 
-  return [
+  const lines = [
     '## Consumer Repo Drift Detected',
     '',
     'One or more consumer repos have drifted from the Workflows templates or manifest entries.',
@@ -107,12 +141,22 @@ function formatIssueBody(report, options = {}) {
     '- Review `consumer-sync-drift-report` for exact file paths.',
     '- Close this issue when Health 68 passes.',
     '',
+  ];
+  if (openSyncPrs.length > 0) {
+    lines.push(
+      '### Open sync PRs',
+      ...openSyncPrs,
+      '',
+    );
+  }
+  lines.push(
     '### Notes',
     '- Files marked with `sync_mode: create_only` are excluded from this check.',
     '- Workflows-Integration-Tests is validated separately by Health 67.',
     '',
     formatIssueMarker(report, options),
-  ].join('\n');
+  );
+  return lines.join('\n');
 }
 
 function mergeIssueBody(existingBody, report, options = {}) {
@@ -132,8 +176,9 @@ function formatIssueComment(report, options = {}) {
   const runUrl = options.runUrl || '';
   const runNumber = options.runNumber || '';
   const runLink = runUrl && runNumber ? `[run #${runNumber}](${runUrl})` : runUrl || 'latest run';
+  const openSyncPrs = formatOpenSyncPrs(report, 5);
 
-  return [
+  const lines = [
     `Drift still detected in ${runLink}.`,
     '',
     `Counts: ${countsLine(report)}`,
@@ -143,12 +188,17 @@ function formatIssueComment(report, options = {}) {
     '',
     'Follow-up:',
     ...followUpLines(report),
-  ].join('\n');
+  ];
+  if (openSyncPrs.length > 0) {
+    lines.push('', 'Open sync PRs:', ...openSyncPrs);
+  }
+  return lines.join('\n');
 }
 
 module.exports = {
   countsLine,
   compactMarkerPayload,
+  formatOpenSyncPrs,
   formatIssueBody,
   formatIssueComment,
   formatIssueMarker,

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -865,6 +865,31 @@ jobs:
           git push --quiet -u origin "$branch_name"
 
           # Create PR
+          sync_marker=$(jq -nc \
+            --arg schema "workflows-consumer-sync-pr/v1" \
+            --arg consumer_repo "${{ matrix.repo }}" \
+            --arg source_repository "$GITHUB_REPOSITORY" \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg template_hash "${{ needs.prepare.outputs.template_hash }}" \
+            --arg sync_branch "$branch_name" \
+            --arg manifest ".github/sync-manifest.yml" \
+            --arg lifecycle_state "opened" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson changes_count "${{ steps.sync.outputs.changes_count || '0' }}" \
+            '{
+              schema: $schema,
+              consumer_repo: $consumer_repo,
+              source_repository: $source_repository,
+              source_sha: $source_sha,
+              template_hash: $template_hash,
+              sync_branch: $sync_branch,
+              manifest: $manifest,
+              lifecycle_state: $lifecycle_state,
+              run_id: $run_id,
+              run_attempt: $run_attempt,
+              changes_count: $changes_count
+            }')
           pr_body=$(cat ../sync_summary.md)
           pr_body="$pr_body
 
@@ -875,7 +900,13 @@ jobs:
           - [ ] No repo-specific customizations were overwritten
 
           **Source:** stranske/Workflows
-          **Manifest:** \`.github/sync-manifest.yml\`"
+          **Source SHA:** \`$GITHUB_SHA\`
+          **Template hash:** \`${{ needs.prepare.outputs.template_hash }}\`
+          **Sync branch:** \`$branch_name\`
+          **Consumer repo:** \`${{ matrix.repo }}\`
+          **Manifest:** \`.github/sync-manifest.yml\`
+
+          <!-- workflows-consumer-sync:v1 $sync_marker -->"
 
           pr_url=$(gh pr create \
             --head "$branch_name" \

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -15,6 +15,7 @@ import yaml
 REPORT_SCHEMA = "workflows-consumer-sync-drift/v1"
 SUMMARY_ITEM_LIMIT = 50
 CONTENT_ERROR_THRESHOLD = 5
+SYNC_BRANCH_PREFIX = "sync/workflows-"
 TOKEN_ENV_ORDER = (
     "DRIFT_TOKEN",
     "SERVICE_BOT_PAT",
@@ -341,6 +342,45 @@ def build_top_repo_gaps(
     return sorted(gaps, key=lambda item: (-int(item["total"]), str(item["repo"])))[:limit]
 
 
+def fetch_open_sync_prs(
+    session: requests.Session, repo: str
+) -> tuple[list[dict[str, object]], str | None]:
+    """Return open Workflows sync PRs for a consumer repo, or a non-fatal lookup error."""
+    response = session.get(f"https://api.github.com/repos/{repo}/pulls?state=open&per_page=50")
+    if response.status_code >= 400:
+        return [], f"{repo}: sync PR lookup failed ({response_failure_reason(response)})"
+
+    prs: list[dict[str, object]] = []
+    for item in response.json() or []:
+        if not isinstance(item, dict):
+            continue
+        head = item.get("head") if isinstance(item.get("head"), dict) else {}
+        branch = str(head.get("ref", "")).strip()
+        if not branch.startswith(SYNC_BRANCH_PREFIX):
+            continue
+        prs.append(
+            {
+                "repo": repo,
+                "number": item.get("number"),
+                "title": item.get("title", ""),
+                "url": item.get("html_url", ""),
+                "branch": branch,
+                "head_sha": head.get("sha", ""),
+                "created_at": item.get("created_at", ""),
+                "updated_at": item.get("updated_at", ""),
+            }
+        )
+    prs.sort(
+        key=lambda item: (
+            str(item.get("repo", "")),
+            str(item.get("created_at", "")),
+            int(item.get("number") or 0),
+        ),
+        reverse=True,
+    )
+    return prs, None
+
+
 def record_content_error(
     *,
     errors: set[str],
@@ -372,9 +412,13 @@ def build_report(
     errors: set[str],
     obsolete: set[str],
     skipped: set[str] | None = None,
+    open_sync_prs: list[dict[str, object]] | None = None,
+    sync_pr_lookup_errors: list[str] | None = None,
     token_diagnostics: dict[str, object] | None = None,
 ) -> dict[str, object]:
     skipped = skipped or set()
+    open_sync_prs = open_sync_prs or []
+    sync_pr_lookup_errors = sync_pr_lookup_errors or []
     counts = {
         "drift": len(drift),
         "missing": len(missing),
@@ -391,6 +435,11 @@ def build_report(
     )
     top_repo_gaps = build_top_repo_gaps(repo_summaries)
     targeted_repos = [str(item["repo"]) for item in top_repo_gaps]
+    open_sync_repo_count = len({str(item.get("repo", "")) for item in open_sync_prs if item})
+    latest_open_sync_pr = open_sync_prs[0] if open_sync_prs else None
+    remediation_state = "pass"
+    if status != "pass":
+        remediation_state = "pending_sync_prs" if open_sync_prs else "needs_sync"
     report: dict[str, object] = {
         "schema": REPORT_SCHEMA,
         "status": status,
@@ -422,6 +471,15 @@ def build_report(
         "summary_limits": {
             "content_error_threshold_per_repo": CONTENT_ERROR_THRESHOLD,
             "max_items_per_section": SUMMARY_ITEM_LIMIT,
+        },
+        "sync_remediation": {
+            "state": remediation_state,
+            "open_pr_count": len(open_sync_prs),
+            "repo_count": open_sync_repo_count,
+            "latest_open_pr": latest_open_sync_pr,
+            "stale_open_pr_count": max(0, len(open_sync_prs) - open_sync_repo_count),
+            "open_prs": open_sync_prs,
+            "lookup_errors": sync_pr_lookup_errors,
         },
         "skip_count": len(skipped),
         "skipped": sorted_items(skipped),
@@ -504,6 +562,25 @@ def write_summary_markdown(path: str, report: dict[str, object]) -> None:
                     handle.write(f"- All repos: `{all_repos_command}`\n")
                 if targeted_repos_command:
                     handle.write(f"- Top repos: `{targeted_repos_command}`\n")
+                handle.write("\n")
+
+        sync_remediation = report.get("sync_remediation", {})
+        if isinstance(sync_remediation, dict):
+            open_prs = sync_remediation.get("open_prs", [])
+            if isinstance(open_prs, list) and open_prs:
+                open_pr_limit = 10
+                handle.write("### Open sync PRs\n")
+                for item in open_prs[:open_pr_limit]:
+                    if not isinstance(item, dict):
+                        continue
+                    repo = item.get("repo", "unknown")
+                    number = item.get("number", "")
+                    branch = item.get("branch", "")
+                    url = item.get("url", "")
+                    handle.write(f"- {repo}#{number}: `{branch}` {url}\n")
+                remaining = len(open_prs) - open_pr_limit
+                if remaining > 0:
+                    handle.write(f"- ... {remaining} more in consumer-sync-drift-report.json\n")
                 handle.write("\n")
 
         for title, key in (
@@ -674,12 +751,18 @@ def main() -> int:
     skipped: set[str] = set()
 
     remote_trees: dict[str, dict[str, dict[str, object]]] = {}
+    open_sync_prs: list[dict[str, object]] = []
+    sync_pr_lookup_errors: list[str] = []
     for repo in repos:
         remote_tree, tree_error = fetch_remote_tree(session, repo)
         if tree_error:
             errors.add(tree_error)
         else:
             remote_trees[repo] = remote_tree or {}
+        repo_sync_prs, sync_pr_error = fetch_open_sync_prs(session, repo)
+        open_sync_prs.extend(repo_sync_prs)
+        if sync_pr_error:
+            sync_pr_lookup_errors.append(sync_pr_error)
 
     def _check_file(local_file: Path, remote_target: str, repo: str) -> None:
         """Compare a single local file against its remote counterpart."""
@@ -737,6 +820,8 @@ def main() -> int:
         errors=errors,
         obsolete=obsolete,
         skipped=skipped,
+        open_sync_prs=open_sync_prs,
+        sync_pr_lookup_errors=sync_pr_lookup_errors,
         token_diagnostics=token_diagnostics,
     )
     write_report_json(args.report_json, report)

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -54,6 +54,15 @@ def test_build_report_returns_machine_readable_counts() -> None:
         ),
     }
     assert report["summary_limits"]["content_error_threshold_per_repo"] == 5
+    assert report["sync_remediation"] == {
+        "state": "needs_sync",
+        "open_pr_count": 0,
+        "repo_count": 0,
+        "latest_open_pr": None,
+        "stale_open_pr_count": 0,
+        "open_prs": [],
+        "lookup_errors": [],
+    }
     assert report["drift"] == ["owner/b: .github/workflows/a.yml"]
     assert report["token_diagnostics"] == token_diagnostics
 
@@ -106,6 +115,117 @@ def test_build_report_surfaces_manifest_skips_without_failing() -> None:
     assert report["counts"] == {"drift": 0, "missing": 0, "errors": 0, "obsolete": 0}
     assert report["skip_count"] == 1
     assert report["skipped"] == ["owner/custom: AGENTS.md (Uses historical Agents.md casing)"]
+    assert report["sync_remediation"]["state"] == "pass"
+
+
+def test_build_report_surfaces_pending_sync_prs() -> None:
+    report = check_consumer_sync_drift.build_report(
+        repos=["owner/repo"],
+        drift={"owner/repo: .github/workflows/a.yml"},
+        missing=set(),
+        errors=set(),
+        obsolete=set(),
+        open_sync_prs=[
+            {
+                "repo": "owner/repo",
+                "number": 12,
+                "url": "https://github.com/owner/repo/pull/12",
+                "branch": "sync/workflows-abc123",
+            }
+        ],
+        sync_pr_lookup_errors=["owner/other: sync PR lookup failed (HTTP 403)"],
+    )
+
+    assert report["sync_remediation"] == {
+        "state": "pending_sync_prs",
+        "open_pr_count": 1,
+        "repo_count": 1,
+        "latest_open_pr": {
+            "repo": "owner/repo",
+            "number": 12,
+            "url": "https://github.com/owner/repo/pull/12",
+            "branch": "sync/workflows-abc123",
+        },
+        "stale_open_pr_count": 0,
+        "open_prs": [
+            {
+                "repo": "owner/repo",
+                "number": 12,
+                "url": "https://github.com/owner/repo/pull/12",
+                "branch": "sync/workflows-abc123",
+            }
+        ],
+        "lookup_errors": ["owner/other: sync PR lookup failed (HTTP 403)"],
+    }
+
+
+def test_fetch_open_sync_prs_filters_to_workflows_sync_branches() -> None:
+    class Response:
+        status_code = 200
+
+        def json(self) -> list[dict[str, object]]:
+            return [
+                {
+                    "number": 5,
+                    "title": "ordinary",
+                    "html_url": "https://github.com/owner/repo/pull/5",
+                    "head": {"ref": "feature/example", "sha": "bad"},
+                },
+                {
+                    "number": 6,
+                    "title": "sync",
+                    "html_url": "https://github.com/owner/repo/pull/6",
+                    "head": {"ref": "sync/workflows-abc123", "sha": "good"},
+                    "created_at": "2026-04-26T01:00:00Z",
+                    "updated_at": "2026-04-26T02:00:00Z",
+                },
+                {
+                    "number": 7,
+                    "title": "newer sync",
+                    "html_url": "https://github.com/owner/repo/pull/7",
+                    "head": {"ref": "sync/workflows-def456", "sha": "newer"},
+                    "created_at": "2026-04-26T03:00:00Z",
+                    "updated_at": "2026-04-26T04:00:00Z",
+                },
+            ]
+
+    class Session:
+        requested_urls: list[str] = []
+
+        def get(self, url: str) -> Response:
+            self.requested_urls.append(url)
+            return Response()
+
+    session = Session()
+
+    prs, error = check_consumer_sync_drift.fetch_open_sync_prs(session, "owner/repo")
+
+    assert error is None
+    assert session.requested_urls == [
+        "https://api.github.com/repos/owner/repo/pulls?state=open&per_page=50"
+    ]
+    assert prs == [
+        {
+            "repo": "owner/repo",
+            "number": 7,
+            "title": "newer sync",
+            "url": "https://github.com/owner/repo/pull/7",
+            "branch": "sync/workflows-def456",
+            "head_sha": "newer",
+            "created_at": "2026-04-26T03:00:00Z",
+            "updated_at": "2026-04-26T04:00:00Z",
+        },
+        {
+            "repo": "owner/repo",
+            "number": 6,
+            "title": "sync",
+            "url": "https://github.com/owner/repo/pull/6",
+            "branch": "sync/workflows-abc123",
+            "head_sha": "good",
+            "created_at": "2026-04-26T01:00:00Z",
+            "updated_at": "2026-04-26T02:00:00Z",
+        },
+    ]
 
 
 def test_select_read_token_rejects_rate_limited_candidate() -> None:
@@ -262,12 +382,22 @@ def test_write_report_json_creates_parent_directory(tmp_path) -> None:
 def test_write_summary_markdown_groups_and_bounds_items(tmp_path) -> None:
     output = tmp_path / "summary.md"
     drift = {f"owner/repo: .github/workflows/{index}.yml" for index in range(55)}
+    open_sync_prs = [
+        {
+            "repo": "owner/repo",
+            "number": index,
+            "url": f"https://github.com/owner/repo/pull/{index}",
+            "branch": f"sync/workflows-{index}",
+        }
+        for index in range(12)
+    ]
     report = check_consumer_sync_drift.build_report(
         repos=["owner/repo"],
         drift=drift,
         missing={"owner/repo: scripts/langchain/formatter.py"},
         errors=set(),
         obsolete=set(),
+        open_sync_prs=open_sync_prs,
     )
 
     check_consumer_sync_drift.write_summary_markdown(str(output), report)
@@ -279,6 +409,10 @@ def test_write_summary_markdown_groups_and_bounds_items(tmp_path) -> None:
     assert "- owner/repo: total=56, drift=55, missing=1, errors=0, obsolete=0" in contents
     assert "- drift: .github/workflows=55" in contents
     assert "gh workflow run maint-68-sync-consumer-repos.yml" in contents
+    assert "- owner/repo#0: `sync/workflows-0` https://github.com/owner/repo/pull/0" in contents
+    assert "- owner/repo#9: `sync/workflows-9` https://github.com/owner/repo/pull/9" in contents
+    assert "- owner/repo#10: `sync/workflows-10`" not in contents
+    assert "... 2 more in consumer-sync-drift-report.json" in contents
     assert "... 5 more in consumer-sync-drift-report.json" in contents
 
 

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -205,6 +205,16 @@ def test_consumer_sync_run_uploads_machine_readable_report():
     assert (
         "sync_failed" in text and "create_pr_failed" in text
     ), "Maint 68 report must distinguish sync failures from PR creation failures"
+    assert (
+        "workflows-consumer-sync-pr/v1" in text
+        and "<!-- workflows-consumer-sync:v1 $sync_marker -->" in text
+    ), "Maint 68-created sync PRs must carry a machine-readable lifecycle marker"
+    assert (
+        "**Source SHA:**" in text
+        and "**Template hash:**" in text
+        and "**Sync branch:**" in text
+        and "**Consumer repo:**" in text
+    ), "Maint 68 sync PR bodies must expose source SHA, branch, hash, and repo metadata"
 
 
 def test_auto_label_uses_retry_paginate_with_github_client_first():


### PR DESCRIPTION
## Summary
- add Health 68 sync_remediation details for open Workflows sync PRs, including latest PR and stale-open counts
- include open sync PRs in drift issue bodies/comments and compact marker payloads
- add Maint 68 sync PR metadata marker with source SHA, template hash, sync branch, consumer repo, and lifecycle state

## Validation
- python -m pytest tests/scripts/test_check_consumer_sync_drift.py tests/workflows/test_workflow_agents_consolidation.py -q
- node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js .github/scripts/__tests__/sync-run-contract.test.js .github/scripts/__tests__/sync-pr-merge-contract.test.js
- node --check .github/scripts/consumer_sync_drift_issue_body.js
- python -m py_compile scripts/check_consumer_sync_drift.py
- python scripts/validate_template_sync.py
- python -c "import yaml; yaml.safe_load(open('.github/workflows/maint-68-sync-consumer-repos.yml')); yaml.safe_load(open('.github/workflows/health-68-consumer-sync-drift.yml'))"
- git diff --check origin/main...HEAD

Live targeted check: stranske/Ready currently reports drift with sync_remediation.state=pending_sync_prs and latest_open_pr=https://github.com/stranske/Ready/pull/137.


Source issue: #1836
