### PR TITLE
[codex] Add local GitNexus fleet integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Local workspace artifacts
 Trend_Model_Project/
+.gitnexus/
+.claude/skills/gitnexus/
 
 # Python
 __pycache__/
@@ -83,6 +85,7 @@ codex-output.md
 codex-prompt-*.md
 codex-output-*.md
 verifier-context.md
+verifier-diff-summary.md
 pr_body.md
 Issues.txt
 
@@ -94,10 +97,27 @@ pr_body.md
 # Updated by autofix workflow on every PR
 autofix_report_enriched.json
 .cosmetic-repair-summary.json
+ci/autofix/history.json
+ci/autofix/diagnostics.json
 
 # --- Metrics/History Files (MEDIUM conflict risk - append-only) ---
 # These accumulate data; prefer workflow artifacts over git commits
+keepalive_status.md
+docs/keepalive/status/
 keepalive-metrics.ndjson
+coverage-trend-history.ndjson
+metrics-history.ndjson
+metrics-retention.ndjson
+residual-trend-history.ndjson
+archives/metrics/
+
+# --- Build and coverage artifacts ---
+.autofix-venv/
+coverage.xml
+
+# --- Wrong package manager artifacts (defense-in-depth) ---
+Pipfile.lock
+poetry.lock
 
 # --- Local repo-review output (ephemeral human decision packets) ---
 docs/reports/repo-review/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@ Start with the current docs instead of inferring behavior from old comments:
 - Read `docs/guides/ADD_NEW_AGENT.md` before adding or changing agent support.
 - The current consumer default entry points are `agents-issue-intake.yml`, `agents-80-pr-event-hub.yml`, `agents-81-gate-followups.yml`, `agents-verifier.yml`, `autofix.yml`, `ci.yml`, and `pr-00-gate.yml`.
 
+## Optional GitNexus Context
+
+- GitNexus is an optional local MCP/indexing layer for cross-repo search and impact checks. Read `docs/ops/GITNEXUS.md` before changing its setup.
+- Use GitNexus opportunistically for workflow/template drift, reusable workflow blast-radius checks, and Workflows-vs-consumer ownership questions when the MCP server is available and indexes are fresh.
+- Treat `.gitnexus/` and `~/.gitnexus/` as local derived cache. Do not commit indexes or make CI, remote workflows, or correctness depend on GitNexus output.
+- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is temporary automation state and must be ignored.
+- If GitNexus is unavailable or stale, continue with normal `rg`, git, and test-based repository exploration.
+
 ## Workflow PR Checklist
 
 1. Decide whether the change belongs in a reusable workflow, a consumer template, or a consumer repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,14 @@ Start with the current docs instead of inferring behavior from old comments:
 - Read `docs/guides/ADD_NEW_AGENT.md` before adding or changing agent support.
 - The current consumer default entry points are `agents-issue-intake.yml`, `agents-80-pr-event-hub.yml`, `agents-81-gate-followups.yml`, `agents-verifier.yml`, `autofix.yml`, `ci.yml`, and `pr-00-gate.yml`.
 
+## Optional GitNexus Context
+
+- GitNexus is an optional local MCP/indexing layer for cross-repo search and impact checks. Read `docs/ops/GITNEXUS.md` before changing its setup.
+- Use GitNexus opportunistically for workflow/template drift, reusable workflow blast-radius checks, and Workflows-vs-consumer ownership questions when the MCP server is available and indexes are fresh.
+- Treat `.gitnexus/` and `~/.gitnexus/` as local derived cache. Do not commit indexes or make CI, remote workflows, or correctness depend on GitNexus output.
+- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is temporary automation state and must be ignored.
+- If GitNexus is unavailable or stale, continue with normal `rg`, git, and test-based repository exploration.
+
 ## Workflow PR Checklist
 
 1. Decide whether the change belongs in a reusable workflow, a consumer template, or a consumer repo.

--- a/docs/ops/GITNEXUS.md
+++ b/docs/ops/GITNEXUS.md
@@ -42,8 +42,8 @@ GitNexus writes repo-local `.gitnexus/` indexes, may generate
 Install the pinned CLI once:
 
 ```bash
-scripts/gitnexus_fleet.sh install
-scripts/gitnexus_fleet.sh check-version
+docs/ops/bin/gitnexus_fleet.sh install
+docs/ops/bin/gitnexus_fleet.sh check-version
 ```
 
 Use one global MCP server for Codex:
@@ -57,7 +57,7 @@ args = ["mcp"]
 The helper prints the current snippet:
 
 ```bash
-scripts/gitnexus_fleet.sh mcp-config
+docs/ops/bin/gitnexus_fleet.sh mcp-config
 ```
 
 ## Index Freshness
@@ -73,25 +73,28 @@ Baseline indexing intentionally leaves embeddings off and skips
 GitNexus-managed `AGENTS.md` / `CLAUDE.md` rewrites:
 
 ```bash
-scripts/gitnexus_fleet.sh index all
-scripts/gitnexus_fleet.sh group-create
-scripts/gitnexus_fleet.sh group-add
-scripts/gitnexus_fleet.sh group-sync
+docs/ops/bin/gitnexus_fleet.sh ensure-ignores all
+docs/ops/bin/gitnexus_fleet.sh index all
+docs/ops/bin/gitnexus_fleet.sh group-create
+docs/ops/bin/gitnexus_fleet.sh group-add
+docs/ops/bin/gitnexus_fleet.sh group-sync
 ```
 
-Use `scripts/gitnexus_fleet.sh status all` or
-`scripts/gitnexus_fleet.sh group-status` before relying on GitNexus context.
+Use `docs/ops/bin/gitnexus_fleet.sh status all` or
+`docs/ops/bin/gitnexus_fleet.sh group-status` before relying on GitNexus
+context.
 
 ## Tool Freshness
 
 The GitNexus tool version is intentionally separate from repository dependency
-updates. Update `GITNEXUS_VERSION` in `scripts/gitnexus_fleet.sh`, then run the
-pinned global install, only after a manual smoke test on a single repo succeeds.
+updates. Update `GITNEXUS_VERSION` in `docs/ops/bin/gitnexus_fleet.sh`, then
+run the pinned global install, only after a manual smoke test on a single repo
+succeeds.
 
 Recommended upgrade flow:
 
 1. Run the current pinned version against `Template`.
-2. Test the candidate version with `GITNEXUS_VERSION=<version> scripts/gitnexus_fleet.sh install`.
+2. Test the candidate version with `GITNEXUS_VERSION=<version> docs/ops/bin/gitnexus_fleet.sh install`.
 3. Confirm `check-version`, `index Template`, `status Template`, and group commands still work.
 4. Update the pin and this document in the same Workflows change.
 

--- a/docs/ops/GITNEXUS.md
+++ b/docs/ops/GITNEXUS.md
@@ -1,0 +1,108 @@
+# GitNexus Local Code Intelligence
+
+GitNexus is an optional local code-intelligence layer for the active Code
+workspace. It is not a CI dependency, runtime dependency, or source of truth.
+GitHub and the checked-out source tree remain authoritative.
+
+## Scope
+
+The canonical GitNexus fleet is:
+
+- `Workflows`
+- `Template`
+- `Manager-Database`
+- `Travel-Plan-Permission`
+- `trip-planner`
+- `Inv-Man-Intake`
+- `Pension-Data`
+- `Counter_Risk`
+- `Trend_Model_Project`
+- `Portable-Alpha-Extension-Model`
+- `Collab-Admin`
+
+`Workflows-steward` is temporary automation state and must be ignored by
+GitNexus. Do not add short-lived issue, PR, or review clones to the registry.
+
+## Local Cache Policy
+
+GitNexus writes repo-local `.gitnexus/` indexes, may generate
+`.claude/skills/gitnexus/`, and keeps global registry state under
+`~/.gitnexus/`. Treat all of these as derived local cache.
+
+- Do not commit `.gitnexus/`.
+- Do not commit `.claude/skills/gitnexus/`.
+- Keep `.gitnexus` or `.gitnexus/` ignore entries if GitNexus adds them to
+  a repo `.gitignore`.
+- Do not require GitNexus for CI or remote workflows.
+- Do not make correctness depend on GitNexus output.
+- Use normal `rg`, git, and repository tests as the fallback path.
+
+## MCP Setup
+
+Install the pinned CLI once:
+
+```bash
+scripts/gitnexus_fleet.sh install
+scripts/gitnexus_fleet.sh check-version
+```
+
+Use one global MCP server for Codex:
+
+```toml
+[mcp_servers.gitnexus]
+command = "gitnexus"
+args = ["mcp"]
+```
+
+The helper prints the current snippet:
+
+```bash
+scripts/gitnexus_fleet.sh mcp-config
+```
+
+## Index Freshness
+
+Refresh indexes after source changes that can make graph data stale:
+
+- after `git pull`, merge, rebase, or branch switch
+- before large cross-repo automation runs
+- before impact analysis on workflow/template changes
+- after a Codex automation lands significant code changes
+
+Baseline indexing intentionally leaves embeddings off and skips
+GitNexus-managed `AGENTS.md` / `CLAUDE.md` rewrites:
+
+```bash
+scripts/gitnexus_fleet.sh index all
+scripts/gitnexus_fleet.sh group-create
+scripts/gitnexus_fleet.sh group-add
+scripts/gitnexus_fleet.sh group-sync
+```
+
+Use `scripts/gitnexus_fleet.sh status all` or
+`scripts/gitnexus_fleet.sh group-status` before relying on GitNexus context.
+
+## Tool Freshness
+
+The GitNexus tool version is intentionally separate from repository dependency
+updates. Update `GITNEXUS_VERSION` in `scripts/gitnexus_fleet.sh`, then run the
+pinned global install, only after a manual smoke test on a single repo succeeds.
+
+Recommended upgrade flow:
+
+1. Run the current pinned version against `Template`.
+2. Test the candidate version with `GITNEXUS_VERSION=<version> scripts/gitnexus_fleet.sh install`.
+3. Confirm `check-version`, `index Template`, `status Template`, and group commands still work.
+4. Update the pin and this document in the same Workflows change.
+
+## Agent And Automation Use
+
+Agents and local Codex automations may use GitNexus opportunistically when the
+MCP server is available and indexes are fresh. Good uses include:
+
+- cross-repo workflow/template drift checks
+- impact analysis before reusable workflow changes
+- locating shared agent, keepalive, verifier, and autofix behavior
+- checking whether a change belongs in `Workflows` or a consumer repo
+
+If GitNexus is unavailable or stale, continue with normal repo exploration.

--- a/docs/ops/bin/gitnexus_fleet.sh
+++ b/docs/ops/bin/gitnexus_fleet.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 GITNEXUS_VERSION="${GITNEXUS_VERSION:-1.6.3}"
 GROUP_NAME="${GITNEXUS_GROUP_NAME:-stranske-code}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKFLOWS_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKFLOWS_ROOT="${WORKFLOWS_ROOT:-$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)}"
 CODE_ROOT="${CODE_ROOT:-$(cd "${WORKFLOWS_ROOT}/.." && pwd)}"
 GITNEXUS_BIN="${GITNEXUS_BIN:-gitnexus}"
 
@@ -40,10 +40,12 @@ run_gitnexus() {
 
 usage() {
   cat <<USAGE
-Usage: scripts/gitnexus_fleet.sh <command> [repo-name]
+Usage: docs/ops/bin/gitnexus_fleet.sh <command> [repo-name]
 
 Commands:
   list                 Show canonical repos in the GitNexus fleet.
+  ensure-ignores [repo|all]
+                       Ensure local GitNexus cache patterns are in .gitignore.
   index [repo|all]     Run gitnexus analyze with local-cache defaults.
   status [repo|all]    Run gitnexus status for indexed repos.
   group-create         Create the ${GROUP_NAME} GitNexus group.
@@ -78,9 +80,24 @@ require_repo() {
   fi
 }
 
+ensure_repo_ignores() {
+  local repo="$1"
+  local ignore_file pattern
+  require_repo "${repo}"
+  ignore_file="$(repo_path "${repo}")/.gitignore"
+  touch "${ignore_file}"
+  for pattern in ".gitnexus/" ".claude/skills/gitnexus/"; do
+    if ! grep -Fxq "${pattern}" "${ignore_file}"; then
+      printf '%s\n' "${pattern}" >> "${ignore_file}"
+      echo "Added ${pattern} to ${repo}/.gitignore"
+    fi
+  done
+}
+
 index_repo() {
   local repo="$1"
   require_repo "${repo}"
+  ensure_repo_ignores "${repo}"
   echo "Indexing ${repo}"
   run_gitnexus analyze "$(repo_path "${repo}")" --skip-agents-md
 }
@@ -95,6 +112,16 @@ status_repo() {
 case "${1:-}" in
   list)
     printf '%s\n' "${FLEET_REPOS[@]}"
+    ;;
+  ensure-ignores)
+    target="${2:-all}"
+    if [[ "${target}" == "all" ]]; then
+      for repo in "${FLEET_REPOS[@]}"; do
+        ensure_repo_ignores "${repo}"
+      done
+    else
+      ensure_repo_ignores "${target}"
+    fi
     ;;
   index)
     target="${2:-all}"

--- a/scripts/gitnexus_fleet.sh
+++ b/scripts/gitnexus_fleet.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Local GitNexus fleet helper for the stranske Code workspace.
+#
+# GitNexus is an optional local code-intelligence layer. GitHub remains the
+# source of truth; .gitnexus/ indexes are derived local cache and are ignored.
+
+set -euo pipefail
+
+GITNEXUS_VERSION="${GITNEXUS_VERSION:-1.6.3}"
+GROUP_NAME="${GITNEXUS_GROUP_NAME:-stranske-code}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOWS_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CODE_ROOT="${CODE_ROOT:-$(cd "${WORKFLOWS_ROOT}/.." && pwd)}"
+GITNEXUS_BIN="${GITNEXUS_BIN:-gitnexus}"
+
+# Canonical repos only. Workflows-steward is a temporary automation worktree
+# and must not be registered in GitNexus.
+FLEET_REPOS=(
+  "Workflows"
+  "Template"
+  "Manager-Database"
+  "Travel-Plan-Permission"
+  "trip-planner"
+  "Inv-Man-Intake"
+  "Pension-Data"
+  "Counter_Risk"
+  "Trend_Model_Project"
+  "Portable-Alpha-Extension-Model"
+  "Collab-Admin"
+)
+
+repo_path() {
+  printf '%s/%s\n' "${CODE_ROOT}" "$1"
+}
+
+run_gitnexus() {
+  # shellcheck disable=SC2086
+  ${GITNEXUS_BIN} "$@"
+}
+
+usage() {
+  cat <<USAGE
+Usage: scripts/gitnexus_fleet.sh <command> [repo-name]
+
+Commands:
+  list                 Show canonical repos in the GitNexus fleet.
+  index [repo|all]     Run gitnexus analyze with local-cache defaults.
+  status [repo|all]    Run gitnexus status for indexed repos.
+  group-create         Create the ${GROUP_NAME} GitNexus group.
+  group-add            Add canonical repos to the ${GROUP_NAME} group.
+  group-sync           Run GitNexus group sync for ${GROUP_NAME}.
+  group-status         Show GitNexus group staleness for ${GROUP_NAME}.
+  install              Install the pinned GitNexus CLI globally with npm.
+  check-version        Verify the installed GitNexus CLI matches the pin.
+  mcp-config           Print the pinned Codex MCP config snippet.
+  version              Print the pinned GitNexus version.
+
+Environment:
+  CODE_ROOT            Code workspace root. Default: parent of Workflows.
+  GITNEXUS_VERSION     GitNexus npm version. Default: ${GITNEXUS_VERSION}.
+  GITNEXUS_BIN         Command prefix. Default: gitnexus.
+  GITNEXUS_GROUP_NAME  Group name. Default: ${GROUP_NAME}.
+
+Notes:
+  - This script intentionally ignores Workflows-steward.
+  - Initial indexing leaves embeddings off and skips AGENTS/CLAUDE rewrites.
+  - Use --embeddings manually only after baseline indexing proves useful.
+USAGE
+}
+
+require_repo() {
+  local repo="$1"
+  local path
+  path="$(repo_path "${repo}")"
+  if [[ ! -d "${path}" ]]; then
+    echo "Missing repo path: ${path}" >&2
+    return 1
+  fi
+}
+
+index_repo() {
+  local repo="$1"
+  require_repo "${repo}"
+  echo "Indexing ${repo}"
+  run_gitnexus analyze "$(repo_path "${repo}")" --skip-agents-md
+}
+
+status_repo() {
+  local repo="$1"
+  require_repo "${repo}"
+  echo "Status ${repo}"
+  (cd "$(repo_path "${repo}")" && run_gitnexus status)
+}
+
+case "${1:-}" in
+  list)
+    printf '%s\n' "${FLEET_REPOS[@]}"
+    ;;
+  index)
+    target="${2:-all}"
+    if [[ "${target}" == "all" ]]; then
+      for repo in "${FLEET_REPOS[@]}"; do
+        index_repo "${repo}"
+      done
+    else
+      index_repo "${target}"
+    fi
+    ;;
+  status)
+    target="${2:-all}"
+    if [[ "${target}" == "all" ]]; then
+      for repo in "${FLEET_REPOS[@]}"; do
+        status_repo "${repo}" || true
+      done
+    else
+      status_repo "${target}"
+    fi
+    ;;
+  group-create)
+    run_gitnexus group create "${GROUP_NAME}"
+    ;;
+  group-add)
+    for repo in "${FLEET_REPOS[@]}"; do
+      run_gitnexus group add "${GROUP_NAME}" "${repo}" "${repo}" || true
+    done
+    ;;
+  group-sync)
+    run_gitnexus group sync "${GROUP_NAME}"
+    ;;
+  group-status)
+    run_gitnexus group status "${GROUP_NAME}"
+    ;;
+  install)
+    npm install -g "gitnexus@${GITNEXUS_VERSION}"
+    ;;
+  check-version)
+    installed="$(${GITNEXUS_BIN} --version)"
+    if [[ "${installed}" != "${GITNEXUS_VERSION}" ]]; then
+      echo "GitNexus version mismatch: installed ${installed}, expected ${GITNEXUS_VERSION}" >&2
+      exit 1
+    fi
+    echo "GitNexus ${installed}"
+    ;;
+  mcp-config)
+    cat <<CONFIG
+[mcp_servers.gitnexus]
+command = "gitnexus"
+args = ["mcp"]
+CONFIG
+    ;;
+  version)
+    printf '%s\n' "${GITNEXUS_VERSION}"
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/templates/consumer-repo/.gitignore
+++ b/templates/consumer-repo/.gitignore
@@ -1,4 +1,6 @@
 # Byte-compiled / optimized / DLL files
+.gitnexus/
+.claude/skills/gitnexus/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/templates/consumer-repo/AGENTS.md
+++ b/templates/consumer-repo/AGENTS.md
@@ -72,6 +72,13 @@ If yes:
 2. Update the sync manifest if a consumer-facing file changed
 3. Sync or manually align this repo afterward
 
+## Optional GitNexus Context
+
+- GitNexus may be available as a local MCP/indexing layer for cross-repo search and impact checks.
+- Use it opportunistically for workflow/template drift, blast-radius checks, and Workflows-vs-consumer ownership questions when indexes are fresh.
+- Treat `.gitnexus/` as local derived cache. Do not commit it, require it in CI, or make correctness depend on it.
+- If GitNexus is unavailable or stale, continue with normal `rg`, git, and repository tests.
+
 ## Useful References
 
 - `stranske/Workflows/README.md`

--- a/templates/consumer-repo/CLAUDE.md
+++ b/templates/consumer-repo/CLAUDE.md
@@ -72,6 +72,13 @@ If yes:
 2. Update the sync manifest if a consumer-facing file changed
 3. Sync or manually align this repo afterward
 
+## Optional GitNexus Context
+
+- GitNexus may be available as a local MCP/indexing layer for cross-repo search and impact checks.
+- Use it opportunistically for workflow/template drift, blast-radius checks, and Workflows-vs-consumer ownership questions when indexes are fresh.
+- Treat `.gitnexus/` as local derived cache. Do not commit it, require it in CI, or make correctness depend on it.
+- If GitNexus is unavailable or stale, continue with normal `rg`, git, and repository tests.
+
 ## Useful References
 
 - `stranske/Workflows/README.md`


### PR DESCRIPTION
## Summary

Adds a local GitNexus fleet integration for the active Code workspace:

- documents GitNexus as optional local code intelligence in `docs/ops/GITNEXUS.md`
- adds `scripts/gitnexus_fleet.sh` for pinned install, version checks, indexing, group sync, and MCP config output
- updates Workflows and consumer-template `AGENTS.md` / `CLAUDE.md` guidance
- ignores local GitNexus cache outputs in Workflows and consumer templates

The canonical fleet includes `Template` and excludes temporary `Workflows-steward` automation state.

## Validation

- `python -m scripts.validate_template_completeness`
- `python -m scripts.validate_template_sync`
- `python -m scripts.sync_status_file_ignores --check`
- `bash -n scripts/gitnexus_fleet.sh`
- `scripts/gitnexus_fleet.sh check-version`
- `scripts/gitnexus_fleet.sh group-status`

## Notes

GitNexus indexing is local-only. `.gitnexus/`, `.claude/skills/gitnexus/`, and `~/.gitnexus/` remain derived local cache and are not required for CI or remote workflows.
