### PR TITLE
Use global excludes for GitNexus cache

### DIFF
--- a/docs/ops/GITNEXUS.md
+++ b/docs/ops/GITNEXUS.md
@@ -31,8 +31,10 @@ GitNexus writes repo-local `.gitnexus/` indexes, may generate
 
 - Do not commit `.gitnexus/`.
 - Do not commit `.claude/skills/gitnexus/`.
-- Keep `.gitnexus` or `.gitnexus/` ignore entries if GitNexus adds them to
-  a repo `.gitignore`.
+- Prefer global git excludes for GitNexus cache paths so local-only setup does
+  not dirty every repo worktree.
+- Do not add repo-specific `.gitignore` entries solely for GitNexus unless that
+  repo intentionally wants to track them.
 - Do not require GitNexus for CI or remote workflows.
 - Do not make correctness depend on GitNexus output.
 - Use normal `rg`, git, and repository tests as the fallback path.
@@ -44,6 +46,7 @@ Install the pinned CLI once:
 ```bash
 docs/ops/bin/gitnexus_fleet.sh install
 docs/ops/bin/gitnexus_fleet.sh check-version
+docs/ops/bin/gitnexus_fleet.sh ensure-global-ignore
 ```
 
 Use one global MCP server for Codex:
@@ -73,7 +76,7 @@ Baseline indexing intentionally leaves embeddings off and skips
 GitNexus-managed `AGENTS.md` / `CLAUDE.md` rewrites:
 
 ```bash
-docs/ops/bin/gitnexus_fleet.sh ensure-ignores all
+docs/ops/bin/gitnexus_fleet.sh ensure-global-ignore
 docs/ops/bin/gitnexus_fleet.sh index all
 docs/ops/bin/gitnexus_fleet.sh group-create
 docs/ops/bin/gitnexus_fleet.sh group-add

--- a/docs/ops/bin/gitnexus_fleet.sh
+++ b/docs/ops/bin/gitnexus_fleet.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOWS_ROOT="${WORKFLOWS_ROOT:-$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)}"
 CODE_ROOT="${CODE_ROOT:-$(cd "${WORKFLOWS_ROOT}/.." && pwd)}"
 GITNEXUS_BIN="${GITNEXUS_BIN:-gitnexus}"
+GITNEXUS_GLOBAL_IGNORE="${GITNEXUS_GLOBAL_IGNORE:-${HOME}/.gitignore_global}"
 
 # Canonical repos only. Workflows-steward is a temporary automation worktree
 # and must not be registered in GitNexus.
@@ -44,8 +45,8 @@ Usage: docs/ops/bin/gitnexus_fleet.sh <command> [repo-name]
 
 Commands:
   list                 Show canonical repos in the GitNexus fleet.
-  ensure-ignores [repo|all]
-                       Ensure local GitNexus cache patterns are in .gitignore.
+  ensure-global-ignore
+                       Ensure local GitNexus cache patterns are globally ignored.
   index [repo|all]     Run gitnexus analyze with local-cache defaults.
   status [repo|all]    Run gitnexus status for indexed repos.
   group-create         Create the ${GROUP_NAME} GitNexus group.
@@ -62,6 +63,8 @@ Environment:
   GITNEXUS_VERSION     GitNexus npm version. Default: ${GITNEXUS_VERSION}.
   GITNEXUS_BIN         Command prefix. Default: gitnexus.
   GITNEXUS_GROUP_NAME  Group name. Default: ${GROUP_NAME}.
+  GITNEXUS_GLOBAL_IGNORE
+                       Global excludes file. Default: ${GITNEXUS_GLOBAL_IGNORE}.
 
 Notes:
   - This script intentionally ignores Workflows-steward.
@@ -80,24 +83,24 @@ require_repo() {
   fi
 }
 
-ensure_repo_ignores() {
-  local repo="$1"
+ensure_global_ignore() {
   local ignore_file pattern
-  require_repo "${repo}"
-  ignore_file="$(repo_path "${repo}")/.gitignore"
+  ignore_file="${GITNEXUS_GLOBAL_IGNORE}"
+  mkdir -p "$(dirname "${ignore_file}")"
   touch "${ignore_file}"
   for pattern in ".gitnexus/" ".claude/skills/gitnexus/"; do
     if ! grep -Fxq "${pattern}" "${ignore_file}"; then
       printf '%s\n' "${pattern}" >> "${ignore_file}"
-      echo "Added ${pattern} to ${repo}/.gitignore"
+      echo "Added ${pattern} to ${ignore_file}"
     fi
   done
+  git config --global core.excludesfile "${ignore_file}"
+  echo "Global git excludes: ${ignore_file}"
 }
 
 index_repo() {
   local repo="$1"
   require_repo "${repo}"
-  ensure_repo_ignores "${repo}"
   echo "Indexing ${repo}"
   run_gitnexus analyze "$(repo_path "${repo}")" --skip-agents-md
 }
@@ -113,15 +116,8 @@ case "${1:-}" in
   list)
     printf '%s\n' "${FLEET_REPOS[@]}"
     ;;
-  ensure-ignores)
-    target="${2:-all}"
-    if [[ "${target}" == "all" ]]; then
-      for repo in "${FLEET_REPOS[@]}"; do
-        ensure_repo_ignores "${repo}"
-      done
-    else
-      ensure_repo_ignores "${target}"
-    fi
+  ensure-global-ignore)
+    ensure_global_ignore
     ;;
   index)
     target="${2:-all}"

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -470,11 +470,7 @@ def build_review_execution(state: dict[str, Any]) -> dict[str, Any]:
     repo_path = Path(state["local_path"])
     tracked_files = tracked_repo_files(repo_path)
     evidence_files = [path for path in tracked_files if not is_evidence_noise_file(path)]
-    implementation_files = [
-        path
-        for path in evidence_files
-        if is_implementation_file(path)
-    ]
+    implementation_files = [path for path in evidence_files if is_implementation_file(path)]
     test_files = [path for path in evidence_files if is_test_file(path)]
     implementation_scan_files = implementation_files[:REVIEW_SCAN_FILE_LIMIT]
     test_scan_files = test_files[:REVIEW_SCAN_FILE_LIMIT]


### PR DESCRIPTION
## Summary
- switch the GitNexus fleet helper from tracked repo .gitignore edits to a global git excludes setup
- update GitNexus ops docs to preserve the local-only dependency model
- apply Black formatting to an existing Workflows script so current CI format checks pass

## Validation
- bash -n docs/ops/bin/gitnexus_fleet.sh
- docs/ops/bin/gitnexus_fleet.sh ensure-global-ignore
- docs/ops/bin/gitnexus_fleet.sh check-version
- python -m scripts.validate_template_completeness
- python -m scripts.validate_template_sync
- python -m scripts.sync_status_file_ignores --check
- python -m ruff check .
- python -m black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .
- python -m mypy src