### PR TITLE
[codex] Harden telemetry source contracts

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -349,6 +349,30 @@ test('does not require verifier model metadata when mode is unknown', () => {
   assert.deepEqual(report.enforcement.blockers, []);
 });
 
+test('requires verifier model metadata for post-contract records with unknown mode', () => {
+  const report = summarizeTerminalDispositionCoverage(
+    [
+      {
+        schema: 'workflows-terminal-disposition/v1',
+        artifact_family: 'verifier-terminal-disposition',
+        source_type: 'pull-request',
+        source_id: '1874',
+        pr_number: 1874,
+        run_id: '24948023779',
+        disposition: 'verifier-error',
+      },
+    ],
+    {
+      model_metadata_required_after: '2026-04-26T04:25:00Z',
+    }
+  );
+
+  assert.equal(report.status, 'warning');
+  assert.equal(report.verifier_model_compatibility.missing_model_record_count, 1);
+  assert.deepEqual(report.enforcement.blockers, ['missing-verifier-model-metadata']);
+  assert.equal(report.verifier_model_compatibility.missing_model_records[0].verifier_mode, 'unknown');
+});
+
 test('suppresses pre-contract verifier terminal records missing model metadata', () => {
   const report = summarizeTerminalDispositionCoverage(
     [

--- a/.github/scripts/__tests__/terminal-disposition.test.js
+++ b/.github/scripts/__tests__/terminal-disposition.test.js
@@ -50,6 +50,25 @@ test('normalizes terminal disposition records with stable source keys', () => {
   assert.equal(record.needs_human, false);
 });
 
+test('normalizes boolean-like optional fields without stringifying them', () => {
+  const terminal = normalizeTerminalDisposition({
+    sourceId: 42,
+    needsHuman: 'false',
+  });
+  const ledger = normalizeVerifierFollowupLedger({
+    prNumber: 101,
+    verificationRunId: 249,
+    needsHuman: 'true',
+    followupPolicy: {
+      depthLimitExceeded: 'false',
+    },
+  });
+
+  assert.equal(terminal.needs_human, false);
+  assert.equal(ledger.needs_human, true);
+  assert.equal(ledger.followup_policy.depth_limit_exceeded, false);
+});
+
 test('sourceKey falls back to unknown for blank values', () => {
   assert.equal(sourceKey('', ''), 'unknown:unknown');
 });

--- a/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-download-manifest.test.js
@@ -183,6 +183,28 @@ test('records download and unzip outcomes and finalizes warning status', () => {
   assert.equal(manifest.artifacts[1].unzip.error, 'download-failed');
 });
 
+test('records outcomes against legacy manifest entries missing result objects', () => {
+  const manifest = buildInitialManifest(selection);
+  delete manifest.artifacts[0].download;
+  delete manifest.artifacts[0].unzip;
+
+  updateArtifactResult(manifest, {
+    id: '42',
+    artifact_dir: 'artifacts/keepalive-metrics/42',
+    download_status: 'pass',
+    unzip_status: 'pass',
+  });
+  finalizeManifest(manifest);
+
+  assert.equal(manifest.status, 'warning');
+  assert.equal(manifest.artifacts[0].download.status, 'pass');
+  assert.equal(manifest.artifacts[0].download.bytes, null);
+  assert.equal(manifest.artifacts[0].unzip.status, 'pass');
+  assert.equal(manifest.artifacts[0].unzip.path, 'artifacts/keepalive-metrics/42');
+  assert.equal(manifest.stats.download_pass_count, 1);
+  assert.equal(manifest.stats.unzip_pass_count, 1);
+});
+
 test('finalizes pass when every selected artifact downloads and extracts', () => {
   const manifest = buildInitialManifest(selection);
   for (const artifact of manifest.artifacts) {

--- a/.github/scripts/terminal_disposition.js
+++ b/.github/scripts/terminal_disposition.js
@@ -37,6 +37,21 @@ function normalizeSourceId(value, fallback) {
   return fallbackText || 'unknown';
 }
 
+function normalizeOptionalValue(key, value) {
+  if (value === null || value === undefined) return undefined;
+  if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
+    const parsed = cleanInt(value);
+    return parsed === null ? undefined : parsed;
+  }
+  if (key === 'needs_human' || key === 'depth_limit_exceeded') {
+    const parsed = cleanBool(value);
+    return parsed === null ? undefined : parsed;
+  }
+  const cleaned = typeof value === 'boolean' ? value : cleanString(value);
+  if (cleaned === '') return undefined;
+  return typeof value === 'string' ? cleaned : value;
+}
+
 function sourceKey(sourceType, sourceId) {
   return `${normalizeSourceType(sourceType)}:${normalizeSourceId(sourceId)}`;
 }
@@ -216,10 +231,8 @@ function normalizeTerminalDisposition(input = {}) {
   };
 
   for (const [key, value] of Object.entries(optional)) {
-    if (value === null || value === undefined) continue;
-    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
-    if (cleaned === '') continue;
-    record[key] = typeof value === 'string' ? cleaned : value;
+    const normalized = normalizeOptionalValue(key, value);
+    if (normalized !== undefined) record[key] = normalized;
   }
 
   return record;
@@ -274,15 +287,8 @@ function normalizeVerifierFollowupLedger(input = {}) {
   };
 
   for (const [key, value] of Object.entries(optional)) {
-    if (value === null || value === undefined) continue;
-    if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
-      const parsed = cleanInt(value);
-      if (parsed !== null) record[key] = parsed;
-      continue;
-    }
-    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
-    if (cleaned === '') continue;
-    record[key] = typeof value === 'string' ? cleaned : value;
+    const normalized = normalizeOptionalValue(key, value);
+    if (normalized !== undefined) record[key] = normalized;
   }
 
   return record;
@@ -362,6 +368,7 @@ module.exports = {
   normalizeVerifierFollowupLedger,
   normalizeVerifierFollowupPolicy,
   normalizeLedgerDisposition,
+  normalizeOptionalValue,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/.github/scripts/terminal_disposition_coverage.js
+++ b/.github/scripts/terminal_disposition_coverage.js
@@ -174,7 +174,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
+    const requiresCodexModel = verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel && modelMetadataContract.model_metadata_required) {

--- a/.github/scripts/weekly_metrics_download_manifest.js
+++ b/.github/scripts/weekly_metrics_download_manifest.js
@@ -120,11 +120,44 @@ function findArtifact(manifest, id, name) {
   });
 }
 
+function normalizeArtifactResultShape(artifact) {
+  if (!artifact || typeof artifact !== 'object') return;
+  if (!artifact.download || typeof artifact.download !== 'object') {
+    artifact.download = {
+      status: 'pending',
+      bytes: null,
+      error: '',
+    };
+  }
+  if (!artifact.unzip || typeof artifact.unzip !== 'object') {
+    artifact.unzip = {
+      status: 'pending',
+      path: artifact.artifact_dir || '',
+      error: '',
+    };
+  }
+  artifact.download.status = normalizeStatus(
+    artifact.download.status,
+    ['pending', 'pass', 'failed', 'skipped'],
+    'pending'
+  );
+  artifact.unzip.status = normalizeStatus(
+    artifact.unzip.status,
+    ['pending', 'pass', 'failed', 'skipped'],
+    'pending'
+  );
+  if (!artifact.unzip.path) artifact.unzip.path = artifact.artifact_dir || '';
+  if (artifact.download.bytes === undefined) artifact.download.bytes = null;
+  if (artifact.download.error === undefined) artifact.download.error = '';
+  if (artifact.unzip.error === undefined) artifact.unzip.error = '';
+}
+
 function updateArtifactResult(manifest, result = {}) {
   const artifact = findArtifact(manifest, result.id, result.name);
   if (!artifact) {
     throw new Error(`Artifact is not present in manifest: ${cleanString(result.id || result.name)}`);
   }
+  normalizeArtifactResultShape(artifact);
   const artifactDir = cleanString(result.artifact_dir || result.artifactDir);
   const zipPath = cleanString(result.zip_path || result.zipPath);
   const zipBytes = Number.parseInt(cleanString(result.zip_bytes || result.zipBytes), 10);

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -568,7 +568,7 @@ def _summarise_verifier(
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal and model_metadata_required:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode and verifier_mode != "evaluate":
+            if verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
                     legacy_missing_verifier_model_metadata[str(disposition)] += 1

--- a/templates/consumer-repo/.github/scripts/terminal_disposition.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition.js
@@ -37,6 +37,21 @@ function normalizeSourceId(value, fallback) {
   return fallbackText || 'unknown';
 }
 
+function normalizeOptionalValue(key, value) {
+  if (value === null || value === undefined) return undefined;
+  if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
+    const parsed = cleanInt(value);
+    return parsed === null ? undefined : parsed;
+  }
+  if (key === 'needs_human' || key === 'depth_limit_exceeded') {
+    const parsed = cleanBool(value);
+    return parsed === null ? undefined : parsed;
+  }
+  const cleaned = typeof value === 'boolean' ? value : cleanString(value);
+  if (cleaned === '') return undefined;
+  return typeof value === 'string' ? cleaned : value;
+}
+
 function sourceKey(sourceType, sourceId) {
   return `${normalizeSourceType(sourceType)}:${normalizeSourceId(sourceId)}`;
 }
@@ -216,10 +231,8 @@ function normalizeTerminalDisposition(input = {}) {
   };
 
   for (const [key, value] of Object.entries(optional)) {
-    if (value === null || value === undefined) continue;
-    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
-    if (cleaned === '') continue;
-    record[key] = typeof value === 'string' ? cleaned : value;
+    const normalized = normalizeOptionalValue(key, value);
+    if (normalized !== undefined) record[key] = normalized;
   }
 
   return record;
@@ -274,15 +287,8 @@ function normalizeVerifierFollowupLedger(input = {}) {
   };
 
   for (const [key, value] of Object.entries(optional)) {
-    if (value === null || value === undefined) continue;
-    if (key.endsWith('_number') || key === 'chain_depth' || key === 'verification_run_attempt') {
-      const parsed = cleanInt(value);
-      if (parsed !== null) record[key] = parsed;
-      continue;
-    }
-    const cleaned = typeof value === 'boolean' ? value : cleanString(value);
-    if (cleaned === '') continue;
-    record[key] = typeof value === 'string' ? cleaned : value;
+    const normalized = normalizeOptionalValue(key, value);
+    if (normalized !== undefined) record[key] = normalized;
   }
 
   return record;
@@ -362,6 +368,7 @@ module.exports = {
   normalizeVerifierFollowupLedger,
   normalizeVerifierFollowupPolicy,
   normalizeLedgerDisposition,
+  normalizeOptionalValue,
   summarizeTerminalDispositionSources,
   formatTerminalDispositionMarkdown,
   sourceKey,

--- a/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition_coverage.js
@@ -174,7 +174,7 @@ function summarizeVerifierModelCompatibility(records = [], options = {}) {
     const model = cleanString(record.llm_model ?? record.model).toLowerCase();
     const reason = cleanString(record.model_selection_reason);
     const verifierMode = cleanString(record.verifier_mode).toLowerCase();
-    const requiresCodexModel = Boolean(verifierMode) && verifierMode !== 'evaluate';
+    const requiresCodexModel = verifierMode !== 'evaluate';
     if (model) selectedModels[model] = (selectedModels[model] || 0) + 1;
     if (reason) modelSelectionReasons[reason] = (modelSelectionReasons[reason] || 0) + 1;
     if (!model && requiresCodexModel && modelMetadataContract.model_metadata_required) {

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_download_manifest.js
@@ -120,11 +120,44 @@ function findArtifact(manifest, id, name) {
   });
 }
 
+function normalizeArtifactResultShape(artifact) {
+  if (!artifact || typeof artifact !== 'object') return;
+  if (!artifact.download || typeof artifact.download !== 'object') {
+    artifact.download = {
+      status: 'pending',
+      bytes: null,
+      error: '',
+    };
+  }
+  if (!artifact.unzip || typeof artifact.unzip !== 'object') {
+    artifact.unzip = {
+      status: 'pending',
+      path: artifact.artifact_dir || '',
+      error: '',
+    };
+  }
+  artifact.download.status = normalizeStatus(
+    artifact.download.status,
+    ['pending', 'pass', 'failed', 'skipped'],
+    'pending'
+  );
+  artifact.unzip.status = normalizeStatus(
+    artifact.unzip.status,
+    ['pending', 'pass', 'failed', 'skipped'],
+    'pending'
+  );
+  if (!artifact.unzip.path) artifact.unzip.path = artifact.artifact_dir || '';
+  if (artifact.download.bytes === undefined) artifact.download.bytes = null;
+  if (artifact.download.error === undefined) artifact.download.error = '';
+  if (artifact.unzip.error === undefined) artifact.unzip.error = '';
+}
+
 function updateArtifactResult(manifest, result = {}) {
   const artifact = findArtifact(manifest, result.id, result.name);
   if (!artifact) {
     throw new Error(`Artifact is not present in manifest: ${cleanString(result.id || result.name)}`);
   }
+  normalizeArtifactResultShape(artifact);
   const artifactDir = cleanString(result.artifact_dir || result.artifactDir);
   const zipPath = cleanString(result.zip_path || result.zipPath);
   const zipBytes = Number.parseInt(cleanString(result.zip_bytes || result.zipBytes), 10);

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -568,7 +568,7 @@ def _summarise_verifier(
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal and model_metadata_required:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode and verifier_mode != "evaluate":
+            if verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
                     legacy_missing_verifier_model_metadata[str(disposition)] += 1

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -865,6 +865,29 @@ def test_verifier_summary_counts_missing_model_metadata(
     assert "Missing verifier model metadata: verifier-error (1)" in summary
 
 
+def test_verifier_summary_counts_missing_model_metadata_for_unknown_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER",
+        "2026-04-26T04:25:00Z",
+    )
+
+    verifier = aggregate_agent_metrics._summarise_verifier(
+        [
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "run_id": "24948023779",
+                "pr_number": 1874,
+                "disposition": "verifier-error",
+            },
+        ]
+    )
+
+    assert verifier["missing_verifier_model_metadata"]["verifier-error"] == 1
+
+
 def test_verifier_summary_suppresses_pre_contract_missing_model_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- tolerate older weekly metrics download manifests that lack download/unzip result objects before recording outcomes
- preserve boolean terminal-disposition fields as booleans in terminal and verifier follow-up contracts
- require verifier model metadata for post-contract verifier terminal records unless the mode is explicitly evaluate
- sync the consumer template copies of the shared scripts

## Verification
- node --test .github/scripts/__tests__/weekly-metrics-download-manifest.test.js .github/scripts/__tests__/terminal-disposition.test.js .github/scripts/__tests__/terminal-disposition-coverage.test.js
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q
- python -m ruff check scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- python -m black --check --line-length 100 --target-version py312 scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- python -m scripts.validate_template_sync
- python -m scripts.validate_template_completeness
- git diff --check