### PR TITLE
[codex] Restore terminal coverage env test state after #1917

### DIFF
--- a/.github/scripts/__tests__/terminal-disposition-coverage.test.js
+++ b/.github/scripts/__tests__/terminal-disposition-coverage.test.js
@@ -289,13 +289,28 @@ test('summarizes verifier model compatibility with configurable unsupported mode
 });
 
 test('accepts aggregate metrics unsupported verifier model env name', () => {
+  const originalUnsupportedVerifierModels = process.env.UNSUPPORTED_VERIFIER_MODELS;
+  const originalTerminalDispositionUnsupportedCodexModels =
+    process.env.TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS;
+
   process.env.UNSUPPORTED_VERIFIER_MODELS = 'legacy-bad, gpt-5.2-codex';
   delete process.env.TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS;
 
   try {
     assert.deepEqual(normalizeUnsupportedCodexModels(), ['gpt-5.2-codex', 'legacy-bad']);
   } finally {
-    delete process.env.UNSUPPORTED_VERIFIER_MODELS;
+    if (originalUnsupportedVerifierModels === undefined) {
+      delete process.env.UNSUPPORTED_VERIFIER_MODELS;
+    } else {
+      process.env.UNSUPPORTED_VERIFIER_MODELS = originalUnsupportedVerifierModels;
+    }
+
+    if (originalTerminalDispositionUnsupportedCodexModels === undefined) {
+      delete process.env.TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS;
+    } else {
+      process.env.TERMINAL_DISPOSITION_UNSUPPORTED_CODEX_MODELS =
+        originalTerminalDispositionUnsupportedCodexModels;
+    }
   }
 });
 

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -499,6 +499,52 @@ def test_append_parse_error_detail_caps_stored_details() -> None:
     assert details[-1].line is None
 
 
+def test_parse_error_detail_overflow_does_not_use_incoming_identity() -> None:
+    details = [
+        aggregate_agent_metrics.ParseErrorDetail(
+            path="first.ndjson",
+            artifact="first-artifact",
+            artifact_family="first-family",
+            line=1,
+            reason="invalid-json",
+        ),
+        aggregate_agent_metrics.ParseErrorDetail(
+            path="second.ndjson",
+            artifact="second-artifact",
+            artifact_family="second-family",
+            line=2,
+            reason="non-object-json",
+        ),
+    ]
+
+    aggregate_agent_metrics._append_parse_error_detail(
+        details,
+        aggregate_agent_metrics.ParseErrorDetail(
+            path="third.ndjson",
+            artifact="third-artifact",
+            artifact_family="third-family",
+            line=3,
+            reason="unreadable-file",
+        ),
+        detail_limit=2,
+    )
+
+    contract = aggregate_agent_metrics._parse_error_contract(details)
+
+    assert len(details) == 2
+    assert details[0].path == "first.ndjson"
+    assert details[-1].path == "__multiple__"
+    assert details[-1].artifact == "__multiple__"
+    assert details[-1].artifact_family == "__multiple__"
+    assert details[-1].reason == "additional-parse-errors-after-detail-limit"
+    assert contract["count"] == 3
+    assert contract["by_reason"] == {
+        "additional-parse-errors-after-detail-limit": 2,
+        "invalid-json": 1,
+    }
+    assert "third-artifact" not in contract["by_artifact"]
+
+
 def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Path) -> None:
     metrics_dir = (
         tmp_path


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1836 -->
> **Source:** Issue #1836

Related to campaign issue #1836

<!-- pr-preamble:end -->

## Summary

- follow up on Copilot review feedback from #1917
- restore both unsupported-model env vars after the terminal coverage env-alias test
- prevent environment leakage between Node tests when the suite runs with caller-provided env vars
- lock aggregate metrics parse-error overflow attribution to the stable sentinel bucket

## Verification

- node --test .github/scripts/__tests__/terminal-disposition-coverage.test.js
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q
- python -m ruff check tests/scripts/test_aggregate_agent_metrics.py
- python -m black --check --line-length 100 --target-version py312 tests/scripts/test_aggregate_agent_metrics.py
- git diff --check

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
# Sync/Dependabot Campaign Queue

Remote GitHub Actions owns discovery for sync-generated and Dependabot PR rounds. Local Codex should only claim items from this issue when `needs-local-codex` work is queued.

## Summary

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#931](https://github.com/stranske/Travel-Plan-Permission/issues/931)
- [stranske/Workflows#1911](https://github.com/stranske/Workflows/issues/1911)
- [stranske/Travel-Plan-Permission#933](https://github.com/stranske/Travel-Plan-Permission/issues/933)
- [stranske/Travel-Plan-Permission#930](https://github.com/stranske/Travel-Plan-Permission/issues/930)
- [stranske/Travel-Plan-Permission#929](https://github.com/stranske/Travel-Plan-Permission/issues/929)
- [stranske/Travel-Plan-Permission#928](https://github.com/stranske/Travel-Plan-Permission/issues/928)
- [stranske/Travel-Plan-Permission#927](https://github.com/stranske/Travel-Plan-Permission/issues/927)
- [stranske/Travel-Plan-Permission#926](https://github.com/stranske/Travel-Plan-Permission/issues/926)
- [stranske/Travel-Plan-Permission#924](https://github.com/stranske/Travel-Plan-Permission/issues/924)
- [stranske/Travel-Plan-Permission#922](https://github.com/stranske/Travel-Plan-Permission/issues/922)
- [stranske/Travel-Plan-Permission#921](https://github.com/stranske/Travel-Plan-Permission/issues/921)
- [stranske/Travel-Plan-Permission#920](https://github.com/stranske/Travel-Plan-Permission/issues/920)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Updated: 2026-04-26T20:14:45.242Z
- [ ] Repos checked: 11/11
- [ ] Open sync PRs: 593
- [ ] Open Dependabot PRs: 0
- [ ] Active review threads queued: 1176
- [ ] Items needing local Codex: 0
- [ ] Actionable local Codex items: 0
- [ ] Claimable local Codex items: 0
- [ ] Source-fixed candidates: 1
- [ ] Superseded sync candidates: 119
- [ ] Finished local results without published source changes: 0
- [ ] Claimed local Codex items: 0
- [ ] Next claim lease expires: -

#### Acceptance criteria
- [ ] Status: local-codex-source-fixed-candidate
- [ ] Source repo: stranske/Workflows
- [ ] Prior source-fix match: [sync-review-comments:stranske/Travel-Plan-Permission#931:8aaa71fdb6846c83756f](https://github.com/stranske/Travel-Plan-Permission/pull/931) (2026-04-26T18:13:29Z)
- [ ] Prior source-fix summary: Implemented the source fix in `stranske/Workflows` and opened PR: https://github.com/stranske/Workflows/pull/1911 Addressed all 3 active review threads from `stranske/Travel-Pla...
  - [ ] [.github/workflows/agents-verify-to-new-pr.yml:35](https://github.com/stranske/Travel-Plan-Permission/pull/931#discussion_r3143894651) (copilot-pull-request-reviewer): This workflow switches from commit-SHA pinned actions to floating tags (e.g., actions/github-script@v9). In this repo...
  - [ ] [.github/workflows/agents-verify-to-new-pr.yml:1009](https://github.com/stranske/Travel-Plan-Permission/pull/931#discussion_r3143894656) (copilot-pull-request-reviewer): actions/upload-artifact is referenced as actions/upload-artifact@v7 here, but most workflows in this repo pin upload-...

**Head SHA:** 63160cfe70075df279ab9c401f68006dc9b0937b
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096783) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096800) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096807) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096789) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096801) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096798) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096784) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096786) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096795) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24967096793) |
<!-- auto-status-summary:end -->