### PR TITLE
[codex] Add workflow source context contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [ ] Direct PR / remote GitHub work
+- [ ] Local Codex/user request
+- [ ] Automation run
+- [ ] Review follow-up from PR #
+- [ ] Sync / maintenance campaign
+- [ ] Dependabot or dependency update
+- [ ] Do not automate
+
+Automation intent:
+- [ ] Verifier should review this
+- [ ] Keepalive may manage this PR
+- [ ] Human-only unless checks fail
+
+Notes:
+<!-- If there is no linked issue, briefly describe the source. Automation also accepts workflow source labels such as workflow:source-direct-pr. -->
+
+## Summary
+
+
+## Testing

--- a/.github/labels-core.yml
+++ b/.github/labels-core.yml
@@ -63,6 +63,35 @@
   color: 0366d6
   description: PR was created by or for Copilot
 
+# Workflow source labels (used when a PR has no GitHub issue)
+- name: workflow:source-issue
+  color: 0e8a16
+  description: PR source is a GitHub issue
+- name: workflow:source-local-request
+  color: 0e8a16
+  description: PR source is a local Codex or user request
+- name: workflow:source-automation
+  color: ededed
+  description: PR source is an automation or workflow run
+- name: workflow:source-sync
+  color: 1d76db
+  description: PR source is a sync or maintenance campaign
+- name: workflow:source-dependabot
+  color: 0366d6
+  description: PR source is Dependabot or dependency automation
+- name: workflow:source-review-followup
+  color: 5319e7
+  description: PR source is follow-up from review feedback
+- name: workflow:source-direct-pr
+  color: fbca04
+  description: PR was started directly on GitHub without a source issue
+- name: workflow:no-automation
+  color: b60205
+  description: Do not let workflow automation manage this PR unless checks fail
+- name: workflow:source-needed
+  color: d93f0b
+  description: Workflow source context is missing or ambiguous
+
 # Autofix labels (required for autofix workflow)
 - name: autofix
   color: 0366d6

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -58,6 +58,35 @@
   color: 0366d6
   description: PR was created by or for Copilot
 
+# Workflow source labels
+- name: workflow:source-issue
+  color: 0e8a16
+  description: PR source is a GitHub issue
+- name: workflow:source-local-request
+  color: 0e8a16
+  description: PR source is a local Codex or user request
+- name: workflow:source-automation
+  color: ededed
+  description: PR source is an automation or workflow run
+- name: workflow:source-sync
+  color: 1d76db
+  description: PR source is a sync or maintenance campaign
+- name: workflow:source-dependabot
+  color: 0366d6
+  description: PR source is Dependabot or dependency automation
+- name: workflow:source-review-followup
+  color: 5319e7
+  description: PR source is follow-up from review feedback
+- name: workflow:source-direct-pr
+  color: fbca04
+  description: PR was started directly on GitHub without a source issue
+- name: workflow:no-automation
+  color: b60205
+  description: Do not let workflow automation manage this PR unless checks fail
+- name: workflow:source-needed
+  color: d93f0b
+  description: Workflow source context is missing or ambiguous
+
 # Autofix labels
 - name: autofix
   color: 0366d6

--- a/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
@@ -385,6 +385,91 @@ test('keepalive detection captures instruction body without status bundle', asyn
   assert.ok(reactionCalls.includes('hooray'));
 });
 
+test('keepalive detection accepts valid non-issue source context', async () => {
+  const outputs = {};
+  const reactionCalls = [];
+  const scopeBlock = [
+    '<!-- codex-keepalive-round: 3 -->',
+    '<!-- codex-keepalive-marker -->',
+    '<!-- codex-keepalive-trace: trace-local -->',
+    '@codex Continue working on the local request.',
+  ].join('\n');
+
+  const github = {
+    rest: {
+      pulls: {
+        async get() {
+          return {
+            data: {
+              body: '<!-- workflow-source:local_request -->\n<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+              head: { ref: 'codex/source-context', repo: { fork: false, owner: { login: 'stranske' } } },
+              base: { ref: 'main', repo: { owner: { login: 'stranske' } } },
+              title: 'Add source context',
+            },
+          };
+        },
+      },
+      issues: {
+        async listComments() {
+          return { data: [] };
+        },
+      },
+      reactions: {
+        async listForIssueComment() {
+          return { data: [] };
+        },
+        async createForIssueComment({ content }) {
+          reactionCalls.push(content);
+          return { status: 201, data: { content } };
+        },
+      },
+    },
+    async paginate(method) {
+      if (method === this.rest.issues.listComments) {
+        return [];
+      }
+      if (method === this.rest.reactions.listForIssueComment) {
+        return [];
+      }
+      return [];
+    },
+  };
+
+  const context = {
+    repo: { owner: 'stranske', repo: 'Workflows' },
+    payload: {
+      comment: {
+        id: 199,
+        html_url: 'https://example.test/comment/199',
+        body: scopeBlock,
+        user: { login: 'stranske' },
+      },
+      issue: { number: 4001 },
+    },
+  };
+
+  const env = {
+    ALLOWED_LOGINS: 'stranske',
+    KEEPALIVE_MARKER: '<!-- codex-keepalive-marker -->',
+    GATE_OK: 'true',
+  };
+
+  await detectKeepalive({
+    core: createCore(outputs),
+    github,
+    context,
+    env,
+  });
+
+  assert.equal(outputs.dispatch, 'true');
+  assert.equal(outputs.reason, 'keepalive-detected');
+  assert.equal(outputs.issue, '');
+  assert.equal(outputs.source_type, 'local_request');
+  assert.equal(outputs.source_ref, 'codex-thread-2026-04-26');
+  assert.ok(reactionCalls.includes('hooray'));
+  assert.ok(reactionCalls.includes('rocket'));
+});
+
 test('detectKeepalive caches pull request lookups across invocations', async () => {
   const outputsFirst = {};
   const outputsSecond = {};

--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -15,6 +15,9 @@ const {
   upsertCompletionAuthorWarning,
   buildStatusBlock,
   buildPreamble,
+  buildSourceContextRepairCommentBody,
+  buildSourceContextResolvedCommentBody,
+  resolveSourceContextRepairComment,
   resolveAgentType,
   stripPrTemplateContent,
   augmentContextWithRelatedIssues,
@@ -400,6 +403,82 @@ test('buildPreamble does not close active campaign issues', () => {
   assert.ok(result.includes('> **Source:** Issue #1836'));
   assert.ok(result.includes('Related to campaign issue #1836'));
   assert.ok(!result.includes('Closes #1836'));
+});
+
+test('buildSourceContextRepairCommentBody explains non-issue source options', () => {
+  const result = buildSourceContextRepairCommentBody(55);
+
+  assert.ok(result.includes('<!-- missing-issue-warning -->'));
+  assert.ok(result.includes('PR #55 does not need a GitHub issue'));
+  assert.ok(result.includes('<!-- workflow-source:local_request -->'));
+  assert.ok(result.includes('workflow:source-direct-pr'));
+  assert.ok(result.includes('workflow:no-automation'));
+});
+
+test('buildSourceContextResolvedCommentBody retires stale source repair comments', () => {
+  const result = buildSourceContextResolvedCommentBody(55, {
+    sourceType: 'local_request',
+    sourceRef: 'codex-thread-2026-04-26',
+  });
+
+  assert.ok(result.includes('<!-- missing-issue-warning -->'));
+  assert.ok(result.includes('PR #55 now has valid workflow source context'));
+  assert.ok(result.includes('local_request'));
+  assert.ok(result.includes('codex-thread-2026-04-26'));
+  assert.ok(result.includes('No linked GitHub issue is required'));
+});
+
+test('resolveSourceContextRepairComment updates an existing warning once', async () => {
+  const calls = { update: 0, body: '' };
+  const github = {
+    rest: {
+      issues: {
+        updateComment: async ({ comment_id, body }) => {
+          assert.strictEqual(comment_id, 99);
+          calls.update += 1;
+          calls.body = body;
+        },
+      },
+    },
+  };
+
+  const updated = await resolveSourceContextRepairComment({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 55,
+    comments: [{ id: 99, body: '<!-- missing-issue-warning -->\nold warning' }],
+    sourceContext: { sourceType: 'local_request', sourceRef: 'codex-thread-2026-04-26' },
+    core: { info: () => {} },
+  });
+
+  assert.strictEqual(updated, true);
+  assert.strictEqual(calls.update, 1);
+  assert.ok(calls.body.includes('Workflow source detected'));
+});
+
+test('resolveSourceContextRepairComment skips when no warning exists', async () => {
+  const github = {
+    rest: {
+      issues: {
+        updateComment: async () => {
+          throw new Error('should not update');
+        },
+      },
+    },
+  };
+
+  const updated = await resolveSourceContextRepairComment({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 55,
+    comments: [],
+    sourceContext: { sourceType: 'local_request' },
+    core: { info: () => {} },
+  });
+
+  assert.strictEqual(updated, false);
 });
 
 // ========== fetchConnectorCheckboxStates tests ==========

--- a/.github/scripts/__tests__/pr-source-context-report.test.js
+++ b/.github/scripts/__tests__/pr-source-context-report.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  REPORT_SCHEMA,
+  buildPrSourceContextReport,
+  renderMarkdown,
+  writeReport,
+} = require('../pr_source_context_report.js');
+
+test('buildPrSourceContextReport skips non-PR events without failing', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'push',
+    event: {
+      repository: { full_name: 'octo/demo' },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.schema, REPORT_SCHEMA);
+  assert.equal(report.status, 'skipped');
+  assert.equal(report.reason, 'not-pull-request');
+  assert.equal(report.repository, 'octo/demo');
+  assert.equal(report.source_context.isValid, false);
+});
+
+test('buildPrSourceContextReport passes source-issue PRs', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      repository: { full_name: 'octo/demo' },
+      pull_request: {
+        number: 42,
+        title: 'Implement issue work',
+        body: '<!-- meta:issue:1836 -->\nRelated to campaign issue #1836',
+        head: { ref: 'codex/issue-1836' },
+        base: { ref: 'main' },
+        user: { login: 'codex' },
+        labels: [{ name: 'codex' }],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.reason, 'source-context-detected');
+  assert.equal(report.source_context.sourceType, 'github_issue');
+  assert.equal(report.source_context.issueNumber, 1836);
+  assert.equal(report.source_context.isExplicit, true);
+  assert.deepEqual(report.warnings, []);
+});
+
+test('buildPrSourceContextReport accepts explicit local request PRs', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      pull_request: {
+        number: 7,
+        title: 'Manual automation follow-up',
+        body: '<!-- workflow-source:local_request -->\n<!-- workflow-source-ref:codex-thread-107 -->',
+        head: { ref: 'codex/source-context-contract-107' },
+        base: { ref: 'main' },
+        user: { login: 'teacher' },
+        labels: [{ name: 'codex' }],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.source_context.sourceType, 'local_request');
+  assert.equal(report.source_context.sourceRef, 'codex-thread-107');
+  assert.equal(report.source_context.requiresIssue, false);
+});
+
+test('buildPrSourceContextReport warns when PR source is unknown', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      pull_request: {
+        number: 8,
+        title: 'Unlinked change',
+        body: 'No source context here.',
+        head: { ref: 'feature/no-source' },
+        base: { ref: 'main' },
+        user: { login: 'teacher' },
+        labels: [],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.status, 'warning');
+  assert.equal(report.reason, 'source-context-unknown');
+  assert.equal(report.source_context.sourceType, 'unknown');
+  assert.match(report.warnings[0], /No source issue/);
+});
+
+test('buildPrSourceContextReport reports inferred maintenance origins as warnings', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      pull_request: {
+        number: 9,
+        title: 'sync workflow templates',
+        body: '',
+        head: { ref: 'sync/workflows-abcdef' },
+        base: { ref: 'main' },
+        user: { login: 'github-actions[bot]' },
+        labels: [{ name: 'campaign:sync-dependabot' }],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.status, 'pass');
+  assert.equal(report.source_context.sourceType, 'sync_campaign');
+  assert.equal(report.source_context.isExplicit, false);
+  assert.match(report.warnings[0], /inferred from PR metadata/);
+});
+
+test('renderMarkdown and writeReport publish human and machine-readable contracts', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-source-context-'));
+  const outputJson = path.join(tmpDir, 'nested', 'report.json');
+  const outputMd = path.join(tmpDir, 'nested', 'report.md');
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      pull_request: {
+        number: 10,
+        title: 'Local request',
+        body: '<!-- workflow-source:local_request -->',
+        head: { ref: 'codex/local' },
+        base: { ref: 'main' },
+        user: { login: 'teacher' },
+        labels: [],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  writeReport(report, { outputJson, outputMd });
+
+  const parsed = JSON.parse(fs.readFileSync(outputJson, 'utf8'));
+  const markdown = fs.readFileSync(outputMd, 'utf8');
+
+  assert.equal(parsed.schema, REPORT_SCHEMA);
+  assert.match(renderMarkdown(report), /PR Source Context/);
+  assert.match(markdown, /Schema: `workflows-pr-source-context\/v1`/);
+});

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  SOURCE_TYPES,
+  extractIssueNumberFromPull,
+  normalizeSourceType,
+  parseWorkflowSourceBlock,
+  resolvePrSourceContext,
+  sourceTypeFromCheckedTemplate,
+  sourceTypeFromLabels,
+} = require('../source_context.js');
+
+test('normalizeSourceType maps human aliases to canonical origin types', () => {
+  assert.equal(normalizeSourceType('GitHub Issue'), SOURCE_TYPES.GITHUB_ISSUE);
+  assert.equal(normalizeSourceType('local Codex request'), SOURCE_TYPES.LOCAL_REQUEST);
+  assert.equal(normalizeSourceType('workflow run'), SOURCE_TYPES.AUTOMATION_RUN);
+  assert.equal(normalizeSourceType('maintenance sync'), SOURCE_TYPES.SYNC_CAMPAIGN);
+  assert.equal(normalizeSourceType('dependency update'), SOURCE_TYPES.DEPENDABOT);
+  assert.equal(normalizeSourceType('review follow-up'), SOURCE_TYPES.REVIEW_FOLLOWUP);
+  assert.equal(normalizeSourceType('direct PR'), SOURCE_TYPES.MANUAL_REMOTE);
+  assert.equal(normalizeSourceType(''), SOURCE_TYPES.UNKNOWN);
+});
+
+test('extractIssueNumberFromPull keeps existing issue resolution behavior', () => {
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: '<!-- meta:issue:42 --> Run #2615 timed out',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    42,
+  );
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Run #2615 timed out. Relates to #88',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    88,
+  );
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Run #2615 timed out after 45 minutes',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    null,
+  );
+});
+
+test('parseWorkflowSourceBlock reads source-context fields from hidden block', () => {
+  const block = parseWorkflowSourceBlock(`
+<!-- workflow-source:start -->
+origin: local_request
+source_ref: codex-thread-abc
+lifecycle: substantive_delivery
+automation: verifier_required
+<!-- workflow-source:end -->
+`);
+
+  assert.deepEqual(block, {
+    origin: 'local_request',
+    source_ref: 'codex-thread-abc',
+    lifecycle: 'substantive_delivery',
+    automation: 'verifier_required',
+  });
+});
+
+test('sourceTypeFromCheckedTemplate reads direct GitHub PR source choice', () => {
+  const body = `
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [x] Direct PR / remote GitHub work
+- [ ] Local Codex/user request
+`;
+
+  assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.MANUAL_REMOTE);
+});
+
+test('sourceTypeFromCheckedTemplate treats human-only PRs as manual remote work', () => {
+  const body = `
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [x] Do not automate
+
+Automation intent:
+- [x] Human-only unless checks fail
+`;
+
+  assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.MANUAL_REMOTE);
+});
+
+test('sourceTypeFromLabels accepts workflow source labels', () => {
+  const pull = {
+    labels: [{ name: 'workflow:source-local-request' }],
+  };
+
+  assert.equal(sourceTypeFromLabels(pull), SOURCE_TYPES.LOCAL_REQUEST);
+});
+
+test('resolvePrSourceContext prefers source issue when issue metadata exists', () => {
+  const context = resolvePrSourceContext({
+    body: '<!-- meta:issue:123 -->\n<!-- workflow-source:local_request -->',
+    head: { ref: 'codex/feature' },
+    title: 'Implement change',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.GITHUB_ISSUE);
+  assert.equal(context.issueNumber, 123);
+  assert.equal(context.sourceRef, '#123');
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, true);
+});
+
+test('resolvePrSourceContext accepts explicit local request without issue', () => {
+  const context = resolvePrSourceContext({
+    body: '<!-- workflow-source:local_request -->\n<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+    head: { ref: 'codex/source-context' },
+    title: 'Add source context',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.LOCAL_REQUEST);
+  assert.equal(context.issueNumber, null);
+  assert.equal(context.sourceRef, 'codex-thread-2026-04-26');
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, false);
+});
+
+test('resolvePrSourceContext infers sync and dependabot sources for maintenance PRs', () => {
+  assert.equal(
+    resolvePrSourceContext({
+      body: '',
+      head: { ref: 'sync/workflows-abcdef' },
+      title: 'chore: sync template scripts',
+    }).sourceType,
+    SOURCE_TYPES.SYNC_CAMPAIGN,
+  );
+
+  assert.equal(
+    resolvePrSourceContext({
+      body: '',
+      head: { ref: 'dependabot/pip/package-1.2.3' },
+      title: 'deps: bump package',
+      user: { login: 'dependabot[bot]' },
+    }).sourceType,
+    SOURCE_TYPES.DEPENDABOT,
+  );
+});
+
+test('resolvePrSourceContext leaves unrelated PRs unknown', () => {
+  const context = resolvePrSourceContext({
+    body: 'No source fields here',
+    head: { ref: 'feature/no-source' },
+    title: 'Change code',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.UNKNOWN);
+  assert.equal(context.isValid, false);
+});

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -3,6 +3,10 @@
 const { createGithubApiCache } = require('./github-api-cache-client');
 const { makeTrace } = require('./keepalive_contract.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 const DEFAULT_INSTRUCTION_SIGNATURE =
   'keepalive workflow continues nudging until everything is complete';
@@ -335,6 +339,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     instruction_bytes: '0',
     agent_alias: '',
     head_sha: '',
+    source_type: '',
+    source_ref: '',
   };
 
   const setBasicOutputs = () => {
@@ -359,6 +365,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     core.setOutput('instruction_bytes', outputs.instruction_bytes || '0');
     core.setOutput('agent_alias', outputs.agent_alias || '');
     core.setOutput('head_sha', outputs.head_sha || '');
+    core.setOutput('source_type', outputs.source_type || '');
+    core.setOutput('source_ref', outputs.source_ref || '');
   };
 
   const { comment, issue } = context.payload || {};
@@ -645,6 +653,13 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   if (issueNumber) {
     outputs.issue = String(issueNumber);
   }
+  const sourceContext = resolvePrSourceContext(pull);
+  if (sourceContext.isKnown) {
+    outputs.source_type = sourceContext.sourceType;
+  }
+  if (sourceContext.sourceRef) {
+    outputs.source_ref = sourceContext.sourceRef;
+  }
 
   let reactions = [];
   try {
@@ -741,9 +756,17 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   }
 
   if (!issueNumber) {
-    outputs.reason = 'missing-issue-reference';
-    core.info('Keepalive dispatch skipped: unable to determine linked issue number.');
-    return finalise();
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `Keepalive dispatch continuing with non-issue workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+      );
+    } else {
+      outputs.reason = 'missing-source-context';
+      core.info(
+        'Keepalive dispatch skipped: unable to determine linked issue number or another valid workflow source context.',
+      );
+      return finalise();
+    }
   }
 
   // Add agents:activated label on first human activation per GoalsAndPlumbing.md Section 1

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -15,6 +15,10 @@ const fs = require('fs');
 const os = require('os');
 const childProcess = require('child_process');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 class RateLimitError extends Error {
   constructor(message, options = {}) {
@@ -930,6 +934,66 @@ function isCampaignIssue(issue = {}) {
   return labels.has('campaign:sync-dependabot') || labels.has('campaign:active');
 }
 
+function buildSourceContextRepairCommentBody(prNumber) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source needed',
+    '',
+    `PR #${prNumber} does not need a GitHub issue, but Workflows needs one valid source context before PR metadata automation can manage it safely.`,
+    '',
+    'Please do one of:',
+    '',
+    '- Add `<!-- meta:issue:123 -->` or a normal `Closes #123` / `Related to #123` line.',
+    '- Check one `Workflow Source` option in the PR body.',
+    '- Add a hidden marker such as `<!-- workflow-source:local_request -->`, `<!-- workflow-source:manual_remote -->`, `<!-- workflow-source:review_followup -->`, `<!-- workflow-source:sync_campaign -->`, or `<!-- workflow-source:dependabot -->`.',
+    '- Add a workflow source label such as `workflow:source-direct-pr`, `workflow:source-local-request`, `workflow:source-review-followup`, `workflow:source-sync`, or `workflow:no-automation`.',
+    '',
+    'Once a valid source is present, this warning will not be reposted.',
+  ].join('\n');
+}
+
+function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source detected',
+    '',
+    `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+    '',
+    'No linked GitHub issue is required for this PR.',
+  ].join('\n');
+}
+
+async function resolveSourceContextRepairComment({
+  github,
+  owner,
+  repo,
+  prNumber,
+  comments,
+  sourceContext,
+  core,
+}) {
+  const marker = '<!-- missing-issue-warning -->';
+  const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
+  if (!existingWarning) {
+    return false;
+  }
+
+  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext);
+  if (existingWarning.body === resolvedBody) {
+    core?.info?.(`Workflow source repair comment already resolved (id: ${existingWarning.id})`);
+    return false;
+  }
+
+  await github.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: existingWarning.id,
+    body: resolvedBody,
+  });
+  core?.info?.(`Resolved workflow source repair comment (id: ${existingWarning.id})`);
+  return true;
+}
+
 function buildPreamble(sections) {
   const lines = ['<!-- pr-preamble:start -->'];
   
@@ -1231,9 +1295,35 @@ async function run({github: rawGithub, context, core, inputs}) {
   }
 
   const issueNumber = extractIssueNumberFromPull(pr);
+  const sourceContext = resolvePrSourceContext(pr);
   if (!issueNumber) {
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `PR #${pr.number} has valid non-issue workflow source context (${formatSourceContextForLog(sourceContext)}); skipping issue-sourced body sync.`,
+      );
+      try {
+        const comments = await github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pr.number,
+        });
+        await resolveSourceContextRepairComment({
+          github,
+          owner,
+          repo,
+          prNumber: pr.number,
+          comments,
+          sourceContext,
+          core,
+        });
+      } catch (error) {
+        core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+      }
+      return;
+    }
+
     const marker = '<!-- missing-issue-warning -->';
-    const warningMsg = `Unable to determine source issue for PR #${pr.number}. The PR title, branch name, or body must contain the issue number (e.g. #123, branch: issue-123, or the hidden marker <!-- meta:issue:123 -->).`;
+    const warningMsg = `Unable to determine workflow source context for PR #${pr.number}. Add a GitHub issue reference or another valid Workflow Source entry.`;
     core.warning(warningMsg);
 
     try {
@@ -1244,11 +1334,20 @@ async function run({github: rawGithub, context, core, inputs}) {
       });
       // Find existing warning comment by marker to enable upsert pattern
       const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
-      const commentBody = `${marker}\n⚠️ **Action Required**: ${warningMsg}`;
+      const commentBody = buildSourceContextRepairCommentBody(pr.number);
       
       if (existingWarning) {
-        // Update existing comment (avoids duplicates from race conditions)
-        core.info(`Warning comment already exists (id: ${existingWarning.id}), skipping duplicate`);
+        if (existingWarning.body !== commentBody) {
+          await github.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existingWarning.id,
+            body: commentBody,
+          });
+          core.info(`Updated workflow source repair comment (id: ${existingWarning.id})`);
+        } else {
+          core.info(`Workflow source repair comment already exists (id: ${existingWarning.id})`);
+        }
       } else {
         await github.rest.issues.createComment({
           owner,
@@ -1435,6 +1534,9 @@ module.exports = {
   filterWorkflowRunsForStatus,
   buildContextBlock,
   buildPreamble,
+  buildSourceContextRepairCommentBody,
+  buildSourceContextResolvedCommentBody,
+  resolveSourceContextRepairComment,
   isCampaignIssue,
   buildStatusBlock,
   withRetries,

--- a/.github/scripts/pr_source_context_report.js
+++ b/.github/scripts/pr_source_context_report.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  SOURCE_TYPES,
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
+
+const REPORT_SCHEMA = 'workflows-pr-source-context/v1';
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function ensureParentDirectory(filePath) {
+  if (!filePath) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readEventFile(eventPath) {
+  if (!eventPath) {
+    return {};
+  }
+  const raw = fs.readFileSync(eventPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function labelNames(pull = {}) {
+  return Array.isArray(pull.labels)
+    ? pull.labels
+        .map((label) => cleanString(typeof label === 'string' ? label : label?.name || ''))
+        .filter(Boolean)
+    : [];
+}
+
+function buildPrSourceContextReport(options = {}) {
+  const event = options.event && typeof options.event === 'object' ? options.event : {};
+  const pull = event.pull_request && typeof event.pull_request === 'object' ? event.pull_request : null;
+  const now = options.now || new Date().toISOString();
+  const repository =
+    cleanString(options.repository) ||
+    cleanString(event.repository?.full_name) ||
+    cleanString(process.env.GITHUB_REPOSITORY);
+
+  const report = {
+    schema: REPORT_SCHEMA,
+    generated_at: now,
+    repository,
+    event_name: cleanString(options.eventName) || cleanString(process.env.GITHUB_EVENT_NAME),
+    run_id: cleanString(options.runId) || cleanString(process.env.GITHUB_RUN_ID),
+    run_attempt: cleanString(options.runAttempt) || cleanString(process.env.GITHUB_RUN_ATTEMPT),
+    status: 'skipped',
+    reason: 'not-pull-request',
+    pull_request: null,
+    source_context: {
+      sourceType: SOURCE_TYPES.UNKNOWN,
+      issueNumber: null,
+      sourceRef: '',
+      lifecycle: '',
+      automation: '',
+      isKnown: false,
+      isValid: false,
+      isExplicit: false,
+      requiresIssue: false,
+    },
+    warnings: [],
+  };
+
+  if (!pull) {
+    return report;
+  }
+
+  const context = resolvePrSourceContext(pull);
+  const valid = Boolean(context.isValid);
+  const explicit = Boolean(context.isExplicit);
+
+  report.status = valid ? 'pass' : 'warning';
+  report.reason = valid ? 'source-context-detected' : 'source-context-unknown';
+  report.pull_request = {
+    number: pull.number || event.number || null,
+    title: cleanString(pull.title),
+    author: cleanString(pull.user?.login),
+    head_ref: cleanString(pull.head?.ref),
+    base_ref: cleanString(pull.base?.ref),
+    labels: labelNames(pull),
+  };
+  report.source_context = context;
+
+  if (!valid) {
+    report.warnings.push(
+      'No source issue, workflow-source marker, workflow source label, or recognized maintenance origin was found.',
+    );
+  } else if (!explicit) {
+    report.warnings.push(
+      `Source context was inferred from PR metadata (${formatSourceContextForLog(context)}).`,
+    );
+  }
+
+  return report;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '# PR Source Context',
+    '',
+    `- Schema: \`${report.schema || REPORT_SCHEMA}\``,
+    `- Status: \`${report.status || 'unknown'}\``,
+    `- Reason: \`${report.reason || 'unknown'}\``,
+  ];
+
+  if (report.pull_request) {
+    lines.push(
+      `- PR: #${report.pull_request.number || 'unknown'}`,
+      `- Source: \`${formatSourceContextForLog(report.source_context)}\``,
+      `- Explicit source marker: \`${report.source_context?.isExplicit ? 'true' : 'false'}\``,
+    );
+  }
+
+  if (Array.isArray(report.warnings) && report.warnings.length > 0) {
+    lines.push('', '## Warnings');
+    for (const warning of report.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function writeReport(report, options = {}) {
+  if (options.outputJson) {
+    ensureParentDirectory(options.outputJson);
+    fs.writeFileSync(options.outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+  if (options.outputMd) {
+    ensureParentDirectory(options.outputMd);
+    fs.writeFileSync(options.outputMd, renderMarkdown(report), 'utf8');
+  }
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = {
+    eventPath: process.env.GITHUB_EVENT_PATH || '',
+    eventName: process.env.GITHUB_EVENT_NAME || '',
+    outputJson: 'pr-source-context.json',
+    outputMd: 'pr-source-context.md',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--event-path') {
+      args.eventPath = argv[++index] || '';
+    } else if (arg === '--event-name') {
+      args.eventName = argv[++index] || '';
+    } else if (arg === '--output-json') {
+      args.outputJson = argv[++index] || '';
+    } else if (arg === '--output-md') {
+      args.outputMd = argv[++index] || '';
+    }
+  }
+
+  return args;
+}
+
+function main() {
+  const args = parseArgs();
+  let event = {};
+  let readError = '';
+  try {
+    event = readEventFile(args.eventPath);
+  } catch (error) {
+    readError = error instanceof Error ? error.message : String(error);
+  }
+
+  const report = buildPrSourceContextReport({
+    event,
+    eventName: args.eventName,
+  });
+
+  if (readError) {
+    report.status = 'warning';
+    report.reason = 'event-read-error';
+    report.warnings.push(`Unable to read GitHub event payload: ${readError}`);
+  }
+
+  writeReport(report, {
+    outputJson: args.outputJson,
+    outputMd: args.outputMd,
+  });
+
+  console.log(renderMarkdown(report));
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  REPORT_SCHEMA,
+  buildPrSourceContextReport,
+  parseArgs,
+  renderMarkdown,
+  writeReport,
+};

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -1,0 +1,322 @@
+'use strict';
+
+const SOURCE_TYPES = Object.freeze({
+  GITHUB_ISSUE: 'github_issue',
+  LOCAL_REQUEST: 'local_request',
+  AUTOMATION_RUN: 'automation_run',
+  SYNC_CAMPAIGN: 'sync_campaign',
+  DEPENDABOT: 'dependabot',
+  REVIEW_FOLLOWUP: 'review_followup',
+  MANUAL_REMOTE: 'manual_remote',
+  UNKNOWN: 'unknown',
+});
+
+const VALID_SOURCE_TYPES = new Set(Object.values(SOURCE_TYPES).filter((type) => type !== SOURCE_TYPES.UNKNOWN));
+
+const SOURCE_LABELS = Object.freeze({
+  'workflow:source-issue': SOURCE_TYPES.GITHUB_ISSUE,
+  workflow_source_issue: SOURCE_TYPES.GITHUB_ISSUE,
+  'workflow:source-local-request': SOURCE_TYPES.LOCAL_REQUEST,
+  workflow_source_local_request: SOURCE_TYPES.LOCAL_REQUEST,
+  'workflow:source-automation': SOURCE_TYPES.AUTOMATION_RUN,
+  workflow_source_automation: SOURCE_TYPES.AUTOMATION_RUN,
+  'workflow:source-sync': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_sync: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-maintenance': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_maintenance: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-dependabot': SOURCE_TYPES.DEPENDABOT,
+  workflow_source_dependabot: SOURCE_TYPES.DEPENDABOT,
+  'workflow:source-review-followup': SOURCE_TYPES.REVIEW_FOLLOWUP,
+  workflow_source_review_followup: SOURCE_TYPES.REVIEW_FOLLOWUP,
+  'workflow:source-direct-pr': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_source_direct_pr: SOURCE_TYPES.MANUAL_REMOTE,
+  'workflow:no-automation': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_no_automation: SOURCE_TYPES.MANUAL_REMOTE,
+});
+
+const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
+  [SOURCE_TYPES.GITHUB_ISSUE, /\bgithub\s+issue\b|\bsource\s+issue\b/i],
+  [
+    SOURCE_TYPES.MANUAL_REMOTE,
+    /\bdirect\s+pr\b|\bremote\s+github\s+work\b|\bstarted\s+directly\b|\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i,
+  ],
+  [SOURCE_TYPES.LOCAL_REQUEST, /\blocal\s+(?:codex|user)\s+request\b|\blocal\s+request\b/i],
+  [SOURCE_TYPES.AUTOMATION_RUN, /\bautomation\s+run\b|\bworkflow\s+run\b/i],
+  [SOURCE_TYPES.REVIEW_FOLLOWUP, /\breview\s+follow[- ]?up\b|\bfollow[- ]?up\s+from\s+pr\b/i],
+  [SOURCE_TYPES.SYNC_CAMPAIGN, /\bsync\b|\bmaintenance\s+campaign\b|\bmaintenance\b/i],
+  [SOURCE_TYPES.DEPENDABOT, /\bdependabot\b|\bdependency\s+update\b/i],
+]);
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeToken(value) {
+  return cleanString(value)
+    .toLowerCase()
+    .replace(/[`*~]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function normalizeSourceType(value) {
+  const token = normalizeToken(value);
+  if (!token) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+
+  const aliases = new Map([
+    ['issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['github_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['source_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['local', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_codex_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_user_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['automation', SOURCE_TYPES.AUTOMATION_RUN],
+    ['automation_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['workflow_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['sync_campaign', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance_sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['dependabot', SOURCE_TYPES.DEPENDABOT],
+    ['dependency_update', SOURCE_TYPES.DEPENDABOT],
+    ['review_followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['review_follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['manual', SOURCE_TYPES.MANUAL_REMOTE],
+    ['manual_remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct_pr', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote_github_work', SOURCE_TYPES.MANUAL_REMOTE],
+    ['no_automation', SOURCE_TYPES.MANUAL_REMOTE],
+  ]);
+
+  return aliases.get(token) || SOURCE_TYPES.UNKNOWN;
+}
+
+function labelNames(pull = {}) {
+  return Array.isArray(pull.labels)
+    ? pull.labels
+        .map((label) => cleanString(typeof label === 'string' ? label : label?.name || ''))
+        .filter(Boolean)
+    : [];
+}
+
+function extractIssueNumberFromText(text) {
+  const value = String(text || '');
+  for (const match of value.matchAll(/#([0-9]+)/g)) {
+    if (!match[1]) {
+      continue;
+    }
+    const before = value.slice(Math.max(0, match.index - 200), match.index);
+    const token = before.split(/\s/).pop() || '';
+    if (token.includes('/')) {
+      continue;
+    }
+    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
+      continue;
+    }
+    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
+    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function extractIssueNumberFromPull(pull = {}) {
+  const bodyText = String(pull?.body || '');
+  const metaMatch = bodyText.match(/<!--\s*meta:issue:([0-9]+)\s*-->/i);
+  if (metaMatch) {
+    return Number.parseInt(metaMatch[1], 10);
+  }
+
+  const branch = String(pull?.head?.ref || '');
+  const branchMatch = branch.match(/issue-#?([0-9]+)/i) || branch.match(/-issue-#([0-9]+)(?:$|[^0-9])/i);
+  if (branchMatch) {
+    return Number.parseInt(branchMatch[1], 10);
+  }
+
+  const titleNumber = extractIssueNumberFromText(pull?.title || '');
+  if (titleNumber) {
+    return titleNumber;
+  }
+
+  return extractIssueNumberFromText(bodyText);
+}
+
+function parseHtmlMarker(body, name) {
+  const pattern = new RegExp(`<!--\\s*${name}\\s*:\\s*([\\s\\S]*?)\\s*-->`, 'i');
+  const match = String(body || '').match(pattern);
+  return match ? cleanString(match[1]) : '';
+}
+
+function parseWorkflowSourceBlock(body) {
+  const match = String(body || '').match(
+    /<!--\s*workflow-source:start\s*-->([\s\S]*?)<!--\s*workflow-source:end\s*-->/i,
+  );
+  if (!match) {
+    return {};
+  }
+
+  const result = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const fieldMatch = line.match(/^\s*[-*]?\s*([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$/);
+    if (!fieldMatch) {
+      continue;
+    }
+    const key = normalizeToken(fieldMatch[1]);
+    const value = cleanString(fieldMatch[2]);
+    if (key && value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function sourceTypeFromCheckedTemplate(body) {
+  const lines = String(body || '').split(/\r?\n/);
+  const start = lines.findIndex((line) => /^#{1,6}\s+Workflow Source\s*$/i.test(line));
+  if (start < 0) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{1,6}\s+\S/.test(line)) {
+      break;
+    }
+    sectionLines.push(line);
+  }
+  const text = sectionLines.join('\n');
+  for (const line of text.split(/\r?\n/)) {
+    const checkbox = line.match(/^\s*[-*]\s+\[[xX]\]\s+(.+?)\s*$/);
+    if (!checkbox) {
+      continue;
+    }
+    const label = checkbox[1];
+    for (const [sourceType, pattern] of CHECKBOX_SOURCE_PATTERNS) {
+      if (pattern.test(label)) {
+        return sourceType;
+      }
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function sourceTypeFromLabels(pull = {}) {
+  for (const label of labelNames(pull)) {
+    const sourceType = SOURCE_LABELS[label.toLowerCase()] || SOURCE_LABELS[normalizeToken(label)];
+    if (sourceType) {
+      return sourceType;
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function inferredSourceType(pull = {}) {
+  const branch = cleanString(pull?.head?.ref).toLowerCase();
+  const title = cleanString(pull?.title).toLowerCase();
+  const author = cleanString(pull?.user?.login).toLowerCase();
+  const labels = labelNames(pull).map((label) => label.toLowerCase());
+
+  if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
+    return SOURCE_TYPES.DEPENDABOT;
+  }
+  if (
+    branch.startsWith('sync/') ||
+    branch.startsWith('sync-') ||
+    labels.includes('campaign:sync-dependabot') ||
+    /\bsync\b/.test(title)
+  ) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
+    return SOURCE_TYPES.REVIEW_FOLLOWUP;
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function resolvePrSourceContext(pull = {}) {
+  const body = String(pull?.body || '');
+  const block = parseWorkflowSourceBlock(body);
+  const issueNumber = extractIssueNumberFromPull(pull);
+
+  const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));
+  const blockType = normalizeSourceType(block.origin || block.source || block.type);
+  const checkboxType = sourceTypeFromCheckedTemplate(body);
+  const labelType = sourceTypeFromLabels(pull);
+  const inferredType = inferredSourceType(pull);
+  const sourceType = issueNumber
+    ? SOURCE_TYPES.GITHUB_ISSUE
+    : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
+      || SOURCE_TYPES.UNKNOWN;
+
+  const sourceRef =
+    cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
+    cleanString(block.source_ref || block.ref || block.reference) ||
+    (issueNumber ? `#${issueNumber}` : '');
+  const lifecycle =
+    cleanString(parseHtmlMarker(body, 'workflow-lifecycle')) ||
+    cleanString(block.lifecycle || block.intended_lifecycle);
+  const automation =
+    cleanString(parseHtmlMarker(body, 'workflow-automation')) ||
+    cleanString(block.automation || block.automation_intent);
+
+  return {
+    sourceType,
+    issueNumber,
+    sourceRef,
+    lifecycle,
+    automation,
+    isKnown: sourceType !== SOURCE_TYPES.UNKNOWN,
+    isValid: VALID_SOURCE_TYPES.has(sourceType),
+    isExplicit: Boolean(
+      issueNumber ||
+        markerType !== SOURCE_TYPES.UNKNOWN ||
+        blockType !== SOURCE_TYPES.UNKNOWN ||
+        checkboxType !== SOURCE_TYPES.UNKNOWN ||
+        labelType !== SOURCE_TYPES.UNKNOWN
+    ),
+    requiresIssue: sourceType === SOURCE_TYPES.GITHUB_ISSUE,
+  };
+}
+
+function hasValidNonIssueSourceContext(pull = {}) {
+  const context = resolvePrSourceContext(pull);
+  return context.isValid && !context.requiresIssue;
+}
+
+function formatSourceContextForLog(context = {}) {
+  const parts = [`origin=${context.sourceType || SOURCE_TYPES.UNKNOWN}`];
+  if (context.sourceRef) {
+    parts.push(`ref=${context.sourceRef}`);
+  }
+  if (context.lifecycle) {
+    parts.push(`lifecycle=${context.lifecycle}`);
+  }
+  if (context.automation) {
+    parts.push(`automation=${context.automation}`);
+  }
+  return parts.join(' ');
+}
+
+module.exports = {
+  SOURCE_TYPES,
+  VALID_SOURCE_TYPES,
+  normalizeSourceType,
+  extractIssueNumberFromPull,
+  parseWorkflowSourceBlock,
+  sourceTypeFromCheckedTemplate,
+  sourceTypeFromLabels,
+  resolvePrSourceContext,
+  hasValidNonIssueSourceContext,
+  formatSourceContextForLog,
+};

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -299,6 +299,9 @@ scripts:
   - source: .github/scripts/issue_pr_locator.js
     description: "Locates PRs associated with issues"
 
+  - source: .github/scripts/source_context.js
+    description: "Classifies PR workflow source context for issue, local, automation, sync, Dependabot, review follow-up, and direct GitHub work"
+
   - source: .github/scripts/issue_context_utils.js
     description: "Utilities for issue context extraction"
 
@@ -554,6 +557,9 @@ scripts:
 templates:
   - source: .github/templates/keepalive-instruction.md
     description: "Keepalive instruction template - directives for Codex on each round"
+
+  - source: .github/PULL_REQUEST_TEMPLATE.md
+    description: "Pull request template with Workflow Source fields for direct GitHub and non-issue work"
 
 # Actions required by reusable workflows
 actions:

--- a/.github/workflows/pr-11-ci-smoke.yml
+++ b/.github/workflows/pr-11-ci-smoke.yml
@@ -83,3 +83,22 @@ jobs:
               raise SystemExit(f"Found {len(errors)} syntax errors in scripts")
           print(f"\nAll scripts have valid syntax")
           PY
+
+      - name: Report PR source context
+        run: |
+          node .github/scripts/pr_source_context_report.js \
+            --output-json pr-source-context.json \
+            --output-md pr-source-context.md
+          if [ -f pr-source-context.md ]; then
+            cat pr-source-context.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload PR source context report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-source-context
+          path: |
+            pr-source-context.json
+            pr-source-context.md
+          if-no-files-found: warn

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -246,6 +246,30 @@ These labels control the LangChain-powered issue formatting pipeline introduced 
 
 ---
 
+## Workflow Source Labels
+
+These labels let direct GitHub PRs and non-issue-origin PRs integrate with
+Workflows source classification without forcing a GitHub issue.
+
+| Label | Applies to | Effect |
+|-------|------------|--------|
+| `workflow:source-issue` | Pull Requests | PR source is a GitHub issue. |
+| `workflow:source-local-request` | Pull Requests | PR source is a local Codex/user request. |
+| `workflow:source-automation` | Pull Requests | PR source is an automation or workflow run. |
+| `workflow:source-sync` | Pull Requests | PR source is a sync or maintenance campaign. |
+| `workflow:source-dependabot` | Pull Requests | PR source is Dependabot or dependency automation. |
+| `workflow:source-review-followup` | Pull Requests | PR source is review feedback follow-up. |
+| `workflow:source-direct-pr` | Pull Requests | PR was started directly on GitHub without a source issue. |
+| `workflow:no-automation` | Pull Requests | Automation should not manage the PR unless checks fail. |
+| `workflow:source-needed` | Pull Requests | Source context is missing or ambiguous. |
+
+Use these labels as a backup to the PR template's Workflow Source section. If a
+PR has no linked issue and no valid Workflow Source, the PR metadata automation
+posts one repair comment instead of repeatedly treating the PR as issue-delivery
+work.
+
+---
+
 ## Verifier Labels
 
 These labels trigger the post-merge verifier workflow on a merged PR.

--- a/docs/keepalive/GoalsAndPlumbing.md
+++ b/docs/keepalive/GoalsAndPlumbing.md
@@ -201,7 +201,7 @@ The Keepalive workflow depends on the **Automated Status Summary** block in the 
 3. **Keepalive Execution:** The keepalive loop extracts tasks from the Automated Status Summary and injects them into the agent prompt via the task appendix.
 
 ### Failure Modes & Recovery
-- **Missing Link:** If the PR lacks the issue number, add a hidden `<!-- meta:issue:<issue_number> -->` marker and a visible `Related to #<issue_number>` or `Closes #<issue_number>` line. Use `Related to` for active campaign/controller issues that must remain open.
+- **Missing Workflow Source:** If the PR lacks a source issue, it may still be valid. Add either a hidden `<!-- meta:issue:<issue_number> -->` marker plus a visible `Related to #<issue_number>` or `Closes #<issue_number>` line, or mark another valid source in the PR body/labels. Supported non-issue sources are local request, automation run, sync/maintenance campaign, Dependabot, review follow-up, and direct GitHub PR. Use `Related to` for active campaign/controller issues that must remain open.
 - **Missing Sections:** If the source Issue lacks "Scope"/"Tasks"/"Acceptance", update the source Issue text.
 - **No Tasks:** If no checkboxes are found, keepalive will stop with reason `no-checklists`.
 

--- a/templates/consumer-repo/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/consumer-repo/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [ ] Direct PR / remote GitHub work
+- [ ] Local Codex/user request
+- [ ] Automation run
+- [ ] Review follow-up from PR #
+- [ ] Sync / maintenance campaign
+- [ ] Dependabot or dependency update
+- [ ] Do not automate
+
+Automation intent:
+- [ ] Verifier should review this
+- [ ] Keepalive may manage this PR
+- [ ] Human-only unless checks fail
+
+Notes:
+<!-- If there is no linked issue, briefly describe the source. Automation also accepts workflow source labels such as workflow:source-direct-pr. -->
+
+## Summary
+
+
+## Testing

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -3,6 +3,10 @@
 const { createGithubApiCache } = require('./github-api-cache-client');
 const { makeTrace } = require('./keepalive_contract.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 const DEFAULT_INSTRUCTION_SIGNATURE =
   'keepalive workflow continues nudging until everything is complete';
@@ -335,6 +339,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     instruction_bytes: '0',
     agent_alias: '',
     head_sha: '',
+    source_type: '',
+    source_ref: '',
   };
 
   const setBasicOutputs = () => {
@@ -359,6 +365,8 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     core.setOutput('instruction_bytes', outputs.instruction_bytes || '0');
     core.setOutput('agent_alias', outputs.agent_alias || '');
     core.setOutput('head_sha', outputs.head_sha || '');
+    core.setOutput('source_type', outputs.source_type || '');
+    core.setOutput('source_ref', outputs.source_ref || '');
   };
 
   const { comment, issue } = context.payload || {};
@@ -645,6 +653,13 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   if (issueNumber) {
     outputs.issue = String(issueNumber);
   }
+  const sourceContext = resolvePrSourceContext(pull);
+  if (sourceContext.isKnown) {
+    outputs.source_type = sourceContext.sourceType;
+  }
+  if (sourceContext.sourceRef) {
+    outputs.source_ref = sourceContext.sourceRef;
+  }
 
   let reactions = [];
   try {
@@ -741,9 +756,17 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
   }
 
   if (!issueNumber) {
-    outputs.reason = 'missing-issue-reference';
-    core.info('Keepalive dispatch skipped: unable to determine linked issue number.');
-    return finalise();
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `Keepalive dispatch continuing with non-issue workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+      );
+    } else {
+      outputs.reason = 'missing-source-context';
+      core.info(
+        'Keepalive dispatch skipped: unable to determine linked issue number or another valid workflow source context.',
+      );
+      return finalise();
+    }
   }
 
   // Add agents:activated label on first human activation per GoalsAndPlumbing.md Section 1

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -15,6 +15,10 @@ const fs = require('fs');
 const os = require('os');
 const childProcess = require('child_process');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const {
+  formatSourceContextForLog,
+  resolvePrSourceContext,
+} = require('./source_context.js');
 
 class RateLimitError extends Error {
   constructor(message, options = {}) {
@@ -930,6 +934,66 @@ function isCampaignIssue(issue = {}) {
   return labels.has('campaign:sync-dependabot') || labels.has('campaign:active');
 }
 
+function buildSourceContextRepairCommentBody(prNumber) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source needed',
+    '',
+    `PR #${prNumber} does not need a GitHub issue, but Workflows needs one valid source context before PR metadata automation can manage it safely.`,
+    '',
+    'Please do one of:',
+    '',
+    '- Add `<!-- meta:issue:123 -->` or a normal `Closes #123` / `Related to #123` line.',
+    '- Check one `Workflow Source` option in the PR body.',
+    '- Add a hidden marker such as `<!-- workflow-source:local_request -->`, `<!-- workflow-source:manual_remote -->`, `<!-- workflow-source:review_followup -->`, `<!-- workflow-source:sync_campaign -->`, or `<!-- workflow-source:dependabot -->`.',
+    '- Add a workflow source label such as `workflow:source-direct-pr`, `workflow:source-local-request`, `workflow:source-review-followup`, `workflow:source-sync`, or `workflow:no-automation`.',
+    '',
+    'Once a valid source is present, this warning will not be reposted.',
+  ].join('\n');
+}
+
+function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+  return [
+    '<!-- missing-issue-warning -->',
+    '### Workflow source detected',
+    '',
+    `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
+    '',
+    'No linked GitHub issue is required for this PR.',
+  ].join('\n');
+}
+
+async function resolveSourceContextRepairComment({
+  github,
+  owner,
+  repo,
+  prNumber,
+  comments,
+  sourceContext,
+  core,
+}) {
+  const marker = '<!-- missing-issue-warning -->';
+  const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
+  if (!existingWarning) {
+    return false;
+  }
+
+  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext);
+  if (existingWarning.body === resolvedBody) {
+    core?.info?.(`Workflow source repair comment already resolved (id: ${existingWarning.id})`);
+    return false;
+  }
+
+  await github.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: existingWarning.id,
+    body: resolvedBody,
+  });
+  core?.info?.(`Resolved workflow source repair comment (id: ${existingWarning.id})`);
+  return true;
+}
+
 function buildPreamble(sections) {
   const lines = ['<!-- pr-preamble:start -->'];
   
@@ -1231,9 +1295,35 @@ async function run({github: rawGithub, context, core, inputs}) {
   }
 
   const issueNumber = extractIssueNumberFromPull(pr);
+  const sourceContext = resolvePrSourceContext(pr);
   if (!issueNumber) {
+    if (sourceContext.isValid && !sourceContext.requiresIssue) {
+      core.info(
+        `PR #${pr.number} has valid non-issue workflow source context (${formatSourceContextForLog(sourceContext)}); skipping issue-sourced body sync.`,
+      );
+      try {
+        const comments = await github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pr.number,
+        });
+        await resolveSourceContextRepairComment({
+          github,
+          owner,
+          repo,
+          prNumber: pr.number,
+          comments,
+          sourceContext,
+          core,
+        });
+      } catch (error) {
+        core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+      }
+      return;
+    }
+
     const marker = '<!-- missing-issue-warning -->';
-    const warningMsg = `Unable to determine source issue for PR #${pr.number}. The PR title, branch name, or body must contain the issue number (e.g. #123, branch: issue-123, or the hidden marker <!-- meta:issue:123 -->).`;
+    const warningMsg = `Unable to determine workflow source context for PR #${pr.number}. Add a GitHub issue reference or another valid Workflow Source entry.`;
     core.warning(warningMsg);
 
     try {
@@ -1244,11 +1334,20 @@ async function run({github: rawGithub, context, core, inputs}) {
       });
       // Find existing warning comment by marker to enable upsert pattern
       const existingWarning = comments.find((c) => c.body && c.body.includes(marker));
-      const commentBody = `${marker}\n⚠️ **Action Required**: ${warningMsg}`;
+      const commentBody = buildSourceContextRepairCommentBody(pr.number);
       
       if (existingWarning) {
-        // Update existing comment (avoids duplicates from race conditions)
-        core.info(`Warning comment already exists (id: ${existingWarning.id}), skipping duplicate`);
+        if (existingWarning.body !== commentBody) {
+          await github.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existingWarning.id,
+            body: commentBody,
+          });
+          core.info(`Updated workflow source repair comment (id: ${existingWarning.id})`);
+        } else {
+          core.info(`Workflow source repair comment already exists (id: ${existingWarning.id})`);
+        }
       } else {
         await github.rest.issues.createComment({
           owner,
@@ -1435,6 +1534,9 @@ module.exports = {
   filterWorkflowRunsForStatus,
   buildContextBlock,
   buildPreamble,
+  buildSourceContextRepairCommentBody,
+  buildSourceContextResolvedCommentBody,
+  resolveSourceContextRepairComment,
   isCampaignIssue,
   buildStatusBlock,
   withRetries,

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -1,0 +1,322 @@
+'use strict';
+
+const SOURCE_TYPES = Object.freeze({
+  GITHUB_ISSUE: 'github_issue',
+  LOCAL_REQUEST: 'local_request',
+  AUTOMATION_RUN: 'automation_run',
+  SYNC_CAMPAIGN: 'sync_campaign',
+  DEPENDABOT: 'dependabot',
+  REVIEW_FOLLOWUP: 'review_followup',
+  MANUAL_REMOTE: 'manual_remote',
+  UNKNOWN: 'unknown',
+});
+
+const VALID_SOURCE_TYPES = new Set(Object.values(SOURCE_TYPES).filter((type) => type !== SOURCE_TYPES.UNKNOWN));
+
+const SOURCE_LABELS = Object.freeze({
+  'workflow:source-issue': SOURCE_TYPES.GITHUB_ISSUE,
+  workflow_source_issue: SOURCE_TYPES.GITHUB_ISSUE,
+  'workflow:source-local-request': SOURCE_TYPES.LOCAL_REQUEST,
+  workflow_source_local_request: SOURCE_TYPES.LOCAL_REQUEST,
+  'workflow:source-automation': SOURCE_TYPES.AUTOMATION_RUN,
+  workflow_source_automation: SOURCE_TYPES.AUTOMATION_RUN,
+  'workflow:source-sync': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_sync: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-maintenance': SOURCE_TYPES.SYNC_CAMPAIGN,
+  workflow_source_maintenance: SOURCE_TYPES.SYNC_CAMPAIGN,
+  'workflow:source-dependabot': SOURCE_TYPES.DEPENDABOT,
+  workflow_source_dependabot: SOURCE_TYPES.DEPENDABOT,
+  'workflow:source-review-followup': SOURCE_TYPES.REVIEW_FOLLOWUP,
+  workflow_source_review_followup: SOURCE_TYPES.REVIEW_FOLLOWUP,
+  'workflow:source-direct-pr': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_source_direct_pr: SOURCE_TYPES.MANUAL_REMOTE,
+  'workflow:no-automation': SOURCE_TYPES.MANUAL_REMOTE,
+  workflow_no_automation: SOURCE_TYPES.MANUAL_REMOTE,
+});
+
+const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
+  [SOURCE_TYPES.GITHUB_ISSUE, /\bgithub\s+issue\b|\bsource\s+issue\b/i],
+  [
+    SOURCE_TYPES.MANUAL_REMOTE,
+    /\bdirect\s+pr\b|\bremote\s+github\s+work\b|\bstarted\s+directly\b|\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i,
+  ],
+  [SOURCE_TYPES.LOCAL_REQUEST, /\blocal\s+(?:codex|user)\s+request\b|\blocal\s+request\b/i],
+  [SOURCE_TYPES.AUTOMATION_RUN, /\bautomation\s+run\b|\bworkflow\s+run\b/i],
+  [SOURCE_TYPES.REVIEW_FOLLOWUP, /\breview\s+follow[- ]?up\b|\bfollow[- ]?up\s+from\s+pr\b/i],
+  [SOURCE_TYPES.SYNC_CAMPAIGN, /\bsync\b|\bmaintenance\s+campaign\b|\bmaintenance\b/i],
+  [SOURCE_TYPES.DEPENDABOT, /\bdependabot\b|\bdependency\s+update\b/i],
+]);
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeToken(value) {
+  return cleanString(value)
+    .toLowerCase()
+    .replace(/[`*~]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function normalizeSourceType(value) {
+  const token = normalizeToken(value);
+  if (!token) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+
+  const aliases = new Map([
+    ['issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['github_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['source_issue', SOURCE_TYPES.GITHUB_ISSUE],
+    ['local', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_codex_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['local_user_request', SOURCE_TYPES.LOCAL_REQUEST],
+    ['automation', SOURCE_TYPES.AUTOMATION_RUN],
+    ['automation_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['workflow_run', SOURCE_TYPES.AUTOMATION_RUN],
+    ['sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['sync_campaign', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['maintenance_sync', SOURCE_TYPES.SYNC_CAMPAIGN],
+    ['dependabot', SOURCE_TYPES.DEPENDABOT],
+    ['dependency_update', SOURCE_TYPES.DEPENDABOT],
+    ['review_followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['review_follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['followup', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['follow_up', SOURCE_TYPES.REVIEW_FOLLOWUP],
+    ['manual', SOURCE_TYPES.MANUAL_REMOTE],
+    ['manual_remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct', SOURCE_TYPES.MANUAL_REMOTE],
+    ['direct_pr', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote', SOURCE_TYPES.MANUAL_REMOTE],
+    ['remote_github_work', SOURCE_TYPES.MANUAL_REMOTE],
+    ['no_automation', SOURCE_TYPES.MANUAL_REMOTE],
+  ]);
+
+  return aliases.get(token) || SOURCE_TYPES.UNKNOWN;
+}
+
+function labelNames(pull = {}) {
+  return Array.isArray(pull.labels)
+    ? pull.labels
+        .map((label) => cleanString(typeof label === 'string' ? label : label?.name || ''))
+        .filter(Boolean)
+    : [];
+}
+
+function extractIssueNumberFromText(text) {
+  const value = String(text || '');
+  for (const match of value.matchAll(/#([0-9]+)/g)) {
+    if (!match[1]) {
+      continue;
+    }
+    const before = value.slice(Math.max(0, match.index - 200), match.index);
+    const token = before.split(/\s/).pop() || '';
+    if (token.includes('/')) {
+      continue;
+    }
+    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
+      continue;
+    }
+    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
+    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function extractIssueNumberFromPull(pull = {}) {
+  const bodyText = String(pull?.body || '');
+  const metaMatch = bodyText.match(/<!--\s*meta:issue:([0-9]+)\s*-->/i);
+  if (metaMatch) {
+    return Number.parseInt(metaMatch[1], 10);
+  }
+
+  const branch = String(pull?.head?.ref || '');
+  const branchMatch = branch.match(/issue-#?([0-9]+)/i) || branch.match(/-issue-#([0-9]+)(?:$|[^0-9])/i);
+  if (branchMatch) {
+    return Number.parseInt(branchMatch[1], 10);
+  }
+
+  const titleNumber = extractIssueNumberFromText(pull?.title || '');
+  if (titleNumber) {
+    return titleNumber;
+  }
+
+  return extractIssueNumberFromText(bodyText);
+}
+
+function parseHtmlMarker(body, name) {
+  const pattern = new RegExp(`<!--\\s*${name}\\s*:\\s*([\\s\\S]*?)\\s*-->`, 'i');
+  const match = String(body || '').match(pattern);
+  return match ? cleanString(match[1]) : '';
+}
+
+function parseWorkflowSourceBlock(body) {
+  const match = String(body || '').match(
+    /<!--\s*workflow-source:start\s*-->([\s\S]*?)<!--\s*workflow-source:end\s*-->/i,
+  );
+  if (!match) {
+    return {};
+  }
+
+  const result = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const fieldMatch = line.match(/^\s*[-*]?\s*([A-Za-z][A-Za-z0-9_-]*)\s*:\s*(.+?)\s*$/);
+    if (!fieldMatch) {
+      continue;
+    }
+    const key = normalizeToken(fieldMatch[1]);
+    const value = cleanString(fieldMatch[2]);
+    if (key && value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function sourceTypeFromCheckedTemplate(body) {
+  const lines = String(body || '').split(/\r?\n/);
+  const start = lines.findIndex((line) => /^#{1,6}\s+Workflow Source\s*$/i.test(line));
+  if (start < 0) {
+    return SOURCE_TYPES.UNKNOWN;
+  }
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{1,6}\s+\S/.test(line)) {
+      break;
+    }
+    sectionLines.push(line);
+  }
+  const text = sectionLines.join('\n');
+  for (const line of text.split(/\r?\n/)) {
+    const checkbox = line.match(/^\s*[-*]\s+\[[xX]\]\s+(.+?)\s*$/);
+    if (!checkbox) {
+      continue;
+    }
+    const label = checkbox[1];
+    for (const [sourceType, pattern] of CHECKBOX_SOURCE_PATTERNS) {
+      if (pattern.test(label)) {
+        return sourceType;
+      }
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function sourceTypeFromLabels(pull = {}) {
+  for (const label of labelNames(pull)) {
+    const sourceType = SOURCE_LABELS[label.toLowerCase()] || SOURCE_LABELS[normalizeToken(label)];
+    if (sourceType) {
+      return sourceType;
+    }
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function inferredSourceType(pull = {}) {
+  const branch = cleanString(pull?.head?.ref).toLowerCase();
+  const title = cleanString(pull?.title).toLowerCase();
+  const author = cleanString(pull?.user?.login).toLowerCase();
+  const labels = labelNames(pull).map((label) => label.toLowerCase());
+
+  if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
+    return SOURCE_TYPES.DEPENDABOT;
+  }
+  if (
+    branch.startsWith('sync/') ||
+    branch.startsWith('sync-') ||
+    labels.includes('campaign:sync-dependabot') ||
+    /\bsync\b/.test(title)
+  ) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
+    return SOURCE_TYPES.REVIEW_FOLLOWUP;
+  }
+  return SOURCE_TYPES.UNKNOWN;
+}
+
+function resolvePrSourceContext(pull = {}) {
+  const body = String(pull?.body || '');
+  const block = parseWorkflowSourceBlock(body);
+  const issueNumber = extractIssueNumberFromPull(pull);
+
+  const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));
+  const blockType = normalizeSourceType(block.origin || block.source || block.type);
+  const checkboxType = sourceTypeFromCheckedTemplate(body);
+  const labelType = sourceTypeFromLabels(pull);
+  const inferredType = inferredSourceType(pull);
+  const sourceType = issueNumber
+    ? SOURCE_TYPES.GITHUB_ISSUE
+    : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
+      || SOURCE_TYPES.UNKNOWN;
+
+  const sourceRef =
+    cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
+    cleanString(block.source_ref || block.ref || block.reference) ||
+    (issueNumber ? `#${issueNumber}` : '');
+  const lifecycle =
+    cleanString(parseHtmlMarker(body, 'workflow-lifecycle')) ||
+    cleanString(block.lifecycle || block.intended_lifecycle);
+  const automation =
+    cleanString(parseHtmlMarker(body, 'workflow-automation')) ||
+    cleanString(block.automation || block.automation_intent);
+
+  return {
+    sourceType,
+    issueNumber,
+    sourceRef,
+    lifecycle,
+    automation,
+    isKnown: sourceType !== SOURCE_TYPES.UNKNOWN,
+    isValid: VALID_SOURCE_TYPES.has(sourceType),
+    isExplicit: Boolean(
+      issueNumber ||
+        markerType !== SOURCE_TYPES.UNKNOWN ||
+        blockType !== SOURCE_TYPES.UNKNOWN ||
+        checkboxType !== SOURCE_TYPES.UNKNOWN ||
+        labelType !== SOURCE_TYPES.UNKNOWN
+    ),
+    requiresIssue: sourceType === SOURCE_TYPES.GITHUB_ISSUE,
+  };
+}
+
+function hasValidNonIssueSourceContext(pull = {}) {
+  const context = resolvePrSourceContext(pull);
+  return context.isValid && !context.requiresIssue;
+}
+
+function formatSourceContextForLog(context = {}) {
+  const parts = [`origin=${context.sourceType || SOURCE_TYPES.UNKNOWN}`];
+  if (context.sourceRef) {
+    parts.push(`ref=${context.sourceRef}`);
+  }
+  if (context.lifecycle) {
+    parts.push(`lifecycle=${context.lifecycle}`);
+  }
+  if (context.automation) {
+    parts.push(`automation=${context.automation}`);
+  }
+  return parts.join(' ');
+}
+
+module.exports = {
+  SOURCE_TYPES,
+  VALID_SOURCE_TYPES,
+  normalizeSourceType,
+  extractIssueNumberFromPull,
+  parseWorkflowSourceBlock,
+  sourceTypeFromCheckedTemplate,
+  sourceTypeFromLabels,
+  resolvePrSourceContext,
+  hasValidNonIssueSourceContext,
+  formatSourceContextForLog,
+};

--- a/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
+++ b/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
@@ -76,7 +76,32 @@ Issue: "Add user authentication"
 
 ---
 
-### 3. End-to-End Automation (Auto-Pilot)
+### 3. Start Work Directly From a PR
+
+**Use Case:** You are opening a PR without first creating a GitHub issue
+
+**Steps:**
+1. Fill out exactly one option in the PR template's `Workflow Source` section
+2. If the PR came from an issue, include `Closes #123` or `Related to #123`
+3. If there is no issue, choose the direct, local request, automation, review follow-up, sync/maintenance, or Dependabot source
+4. Use a `workflow:source-*` label if you need to classify an existing PR from the PR list
+
+**What Happens:**
+- Workflows treats valid non-issue sources as intentional work instead of missing process state
+- PR metadata automation avoids repeated missing-source repair comments
+- Keepalive still requires a linked issue before it dispatches follow-up agent work
+
+**Common labels:**
+- `workflow:source-direct-pr`
+- `workflow:source-local-request`
+- `workflow:source-review-followup`
+- `workflow:source-sync`
+- `workflow:source-dependabot`
+- `workflow:no-automation`
+
+---
+
+### 4. End-to-End Automation (Auto-Pilot)
 
 **Use Case:** You want complete hands-off automation from issue to merged PR
 

--- a/templates/consumer-repo/docs/LABELS.md
+++ b/templates/consumer-repo/docs/LABELS.md
@@ -212,6 +212,30 @@ To establish a single canonical TripPlan contract and eliminate inconsistencies.
 
 ---
 
+## Workflow Source Labels
+
+These labels let direct GitHub PRs and non-issue-origin PRs integrate with
+Workflows source classification without forcing a GitHub issue.
+
+| Label | Applies to | Effect |
+|-------|------------|--------|
+| `workflow:source-issue` | Pull Requests | PR source is a GitHub issue. |
+| `workflow:source-local-request` | Pull Requests | PR source is a local Codex/user request. |
+| `workflow:source-automation` | Pull Requests | PR source is an automation or workflow run. |
+| `workflow:source-sync` | Pull Requests | PR source is a sync or maintenance campaign. |
+| `workflow:source-dependabot` | Pull Requests | PR source is Dependabot or dependency automation. |
+| `workflow:source-review-followup` | Pull Requests | PR source is review feedback follow-up. |
+| `workflow:source-direct-pr` | Pull Requests | PR was started directly on GitHub without a source issue. |
+| `workflow:no-automation` | Pull Requests | Automation should not manage the PR unless checks fail. |
+| `workflow:source-needed` | Pull Requests | Source context is missing or ambiguous. |
+
+Use these labels as a backup to the PR template's Workflow Source section. If a
+PR has no linked issue and no valid Workflow Source, the PR metadata automation
+posts one repair comment instead of repeatedly treating the PR as issue-delivery
+work.
+
+---
+
 ## Verifier Labels
 
 These labels trigger the post-merge verifier workflow on a merged PR.


### PR DESCRIPTION
<!-- workflow-source:automation_run -->
<!-- workflow-source-ref:workflows-system-review-2 -->
<!-- workflow-lifecycle:source-context-contract -->
<!-- workflow-automation:codex-automation -->

## Summary

- add a shared PR source-context parser for issue, local request, automation, sync, Dependabot, review follow-up, and direct/manual PR origins
- add a warning-only `workflows-pr-source-context/v1` report to PR 11 with JSON/Markdown artifacts
- let PR metadata and keepalive automation accept explicit non-issue source context instead of repeatedly requiring a linked issue
- keep unknown-source PRs deterministic: repair comment for metadata sync, keepalive skip with `missing-source-context`
- sync the parser, PR template, labels, docs, and PR-meta script copies through the consumer template contract

## Testing

- `node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/pr-source-context-report.test.js .github/scripts/__tests__/agents-pr-meta-keepalive.test.js .github/scripts/__tests__/agents-pr-meta-update-body.test.js`
- `python scripts/validate_workflow_yaml.py .github/workflows/pr-11-ci-smoke.yml --no-skip`
- `python -m scripts.validate_template_sync`
- `python -m scripts.validate_template_completeness`
- `git diff --check`
