### PR TITLE
[codex] Fix label docs sync sparse checkout

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/workflows/autofix-versions.env
+            .github/workflows/maint-68-sync-consumer-repos.yml
             scripts/list_registered_consumer_repos.py
             scripts/sync_dev_dependencies.py
           sparse-checkout-cone-mode: false

--- a/.github/workflows/maint-65-sync-label-docs.yml
+++ b/.github/workflows/maint-65-sync-label-docs.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           sparse-checkout: |
             docs/LABELS.md
+            .github/workflows/maint-68-sync-consumer-repos.yml
             scripts/list_registered_consumer_repos.py
           sparse-checkout-cone-mode: false
 

--- a/tests/workflows/test_registered_consumer_repos_helper.py
+++ b/tests/workflows/test_registered_consumer_repos_helper.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+REPO_HELPER = "scripts/list_registered_consumer_repos.py"
+REPO_MANIFEST = ".github/workflows/maint-68-sync-consumer-repos.yml"
+
+
+def test_sparse_checkout_callers_include_registered_repo_manifest():
+    offenders = []
+
+    for workflow_path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        text = workflow_path.read_text(encoding="utf-8")
+        if REPO_HELPER not in text or "sparse-checkout:" not in text:
+            continue
+        if REPO_MANIFEST not in text:
+            offenders.append(str(workflow_path))
+
+    assert offenders == []


### PR DESCRIPTION
<!-- workflow-source:automation_run -->
<!-- workflow-source-ref:workflows-system-review-2 -->
<!-- workflow-lifecycle:post-merge-maint65-followup -->
<!-- workflow-automation:codex-automation -->

## Summary

- include `.github/workflows/maint-68-sync-consumer-repos.yml` in Maint 65 and Maint 52 sparse checkouts whenever they call `scripts/list_registered_consumer_repos.py`
- fixes the post-merge label-doc sync failure where the shared helper could not find its default manifest
- add a regression test so future sparse-checkout callers of the registered-repo helper must include the manifest dependency

## Testing

- `python -m pytest tests/workflows/test_registered_consumer_repos_helper.py -q`
- `python scripts/validate_workflow_yaml.py .github/workflows/maint-65-sync-label-docs.yml .github/workflows/maint-52-sync-dev-versions.yml --no-skip`
- `python scripts/list_registered_consumer_repos.py --separator ,`
- `git diff --check`
