### PR TITLE
[codex] Add PR source context weekly coverage

### DIFF
--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -66,6 +66,34 @@ test('builds a pass monitor contract from warning-only preflight reports', () =>
   assert.match(markdown, /terminal-disposition \| pass/);
 });
 
+test('includes PR source context coverage when configured', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
+  const terminal = writeJson(dir, 'terminal.json', report('pass'));
+  const botAuth = writeJson(dir, 'bot-auth.json', report('pass'));
+  const prSource = writeJson(
+    dir,
+    'pr-source.json',
+    report('warning', {
+      schema: 'workflows-pr-source-context-coverage/v1',
+      warning_count: 1,
+      unknown_source_context_count: 1,
+    })
+  );
+
+  const summary = buildCoverageMonitorSummary({
+    terminal_report: terminal,
+    bot_auth_report: botAuth,
+    pr_source_context_report: prSource,
+  });
+
+  assert.equal(summary.status, 'warning');
+  assert.deepEqual(
+    summary.monitors.map((monitor) => monitor.label),
+    ['terminal-disposition', 'bot-comment-auth', 'pr-source-context']
+  );
+  assert.match(formatMonitorMarkdown(summary), /pr-source-context \| warning/);
+});
+
 test('surfaces warning blockers without activating hard-block policy', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
   const terminal = writeJson(
@@ -241,6 +269,8 @@ test('parses CLI paths and writes summary artifacts without failing warning stat
     terminal,
     '--bot-auth-report',
     botAuth,
+    '--pr-source-context-report',
+    path.join(dir, 'pr-source.json'),
     '--output-json',
     outputJson,
     '--output-md',
@@ -249,6 +279,7 @@ test('parses CLI paths and writes summary artifacts without failing warning stat
 
   assert.equal(options.terminal_report, terminal);
   assert.equal(options.bot_auth_report, botAuth);
+  assert.equal(options.pr_source_context_report, path.join(dir, 'pr-source.json'));
   const result = spawnSync(
     process.execPath,
     [
@@ -257,6 +288,8 @@ test('parses CLI paths and writes summary artifacts without failing warning stat
       terminal,
       '--bot-auth-report',
       botAuth,
+      '--pr-source-context-report',
+      '',
       '--output-json',
       outputJson,
       '--output-md',

--- a/.github/scripts/__tests__/pr-source-context-coverage.test.js
+++ b/.github/scripts/__tests__/pr-source-context-coverage.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  COVERAGE_SCHEMA,
+  buildCoverageReport,
+  shouldFail,
+} = require('../pr_source_context_coverage.js');
+
+function writeReport(root, artifactName, report) {
+  const dir = path.join(root, artifactName, '123');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'pr-source-context.json'), `${JSON.stringify(report)}\n`);
+}
+
+test('buildCoverageReport summarizes PR source context and task-list artifacts', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-source-context-coverage-'));
+  writeReport(root, 'pr-source-context', {
+    schema: 'workflows-pr-source-context/v1',
+    status: 'pass',
+    reason: 'source-context-detected',
+    pull_request: { number: 12, title: 'Implement source contract', head_ref: 'codex/source' },
+    source_context: { sourceType: 'local_request', isValid: true, isExplicit: true },
+    task_list: { has_task_list: true, total: 3, checked: 1, unchecked: 2, open_item_count: 2 },
+  });
+  writeReport(root, 'pr-source-context-2', {
+    schema: 'workflows-pr-source-context/v1',
+    status: 'warning',
+    reason: 'source-context-unknown',
+    pull_request: { number: 13, title: 'Missing context', head_ref: 'feature/no-source' },
+    source_context: { sourceType: 'unknown', isValid: false, isExplicit: false },
+    task_list: { has_task_list: false, total: 0, checked: 0, unchecked: 0, open_item_count: 0 },
+  });
+
+  const report = buildCoverageReport({ root, now: '2026-04-26T23:00:00.000Z' });
+
+  assert.equal(report.schema, COVERAGE_SCHEMA);
+  assert.equal(report.status, 'warning');
+  assert.equal(report.records, 2);
+  assert.equal(report.valid_source_context_count, 1);
+  assert.equal(report.unknown_source_context_count, 1);
+  assert.equal(report.task_items_total, 3);
+  assert.equal(report.task_items_open, 2);
+  assert.deepEqual(report.source_type_counts, { local_request: 1, unknown: 1 });
+  assert.equal(report.open_task_prs[0].number, 12);
+  assert.equal(report.unknown_source_prs[0].number, 13);
+});
+
+test('shouldFail only hard-blocks when explicitly approved', () => {
+  const report = { status: 'warning' };
+  assert.equal(shouldFail(report, {}), false);
+  assert.equal(shouldFail(report, { PR_SOURCE_CONTEXT_COVERAGE_MODE: 'hard-block' }), false);
+  assert.equal(
+    shouldFail(report, {
+      PR_SOURCE_CONTEXT_COVERAGE_MODE: 'hard-block',
+      PR_SOURCE_CONTEXT_HARD_BLOCK_APPROVED: 'true',
+    }),
+    true,
+  );
+});

--- a/.github/scripts/__tests__/pr-source-context-report.test.js
+++ b/.github/scripts/__tests__/pr-source-context-report.test.js
@@ -8,10 +8,35 @@ const path = require('node:path');
 
 const {
   REPORT_SCHEMA,
+  analyzeTaskList,
   buildPrSourceContextReport,
   renderMarkdown,
   writeReport,
 } = require('../pr_source_context_report.js');
+
+test('analyzeTaskList counts checkbox items outside fenced code blocks by section', () => {
+  const result = analyzeTaskList(`
+# Scope
+- [ ] wire source contract
+- [x] keep existing issue links
+
+\`\`\`
+- [ ] not a task
+\`\`\`
+
+## Verification
+1. [ ] run node tests
+`);
+
+  assert.equal(result.has_task_list, true);
+  assert.equal(result.total, 3);
+  assert.equal(result.checked, 1);
+  assert.equal(result.unchecked, 2);
+  assert.deepEqual(result.sections, [
+    { heading: 'Scope', total: 2, checked: 1, unchecked: 1 },
+    { heading: 'Verification', total: 1, checked: 0, unchecked: 1 },
+  ]);
+});
 
 test('buildPrSourceContextReport skips non-PR events without failing', () => {
   const report = buildPrSourceContextReport({
@@ -52,7 +77,31 @@ test('buildPrSourceContextReport passes source-issue PRs', () => {
   assert.equal(report.source_context.sourceType, 'github_issue');
   assert.equal(report.source_context.issueNumber, 1836);
   assert.equal(report.source_context.isExplicit, true);
+  assert.equal(report.task_list.has_task_list, false);
   assert.deepEqual(report.warnings, []);
+});
+
+test('buildPrSourceContextReport includes task-list contract for PR bodies', () => {
+  const report = buildPrSourceContextReport({
+    eventName: 'pull_request',
+    event: {
+      pull_request: {
+        number: 43,
+        title: 'Implement issue checklist',
+        body: '<!-- meta:issue:1836 -->\n## Tasks\n- [ ] first\n- [x] second',
+        head: { ref: 'codex/issue-1836' },
+        base: { ref: 'main' },
+        user: { login: 'codex' },
+        labels: [{ name: 'codex' }],
+      },
+    },
+    now: '2026-04-26T22:00:00.000Z',
+  });
+
+  assert.equal(report.task_list.has_task_list, true);
+  assert.equal(report.task_list.total, 2);
+  assert.equal(report.task_list.open_item_count, 1);
+  assert.equal(report.task_list.sections[0].heading, 'Tasks');
 });
 
 test('buildPrSourceContextReport accepts explicit local request PRs', () => {

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -32,6 +32,7 @@ test('maps metrics artifact names to stable families', () => {
   assert.equal(artifactFamily('keepalive-metrics'), 'keepalive-metrics');
   assert.equal(artifactFamily('codex-cli-freshness'), 'codex-cli-freshness');
   assert.equal(artifactFamily('codex-cli-freshness-123'), 'codex-cli-freshness');
+  assert.equal(artifactFamily('pr-source-context'), 'pr-source-context');
   assert.equal(artifactFamily('autopilot-metrics-42'), 'autopilot-metrics');
   assert.equal(
     artifactFamily('review-thread-terminal-disposition-123'),
@@ -84,15 +85,16 @@ test('selects only recent matching artifacts with a machine-readable report', ()
       artifact(7, 'bot-comment-auth-coverage-wrapper-latest', '2026-04-25T08:00:00Z'),
       artifact(8, 'bot-comment-auth-coverage-wrapper-77-2', '2026-04-25T08:30:00Z'),
       artifact(9, 'codex-cli-freshness-77', '2026-04-25T11:30:00Z'),
+      artifact(10, 'pr-source-context', '2026-04-25T11:45:00Z'),
     ],
     { now_ms: NOW, lookback_days: 14 }
   );
 
   assert.equal(report.schema, SELECTION_SCHEMA);
   assert.equal(report.status, 'pass');
-  assert.equal(report.scanned_count, 9);
-  assert.equal(report.candidate_count, 6);
-  assert.equal(report.selected_count, 6);
+  assert.equal(report.scanned_count, 10);
+  assert.equal(report.candidate_count, 7);
+  assert.equal(report.selected_count, 7);
   assert.equal(report.ignored_name_count, 1);
   assert.equal(report.ignored_old_count, 1);
   assert.equal(report.ignored_expired_count, 1);
@@ -101,6 +103,7 @@ test('selects only recent matching artifacts with a machine-readable report', ()
     'bot-comment-auth-coverage-wrapper': 2,
     'codex-cli-freshness': 1,
     'keepalive-metrics': 1,
+    'pr-source-context': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(report.missing_priority_families, [
@@ -127,6 +130,12 @@ test('selects only recent matching artifacts with a machine-readable report', ()
         name: 'review-thread-terminal-disposition-77',
         created_at: '2026-04-25T11:00:00Z',
         updated_at: '2026-04-25T11:00:00Z',
+      },
+      'pr-source-context': {
+        id: 10,
+        name: 'pr-source-context',
+        created_at: '2026-04-25T11:45:00Z',
+        updated_at: '2026-04-25T11:45:00Z',
       },
     }
   );
@@ -174,6 +183,13 @@ test('selects only recent matching artifacts with a machine-readable report', ()
         selected_count: 0,
         selected_name: '',
       },
+      {
+        family: 'pr-source-context',
+        status: 'selected',
+        candidate_count: 1,
+        selected_count: 1,
+        selected_name: 'pr-source-context',
+      },
     ]
   );
   assert.deepEqual(report.selected_family_counts, {
@@ -181,11 +197,12 @@ test('selects only recent matching artifacts with a machine-readable report', ()
     'bot-comment-auth-coverage-wrapper': 2,
     'codex-cli-freshness': 1,
     'keepalive-metrics': 1,
+    'pr-source-context': 1,
     'review-thread-terminal-disposition': 1,
   });
   assert.deepEqual(
     report.selected_artifacts.map((selected) => selected.id),
-    [9, 5, 8, 4, 7, 1]
+    [9, 5, 8, 10, 4, 7, 1]
   );
 });
 
@@ -206,6 +223,7 @@ test('builds an error report when artifact selection cannot query GitHub', () =>
     'review-thread-terminal-disposition',
     'bot-comment-auth-coverage-wrapper',
     'bot-comment-auth-coverage-reusable',
+    'pr-source-context',
   ]);
   assert.ok(report.priority_family_statuses.every((family) => family.status === 'missing'));
   assert.deepEqual(report.selected_artifacts, []);
@@ -247,6 +265,7 @@ test('reserves priority telemetry artifacts before filling the total cap', () =>
       artifact(5, 'bot-comment-auth-coverage-wrapper-77', '2026-04-25T07:00:00Z'),
       artifact(6, 'bot-comment-auth-coverage-reusable-77', '2026-04-25T06:00:00Z'),
       artifact(7, 'codex-cli-freshness-77', '2026-04-25T05:00:00Z'),
+      artifact(8, 'pr-source-context', '2026-04-25T04:00:00Z'),
     ],
     {
       now_ms: NOW,
@@ -262,15 +281,15 @@ test('reserves priority telemetry artifacts before filling the total cap', () =>
       'review-thread-terminal-disposition-77',
       'bot-comment-auth-coverage-wrapper-77',
       'bot-comment-auth-coverage-reusable-77',
-      'keepalive-metrics',
+      'pr-source-context',
     ]
   );
-  assert.equal(report.ignored_total_limit_count, 1);
+  assert.equal(report.ignored_total_limit_count, 2);
   assert.deepEqual(report.selected_family_counts, {
     'bot-comment-auth-coverage-reusable': 1,
     'bot-comment-auth-coverage-wrapper': 1,
     'codex-cli-freshness': 1,
-    'keepalive-metrics': 1,
+    'pr-source-context': 1,
     'review-thread-terminal-disposition': 1,
     'verifier-terminal-disposition': 1,
   });
@@ -288,6 +307,7 @@ test('reports priority telemetry families that are absent from the scan', () => 
     'verifier-terminal-disposition',
     'review-thread-terminal-disposition',
     'bot-comment-auth-coverage-reusable',
+    'pr-source-context',
   ]);
 });
 
@@ -372,7 +392,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
   assert.match(markdown, /Selected artifacts: 2/);
   assert.match(
     markdown,
-    /Missing priority families: codex-cli-freshness, verifier-terminal-disposition, review-thread-terminal-disposition, bot-comment-auth-coverage-wrapper, bot-comment-auth-coverage-reusable/
+    /Missing priority families: codex-cli-freshness, verifier-terminal-disposition, review-thread-terminal-disposition, bot-comment-auth-coverage-wrapper, bot-comment-auth-coverage-reusable, pr-source-context/
   );
   assert.match(markdown, /Artifact family \| Candidates \| Selected/);
   assert.match(markdown, /Priority family \| Status \| Candidates \| Selected artifact/);

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -140,6 +140,11 @@ function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
+  if (cleanString(options.pr_source_context_report)) {
+    monitors.push(
+      summarizeReport(readJsonReport(options.pr_source_context_report, 'pr-source-context'))
+    );
+  }
   const status = overallStatus(monitors);
   const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);
   const shouldFail = monitors.some((monitor) => monitor.should_fail);
@@ -211,6 +216,8 @@ function parseArgs(argv = process.argv.slice(2)) {
       process.env.COVERAGE_MONITOR_TERMINAL_JSON || 'terminal-disposition-coverage.json',
     bot_auth_report:
       process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
+    pr_source_context_report:
+      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || 'pr-source-context-coverage.json',
     output_json:
       process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
     output_md:
@@ -225,6 +232,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--bot-auth-report') {
       options.bot_auth_report = next;
+      index += 1;
+    } else if (arg === '--pr-source-context-report') {
+      options.pr_source_context_report = next;
       index += 1;
     } else if (arg === '--output-json') {
       options.output_json = next;

--- a/.github/scripts/pr_source_context_coverage.js
+++ b/.github/scripts/pr_source_context_coverage.js
@@ -1,0 +1,248 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const COVERAGE_SCHEMA = 'workflows-pr-source-context-coverage/v1';
+const SOURCE_CONTEXT_SCHEMA = 'workflows-pr-source-context/v1';
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function ensureParentDirectory(filePath) {
+  if (!filePath) return;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function increment(map, key) {
+  const cleanKey = cleanString(key) || 'unknown';
+  map.set(cleanKey, (map.get(cleanKey) || 0) + 1);
+}
+
+function sortedObject(map) {
+  return Object.fromEntries([...map.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+}
+
+function walkFiles(root) {
+  if (!root || !fs.existsSync(root)) return [];
+  const stat = fs.statSync(root);
+  if (stat.isFile()) return [root];
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function readSourceContextReports(root) {
+  const reports = [];
+  const parse_errors = [];
+  for (const file of walkFiles(root)) {
+    if (path.basename(file) !== 'pr-source-context.json') {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (parsed && parsed.schema === SOURCE_CONTEXT_SCHEMA) {
+        reports.push({ path: file, report: parsed });
+      }
+    } catch (error) {
+      parse_errors.push({
+        path: file,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return { reports, parse_errors };
+}
+
+function buildCoverageReport(options = {}) {
+  const root = cleanString(options.root || options.dir) || 'artifacts';
+  const now = options.now || new Date().toISOString();
+  const { reports, parse_errors } = readSourceContextReports(root);
+  const statusCounts = new Map();
+  const reasonCounts = new Map();
+  const sourceTypeCounts = new Map();
+  let explicitCount = 0;
+  let inferredCount = 0;
+  let validCount = 0;
+  let unknownCount = 0;
+  let taskListRecords = 0;
+  let taskItemsTotal = 0;
+  let taskItemsOpen = 0;
+  let taskItemsCompleted = 0;
+  const openTaskPrs = [];
+  const unknownSourcePrs = [];
+
+  for (const item of reports) {
+    const report = item.report || {};
+    const source = report.source_context || {};
+    const taskList = report.task_list || {};
+    const pr = report.pull_request || {};
+    const status = cleanString(report.status) || 'unknown';
+    const reason = cleanString(report.reason) || 'unknown';
+    const sourceType = cleanString(source.sourceType) || 'unknown';
+    increment(statusCounts, status);
+    increment(reasonCounts, reason);
+    increment(sourceTypeCounts, sourceType);
+    if (source.isValid) validCount += 1;
+    if (source.isExplicit) explicitCount += 1;
+    else inferredCount += 1;
+    if (sourceType === 'unknown' || !source.isValid) {
+      unknownCount += 1;
+      if (unknownSourcePrs.length < 20) {
+        unknownSourcePrs.push({
+          number: pr.number || null,
+          title: cleanString(pr.title),
+          head_ref: cleanString(pr.head_ref),
+          report_path: item.path,
+        });
+      }
+    }
+    if (taskList.has_task_list) {
+      taskListRecords += 1;
+    }
+    const total = Number(taskList.total || 0);
+    const open = Number(taskList.open_item_count ?? taskList.unchecked ?? 0);
+    const completed = Number(taskList.completed_item_count ?? taskList.checked ?? 0);
+    taskItemsTotal += Number.isFinite(total) ? total : 0;
+    taskItemsOpen += Number.isFinite(open) ? open : 0;
+    taskItemsCompleted += Number.isFinite(completed) ? completed : 0;
+    if (open > 0 && openTaskPrs.length < 20) {
+      openTaskPrs.push({
+        number: pr.number || null,
+        title: cleanString(pr.title),
+        open_item_count: open,
+        total: Number.isFinite(total) ? total : 0,
+        report_path: item.path,
+      });
+    }
+  }
+
+  const warningCount = (statusCounts.get('warning') || 0) + unknownCount + parse_errors.length;
+  const status = parse_errors.length > 0 ? 'warning' : unknownCount > 0 ? 'warning' : 'pass';
+
+  return {
+    schema: COVERAGE_SCHEMA,
+    generated_at: now,
+    root,
+    status,
+    records: reports.length,
+    parse_error_count: parse_errors.length,
+    parse_errors,
+    warning_count: warningCount,
+    valid_source_context_count: validCount,
+    unknown_source_context_count: unknownCount,
+    explicit_source_context_count: explicitCount,
+    inferred_source_context_count: inferredCount,
+    task_list_records: taskListRecords,
+    task_items_total: taskItemsTotal,
+    task_items_open: taskItemsOpen,
+    task_items_completed: taskItemsCompleted,
+    status_counts: sortedObject(statusCounts),
+    reason_counts: sortedObject(reasonCounts),
+    source_type_counts: sortedObject(sourceTypeCounts),
+    open_task_prs: openTaskPrs,
+    unknown_source_prs: unknownSourcePrs,
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '## PR Source Context Coverage',
+    '',
+    `- Schema: ${report.schema || COVERAGE_SCHEMA}`,
+    `- Status: ${report.status || 'unknown'}`,
+    `- Records: ${report.records || 0}`,
+    `- Valid source contexts: ${report.valid_source_context_count || 0}`,
+    `- Unknown source contexts: ${report.unknown_source_context_count || 0}`,
+    `- Explicit/inferred: ${report.explicit_source_context_count || 0}/${report.inferred_source_context_count || 0}`,
+    `- Task-list records: ${report.task_list_records || 0}`,
+    `- Task items open/completed/total: ${report.task_items_open || 0}/${report.task_items_completed || 0}/${report.task_items_total || 0}`,
+    `- Parse errors: ${report.parse_error_count || 0}`,
+  ];
+
+  if (report.open_task_prs?.length) {
+    lines.push('', '| PR | Open | Total | Title |', '|----|------|-------|-------|');
+    for (const pr of report.open_task_prs) {
+      lines.push(`| #${pr.number || 'unknown'} | ${pr.open_item_count || 0} | ${pr.total || 0} | ${cleanString(pr.title).replace(/\|/g, '\\|')} |`);
+    }
+  }
+
+  if (report.unknown_source_prs?.length) {
+    lines.push('', '### Unknown Source Contexts');
+    for (const pr of report.unknown_source_prs) {
+      lines.push(`- #${pr.number || 'unknown'} ${cleanString(pr.title) || '(untitled)'}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function writeCoverageReport(report, options = {}) {
+  if (options.outputJson) {
+    ensureParentDirectory(options.outputJson);
+    fs.writeFileSync(options.outputJson, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+  if (options.outputMd) {
+    ensureParentDirectory(options.outputMd);
+    fs.writeFileSync(options.outputMd, renderMarkdown(report), 'utf8');
+  }
+}
+
+function shouldFail(report, env = process.env) {
+  const mode = cleanString(env.PR_SOURCE_CONTEXT_COVERAGE_MODE || 'warning-only').toLowerCase();
+  const hardBlockApproved = cleanString(env.PR_SOURCE_CONTEXT_HARD_BLOCK_APPROVED || 'false').toLowerCase() === 'true';
+  return report.status !== 'pass' && mode === 'hard-block' && hardBlockApproved;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = {
+    root: process.env.PR_SOURCE_CONTEXT_COVERAGE_DIR || 'artifacts',
+    outputJson: process.env.PR_SOURCE_CONTEXT_COVERAGE_JSON || 'pr-source-context-coverage.json',
+    outputMd: process.env.PR_SOURCE_CONTEXT_COVERAGE_MD || 'pr-source-context-coverage.md',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--root') {
+      args.root = next || '';
+      index += 1;
+    } else if (arg === '--output-json') {
+      args.outputJson = next || '';
+      index += 1;
+    } else if (arg === '--output-md') {
+      args.outputMd = next || '';
+      index += 1;
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs();
+  const report = buildCoverageReport(args);
+  writeCoverageReport(report, args);
+  process.stdout.write(renderMarkdown(report));
+  return shouldFail(report) ? 1 : 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  COVERAGE_SCHEMA,
+  SOURCE_CONTEXT_SCHEMA,
+  buildCoverageReport,
+  parseArgs,
+  renderMarkdown,
+  shouldFail,
+  writeCoverageReport,
+};

--- a/.github/scripts/pr_source_context_report.js
+++ b/.github/scripts/pr_source_context_report.js
@@ -38,6 +38,70 @@ function labelNames(pull = {}) {
     : [];
 }
 
+function analyzeTaskList(body = '') {
+  const sections = new Map();
+  let currentSection = 'PR body';
+  let total = 0;
+  let checked = 0;
+  let unchecked = 0;
+  let inCodeBlock = false;
+
+  function sectionState(name) {
+    const key = cleanString(name) || 'PR body';
+    if (!sections.has(key)) {
+      sections.set(key, {
+        heading: key,
+        total: 0,
+        checked: 0,
+        unchecked: 0,
+      });
+    }
+    return sections.get(key);
+  }
+
+  for (const line of String(body || '').split(/\r?\n/)) {
+    if (/^\s*```/.test(line)) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) {
+      continue;
+    }
+
+    const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      currentSection = cleanString(heading[1]) || currentSection;
+      continue;
+    }
+
+    const checkbox = line.match(/^\s*(?:[-*+]|\d+[.)])\s+\[( |x|X)\]\s+(.+?)\s*$/);
+    if (!checkbox) {
+      continue;
+    }
+
+    total += 1;
+    const section = sectionState(currentSection);
+    section.total += 1;
+    if (checkbox[1].toLowerCase() === 'x') {
+      checked += 1;
+      section.checked += 1;
+    } else {
+      unchecked += 1;
+      section.unchecked += 1;
+    }
+  }
+
+  return {
+    has_task_list: total > 0,
+    total,
+    checked,
+    unchecked,
+    open_item_count: unchecked,
+    completed_item_count: checked,
+    sections: Array.from(sections.values()),
+  };
+}
+
 function buildPrSourceContextReport(options = {}) {
   const event = options.event && typeof options.event === 'object' ? options.event : {};
   const pull = event.pull_request && typeof event.pull_request === 'object' ? event.pull_request : null;
@@ -68,6 +132,15 @@ function buildPrSourceContextReport(options = {}) {
       isExplicit: false,
       requiresIssue: false,
     },
+    task_list: {
+      has_task_list: false,
+      total: 0,
+      checked: 0,
+      unchecked: 0,
+      open_item_count: 0,
+      completed_item_count: 0,
+      sections: [],
+    },
     warnings: [],
   };
 
@@ -90,6 +163,7 @@ function buildPrSourceContextReport(options = {}) {
     labels: labelNames(pull),
   };
   report.source_context = context;
+  report.task_list = analyzeTaskList(pull.body || '');
 
   if (!valid) {
     report.warnings.push(
@@ -118,6 +192,7 @@ function renderMarkdown(report) {
       `- PR: #${report.pull_request.number || 'unknown'}`,
       `- Source: \`${formatSourceContextForLog(report.source_context)}\``,
       `- Explicit source marker: \`${report.source_context?.isExplicit ? 'true' : 'false'}\``,
+      `- Task list: \`${report.task_list?.total || 0}\` items, \`${report.task_list?.unchecked || 0}\` open`,
     );
   }
 
@@ -202,6 +277,7 @@ if (require.main === module) {
 
 module.exports = {
   REPORT_SCHEMA,
+  analyzeTaskList,
   buildPrSourceContextReport,
   parseArgs,
   renderMarkdown,

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -13,6 +13,7 @@ const EXACT_METRICS_ARTIFACTS = new Set([
   'agents-verifier-metrics',
   'agents-verifier-disposition-metrics',
   'codex-cli-freshness',
+  'pr-source-context',
 ]);
 
 const PREFIXED_METRICS_ARTIFACTS = [
@@ -41,6 +42,7 @@ const PRIORITY_METRICS_FAMILIES = [
   'review-thread-terminal-disposition',
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
+  'pr-source-context',
 ];
 
 function cleanString(value) {

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -24,6 +24,7 @@ jobs:
             .github/scripts/bot_comment_auth_coverage.js
             .github/scripts/coverage_monitor_summary.js
             .github/scripts/github-api-with-retry.js
+            .github/scripts/pr_source_context_coverage.js
             .github/scripts/terminal_disposition.js
             .github/scripts/terminal_disposition_coverage.js
             .github/scripts/token_load_balancer.js
@@ -88,7 +89,13 @@ jobs:
           fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            safe_name="$(node -e 'const { safeArtifactPathSegment } = require("./.github/scripts/weekly_metrics_download_manifest.js"); process.stdout.write(safeArtifactPathSegment(process.argv[1] || ""));' "$name")"
+            safe_name="$(
+              node -e '
+                const { safeArtifactPathSegment } =
+                  require("./.github/scripts/weekly_metrics_download_manifest.js");
+                process.stdout.write(safeArtifactPathSegment(process.argv[1] || ""));
+              ' "$name"
+            )"
             artifact_dir="artifacts/$safe_name/$id"
             mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072
@@ -280,6 +287,31 @@ jobs:
           fi
           echo "BOT_COMMENT_AUTH_COVERAGE_EXIT_STATUS=${bot_comment_auth_status}" >> "$GITHUB_ENV"
 
+      - name: PR source context coverage preflight
+        env:
+          PR_SOURCE_CONTEXT_COVERAGE_DIR: artifacts
+          PR_SOURCE_CONTEXT_COVERAGE_JSON: pr-source-context-coverage.json
+          PR_SOURCE_CONTEXT_COVERAGE_MD: pr-source-context-coverage.md
+          PR_SOURCE_CONTEXT_COVERAGE_MODE: >-
+            ${{ vars.PR_SOURCE_CONTEXT_COVERAGE_MODE || 'warning-only' }}
+          PR_SOURCE_CONTEXT_HARD_BLOCK_APPROVED: >-
+            ${{ vars.PR_SOURCE_CONTEXT_HARD_BLOCK_APPROVED || 'false' }}
+        run: |
+          set +e
+          node .github/scripts/pr_source_context_coverage.js
+          pr_source_context_status=$?
+          set -e
+          if [ -f pr-source-context-coverage.md ]; then
+            cat pr-source-context-coverage.md >> "$GITHUB_STEP_SUMMARY"
+            if [ -f agent-weekly-metrics.md ]; then
+              {
+                printf '\n'
+                cat pr-source-context-coverage.md
+              } >> agent-weekly-metrics.md
+            fi
+          fi
+          echo "PR_SOURCE_CONTEXT_COVERAGE_EXIT_STATUS=${pr_source_context_status}" >> "$GITHUB_ENV"
+
       - name: Coverage monitor checkpoint
         if: ${{ always() }}
         env:
@@ -315,6 +347,8 @@ jobs:
             terminal-disposition-coverage.md
             bot-comment-auth-coverage-summary.json
             bot-comment-auth-coverage-summary.md
+            pr-source-context-coverage.json
+            pr-source-context-coverage.md
             coverage-monitor-summary.json
             coverage-monitor-summary.md
           if-no-files-found: warn
@@ -374,16 +408,23 @@ jobs:
         run: |
           terminal_status="${TERMINAL_DISPOSITION_COVERAGE_EXIT_STATUS:-0}"
           bot_comment_auth_status="${BOT_COMMENT_AUTH_COVERAGE_EXIT_STATUS:-0}"
-          if [ "${terminal_status}" != "0" ] || [ "${bot_comment_auth_status}" != "0" ]; then
+          pr_source_context_status="${PR_SOURCE_CONTEXT_COVERAGE_EXIT_STATUS:-0}"
+          if [ "${terminal_status}" != "0" ] ||
+             [ "${bot_comment_auth_status}" != "0" ] ||
+             [ "${pr_source_context_status}" != "0" ]; then
             echo "::error title=Coverage hard-block failed::" \
               "terminal-disposition-exit-status=${terminal_status}; " \
               "bot-comment-auth-exit-status=${bot_comment_auth_status}; " \
+              "pr-source-context-exit-status=${pr_source_context_status}; " \
               "coverage reports were uploaded before this failure"
             if [ "${terminal_status}" != "0" ]; then
               echo "Failed check: Review-thread terminal coverage preflight"
             fi
             if [ "${bot_comment_auth_status}" != "0" ]; then
               echo "Failed check: Bot-comment auth coverage preflight"
+            fi
+            if [ "${pr_source_context_status}" != "0" ]; then
+              echo "Failed check: PR source context coverage preflight"
             fi
             exit 1
           fi

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -317,6 +317,7 @@ jobs:
         env:
           COVERAGE_MONITOR_TERMINAL_JSON: terminal-disposition-coverage.json
           COVERAGE_MONITOR_BOT_AUTH_JSON: bot-comment-auth-coverage-summary.json
+          COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON: pr-source-context-coverage.json
           COVERAGE_MONITOR_SUMMARY_JSON: coverage-monitor-summary.json
           COVERAGE_MONITOR_SUMMARY_MD: coverage-monitor-summary.md
         run: |

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -140,6 +140,11 @@ function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
+  if (cleanString(options.pr_source_context_report)) {
+    monitors.push(
+      summarizeReport(readJsonReport(options.pr_source_context_report, 'pr-source-context'))
+    );
+  }
   const status = overallStatus(monitors);
   const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);
   const shouldFail = monitors.some((monitor) => monitor.should_fail);
@@ -211,6 +216,8 @@ function parseArgs(argv = process.argv.slice(2)) {
       process.env.COVERAGE_MONITOR_TERMINAL_JSON || 'terminal-disposition-coverage.json',
     bot_auth_report:
       process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
+    pr_source_context_report:
+      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || 'pr-source-context-coverage.json',
     output_json:
       process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
     output_md:
@@ -225,6 +232,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--bot-auth-report') {
       options.bot_auth_report = next;
+      index += 1;
+    } else if (arg === '--pr-source-context-report') {
+      options.pr_source_context_report = next;
       index += 1;
     } else if (arg === '--output-json') {
       options.output_json = next;

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -13,6 +13,7 @@ const EXACT_METRICS_ARTIFACTS = new Set([
   'agents-verifier-metrics',
   'agents-verifier-disposition-metrics',
   'codex-cli-freshness',
+  'pr-source-context',
 ]);
 
 const PREFIXED_METRICS_ARTIFACTS = [
@@ -41,6 +42,7 @@ const PRIORITY_METRICS_FAMILIES = [
   'review-thread-terminal-disposition',
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
+  'pr-source-context',
 ];
 
 function cleanString(value) {


### PR DESCRIPTION
## Summary
- add task-list counts to PR source context reports
- include `pr-source-context` artifacts in weekly metrics artifact selection
- publish warning-only weekly source-context coverage with hard-block plumbing behind explicit vars

## Verification
- `node --test .github/scripts/__tests__/pr-source-context-report.test.js .github/scripts/__tests__/pr-source-context-coverage.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js`
- `python scripts/validate_workflow_yaml.py .github/workflows/agents-weekly-metrics.yml --no-skip`
- `git diff --check`

<!-- workflow-source:automation_run -->
<!-- workflow-source-ref:workflows-system-review-2 -->