### PR TITLE
[codex] Fix Maint 46 post-CI sparse checkout

### DIFF
--- a/.github/workflows/maint-46-post-ci.yml
+++ b/.github/workflows/maint-46-post-ci.yml
@@ -101,6 +101,8 @@ jobs:
             .github/scripts
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            tools/__init__.py
+            tools/ci_failure_triage.py
             tools/post_ci_summary.py
           sparse-checkout-cone-mode: false
 

--- a/tests/workflows/test_maint46_post_ci_sparse_checkout.py
+++ b/tests/workflows/test_maint46_post_ci_sparse_checkout.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_maint46_sparse_checkout_includes_post_ci_import_dependencies():
+    workflow = yaml.safe_load(
+        Path(".github/workflows/maint-46-post-ci.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["summary"]["steps"]
+    checkout = next(step for step in steps if step.get("name") == "Checkout helpers")
+    sparse_checkout = checkout["with"]["sparse-checkout"]
+
+    assert "tools/post_ci_summary.py" in sparse_checkout
+    assert "tools/__init__.py" in sparse_checkout
+    assert "tools/ci_failure_triage.py" in sparse_checkout


### PR DESCRIPTION
## Summary
- include `tools/__init__.py` and `tools/ci_failure_triage.py` in Maint 46 helper checkout
- add a workflow regression test for the sparse-checkout import contract

## Verification
- `python -m pytest tests/workflows/test_maint46_post_ci_sparse_checkout.py tests/test_post_ci_summary.py tests/tools/test_ci_failure_triage.py -q`
- `python scripts/validate_workflow_yaml.py .github/workflows/maint-46-post-ci.yml --no-skip`
- `python scripts/validate_template_completeness.py --workflows-dir .github/workflows --template-dir templates/consumer-repo/.github/workflows --manifest .github/sync-manifest.yml --source sync-manifest --strict`
- `git diff --check`

<!-- workflow-source:automation_run -->
<!-- workflow-source-ref:workflows-system-review-2 -->