### PR TITLE
Add campaign source sync contract telemetry

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -189,11 +189,12 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
     {},
     [item],
     '2026-04-21T05:52:00Z',
-    { reposRequested: 1, reposChecked: 1 },
+    { reposRequested: 1, reposChecked: 1, currentSyncHash: 'newhash123456' },
   );
   const body = formatCampaignBody(state);
   const marker = parseCampaignMarker(formatCampaignMarker(state));
 
+  assert.equal(state.current_sync_hash, 'newhash123456');
   assert.equal(item.source_sync.status, 'superseded');
   assert.equal(item.source_sync.pr_sync_hash, 'oldhash123456');
   assert.equal(state.items[0].status, 'local-codex-superseded-sync-candidate');
@@ -208,12 +209,17 @@ test('buildQueueItem marks old sync branches as superseded by the current templa
   assert.deepEqual(state.stats.local_codex_queue_state_counts, {
     'superseded-sync-candidate': 1,
   });
+  assert.deepEqual(state.stats.source_sync_status_counts, { superseded: 1 });
+  assert.equal(marker.current_sync_hash, 'newhash123456');
+  assert.deepEqual(marker.stats.source_sync_status_counts, { superseded: 1 });
   assert.equal(marker.stats.items_superseded_sync_candidates, 1);
   assert.equal(marker.stats.marker_items_retained, 0);
   assert.equal(marker.stats.marker_items_omitted, 1);
   assert.deepEqual(marker.items, []);
   assert.match(body, /No local Codex work is queued/);
+  assert.match(body, /Current sync hash: newhash123456/);
   assert.match(body, /Superseded sync candidates: 1/);
+  assert.match(body, /Source sync states: superseded=1/);
   assert.match(body, /Source sync state: superseded/);
 });
 
@@ -937,6 +943,7 @@ test('validates campaign item stats against retained queue state', () => {
       items_finished: 0,
       items_blocked: 0,
       status_counts: { 'needs-local-codex': 2 },
+      source_sync_status_counts: { current: 1 },
     },
     items: [
       { id: 'one', status: 'needs-local-codex' },
@@ -959,6 +966,7 @@ test('validates campaign item stats against retained queue state', () => {
   assert.ok(validation.blockers.includes('status-count-mismatch-local-codex-finished'));
   assert.ok(validation.blockers.includes('local-codex-queue-state-count-mismatch-actionable'));
   assert.ok(validation.blockers.includes('local-codex-queue-state-count-mismatch-finished'));
+  assert.ok(validation.blockers.includes('source-sync-status-count-mismatch-current'));
   assert.ok(validation.blockers.includes('item-local-codex-queue-state-annotation-mismatch'));
   assert.ok(validation.blockers.includes('item-local-codex-actionable-annotation-mismatch'));
   assert.ok(validation.blockers.includes('item-local-codex-claimable-annotation-mismatch'));
@@ -1033,7 +1041,7 @@ test('formatCampaignBody omits inactive superseded details from issue marker', (
     {},
     items,
     '2026-04-21T05:52:00Z',
-    { reposRequested: 11, reposChecked: 11, syncPrsOpen: 150 },
+    { reposRequested: 11, reposChecked: 11, syncPrsOpen: 150, currentSyncHash: 'new-sync-hash' },
   );
 
   const body = formatCampaignBody(state);
@@ -1041,6 +1049,8 @@ test('formatCampaignBody omits inactive superseded details from issue marker', (
 
   assert.ok(body.length <= 60000, `body length ${body.length} should fit GitHub issue limit`);
   assert.equal(marker.stats.items_superseded_sync_candidates, 120);
+  assert.equal(marker.current_sync_hash, 'new-sync-hash');
+  assert.deepEqual(marker.stats.source_sync_status_counts, { superseded: 120 });
   assert.equal(marker.stats.marker_items_retained, 0);
   assert.equal(marker.stats.marker_items_omitted, 120);
   assert.deepEqual(marker.items, []);

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -439,6 +439,7 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     updated_at: now,
     run_id: cleanString(options.runId || previousState.run_id),
     controller: 'maint-82-sync-dependabot-campaign',
+    current_sync_hash: normalizeSyncHash(options.currentSyncHash || previousState.current_sync_hash),
     stats: buildStats(items, discoveredItems, options),
     source_review_history: sourceReviewHistory,
     items,
@@ -527,6 +528,17 @@ function localCodexQueueStateCounts(items = []) {
   }, {});
 }
 
+function sourceSyncStatusCounts(items = []) {
+  return cleanArray(items).reduce((counts, item) => {
+    if (item.classification !== 'sync') {
+      return counts;
+    }
+    const status = cleanString(item.source_sync?.status) || 'unknown';
+    counts[status] = (counts[status] || 0) + 1;
+    return counts;
+  }, {});
+}
+
 function localCodexClaimSummary(items = []) {
   const claims = cleanArray(items)
     .filter((item) => item.status === 'local-codex-claimed')
@@ -599,6 +611,7 @@ function buildStats(items, discoveredItems, options = {}) {
     items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(items),
+    source_sync_status_counts: sourceSyncStatusCounts(items),
     local_codex_claims: localCodexClaimSummary(items),
   };
 }
@@ -628,6 +641,7 @@ function deriveItemStats(items = []) {
     items_unpublished_source_results: unpublishedSourceResultCount,
     status_counts: statusCounts,
     local_codex_queue_state_counts: localCodexQueueStateCounts(queueItems),
+    source_sync_status_counts: sourceSyncStatusCounts(queueItems),
     local_codex_claims: localCodexClaimSummary(queueItems),
   };
 }
@@ -672,6 +686,18 @@ function validateCampaignState(state = {}) {
     const expected = Number(derived.local_codex_queue_state_counts?.[queueState] || 0);
     if (actual !== expected) {
       blockers.push(`local-codex-queue-state-count-mismatch-${queueState}`);
+    }
+  }
+
+  const observedSourceSyncStates = new Set([
+    ...Object.keys(stats.source_sync_status_counts || {}),
+    ...Object.keys(derived.source_sync_status_counts || {}),
+  ]);
+  for (const sourceSyncState of observedSourceSyncStates) {
+    const actual = Number(stats.source_sync_status_counts?.[sourceSyncState] || 0);
+    const expected = Number(derived.source_sync_status_counts?.[sourceSyncState] || 0);
+    if (actual !== expected) {
+      blockers.push(`source-sync-status-count-mismatch-${sourceSyncState}`);
     }
   }
 
@@ -739,10 +765,13 @@ function compactStateForMarker(state = {}) {
     updated_at: cleanString(state.updated_at),
     run_id: cleanString(state.run_id),
     controller: cleanString(state.controller),
+    current_sync_hash: cleanString(state.current_sync_hash),
     stats: {
       ...stats,
       local_codex_queue_state_counts:
         stats.local_codex_queue_state_counts || localCodexQueueStateCounts(state.items),
+      source_sync_status_counts:
+        stats.source_sync_status_counts || sourceSyncStatusCounts(state.items),
       local_codex_claims:
         stats.local_codex_claims || localCodexClaimSummary(state.items),
       marker_items_retained: markerItems.length,
@@ -870,6 +899,13 @@ function markdownLink(label, url) {
   return cleanUrl ? `[${cleanLabel}](${cleanUrl})` : cleanLabel;
 }
 
+function formatSourceSyncStatusCounts(counts = {}) {
+  const parts = ['current', 'superseded', 'unknown']
+    .filter((status) => Number(counts[status] || 0) > 0)
+    .map((status) => `${status}=${Number(counts[status] || 0)}`);
+  return parts.length ? parts.join(', ') : '-';
+}
+
 function formatCampaignBody(state) {
   const stats = state.stats || {};
   const claims = stats.local_codex_claims || localCodexClaimSummary(state.items);
@@ -891,6 +927,7 @@ function formatCampaignBody(state) {
     '## Summary',
     '',
     `- Updated: ${state.updated_at}`,
+    `- Current sync hash: ${state.current_sync_hash || '-'}`,
     `- Repos checked: ${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
     `- Open sync PRs: ${stats.sync_prs_open || 0}`,
     `- Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
@@ -900,6 +937,7 @@ function formatCampaignBody(state) {
     `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Source sync states: ${formatSourceSyncStatusCounts(stats.source_sync_status_counts)}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     `- Claimed local Codex items: ${claims.count || 0}`,
     `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
@@ -1060,6 +1098,7 @@ function formatCompactCampaignBody(state) {
     'Remote discovery found more review-thread work than fits in a full GitHub issue body. The marker below retains the compact machine-readable queue for the local watcher.',
     '',
     `- Updated: ${state.updated_at}`,
+    `- Current sync hash: ${state.current_sync_hash || '-'}`,
     `- Repos checked: ${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
     `- Open sync PRs: ${stats.sync_prs_open || 0}`,
     `- Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
@@ -1069,6 +1108,7 @@ function formatCompactCampaignBody(state) {
     `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Source sync states: ${formatSourceSyncStatusCounts(stats.source_sync_status_counts)}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     `- Claimed local Codex items: ${claims.count || 0}`,
     `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
@@ -1437,6 +1477,7 @@ function formatDryRunSummary(state = {}) {
     '[dry-run] Campaign issue update suppressed from logs.',
     `repos_checked=${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
     `repos_failed=${stats.repos_failed || 0}`,
+    `current_sync_hash=${state.current_sync_hash || '-'}`,
     `sync_prs_open=${stats.sync_prs_open || 0}`,
     `dependabot_prs_open=${stats.dependabot_prs_open || 0}`,
     `items_needing_local_codex=${stats.items_needing_local_codex || 0}`,
@@ -1457,6 +1498,7 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Updated: ${cleanString(state.updated_at) || '-'}`,
     `- Run ID: ${cleanString(state.run_id) || '-'}`,
     `- Controller: ${cleanString(state.controller) || 'maint-82-sync-dependabot-campaign'}`,
+    `- Current sync hash: ${cleanString(state.current_sync_hash) || '-'}`,
     `- Campaign issue: ${cleanString(issue?.html_url || issue?.url) || '-'}`,
     `- Repos checked: ${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
     `- Repos failed: ${stats.repos_failed || 0}`,
@@ -1468,6 +1510,7 @@ function formatCampaignRunSummaryMarkdown(state = {}, issue = null) {
     `- Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
     `- Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
     `- Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
+    `- Source sync states: ${formatSourceSyncStatusCounts(stats.source_sync_status_counts)}`,
     `- Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
     `- Items claimed: ${stats.items_claimed || 0}`,
     `- Next claim lease expires: ${claims.next_expires_at || '-'}`,
@@ -1547,6 +1590,7 @@ async function runCampaign({
 
   const state = mergeCampaignState(previousState, discoveredItems, now, {
     runId: context.runId || context.run_id,
+    currentSyncHash,
     reposRequested: repoEntries.length,
     reposChecked: limitedRepoEntries.length - errors.length,
     reposFailed: errors.length,
@@ -1606,6 +1650,7 @@ async function runCampaign({
   if (core && typeof core.setOutput === 'function') {
     const claims = state.stats.local_codex_claims || localCodexClaimSummary(state.items);
     core.setOutput('needs_local_codex', needsLocalCodex ? 'true' : 'false');
+    core.setOutput('current_sync_hash', state.current_sync_hash || '');
     core.setOutput('items_needing_local_codex', String(state.stats.items_needing_local_codex || 0));
     core.setOutput('items_actionable_local_codex', String(state.stats.items_actionable_local_codex || 0));
     core.setOutput('items_claimable_local_codex', String(state.stats.items_claimable_local_codex || 0));

--- a/.github/workflows/maint-82-sync-dependabot-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependabot-campaign.yml
@@ -129,9 +129,16 @@ jobs:
               'sync-dependabot-campaign-summary.md',
               formatCampaignRunSummaryMarkdown(result.state, result.issue)
             );
+            const sourceSyncCounts = stats.source_sync_status_counts || {};
+            const sourceSyncStates = ['current', 'superseded', 'unknown']
+              .filter((status) => Number(sourceSyncCounts[status] || 0) > 0)
+              .map((status) => `${status}=${Number(sourceSyncCounts[status] || 0)}`)
+              .join(', ') || '-';
+            const unpublishedResults = stats.items_unpublished_source_results || 0;
             await core.summary
               .addHeading('Sync/Dependabot Campaign')
               .addList([
+                `Current sync hash: ${result.state.current_sync_hash || '-'}`,
                 `Repos checked: ${stats.repos_checked || 0}/${stats.repos_requested || 0}`,
                 `Open sync PRs: ${stats.sync_prs_open || 0}`,
                 `Open Dependabot PRs: ${stats.dependabot_prs_open || 0}`,
@@ -141,7 +148,8 @@ jobs:
                 `Claimable local Codex items: ${stats.items_claimable_local_codex || 0}`,
                 `Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
                 `Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
-                `Finished local results without published source changes: ${stats.items_unpublished_source_results || 0}`,
+                `Source sync states: ${sourceSyncStates}`,
+                `Finished local results without published source changes: ${unpublishedResults}`,
                 `Campaign issue: ${result.issue?.html_url || '(dry run)'}`,
               ])
               .write();

--- a/tests/workflows/test_maint82_sync_campaign_contract.py
+++ b/tests/workflows/test_maint82_sync_campaign_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(".github/workflows/maint-82-sync-dependabot-campaign.yml")
+
+
+def _refresh_script() -> str:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = data["jobs"]["campaign"]["steps"]
+    refresh_step = next(step for step in steps if step.get("id") == "campaign")
+    return refresh_step["with"]["script"]
+
+
+def test_campaign_refresh_summary_publishes_source_sync_contract():
+    script = _refresh_script()
+
+    assert "result.state.current_sync_hash" in script
+    assert "stats.source_sync_status_counts" in script
+    assert "Source sync states:" in script
+    assert "formatCampaignRunSummaryMarkdown(result.state, result.issue)" in script
+
+
+def test_campaign_refresh_passes_current_sync_hash_to_runner():
+    script = _refresh_script()
+
+    assert "const currentSyncHash = '${{ steps.hash.outputs.hash }}';" in script
+    assert "currentSyncHash," in script


### PR DESCRIPTION
## Summary\n- publish current sync hash in the Sync/Dependabot campaign state, issue marker, issue summary, dry-run output, and run artifact summary\n- add source-sync status counts to campaign stats and validation\n- show source-sync contract values in the Maint 82 workflow step summary\n\n## Verification\n- python scripts/validate_workflow_yaml.py .github/workflows/maint-82-sync-dependabot-campaign.yml --no-skip\n- python -m pytest tests/workflows/test_maint82_sync_campaign_contract.py -q\n- node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js\n- node --check .github/scripts/sync_dependabot_campaign.js\n- git diff --check\n