### PR TITLE
[codex] Harden automation rate-limit deferrals

### DIFF
--- a/.github/scripts/__tests__/github-api-with-retry.test.js
+++ b/.github/scripts/__tests__/github-api-with-retry.test.js
@@ -5,10 +5,24 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  isRateLimitError,
+  isSecondaryRateLimitError,
   withRetry,
   paginateWithRetry,
   createTokenAwareRetry,
 } = require(path.join(__dirname, '../github-api-with-retry'));
+
+test('exports rate limit classifiers for workflow fail-open guards', () => {
+  const primary = new Error('API rate limit exceeded');
+  primary.status = 403;
+  primary.response = { headers: { 'x-ratelimit-remaining': '0' } };
+
+  const secondary = new Error('You have exceeded a secondary rate limit');
+  secondary.status = 403;
+
+  assert.equal(isRateLimitError(primary), true);
+  assert.equal(isSecondaryRateLimitError(secondary), true);
+});
 
 test('withRetry switches tokens on primary rate limit errors', async () => {
   const calls = [];

--- a/.github/scripts/github-api-with-retry.js
+++ b/.github/scripts/github-api-with-retry.js
@@ -609,6 +609,8 @@ async function createTokenAwareRetry(options = {}) {
 }
 
 module.exports = {
+  isRateLimitError,
+  isSecondaryRateLimitError,
   withRetry,
   paginateWithRetry,
   createTokenAwareRetry,

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -259,9 +259,19 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { createTokenAwareRetry } = require(
-              `${scriptsPath}/.github/scripts/github-api-with-retry.js`
-            );
+            const retryHelpers = require(`${scriptsPath}/.github/scripts/github-api-with-retry.js`);
+            const { createTokenAwareRetry } = retryHelpers;
+            const isRateLimitError = retryHelpers.isRateLimitError || ((error) => {
+              const status = error?.status || error?.response?.status;
+              const message = String(
+                error?.message || error?.response?.data?.message || '',
+              ).toLowerCase();
+              const headers = error?.response?.headers || error?.headers || {};
+              const remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+              return status === 429 ||
+                (status === 403 && message.includes('rate limit')) ||
+                (Number.isFinite(remaining) && remaining <= 0);
+            });
             const { withRetry, paginateWithRetry } = await createTokenAwareRetry({
               github,
               core,
@@ -270,6 +280,26 @@ jobs:
             });
 
             let issueNumber, issue, pr;
+            const deferForRateLimit = (stage, error) => {
+              if (!isRateLimitError(error)) {
+                return false;
+              }
+              core.warning(
+                `Auto-pilot determine context deferred during ${stage}: ${error.message}`,
+              );
+              if (issueNumber) {
+                core.setOutput('issue_number', issueNumber);
+              }
+              if (issue?.title) {
+                core.setOutput('issue_title', issue.title);
+              }
+              if (issue?.state) {
+                core.setOutput('issue_state', issue.state);
+              }
+              core.setOutput('should_continue', 'false');
+              core.setOutput('reason', 'rate-limited');
+              return true;
+            };
 
             // Get issue number from various sources (in priority order)
             if (context.eventName === 'workflow_dispatch') {
@@ -308,14 +338,19 @@ jobs:
 
             // Fetch issue if not in payload (with retry)
             if (!issue) {
-              const { data } = await withRetry(() =>
-                github.rest.issues.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber
-                })
-              );
-              issue = data;
+              try {
+                const { data } = await withRetry((client) =>
+                  client.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber
+                  })
+                );
+                issue = data;
+              } catch (error) {
+                if (deferForRateLimit('issue fetch', error)) return;
+                throw error;
+              }
             }
 
             const labels = issue.labels.map(l => l.name);
@@ -356,15 +391,21 @@ jobs:
             // Check for actual optimizer output (not just label)
             // Since we run optimizer inline now, this should always exist after optimize step
             // the optimizer workflow actually completed its work
-            const comments = await paginateWithRetry(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
-              }
-            );
+            let comments = [];
+            try {
+              comments = await paginateWithRetry(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (deferForRateLimit('optimizer comment scan', error)) return;
+              throw error;
+            }
 
             const hasOptimizerOutput = comments.some(c => {
               const body = c.body || '';
@@ -374,15 +415,21 @@ jobs:
             });
 
             // Check for linked PR (with pagination and multiple event types)
-            const timelineEvents = await paginateWithRetry(
-              github.rest.issues.listEventsForTimeline,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
-              }
-            );
+            let timelineEvents = [];
+            try {
+              timelineEvents = await paginateWithRetry(
+                github.rest.issues.listEventsForTimeline,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (deferForRateLimit('timeline scan', error)) return;
+              throw error;
+            }
 
             function matchesIssueReference(text, num) {
               if (!text) return false;
@@ -442,22 +489,44 @@ jobs:
         with:
           script: |
             const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
-            const { paginateWithRetry } = require(
-              `${scriptsPath}/.github/scripts/github-api-with-retry.js`
-            );
+            const retryHelpers = require(`${scriptsPath}/.github/scripts/github-api-with-retry.js`);
+            const { paginateWithRetry } = retryHelpers;
+            const isRateLimitError = retryHelpers.isRateLimitError || ((error) => {
+              const status = error?.status || error?.response?.status;
+              const message = String(
+                error?.message || error?.response?.data?.message || '',
+              ).toLowerCase();
+              const headers = error?.response?.headers || error?.headers || {};
+              const remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+              return status === 429 ||
+                (status === 403 && message.includes('rate limit')) ||
+                (Number.isFinite(remaining) && remaining <= 0);
+            });
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
 
             // Get all comments to count auto-pilot steps (with pagination and retry)
-            const allComments = await paginateWithRetry(
-              github,
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
+            let allComments = [];
+            try {
+              allComments = await paginateWithRetry(
+                github,
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                }
+              );
+            } catch (error) {
+              if (!isRateLimitError(error)) {
+                throw error;
               }
-            );
+              core.warning(`Auto-pilot step count deferred by rate limit: ${error.message}`);
+              core.setOutput('exceeded', 'false');
+              core.setOutput('count', '0');
+              core.setOutput('rate_limited', 'true');
+              return;
+            }
 
             const stepComments = allComments.filter(c =>
               typeof c.body === 'string' && c.body.includes('🤖 Auto-pilot step')
@@ -474,6 +543,7 @@ jobs:
 
             core.setOutput('exceeded', 'false');
             core.setOutput('count', stepCount.toString());
+            core.setOutput('rate_limited', 'false');
 
       - name: Stop if exceeded
         if: steps.cycles.outputs.exceeded == 'true'
@@ -522,7 +592,8 @@ jobs:
       - name: Determine next step
         if: |
           steps.context.outputs.should_continue == 'true' &&
-          steps.cycles.outputs.exceeded != 'true'
+          steps.cycles.outputs.exceeded != 'true' &&
+          steps.cycles.outputs.rate_limited != 'true'
         id: next
         env:
           FORCE_STEP: ${{ inputs.force_step }}
@@ -2516,14 +2587,18 @@ jobs:
                   ? ' Re-dispatched belt dispatcher.'
                   : '';
                 core.info(`Applying branch-creation backoff: waiting ${actualMinutes} minutes`);
+                const backoffBody = [
+                  `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)`,
+                  '',
+                  `Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.` +
+                    redispatchNote,
+                  'Waiting before retry...',
+                ].join('\n');
                 await withRetry((client) => client.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                    body: `🤖 **Auto-pilot**: Backoff delay (${actualMinutes}m)
-
-                    Branch not created yet. Attempt ${stallCount + 1}/${maxStallRetries}.${redispatchNote}
-                    Waiting before retry...`
+                  body: backoffBody,
                 }));
 
                 // Sleep with exponential backoff

--- a/.github/workflows/maint-46-post-ci.yml
+++ b/.github/workflows/maint-46-post-ci.yml
@@ -123,11 +123,13 @@ jobs:
             await discoverWorkflowRuns({ github, context, core });
 
       - name: Download Gate artifacts
+        id: download_gate_artifacts
         if: >-
           ${{
             steps.gate_guard.outputs.recover == 'true' &&
             steps.discover.outputs.gate_run_id != ''
           }}
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: gate-*
@@ -135,6 +137,15 @@ jobs:
           path: ${{ env.ARTIFACT_ROOT }}/downloads
           run-id: ${{ steps.discover.outputs.gate_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Note Gate artifact download limitation
+        if: ${{ steps.download_gate_artifacts.outcome == 'failure' }}
+        run: |
+          echo '::warning::Gate artifact download failed; continuing with API run metadata only.'
+          {
+            echo 'Gate artifact download failed.'
+            echo 'This recovery summary omits artifact-only coverage detail.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Collect coverage payloads
         if: >-

--- a/.github/workflows/reusable-70-orchestrator-init.yml
+++ b/.github/workflows/reusable-70-orchestrator-init.yml
@@ -234,6 +234,16 @@ jobs:
                     githubInstance.paginate(method, params),
                 };
             const { paginateWithRetry } = retryHelpers;
+            const isRateLimitError = retryHelpers.isRateLimitError || ((error) => {
+              const status = error?.status || error?.response?.status;
+              const rawMessage = error?.message || error?.response?.data?.message || '';
+              const message = String(rawMessage).toLowerCase();
+              const headers = error?.response?.headers || error?.headers || {};
+              const remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+              return status === 429 ||
+                (status === 403 && message.includes('rate limit')) ||
+                (Number.isFinite(remaining) && remaining <= 0);
+            });
 
             const normalise = (value) => String(value ?? '').trim();
             const toBool = (value) => {
@@ -290,19 +300,39 @@ jobs:
             }
 
             let count = 0;
-            const openIssues = await paginateWithRetry(
-              github, github.rest.issues.listForRepo,
-              { owner, repo, state: 'open', per_page: 100 }
-            );
-            for (const issue of openIssues) {
-              if (issue.pull_request) continue;
-              const labels = Array.isArray(issue.labels) ? issue.labels : [];
-              if (labels.some((label) => {
-                const name = typeof label === 'string' ? label : label?.name;
-                return typeof name === 'string' && name.startsWith('agent:');
-              })) {
-                count += 1;
-                if (count > 0 && !keepaliveRequested) break;
+            let skippedIssueScan = false;
+            let deferredByRateLimit = false;
+            if (keepaliveRequested) {
+              skippedIssueScan = true;
+              core.info(
+                'Keepalive input already proves work exists; skipping open issue scan.',
+              );
+            } else {
+              let openIssues = [];
+              try {
+                openIssues = await paginateWithRetry(
+                  github, github.rest.issues.listForRepo,
+                  { owner, repo, state: 'open', per_page: 100 }
+                );
+              } catch (error) {
+                if (!isRateLimitError(error)) {
+                  throw error;
+                }
+                deferredByRateLimit = true;
+                const message = error?.message || error;
+                core.warning('Idle precheck deferred: issue scan rate-limited.');
+                core.debug?.(`Idle precheck rate-limit detail: ${message}`);
+              }
+              for (const issue of openIssues) {
+                if (issue.pull_request) continue;
+                const labels = Array.isArray(issue.labels) ? issue.labels : [];
+                if (labels.some((label) => {
+                  const name = typeof label === 'string' ? label : label?.name;
+                  return typeof name === 'string' && name.startsWith('agent:');
+                })) {
+                  count += 1;
+                  if (count > 0) break;
+                }
               }
             }
 
@@ -311,20 +341,34 @@ jobs:
             core.setOutput('has_work', hasWork ? 'true' : 'false');
 
             summary.addHeading('Agents orchestrator idle precheck');
-            summary.addRaw(`agent:* issues detected: ${count}`).addEOL();
+            if (skippedIssueScan) {
+              summary
+                .addRaw('agent:* issue scan: skipped; keepalive was requested.')
+                .addEOL();
+            } else {
+              summary.addRaw(`agent:* issues detected: ${count}`).addEOL();
+            }
             summary.addRaw(`Duration: ${elapsed.toFixed(1)}s`).addEOL();
+            if (deferredByRateLimit) {
+              summary
+                .addRaw('Result: deferred because issue scan exhausted rate limit.')
+                .addEOL();
+            }
             if (keepaliveRequested) {
               const sources = Array.from(keepaliveSources);
                 const sourceList = sources.length ? sources.join(', ') : 'inputs';
                 summary.addRaw(`Keepalive override: requested via ${sourceList}.`).addEOL();
               if (keepaliveTrace) summary.addRaw(`Keepalive trace: \`${keepaliveTrace}\``).addEOL();
             }
-              if (!hasWork) {
+              if (!hasWork && !deferredByRateLimit) {
                 summary.addRaw('Result: idle, skipping orchestrator dispatch.').addEOL();
               }
             await summary.write();
 
-            if (!hasWork) core.info('Idle, skipping orchestrator dispatch.');
+            if (deferredByRateLimit) {
+              core.notice('Rate limit exhausted during idle precheck; deferring dispatch.');
+            }
+            else if (!hasWork) core.info('Idle, skipping orchestrator dispatch.');
             else if (keepaliveRequested) {
               const traceInfo = keepaliveTrace ? ` (trace ${keepaliveTrace})` : '';
                 const keepaliveMessage =

--- a/scripts/langchain/semantic_matcher.py
+++ b/scripts/langchain/semantic_matcher.py
@@ -63,6 +63,9 @@ class EmbeddingAdapter:
         response = self._provider.embed([text], model=self._model)
         return response.vectors[0] if response.vectors else []
 
+    def __call__(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
 
 def _parse_provider_list(value: str | None) -> set[str] | None:
     if not value:

--- a/templates/consumer-repo/.github/scripts/github-api-with-retry.js
+++ b/templates/consumer-repo/.github/scripts/github-api-with-retry.js
@@ -609,6 +609,8 @@ async function createTokenAwareRetry(options = {}) {
 }
 
 module.exports = {
+  isRateLimitError,
+  isSecondaryRateLimitError,
   withRetry,
   paginateWithRetry,
   createTokenAwareRetry,

--- a/tests/scripts/test_semantic_matcher.py
+++ b/tests/scripts/test_semantic_matcher.py
@@ -2,7 +2,7 @@ import sys
 import types
 
 from scripts.langchain import semantic_matcher
-from tools.embedding_provider import FALLBACK_DIMENSIONS
+from tools.embedding_provider import FALLBACK_DIMENSIONS, LocalFallbackEmbeddingProvider
 
 
 class StubEmbeddings:
@@ -104,6 +104,16 @@ def test_get_embedding_client_uses_default_model(monkeypatch):
 
     assert info is not None
     assert info.model == semantic_matcher.DEFAULT_EMBEDDING_MODEL
+
+
+def test_embedding_adapter_is_callable_for_faiss_compatibility():
+    adapter = semantic_matcher.EmbeddingAdapter(
+        LocalFallbackEmbeddingProvider(),
+        "local-hash-bow",
+    )
+
+    assert callable(adapter)
+    assert adapter("alpha") == adapter.embed_query("alpha")
 
 
 def test_generate_embeddings_empty_texts():

--- a/tests/workflows/test_maint46_post_ci_sparse_checkout.py
+++ b/tests/workflows/test_maint46_post_ci_sparse_checkout.py
@@ -14,3 +14,19 @@ def test_maint46_sparse_checkout_includes_post_ci_import_dependencies():
     assert "tools/post_ci_summary.py" in sparse_checkout
     assert "tools/__init__.py" in sparse_checkout
     assert "tools/ci_failure_triage.py" in sparse_checkout
+
+
+def test_maint46_gate_artifact_download_fails_open_to_metadata_summary():
+    workflow = yaml.safe_load(
+        Path(".github/workflows/maint-46-post-ci.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["summary"]["steps"]
+    download = next(step for step in steps if step.get("name") == "Download Gate artifacts")
+    note = next(
+        step for step in steps if step.get("name") == "Note Gate artifact download limitation"
+    )
+
+    assert download["id"] == "download_gate_artifacts"
+    assert download["continue-on-error"] is True
+    assert note["if"] == "${{ steps.download_gate_artifacts.outcome == 'failure' }}"
+    assert "artifact-only coverage detail" in note["run"]

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -98,9 +98,7 @@ def test_agents_orchestrator_exposes_dry_run_toggle():
 
 
 def test_orchestrator_idle_precheck_defers_on_issue_scan_rate_limit():
-    init_text = (WORKFLOWS_DIR / "reusable-70-orchestrator-init.yml").read_text(
-        encoding="utf-8"
-    )
+    init_text = (WORKFLOWS_DIR / "reusable-70-orchestrator-init.yml").read_text(encoding="utf-8")
 
     assert (
         "retryHelpers.isRateLimitError" in init_text

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -97,6 +97,47 @@ def test_agents_orchestrator_exposes_dry_run_toggle():
     assert "dryRun" in resolver_text, "Resolve script should compute and surface the dry_run flag"
 
 
+def test_orchestrator_idle_precheck_defers_on_issue_scan_rate_limit():
+    init_text = (WORKFLOWS_DIR / "reusable-70-orchestrator-init.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "retryHelpers.isRateLimitError" in init_text
+    ), "Idle precheck must use the shared GitHub API rate-limit classifier"
+    assert (
+        "deferredByRateLimit = true" in init_text
+    ), "Idle precheck must record rate-limit deferrals instead of failing"
+    assert (
+        "Rate limit exhausted during idle precheck; deferring dispatch." in init_text
+    ), "Idle precheck must emit a durable deferral notice"
+    assert (
+        "!hasWork && !deferredByRateLimit" in init_text
+    ), "Idle-only messaging must not mask a rate-limit deferral"
+
+
+def test_auto_pilot_context_and_cycle_reads_defer_on_rate_limit():
+    text = (WORKFLOWS_DIR / "agents-auto-pilot.yml").read_text(encoding="utf-8")
+
+    assert (
+        "deferForRateLimit" in text
+    ), "Auto-pilot context discovery must share a rate-limit deferral helper"
+    assert (
+        "Auto-pilot determine context deferred during" in text
+    ), "Auto-pilot must explain which context read was deferred"
+    for stage in ["issue fetch", "optimizer comment scan", "timeline scan"]:
+        assert stage in text, f"Auto-pilot must defer safely during {stage}"
+    assert (
+        "core.setOutput('reason', 'rate-limited')" in text
+    ), "Auto-pilot must expose rate-limited context deferrals as an output"
+    assert (
+        "core.setOutput('rate_limited', 'true')" in text
+    ), "Auto-pilot cycle count must expose rate-limit deferrals as an output"
+    assert (
+        "steps.cycles.outputs.rate_limited != 'true'" in text
+    ), "Auto-pilot must not choose a next step after a rate-limited cycle count"
+
+
 def test_orchestrator_bootstrap_label_delegates_fallback():
     text = (WORKFLOWS_DIR / "agents-70-orchestrator.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
<!-- workflow-source:automation_run -->
<!-- workflow-source-ref:workflows-system-review-2 slice 111 -->
<!-- workflow-lifecycle:implementation -->
<!-- workflow-automation:local-codex -->

## Summary
- Make the shared GitHub API retry helper export rate-limit classifiers for workflow fail-open guards.
- Defer Agents Auto-Pilot context and cycle-count work when comment/timeline scans are rate-limited instead of failing the run.
- Skip the Agents 70 open-issue scan when keepalive input already proves work exists, and record neutral deferrals when the idle scan is rate-limited.
- Let Maint 46 continue from API run metadata when Gate artifact download is rate-limited.
- Restore FAISS compatibility by making the embedding adapter callable.

## Root Cause
The latest automation slice showed hard workflow failures from rate-limited read-only discovery steps and a deterministic auto-label failure where FAISS invoked the embedding adapter as a callable.

## Validation
- `python -m pytest tests/scripts/test_semantic_matcher.py tests/scripts/test_label_matcher.py tests/workflows/test_github_api_retry_transient.py -q`
- `node --check .github/scripts/github-api-with-retry.js && node --test .github/scripts/__tests__/github-api-with-retry.test.js`
- `python -m pytest tests/workflows/test_maint46_post_ci_sparse_checkout.py tests/workflows/test_workflow_agents_consolidation.py -q`
- `python scripts/validate_workflow_yaml.py .github/workflows/agents-auto-pilot.yml .github/workflows/maint-46-post-ci.yml .github/workflows/reusable-70-orchestrator-init.yml`
- `git diff --check`
