### PR TITLE
fix: address downstream sync review comments

### DIFF
--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -100,6 +100,24 @@ test('omits PR source context coverage by default', () => {
   assert.equal(options.pr_source_context_report, '');
 });
 
+test('omits missing optional PR source context coverage report', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
+  const terminal = writeJson(dir, 'terminal.json', report('pass'));
+  const botAuth = writeJson(dir, 'bot-auth.json', report('pass'));
+
+  const summary = buildCoverageMonitorSummary({
+    terminal_report: terminal,
+    bot_auth_report: botAuth,
+    pr_source_context_report: path.join(dir, 'not-created.json'),
+  });
+
+  assert.equal(summary.status, 'pass');
+  assert.deepEqual(
+    summary.monitors.map((monitor) => monitor.label),
+    ['terminal-disposition', 'bot-comment-auth']
+  );
+});
+
 test('surfaces warning blockers without activating hard-block policy', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
   const terminal = writeJson(

--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -94,6 +94,12 @@ test('includes PR source context coverage when configured', () => {
   assert.match(formatMonitorMarkdown(summary), /pr-source-context \| warning/);
 });
 
+test('omits PR source context coverage by default', () => {
+  const options = parseArgs([]);
+
+  assert.equal(options.pr_source_context_report, '');
+});
+
 test('surfaces warning blockers without activating hard-block policy', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
   const terminal = writeJson(

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -49,6 +49,14 @@ test('extractIssueNumberFromPull keeps existing issue resolution behavior', () =
     }),
     null,
   );
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Review follow-up from PR #315. Relates to source review only.',
+      head: { ref: 'review-followup/pr-315' },
+      title: 'Address downstream review',
+    }),
+    null,
+  );
 });
 
 test('parseWorkflowSourceBlock reads source-context fields from hidden block', () => {
@@ -184,6 +192,26 @@ test('resolvePrSourceContext accepts direct-pr labels without issue metadata', (
   });
 
   assert.equal(context.sourceType, SOURCE_TYPES.MANUAL_REMOTE);
+  assert.equal(context.issueNumber, null);
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, false);
+});
+
+test('resolvePrSourceContext keeps review follow-up PR references out of issue source detection', () => {
+  const context = resolvePrSourceContext({
+    body: `
+## Workflow Source
+
+Started from:
+- [ ] GitHub issue: #
+- [x] Review follow-up from PR #315
+- [ ] Direct PR / remote GitHub work
+`,
+    head: { ref: 'review-followup/pr-315' },
+    title: 'fix: address downstream review comments',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.REVIEW_FOLLOWUP);
   assert.equal(context.issueNumber, null);
   assert.equal(context.isValid, true);
   assert.equal(context.requiresIssue, false);

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -217,7 +217,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     bot_auth_report:
       process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
     pr_source_context_report:
-      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || 'pr-source-context-coverage.json',
+      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || '',
     output_json:
       process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
     output_md:

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -136,14 +136,23 @@ function nextAction(status, monitors) {
   return 'continue-monitoring';
 }
 
+function existingReportPath(value) {
+  const reportPath = cleanString(value);
+  if (!reportPath) return '';
+  try {
+    return fs.existsSync(reportPath) && fs.statSync(reportPath).isFile() ? reportPath : '';
+  } catch (_error) {
+    return '';
+  }
+}
+
 function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
-  if (cleanString(options.pr_source_context_report)) {
-    monitors.push(
-      summarizeReport(readJsonReport(options.pr_source_context_report, 'pr-source-context'))
-    );
+  const prSourceContextReport = existingReportPath(options.pr_source_context_report);
+  if (prSourceContextReport) {
+    monitors.push(summarizeReport(readJsonReport(prSourceContextReport, 'pr-source-context')));
   }
   const status = overallStatus(monitors);
   const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -121,7 +121,7 @@ function extractIssueNumberFromText(text) {
       continue;
     }
     const preceding = value.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+    if (/\b(?:run|attempt|step|job|check|version|v|pr|pull\s+request)\s*$/i.test(preceding)) {
       continue;
     }
     const parsed = Number.parseInt(match[1], 10);

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -594,7 +594,7 @@ def _summarise_verifier(
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal and model_metadata_required:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode != "evaluate":
+            if verifier_mode and verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
                     legacy_missing_verifier_model_metadata[str(disposition)] += 1

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -217,7 +217,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     bot_auth_report:
       process.env.COVERAGE_MONITOR_BOT_AUTH_JSON || 'bot-comment-auth-coverage-summary.json',
     pr_source_context_report:
-      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || 'pr-source-context-coverage.json',
+      process.env.COVERAGE_MONITOR_PR_SOURCE_CONTEXT_JSON || '',
     output_json:
       process.env.COVERAGE_MONITOR_SUMMARY_JSON || 'coverage-monitor-summary.json',
     output_md:

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -136,14 +136,23 @@ function nextAction(status, monitors) {
   return 'continue-monitoring';
 }
 
+function existingReportPath(value) {
+  const reportPath = cleanString(value);
+  if (!reportPath) return '';
+  try {
+    return fs.existsSync(reportPath) && fs.statSync(reportPath).isFile() ? reportPath : '';
+  } catch (_error) {
+    return '';
+  }
+}
+
 function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
-  if (cleanString(options.pr_source_context_report)) {
-    monitors.push(
-      summarizeReport(readJsonReport(options.pr_source_context_report, 'pr-source-context'))
-    );
+  const prSourceContextReport = existingReportPath(options.pr_source_context_report);
+  if (prSourceContextReport) {
+    monitors.push(summarizeReport(readJsonReport(prSourceContextReport, 'pr-source-context')));
   }
   const status = overallStatus(monitors);
   const hardBlockActive = monitors.some((monitor) => monitor.hard_block_active);

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -121,7 +121,7 @@ function extractIssueNumberFromText(text) {
       continue;
     }
     const preceding = value.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+    if (/\b(?:run|attempt|step|job|check|version|v|pr|pull\s+request)\s*$/i.test(preceding)) {
       continue;
     }
     const parsed = Number.parseInt(match[1], 10);

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -594,7 +594,7 @@ def _summarise_verifier(
                 unsupported_model_dispositions[str(disposition)] += 1
         elif is_verifier_terminal and model_metadata_required:
             verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode != "evaluate":
+            if verifier_mode and verifier_mode != "evaluate":
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
                     legacy_missing_verifier_model_metadata[str(disposition)] += 1

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -911,7 +911,7 @@ def test_verifier_summary_counts_missing_model_metadata(
     assert "Missing verifier model metadata: verifier-error (1)" in summary
 
 
-def test_verifier_summary_counts_missing_model_metadata_for_unknown_mode(
+def test_verifier_summary_does_not_count_missing_model_metadata_for_unknown_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(
@@ -931,7 +931,7 @@ def test_verifier_summary_counts_missing_model_metadata_for_unknown_mode(
         ]
     )
 
-    assert verifier["missing_verifier_model_metadata"]["verifier-error"] == 1
+    assert verifier["missing_verifier_model_metadata"] == Counter()
 
 
 def test_verifier_summary_suppresses_pre_contract_missing_model_metadata(


### PR DESCRIPTION
## Summary

<!-- workflow-source:review_followup -->
<!-- workflow-source-ref:stranske/Inv-Man-Intake#315 -->

Closes #1937.

Addresses downstream Copilot review comments blocking generated sync PR stranske/Inv-Man-Intake#315. The affected files are Workflows-owned synced sources, so the fixes belong in this source repo before another consumer sync merge attempt.

Changes:
- Ignore PR / pull request references when extracting GitHub issue numbers, preserving review-followup/direct-pr source handling.
- Make PR source context coverage opt-in unless a report path is configured.
- Avoid counting missing verifier model metadata when verifier mode itself is absent.
- Keep the consumer template copies aligned with the Workflows source scripts.

## Validation

- `node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/coverage-monitor-summary.test.js`
- `pytest -q tests/scripts/test_aggregate_agent_metrics.py`
- `python scripts/validate_template_sync.py`

## Links

- Follow-up issue: https://github.com/stranske/Workflows/issues/1937
- Downstream blocker: https://github.com/stranske/Inv-Man-Intake/pull/315
- Prior source verifier follow-up: https://github.com/stranske/Workflows/issues/1932



Closes #1937

