### PR TITLE
fix: address sync source review blockers

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -409,7 +409,7 @@ test('buildSourceContextRepairCommentBody explains non-issue source options', ()
   const result = buildSourceContextRepairCommentBody(55);
 
   assert.ok(result.includes('<!-- missing-issue-warning -->'));
-  assert.ok(result.includes('PR #55 does not need a GitHub issue'));
+  assert.ok(result.includes('PR #55 needs either a linked GitHub issue or one valid non-issue Workflow Source'));
   assert.ok(result.includes('<!-- workflow-source:local_request -->'));
   assert.ok(result.includes('workflow:source-direct-pr'));
   assert.ok(result.includes('workflow:no-automation'));

--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -94,7 +94,7 @@ test('includes PR source context coverage when configured', () => {
   assert.match(formatMonitorMarkdown(summary), /pr-source-context \| warning/);
 });
 
-test('skips absent PR source context report when not configured', () => {
+test('skips PR source context coverage when configured file is absent', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
   const terminal = writeJson(dir, 'terminal.json', report('pass'));
   const botAuth = writeJson(dir, 'bot-auth.json', report('pass'));
@@ -112,7 +112,7 @@ test('skips absent PR source context report when not configured', () => {
   );
 });
 
-test('does not configure PR source context coverage by default', () => {
+test('does not include PR source context coverage by default', () => {
   const options = parseArgs([]);
 
   assert.equal(options.pr_source_context_report, '');

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -123,6 +123,19 @@ Automation intent:
   assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.MANUAL_REMOTE);
 });
 
+test('sourceTypeFromCheckedTemplate rejects ambiguous checked source choices', () => {
+  const body = `
+## Workflow Source
+
+Started from:
+- [x] GitHub issue: #123
+- [x] Direct PR / remote GitHub work
+- [ ] Local Codex/user request
+`;
+
+  assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.UNKNOWN);
+});
+
 test('sourceTypeFromLabels accepts workflow source labels', () => {
   const pull = {
     labels: [{ name: 'workflow:source-local-request' }],

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -49,6 +49,22 @@ test('extractIssueNumberFromPull keeps existing issue resolution behavior', () =
     }),
     null,
   );
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Review follow-up from PR #956',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    null,
+  );
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Mentioned #77 without an issue keyword',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    null,
+  );
 });
 
 test('extractIssueNumberFromPull ignores PR references in workflow source templates', () => {
@@ -223,6 +239,25 @@ test('resolvePrSourceContext accepts direct-pr labels without issue metadata', (
   });
 
   assert.equal(context.sourceType, SOURCE_TYPES.MANUAL_REMOTE);
+  assert.equal(context.issueNumber, null);
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, false);
+});
+
+test('resolvePrSourceContext does not treat review PR references as source issues', () => {
+  const context = resolvePrSourceContext({
+    body: [
+      '## Workflow Source',
+      '',
+      'Started from:',
+      '- [ ] GitHub issue: #',
+      '- [x] Review follow-up from PR #956',
+    ].join('\n'),
+    head: { ref: 'review-followup/pr-956' },
+    title: 'Address review feedback',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.REVIEW_FOLLOWUP);
   assert.equal(context.issueNumber, null);
   assert.equal(context.isValid, true);
   assert.equal(context.requiresIssue, false);

--- a/.github/scripts/__tests__/terminal-disposition.test.js
+++ b/.github/scripts/__tests__/terminal-disposition.test.js
@@ -54,6 +54,7 @@ test('normalizes terminal disposition records with stable source keys', () => {
 test('normalizes Codex CLI version strings', () => {
   assert.equal(normalizeCliVersion('Codex CLI v0.125.0\n'), 'codex-cli 0.125.0');
   assert.equal(normalizeCliVersion('@openai/codex@0.126.1'), 'codex-cli 0.126.1');
+  assert.equal(normalizeCliVersion('Codex CLI v0.127.0-BETA'), 'codex-cli 0.127.0-beta');
   assert.equal(normalizeCliVersion('custom tool 1.0.0'), 'custom tool 1.0.0');
 });
 

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -939,7 +939,7 @@ function buildSourceContextRepairCommentBody(prNumber) {
     '<!-- missing-issue-warning -->',
     '### Workflow source needed',
     '',
-    `PR #${prNumber} does not need a GitHub issue, but Workflows needs one valid source context before PR metadata automation can manage it safely.`,
+    `PR #${prNumber} needs either a linked GitHub issue or one valid non-issue Workflow Source before PR metadata automation can manage it safely.`,
     '',
     'Please do one of:',
     '',
@@ -950,6 +950,30 @@ function buildSourceContextRepairCommentBody(prNumber) {
     '',
     'Once a valid source is present, this warning will not be reposted.',
   ].join('\n');
+}
+
+async function updateIssueCommentWithRetry({ github, owner, repo, commentId, body, core }) {
+  return withRetries(
+    () => github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    }),
+    { description: `issues.updateComment #${commentId}`, core },
+  );
+}
+
+async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, body, core }) {
+  return withRetries(
+    () => github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body,
+    }),
+    { description: `issues.createComment #${issueNumber}`, core },
+  );
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
@@ -984,11 +1008,13 @@ async function resolveSourceContextRepairComment({
     return false;
   }
 
-  await github.rest.issues.updateComment({
+  await updateIssueCommentWithRetry({
+    github,
     owner,
     repo,
-    comment_id: existingWarning.id,
+    commentId: existingWarning.id,
     body: resolvedBody,
+    core,
   });
   core?.info?.(`Resolved workflow source repair comment (id: ${existingWarning.id})`);
   return true;
@@ -1338,22 +1364,26 @@ async function run({github: rawGithub, context, core, inputs}) {
       
       if (existingWarning) {
         if (existingWarning.body !== commentBody) {
-          await github.rest.issues.updateComment({
+          await updateIssueCommentWithRetry({
+            github,
             owner,
             repo,
-            comment_id: existingWarning.id,
+            commentId: existingWarning.id,
             body: commentBody,
+            core,
           });
           core.info(`Updated workflow source repair comment (id: ${existingWarning.id})`);
         } else {
           core.info(`Workflow source repair comment already exists (id: ${existingWarning.id})`);
         }
       } else {
-        await github.rest.issues.createComment({
+        await createIssueCommentWithRetry({
+          github,
           owner,
           repo,
-          issue_number: pr.number,
-          body: commentBody
+          issueNumber: pr.number,
+          body: commentBody,
+          core,
         });
       }
     } catch (error) {

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -213,6 +213,7 @@ function sourceTypeFromCheckedTemplate(body) {
     sectionLines.push(line);
   }
   const text = sectionLines.join('\n');
+  const checkedTypes = new Set();
   for (const line of text.split(/\r?\n/)) {
     const checkbox = line.match(/^\s*[-*]\s+\[[xX]\]\s+(.+?)\s*$/);
     if (!checkbox) {
@@ -221,11 +222,12 @@ function sourceTypeFromCheckedTemplate(body) {
     const label = checkbox[1];
     for (const [sourceType, pattern] of CHECKBOX_SOURCE_PATTERNS) {
       if (pattern.test(label)) {
-        return sourceType;
+        checkedTypes.add(sourceType);
+        break;
       }
     }
   }
-  return SOURCE_TYPES.UNKNOWN;
+  return checkedTypes.size === 1 ? Array.from(checkedTypes)[0] : SOURCE_TYPES.UNKNOWN;
 }
 
 function sourceTypeFromLabels(pull = {}) {

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -115,7 +115,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*$/i.test(
+  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*$/i.test(
     prefix
   );
 }

--- a/.github/scripts/terminal_disposition.js
+++ b/.github/scripts/terminal_disposition.js
@@ -31,7 +31,7 @@ function normalizeCliVersion(value) {
   const version = versionMatch ? versionMatch[1] : '';
   const lower = text.toLowerCase().replace(/_/g, '-');
   if (version && /\bcodex(?:-|\s+)cli\b|\bopenai\/codex\b|\bcodex\b/.test(lower)) {
-    return `codex-cli ${version}`;
+    return `codex-cli ${version}`.toLowerCase();
   }
   return lower;
 }

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -939,7 +939,7 @@ function buildSourceContextRepairCommentBody(prNumber) {
     '<!-- missing-issue-warning -->',
     '### Workflow source needed',
     '',
-    `PR #${prNumber} does not need a GitHub issue, but Workflows needs one valid source context before PR metadata automation can manage it safely.`,
+    `PR #${prNumber} needs either a linked GitHub issue or one valid non-issue Workflow Source before PR metadata automation can manage it safely.`,
     '',
     'Please do one of:',
     '',
@@ -950,6 +950,30 @@ function buildSourceContextRepairCommentBody(prNumber) {
     '',
     'Once a valid source is present, this warning will not be reposted.',
   ].join('\n');
+}
+
+async function updateIssueCommentWithRetry({ github, owner, repo, commentId, body, core }) {
+  return withRetries(
+    () => github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    }),
+    { description: `issues.updateComment #${commentId}`, core },
+  );
+}
+
+async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, body, core }) {
+  return withRetries(
+    () => github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      body,
+    }),
+    { description: `issues.createComment #${issueNumber}`, core },
+  );
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
@@ -984,11 +1008,13 @@ async function resolveSourceContextRepairComment({
     return false;
   }
 
-  await github.rest.issues.updateComment({
+  await updateIssueCommentWithRetry({
+    github,
     owner,
     repo,
-    comment_id: existingWarning.id,
+    commentId: existingWarning.id,
     body: resolvedBody,
+    core,
   });
   core?.info?.(`Resolved workflow source repair comment (id: ${existingWarning.id})`);
   return true;
@@ -1338,22 +1364,26 @@ async function run({github: rawGithub, context, core, inputs}) {
       
       if (existingWarning) {
         if (existingWarning.body !== commentBody) {
-          await github.rest.issues.updateComment({
+          await updateIssueCommentWithRetry({
+            github,
             owner,
             repo,
-            comment_id: existingWarning.id,
+            commentId: existingWarning.id,
             body: commentBody,
+            core,
           });
           core.info(`Updated workflow source repair comment (id: ${existingWarning.id})`);
         } else {
           core.info(`Workflow source repair comment already exists (id: ${existingWarning.id})`);
         }
       } else {
-        await github.rest.issues.createComment({
+        await createIssueCommentWithRetry({
+          github,
           owner,
           repo,
-          issue_number: pr.number,
-          body: commentBody
+          issueNumber: pr.number,
+          body: commentBody,
+          core,
         });
       }
     } catch (error) {

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -213,6 +213,7 @@ function sourceTypeFromCheckedTemplate(body) {
     sectionLines.push(line);
   }
   const text = sectionLines.join('\n');
+  const checkedTypes = new Set();
   for (const line of text.split(/\r?\n/)) {
     const checkbox = line.match(/^\s*[-*]\s+\[[xX]\]\s+(.+?)\s*$/);
     if (!checkbox) {
@@ -221,11 +222,12 @@ function sourceTypeFromCheckedTemplate(body) {
     const label = checkbox[1];
     for (const [sourceType, pattern] of CHECKBOX_SOURCE_PATTERNS) {
       if (pattern.test(label)) {
-        return sourceType;
+        checkedTypes.add(sourceType);
+        break;
       }
     }
   }
-  return SOURCE_TYPES.UNKNOWN;
+  return checkedTypes.size === 1 ? Array.from(checkedTypes)[0] : SOURCE_TYPES.UNKNOWN;
 }
 
 function sourceTypeFromLabels(pull = {}) {

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -115,7 +115,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*$/i.test(
+  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*$/i.test(
     prefix
   );
 }

--- a/templates/consumer-repo/.github/scripts/terminal_disposition.js
+++ b/templates/consumer-repo/.github/scripts/terminal_disposition.js
@@ -31,7 +31,7 @@ function normalizeCliVersion(value) {
   const version = versionMatch ? versionMatch[1] : '';
   const lower = text.toLowerCase().replace(/_/g, '-');
   if (version && /\bcodex(?:-|\s+)cli\b|\bopenai\/codex\b|\bcodex\b/.test(lower)) {
-    return `codex-cli ${version}`;
+    return `codex-cli ${version}`.toLowerCase();
   }
   return lower;
 }

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -934,6 +934,30 @@ def test_verifier_summary_ignores_missing_model_metadata_for_unknown_mode(
     assert verifier["missing_verifier_model_metadata"] == Counter()
 
 
+def test_verifier_summary_counts_missing_model_metadata_for_non_evaluate_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER",
+        "2026-04-26T04:25:00Z",
+    )
+
+    verifier = aggregate_agent_metrics._summarise_verifier(
+        [
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "run_id": "24948023779",
+                "pr_number": 1874,
+                "disposition": "verifier-error",
+                "verifier_mode": "compare",
+            },
+        ]
+    )
+
+    assert verifier["missing_verifier_model_metadata"]["verifier-error"] == 1
+
+
 def test_verifier_summary_suppresses_pre_contract_missing_model_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

<!-- workflow-source:review_followup -->
<!-- workflow-source-ref:stranske/Inv-Man-Intake#315 -->

Closes #1938.
Closes #1937.

Addresses source-of-truth review blockers observed on generated consumer sync PRs, including `stranske/Inv-Man-Intake#315`. The comments target Workflows-synced files, so the fix belongs in `stranske/Workflows` before downstream sync PRs merge.

Changes:
- Tighten source-context issue extraction so PR references and ambiguous workflow-source selections do not become issue-sourced metadata.
- Route workflow-source repair comment updates through the existing retry wrapper and clarify repair wording.
- Normalize Codex CLI version strings consistently to lowercase.
- Keep synced consumer template scripts aligned with the Workflows source scripts.

## Validation

- `node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/terminal-disposition.test.js .github/scripts/__tests__/agents-pr-meta-update-body.test.js .github/scripts/__tests__/coverage-monitor-summary.test.js`
- `pytest -q tests/scripts/test_aggregate_agent_metrics.py`
- `python scripts/validate_template_sync.py`

## Context

- Follow-up issues: https://github.com/stranske/Workflows/issues/1938 and https://github.com/stranske/Workflows/issues/1937
- Downstream blocker: https://github.com/stranske/Inv-Man-Intake/pull/315
- Superseded source PR: https://github.com/stranske/Workflows/pull/1939
