### PR TITLE
test: document verifier follow-up evidence

### DIFF
--- a/.github/scripts/__tests__/coverage-monitor-summary.test.js
+++ b/.github/scripts/__tests__/coverage-monitor-summary.test.js
@@ -9,6 +9,7 @@ const {
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
   normalizeMonitorArtifactSelection,
+  optionalExistingReportPath,
   parseArgs,
   readJsonReport,
   SUMMARY_SCHEMA,
@@ -110,6 +111,16 @@ test('skips PR source context coverage when configured file is absent', () => {
     summary.monitors.map((monitor) => monitor.label),
     ['terminal-disposition', 'bot-comment-auth']
   );
+});
+
+test('treats PR source context coverage as an optional existing file input', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-monitor-'));
+  const prSource = writeJson(dir, 'pr-source.json', report('pass'));
+
+  assert.equal(optionalExistingReportPath(''), '');
+  assert.equal(optionalExistingReportPath(path.join(dir, 'missing-pr-source.json')), '');
+  assert.equal(optionalExistingReportPath(dir), '');
+  assert.equal(optionalExistingReportPath(` ${prSource} `), prSource);
 });
 
 test('does not include PR source context coverage by default', () => {

--- a/.github/scripts/coverage_monitor_summary.js
+++ b/.github/scripts/coverage_monitor_summary.js
@@ -136,16 +136,20 @@ function nextAction(status, monitors) {
   return 'continue-monitoring';
 }
 
+function optionalExistingReportPath(filePath) {
+  const cleanedPath = cleanString(filePath);
+  if (!cleanedPath) return '';
+  if (!fs.existsSync(cleanedPath)) return '';
+  if (!fs.statSync(cleanedPath).isFile()) return '';
+  return cleanedPath;
+}
+
 function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
-  const prSourceContextReportPath = cleanString(options.pr_source_context_report);
-  if (
-    prSourceContextReportPath &&
-    fs.existsSync(prSourceContextReportPath) &&
-    fs.statSync(prSourceContextReportPath).isFile()
-  ) {
+  const prSourceContextReportPath = optionalExistingReportPath(options.pr_source_context_report);
+  if (prSourceContextReportPath) {
     monitors.push(
       summarizeReport(readJsonReport(prSourceContextReportPath, 'pr-source-context'))
     );
@@ -271,6 +275,7 @@ module.exports = {
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
   normalizeMonitorArtifactSelection,
+  optionalExistingReportPath,
   parseArgs,
   readJsonReport,
 };

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -263,6 +263,9 @@ Workflows source classification without forcing a GitHub issue.
 | `workflow:no-automation` | Pull Requests | Automation should not manage the PR unless checks fail. |
 | `workflow:source-needed` | Pull Requests | Source context is missing or ambiguous. |
 
+The Workflow Source table is validated as a three-column Markdown table so label
+rows do not introduce an extra empty column in GitHub rendering.
+
 Use these labels as a backup to the PR template's Workflow Source section. If a
 PR has no linked issue and no valid Workflow Source, the PR metadata automation
 posts one repair comment instead of repeatedly treating the PR as issue-delivery

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -456,6 +456,11 @@ def _is_verifier_terminal_entry(entry: dict[str, Any]) -> bool:
     )
 
 
+def _verifier_mode_requires_model_metadata(entry: dict[str, Any]) -> bool:
+    verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+    return bool(verifier_mode) and verifier_mode != "evaluate"
+
+
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
     stop_reasons = Counter()
     actions = Counter()
@@ -592,14 +597,16 @@ def _summarise_verifier(
                 unsupported_verifier_models[normalized_model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
-        elif is_verifier_terminal and model_metadata_required:
-            verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode and verifier_mode != "evaluate":
-                disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
-                if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
-                    legacy_missing_verifier_model_metadata[str(disposition)] += 1
-                else:
-                    missing_verifier_model_metadata[str(disposition)] += 1
+        elif (
+            is_verifier_terminal
+            and model_metadata_required
+            and _verifier_mode_requires_model_metadata(entry)
+        ):
+            disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
+            if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
+                legacy_missing_verifier_model_metadata[str(disposition)] += 1
+            else:
+                missing_verifier_model_metadata[str(disposition)] += 1
         model_selection_reason = entry.get("codex_model_selection_reason") or entry.get(
             "model_selection_reason"
         )

--- a/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
+++ b/templates/consumer-repo/.github/scripts/coverage_monitor_summary.js
@@ -136,16 +136,20 @@ function nextAction(status, monitors) {
   return 'continue-monitoring';
 }
 
+function optionalExistingReportPath(filePath) {
+  const cleanedPath = cleanString(filePath);
+  if (!cleanedPath) return '';
+  if (!fs.existsSync(cleanedPath)) return '';
+  if (!fs.statSync(cleanedPath).isFile()) return '';
+  return cleanedPath;
+}
+
 function buildCoverageMonitorSummary(options = {}) {
   const terminal = summarizeReport(readJsonReport(options.terminal_report, 'terminal-disposition'));
   const botAuth = summarizeReport(readJsonReport(options.bot_auth_report, 'bot-comment-auth'));
   const monitors = [terminal, botAuth];
-  const prSourceContextReportPath = cleanString(options.pr_source_context_report);
-  if (
-    prSourceContextReportPath &&
-    fs.existsSync(prSourceContextReportPath) &&
-    fs.statSync(prSourceContextReportPath).isFile()
-  ) {
+  const prSourceContextReportPath = optionalExistingReportPath(options.pr_source_context_report);
+  if (prSourceContextReportPath) {
     monitors.push(
       summarizeReport(readJsonReport(prSourceContextReportPath, 'pr-source-context'))
     );
@@ -271,6 +275,7 @@ module.exports = {
   buildCoverageMonitorSummary,
   formatMonitorMarkdown,
   normalizeMonitorArtifactSelection,
+  optionalExistingReportPath,
   parseArgs,
   readJsonReport,
 };

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -456,6 +456,11 @@ def _is_verifier_terminal_entry(entry: dict[str, Any]) -> bool:
     )
 
 
+def _verifier_mode_requires_model_metadata(entry: dict[str, Any]) -> bool:
+    verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
+    return bool(verifier_mode) and verifier_mode != "evaluate"
+
+
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
     stop_reasons = Counter()
     actions = Counter()
@@ -592,14 +597,16 @@ def _summarise_verifier(
                 unsupported_verifier_models[normalized_model_text] += 1
                 disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
                 unsupported_model_dispositions[str(disposition)] += 1
-        elif is_verifier_terminal and model_metadata_required:
-            verifier_mode = str(entry.get("verifier_mode") or "").strip().lower()
-            if verifier_mode and verifier_mode != "evaluate":
-                disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
-                if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
-                    legacy_missing_verifier_model_metadata[str(disposition)] += 1
-                else:
-                    missing_verifier_model_metadata[str(disposition)] += 1
+        elif (
+            is_verifier_terminal
+            and model_metadata_required
+            and _verifier_mode_requires_model_metadata(entry)
+        ):
+            disposition = entry.get("disposition") or entry.get("terminal_state") or "unknown"
+            if _is_pre_contract_verifier_model_record(entry, model_metadata_required_after):
+                legacy_missing_verifier_model_metadata[str(disposition)] += 1
+            else:
+                missing_verifier_model_metadata[str(disposition)] += 1
         model_selection_reason = entry.get("codex_model_selection_reason") or entry.get(
             "model_selection_reason"
         )

--- a/tests/docs/test_labels_markdown_tables.py
+++ b/tests/docs/test_labels_markdown_tables.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 LABELS_DOC = Path("docs/LABELS.md")
 
 
@@ -44,10 +43,7 @@ def test_reviewed_label_rows_stay_three_column_rows() -> None:
         line.strip()
         for line in lines
         if line.strip().startswith("|")
-        and (
-            "`workflow:source-needed`" in line
-            or "`agents:apply-suggestions`" in line
-        )
+        and ("`workflow:source-needed`" in line or "`agents:apply-suggestions`" in line)
     ]
 
     assert reviewed_rows

--- a/tests/docs/test_labels_markdown_tables.py
+++ b/tests/docs/test_labels_markdown_tables.py
@@ -1,0 +1,54 @@
+"""Validate Markdown label tables render with stable column counts."""
+
+from pathlib import Path
+
+
+LABELS_DOC = Path("docs/LABELS.md")
+
+
+def _markdown_tables(lines: list[str]) -> list[list[str]]:
+    tables: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("|") and stripped.endswith("|"):
+            current.append(stripped)
+            continue
+        if current:
+            tables.append(current)
+            current = []
+    if current:
+        tables.append(current)
+    return tables
+
+
+def _cell_count(row: str) -> int:
+    return len(row.strip().strip("|").split("|"))
+
+
+def test_labels_markdown_tables_have_consistent_column_counts() -> None:
+    lines = LABELS_DOC.read_text(encoding="utf-8").splitlines()
+    tables = _markdown_tables(lines)
+
+    assert tables, "Expected docs/LABELS.md to contain Markdown tables"
+
+    for table in tables:
+        expected = _cell_count(table[0])
+        for row in table[1:]:
+            assert _cell_count(row) == expected, row
+
+
+def test_reviewed_label_rows_stay_three_column_rows() -> None:
+    lines = LABELS_DOC.read_text(encoding="utf-8").splitlines()
+    reviewed_rows = [
+        line.strip()
+        for line in lines
+        if line.strip().startswith("|")
+        and (
+            "`workflow:source-needed`" in line
+            or "`agents:apply-suggestions`" in line
+        )
+    ]
+
+    assert reviewed_rows
+    assert all(_cell_count(row) == 3 for row in reviewed_rows)

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -934,6 +934,30 @@ def test_verifier_summary_ignores_missing_model_metadata_for_unknown_mode(
     assert verifier["missing_verifier_model_metadata"] == Counter()
 
 
+def test_verifier_summary_ignores_missing_model_metadata_for_blank_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "TERMINAL_DISPOSITION_VERIFIER_MODEL_METADATA_REQUIRED_AFTER",
+        "2026-04-26T04:25:00Z",
+    )
+
+    verifier = aggregate_agent_metrics._summarise_verifier(
+        [
+            {
+                "schema": "workflows-terminal-disposition/v1",
+                "artifact_family": "verifier-terminal-disposition",
+                "run_id": "24948023780",
+                "pr_number": 1875,
+                "disposition": "verifier-error",
+                "verifier_mode": " ",
+            },
+        ]
+    )
+
+    assert verifier["missing_verifier_model_metadata"] == Counter()
+
+
 def test_verifier_summary_counts_missing_model_metadata_for_non_evaluate_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1937 -->
> **Source:** Issue #1937

Closes #1937

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake sync PR #315 is blocked by unresolved Copilot review threads on Workflows-synced files from `sync/workflows-9a8064d02f64`.

Consumer PR: https://github.com/stranske/Inv-Man-Intake/pull/315  
Source sync branch: `sync/workflows-9a8064d02f64`  
Head: `c1eff4d6f3a05ed020992b990038862509f4068a`

The comments are source-of-truth Workflows concerns, not Inv-Man-Intake product work. The consumer repo should not patch synced files locally.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Inv-Man-Intake#315](https://github.com/stranske/Inv-Man-Intake/issues/315)
- [#315](https://github.com/stranske/Workflows/issues/315)
- [#123](https://github.com/stranske/Workflows/issues/123)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Reproduce the seven review concerns against current Workflows `main` or commit `c1eff4d6f3a05ed020992b990038862509f4068a`.
  - [ ] Define scope for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
- [ ] Update `.github/scripts/source_context.js` to stop treating arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PRs.
- [ ] Update `scripts/aggregate_agent_metrics.py` to avoid counting missing verifier model metadata when `verifier_mode` is empty or unknown, or add a dedicated unknown-mode counter.
- [ ] Update `.github/scripts/coverage_monitor_summary.js` so PR source context coverage is not required when the workflow does not generate the report.
- [ ] Fix the Markdown table rows in `docs/LABELS.md` so they do not render an extra empty column.
- [ ] Add or update focused tests covering source-context issue detection behavior in `.github/scripts/source_context.js`.
- [ ] Add or update focused tests covering optional-report behavior in `.github/scripts/coverage_monitor_summary.js`.
- [ ] Add or update focused tests covering verifier-mode handling in `scripts/aggregate_agent_metrics.py`.
- [ ] Test the changed Workflows scripts and related test suites locally and ensure CI passes for the updated files.
  - [ ] Run the changed Workflows scripts (verify: confirm completion in repo) related test suites locally to verify functionality
  - [ ] Verify that CI passes for all updated files after pushing changes
- [ ] Update the Workflows follow-up PR description or comments with explicit disposition for any review thread that is intentionally not code-actionable.
- [ ] Add a comment on Inv-Man-Intake PR #315 linking to the Workflows follow-up before the downstream lane is paused.
- [ ] Wait for or regenerate the refreshed consumer sync PR through the normal sync flow without making consumer-local patches to synced files.

#### Acceptance criteria
- [ ] `.github/scripts/source_context.js` no longer classifies arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PR references in the added or updated tests.
- [ ] `scripts/aggregate_agent_metrics.py` added or updated tests verify that empty or unknown `verifier_mode` values do not inflate missing verifier model metadata counts, or that a dedicated unknown-mode counter is emitted instead.
- [ ] `.github/scripts/coverage_monitor_summary.js` added or updated tests verify that coverage checks do not fail when the PR source context report is absent and the workflow does not generate it.
- [ ] `docs/LABELS.md` renders the updated table rows without an extra empty column when inspected as valid Markdown table syntax.
- [ ] The Workflows PR contains code changes or explicit documented dispositions for all seven review threads linked from Inv-Man-Intake PR #315.
- [ ] No changes are made in Inv-Man-Intake to patch synced Workflows files locally.
- [ ] The updated Workflows tests pass locally or in CI for the modified scripts.
- [ ] Inv-Man-Intake PR #315 includes a comment linking to the Workflows follow-up PR or commit.

**Head SHA:** 75db591217a7274e579fed6d1ac9bd41882d9fa0
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24971600893) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600902) |
| Health 44 Gate Branch Protection | ⏳ pending | [View run](https://github.com/stranske/Workflows/actions/runs/24971600837) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600811) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24971600841) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600824) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600816) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600812) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600813) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24971600821) |
<!-- auto-status-summary:end -->