### PR TITLE
fix: collect priority weekly artifacts from producers

### DIFF
--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -5,7 +5,10 @@ const {
   SELECTION_SCHEMA,
   artifactFamily,
   buildSelectionErrorReport,
+  collectPriorityWorkflowArtifacts,
   collectRepoArtifacts,
+  dedupeArtifacts,
+  familiesSatisfied,
   formatArtifactTsv,
   formatSelectionMarkdown,
   latestCandidateByFamily,
@@ -389,6 +392,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
 
   assert.match(markdown, /Weekly Metrics Artifact Selection/);
   assert.match(markdown, /Scan cap: 5 pages x 100 artifacts/);
+  assert.match(markdown, /Priority producer scan cap: 10 runs per source workflow/);
   assert.match(markdown, /Selected artifacts: 2/);
   assert.match(
     markdown,
@@ -413,6 +417,136 @@ test('normalizes invalid environment-like limits to defaults', () => {
   assert.equal(options.max_total, 80);
   assert.equal(options.max_per_family, 20);
   assert.equal(options.max_scan_pages, 5);
+  assert.equal(options.priority_workflow_runs_per_source, 10);
+});
+
+test('deduplicates artifacts by stable id before selection', () => {
+  const artifacts = dedupeArtifacts([
+    artifact(1, 'codex-cli-freshness-77', '2026-04-25T11:00:00Z'),
+    artifact(1, 'codex-cli-freshness-77', '2026-04-25T11:00:00Z'),
+    artifact(null, 'bot-comment-auth-coverage-reusable-1', '2026-04-25T10:00:00Z'),
+    artifact(null, 'bot-comment-auth-coverage-reusable-1', '2026-04-25T10:00:00Z'),
+  ]);
+
+  assert.deepEqual(
+    artifacts.map((selected) => selected.name),
+    ['codex-cli-freshness-77', 'bot-comment-auth-coverage-reusable-1']
+  );
+});
+
+test('checks whether priority workflow artifacts satisfy configured families', () => {
+  const config = normalizeSelectionOptions({ now_ms: NOW, lookback_days: 14 });
+
+  assert.equal(
+    familiesSatisfied(
+      [artifact(1, 'bot-comment-auth-coverage-reusable-1', '2026-04-25T10:00:00Z')],
+      ['bot-comment-auth-coverage-reusable'],
+      config
+    ),
+    true
+  );
+  assert.equal(
+    familiesSatisfied(
+      [artifact(2, 'bot-comment-auth-coverage-reusable-old', '2026-03-25T10:00:00Z')],
+      ['bot-comment-auth-coverage-reusable'],
+      config
+    ),
+    false
+  );
+});
+
+test('collects priority artifacts from their producer workflows', async () => {
+  const calls = [];
+  const client = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async (params) => {
+          calls.push(['runs', params.workflow_id, params.per_page]);
+          return {
+            data: {
+              workflow_runs: [
+                { id: 101, created_at: '2026-04-25T11:00:00Z', updated_at: '2026-04-25T11:00:00Z' },
+                { id: 102, created_at: '2026-04-25T10:00:00Z', updated_at: '2026-04-25T10:00:00Z' },
+              ],
+            },
+          };
+        },
+        listWorkflowRunArtifacts: async (params) => {
+          calls.push(['artifacts', params.run_id, params.per_page]);
+          return {
+            data: {
+              artifacts: [
+                artifact(
+                  params.run_id,
+                  params.run_id === 101
+                    ? 'bot-comment-auth-coverage-reusable-101'
+                    : 'keepalive-metrics',
+                  '2026-04-25T11:00:00Z'
+                ),
+              ],
+            },
+          };
+        },
+      },
+    },
+  };
+
+  const artifacts = await collectPriorityWorkflowArtifacts({
+    github: client,
+    owner: 'owner',
+    repo: 'repo',
+    options: {
+      now_ms: NOW,
+      priority_workflow_runs_per_source: 2,
+      per_page: 50,
+    },
+    sources: [
+      {
+        workflow_id: 'reusable-bot-comment-handler.yml',
+        families: ['bot-comment-auth-coverage-reusable'],
+      },
+    ],
+    withRetry: (fn) => fn(client),
+  });
+
+  assert.deepEqual(
+    artifacts.map((selected) => selected.name),
+    ['bot-comment-auth-coverage-reusable-101']
+  );
+  assert.deepEqual(calls, [
+    ['runs', 'reusable-bot-comment-handler.yml', 2],
+    ['artifacts', 101, 50],
+  ]);
+});
+
+test('skips missing priority producer workflows without failing selection', async () => {
+  const client = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => {
+          const error = new Error('Not Found');
+          error.status = 404;
+          throw error;
+        },
+      },
+    },
+  };
+
+  const artifacts = await collectPriorityWorkflowArtifacts({
+    github: client,
+    owner: 'owner',
+    repo: 'repo',
+    options: { now_ms: NOW },
+    sources: [
+      {
+        workflow_id: 'health-76-codex-cli-freshness.yml',
+        families: ['codex-cli-freshness'],
+      },
+    ],
+    withRetry: (fn) => fn(client),
+  });
+
+  assert.deepEqual(artifacts, []);
 });
 
 test('collects repo artifacts within the configured scan page cap', async () => {
@@ -431,6 +565,24 @@ test('collects repo artifacts within the configured scan page cap', async () => 
             },
           };
         },
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              {
+                id: 9001,
+                created_at: '2026-04-25T09:00:00Z',
+                updated_at: '2026-04-25T09:00:00Z',
+              },
+            ],
+          },
+        }),
+        listWorkflowRunArtifacts: async () => ({
+          data: {
+            artifacts: [
+              artifact(9001, 'codex-cli-freshness-9001', '2026-04-25T09:00:00Z'),
+            ],
+          },
+        }),
       },
     },
   };
@@ -447,7 +599,8 @@ test('collects repo artifacts within the configured scan page cap', async () => 
     withRetry: (fn) => fn(client),
   });
 
-  assert.equal(artifacts.length, 4);
+  assert.equal(artifacts.length, 5);
+  assert.ok(artifacts.some((candidate) => candidate.name === 'codex-cli-freshness-9001'));
   assert.deepEqual(
     calls.map((call) => call.page),
     [1, 2]

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -6,6 +6,7 @@ const DEFAULT_MAX_TOTAL = 80;
 const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
+const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -43,6 +44,37 @@ const PRIORITY_METRICS_FAMILIES = [
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
   'pr-source-context',
+];
+
+const PRIORITY_WORKFLOW_ARTIFACT_SOURCES = [
+  {
+    workflow_id: 'health-76-codex-cli-freshness.yml',
+    families: ['codex-cli-freshness'],
+  },
+  {
+    workflow_id: 'reusable-agents-verifier.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-verify-to-new-pr.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-verify-to-issue-v2.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-bot-comment-handler.yml',
+    families: ['review-thread-terminal-disposition', 'bot-comment-auth-coverage-wrapper'],
+  },
+  {
+    workflow_id: 'reusable-bot-comment-handler.yml',
+    families: ['review-thread-terminal-disposition', 'bot-comment-auth-coverage-reusable'],
+  },
+  {
+    workflow_id: 'pr-11-ci-smoke.yml',
+    families: ['pr-source-context'],
+  },
 ];
 
 function cleanString(value) {
@@ -102,6 +134,12 @@ function normalizeSelectionOptions(options = {}) {
     options.per_page ?? options.perPage ?? process.env.METRICS_ARTIFACTS_PER_PAGE,
     DEFAULT_PER_PAGE
   );
+  const priorityWorkflowRunsPerSource = parsePositiveInt(
+    options.priority_workflow_runs_per_source ??
+      options.priorityWorkflowRunsPerSource ??
+      process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
+    DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -110,6 +148,7 @@ function normalizeSelectionOptions(options = {}) {
     max_per_family: maxPerFamily,
     max_scan_pages: maxScanPages,
     per_page: perPage,
+    priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
     cutoff_ms: cutoffMs,
   };
 }
@@ -296,6 +335,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_per_family: config.max_per_family,
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
+      priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -331,6 +371,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_per_family: config.max_per_family,
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
+      priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -368,6 +409,7 @@ function formatSelectionMarkdown(report) {
     `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
+    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -405,6 +447,101 @@ function formatSelectionMarkdown(report) {
   return `${lines.join('\n')}\n`;
 }
 
+function dedupeArtifacts(artifacts = []) {
+  const seen = new Set();
+  const deduped = [];
+  for (const artifact of artifacts) {
+    const id = artifact?.id ?? artifact?.artifact_id ?? artifact?.artifactId;
+    const key = id
+      ? `id:${id}`
+      : `name:${cleanString(artifact?.name)}:${cleanString(artifact?.created_at ?? artifact?.createdAt)}`;
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(artifact);
+  }
+  return deduped;
+}
+
+function familiesSatisfied(artifacts = [], families = [], config = normalizeSelectionOptions()) {
+  const found = new Set();
+  for (const raw of artifacts) {
+    const artifact = normalizeArtifact(raw);
+    if (!artifact.id || artifact.expired || !artifact.family || !families.includes(artifact.family)) {
+      continue;
+    }
+    if (artifact.timestamp_ms > 0 && artifact.timestamp_ms < config.cutoff_ms) {
+      continue;
+    }
+    found.add(artifact.family);
+  }
+  return families.every((family) => found.has(family));
+}
+
+function isNotFoundError(error) {
+  return Number(error?.status) === 404 || Number(error?.response?.status) === 404;
+}
+
+async function collectPriorityWorkflowArtifacts({
+  github,
+  owner,
+  repo,
+  withRetry,
+  options,
+  sources = PRIORITY_WORKFLOW_ARTIFACT_SOURCES,
+}) {
+  const config = normalizeSelectionOptions(options);
+  const artifacts = [];
+  for (const source of sources) {
+    const workflowId = cleanString(source.workflow_id ?? source.workflowId);
+    const families = (source.families || []).map(cleanString).filter(Boolean);
+    if (!workflowId || families.length === 0) continue;
+    let runsResponse;
+    try {
+      runsResponse = await withRetry((client) => client.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: workflowId,
+        per_page: config.priority_workflow_runs_per_source,
+      }));
+    } catch (error) {
+      if (isNotFoundError(error)) continue;
+      throw error;
+    }
+    const runs = runsResponse?.data?.workflow_runs || [];
+    for (const run of runs) {
+      const runTimestamp = Math.max(
+        parseDateMs(run.created_at ?? run.createdAt),
+        parseDateMs(run.updated_at ?? run.updatedAt)
+      );
+      if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
+        continue;
+      }
+      let artifactResponse;
+      try {
+        artifactResponse = await withRetry((client) =>
+          client.rest.actions.listWorkflowRunArtifacts({
+            owner,
+            repo,
+            run_id: run.id,
+            per_page: config.per_page,
+          })
+        );
+      } catch (error) {
+        if (isNotFoundError(error)) continue;
+        throw error;
+      }
+      const matchingArtifacts = (artifactResponse?.data?.artifacts || []).filter((artifact) =>
+        families.includes(artifactFamily(artifact.name))
+      );
+      artifacts.push(...matchingArtifacts);
+      if (familiesSatisfied(artifacts, families, config)) {
+        break;
+      }
+    }
+  }
+  return dedupeArtifacts(artifacts);
+}
+
 async function collectRepoArtifacts({ github, owner, repo, withRetry, options }) {
   const artifacts = [];
   const config = normalizeSelectionOptions(options);
@@ -428,7 +565,14 @@ async function collectRepoArtifacts({ github, owner, repo, withRetry, options })
       break;
     }
   }
-  return artifacts;
+  const priorityArtifacts = await collectPriorityWorkflowArtifacts({
+    github,
+    owner,
+    repo,
+    withRetry,
+    options,
+  });
+  return dedupeArtifacts([...artifacts, ...priorityArtifacts]);
 }
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -461,6 +605,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--max-scan-pages') {
       options.max_scan_pages = next;
+      index += 1;
+    } else if (arg === '--priority-workflow-runs-per-source') {
+      options.priority_workflow_runs_per_source = next;
       index += 1;
     }
   }
@@ -524,11 +671,16 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
   PRIORITY_METRICS_FAMILIES,
+  PRIORITY_WORKFLOW_ARTIFACT_SOURCES,
   SELECTION_SCHEMA,
   artifactFamily,
   buildSelectionErrorReport,
+  collectPriorityWorkflowArtifacts,
   collectRepoArtifacts,
+  dedupeArtifacts,
+  familiesSatisfied,
   formatArtifactTsv,
   formatSelectionMarkdown,
   latestCandidateByFamily,

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -6,6 +6,7 @@ const DEFAULT_MAX_TOTAL = 80;
 const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
+const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -43,6 +44,37 @@ const PRIORITY_METRICS_FAMILIES = [
   'bot-comment-auth-coverage-wrapper',
   'bot-comment-auth-coverage-reusable',
   'pr-source-context',
+];
+
+const PRIORITY_WORKFLOW_ARTIFACT_SOURCES = [
+  {
+    workflow_id: 'health-76-codex-cli-freshness.yml',
+    families: ['codex-cli-freshness'],
+  },
+  {
+    workflow_id: 'reusable-agents-verifier.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-verify-to-new-pr.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-verify-to-issue-v2.yml',
+    families: ['verifier-terminal-disposition'],
+  },
+  {
+    workflow_id: 'agents-bot-comment-handler.yml',
+    families: ['review-thread-terminal-disposition', 'bot-comment-auth-coverage-wrapper'],
+  },
+  {
+    workflow_id: 'reusable-bot-comment-handler.yml',
+    families: ['review-thread-terminal-disposition', 'bot-comment-auth-coverage-reusable'],
+  },
+  {
+    workflow_id: 'pr-11-ci-smoke.yml',
+    families: ['pr-source-context'],
+  },
 ];
 
 function cleanString(value) {
@@ -102,6 +134,12 @@ function normalizeSelectionOptions(options = {}) {
     options.per_page ?? options.perPage ?? process.env.METRICS_ARTIFACTS_PER_PAGE,
     DEFAULT_PER_PAGE
   );
+  const priorityWorkflowRunsPerSource = parsePositiveInt(
+    options.priority_workflow_runs_per_source ??
+      options.priorityWorkflowRunsPerSource ??
+      process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
+    DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -110,6 +148,7 @@ function normalizeSelectionOptions(options = {}) {
     max_per_family: maxPerFamily,
     max_scan_pages: maxScanPages,
     per_page: perPage,
+    priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
     cutoff_ms: cutoffMs,
   };
 }
@@ -296,6 +335,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_per_family: config.max_per_family,
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
+      priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -331,6 +371,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_per_family: config.max_per_family,
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
+      priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -368,6 +409,7 @@ function formatSelectionMarkdown(report) {
     `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
+    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -405,6 +447,101 @@ function formatSelectionMarkdown(report) {
   return `${lines.join('\n')}\n`;
 }
 
+function dedupeArtifacts(artifacts = []) {
+  const seen = new Set();
+  const deduped = [];
+  for (const artifact of artifacts) {
+    const id = artifact?.id ?? artifact?.artifact_id ?? artifact?.artifactId;
+    const key = id
+      ? `id:${id}`
+      : `name:${cleanString(artifact?.name)}:${cleanString(artifact?.created_at ?? artifact?.createdAt)}`;
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(artifact);
+  }
+  return deduped;
+}
+
+function familiesSatisfied(artifacts = [], families = [], config = normalizeSelectionOptions()) {
+  const found = new Set();
+  for (const raw of artifacts) {
+    const artifact = normalizeArtifact(raw);
+    if (!artifact.id || artifact.expired || !artifact.family || !families.includes(artifact.family)) {
+      continue;
+    }
+    if (artifact.timestamp_ms > 0 && artifact.timestamp_ms < config.cutoff_ms) {
+      continue;
+    }
+    found.add(artifact.family);
+  }
+  return families.every((family) => found.has(family));
+}
+
+function isNotFoundError(error) {
+  return Number(error?.status) === 404 || Number(error?.response?.status) === 404;
+}
+
+async function collectPriorityWorkflowArtifacts({
+  github,
+  owner,
+  repo,
+  withRetry,
+  options,
+  sources = PRIORITY_WORKFLOW_ARTIFACT_SOURCES,
+}) {
+  const config = normalizeSelectionOptions(options);
+  const artifacts = [];
+  for (const source of sources) {
+    const workflowId = cleanString(source.workflow_id ?? source.workflowId);
+    const families = (source.families || []).map(cleanString).filter(Boolean);
+    if (!workflowId || families.length === 0) continue;
+    let runsResponse;
+    try {
+      runsResponse = await withRetry((client) => client.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: workflowId,
+        per_page: config.priority_workflow_runs_per_source,
+      }));
+    } catch (error) {
+      if (isNotFoundError(error)) continue;
+      throw error;
+    }
+    const runs = runsResponse?.data?.workflow_runs || [];
+    for (const run of runs) {
+      const runTimestamp = Math.max(
+        parseDateMs(run.created_at ?? run.createdAt),
+        parseDateMs(run.updated_at ?? run.updatedAt)
+      );
+      if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
+        continue;
+      }
+      let artifactResponse;
+      try {
+        artifactResponse = await withRetry((client) =>
+          client.rest.actions.listWorkflowRunArtifacts({
+            owner,
+            repo,
+            run_id: run.id,
+            per_page: config.per_page,
+          })
+        );
+      } catch (error) {
+        if (isNotFoundError(error)) continue;
+        throw error;
+      }
+      const matchingArtifacts = (artifactResponse?.data?.artifacts || []).filter((artifact) =>
+        families.includes(artifactFamily(artifact.name))
+      );
+      artifacts.push(...matchingArtifacts);
+      if (familiesSatisfied(artifacts, families, config)) {
+        break;
+      }
+    }
+  }
+  return dedupeArtifacts(artifacts);
+}
+
 async function collectRepoArtifacts({ github, owner, repo, withRetry, options }) {
   const artifacts = [];
   const config = normalizeSelectionOptions(options);
@@ -428,7 +565,14 @@ async function collectRepoArtifacts({ github, owner, repo, withRetry, options })
       break;
     }
   }
-  return artifacts;
+  const priorityArtifacts = await collectPriorityWorkflowArtifacts({
+    github,
+    owner,
+    repo,
+    withRetry,
+    options,
+  });
+  return dedupeArtifacts([...artifacts, ...priorityArtifacts]);
 }
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -461,6 +605,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--max-scan-pages') {
       options.max_scan_pages = next;
+      index += 1;
+    } else if (arg === '--priority-workflow-runs-per-source') {
+      options.priority_workflow_runs_per_source = next;
       index += 1;
     }
   }
@@ -524,11 +671,16 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
   PRIORITY_METRICS_FAMILIES,
+  PRIORITY_WORKFLOW_ARTIFACT_SOURCES,
   SELECTION_SCHEMA,
   artifactFamily,
   buildSelectionErrorReport,
+  collectPriorityWorkflowArtifacts,
   collectRepoArtifacts,
+  dedupeArtifacts,
+  familiesSatisfied,
   formatArtifactTsv,
   formatSelectionMarkdown,
   latestCandidateByFamily,


### PR DESCRIPTION
## Summary\n- scan priority producer workflows directly for weekly metrics artifacts before selection\n- include a configurable per-source run cap in the selector contract and markdown\n- tolerate missing producer workflows so synced consumer repos keep working when they do not host every Workflows producer\n\n## Verification\n- node --test .github/scripts/__tests__/weekly-metrics-artifacts.test.js .github/scripts/__tests__/weekly-metrics-download-manifest.test.js .github/scripts/__tests__/bot-comment-auth-coverage.test.js\n- python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q\n- python scripts/validate_template_sync.py\n- python scripts/validate_workflow_yaml.py .github/workflows/agents-weekly-metrics.yml .github/workflows/health-76-codex-cli-freshness.yml\n- git diff --check