### PR TITLE
fix: resolve PR body source repair review

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -421,6 +421,8 @@ test('buildSourceContextResolvedCommentBody retires stale source repair comments
   const result = buildSourceContextResolvedCommentBody(55, {
     sourceType: 'local_request',
     sourceRef: 'codex-thread-2026-04-26',
+    isValid: true,
+    requiresIssue: false,
   });
 
   assert.ok(result.includes('<!-- missing-issue-warning -->'));
@@ -430,12 +432,34 @@ test('buildSourceContextResolvedCommentBody retires stale source repair comments
   assert.ok(result.includes('No linked GitHub issue is required'));
 });
 
+test('buildSourceContextResolvedCommentBody explains linked issue source context', () => {
+  const result = buildSourceContextResolvedCommentBody(
+    55,
+    {
+      sourceType: 'github_issue',
+      issueNumber: 123,
+      sourceRef: '#123',
+      isValid: true,
+      requiresIssue: true,
+    },
+    123,
+  );
+
+  assert.ok(result.includes('<!-- missing-issue-warning -->'));
+  assert.ok(result.includes('PR #55 now has valid workflow source context'));
+  assert.ok(result.includes('origin=github_issue'));
+  assert.ok(result.includes('Linked GitHub issue #123 detected for this PR.'));
+  assert.ok(!result.includes('No linked GitHub issue is required'));
+});
+
 test('buildSourceContextResolvedCommentBody explains sync-campaign source context', () => {
   const result = buildSourceContextResolvedCommentBody(956, {
     sourceType: 'sync_campaign',
     sourceRef: 'stranske/Travel-Plan-Permission#956',
     lifecycle: 'consumer-sync',
     automation: 'verify-follow-up',
+    isValid: true,
+    requiresIssue: false,
   });
 
   assert.ok(result.includes('origin=sync_campaign'));
@@ -495,10 +519,47 @@ test('resolveNonIssueWorkflowSourceContextForBodySync preserves issue-sourced sy
         '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
       ].join('\n'),
     },
-    123,
+    {
+      sourceType: 'github_issue',
+      issueNumber: 123,
+      isValid: true,
+      requiresIssue: true,
+    },
   );
 
   assert.equal(context, null);
+});
+
+test('resolveNonIssueWorkflowSourceContextForBodySync keeps explicit non-issue source with broad incidental refs', () => {
+  const context = resolveNonIssueWorkflowSourceContextForBodySync(
+    {
+      title: 'Review follow-up from PR #123',
+      body: [
+        '<!-- workflow-source:local_request -->',
+        '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+        'See PR #123 for background.',
+      ].join('\n'),
+    },
+    {
+      sourceType: 'local_request',
+      issueNumber: null,
+      sourceRef: 'codex-thread-2026-04-26',
+      isValid: true,
+      requiresIssue: false,
+    },
+  );
+
+  assert.deepEqual(context, {
+    sourceType: 'local_request',
+    issueNumber: null,
+    sourceRef: 'codex-thread-2026-04-26',
+    lifecycle: '',
+    automation: '',
+    isKnown: true,
+    isValid: true,
+    isExplicit: true,
+    requiresIssue: false,
+  });
 });
 
 test('resolveSourceContextRepairComment updates an existing warning once', async () => {
@@ -521,13 +582,56 @@ test('resolveSourceContextRepairComment updates an existing warning once', async
     repo: 'demo',
     prNumber: 55,
     comments: [{ id: 99, body: '<!-- missing-issue-warning -->\nold warning' }],
-    sourceContext: { sourceType: 'local_request', sourceRef: 'codex-thread-2026-04-26' },
+    sourceContext: {
+      sourceType: 'local_request',
+      sourceRef: 'codex-thread-2026-04-26',
+      isValid: true,
+      requiresIssue: false,
+    },
     core: { info: () => {} },
   });
 
   assert.strictEqual(updated, true);
   assert.strictEqual(calls.update, 1);
   assert.ok(calls.body.includes('Workflow source detected'));
+  assert.ok(calls.body.includes('No linked GitHub issue is required'));
+});
+
+test('resolveSourceContextRepairComment updates issue-linked warning with issue wording', async () => {
+  const calls = { update: 0, body: '' };
+  const github = {
+    rest: {
+      issues: {
+        updateComment: async ({ comment_id, body }) => {
+          assert.strictEqual(comment_id, 99);
+          calls.update += 1;
+          calls.body = body;
+        },
+      },
+    },
+  };
+
+  const updated = await resolveSourceContextRepairComment({
+    github,
+    owner: 'octo',
+    repo: 'demo',
+    prNumber: 55,
+    comments: [{ id: 99, body: '<!-- missing-issue-warning -->\nold warning' }],
+    sourceContext: {
+      sourceType: 'github_issue',
+      issueNumber: 123,
+      sourceRef: '#123',
+      isValid: true,
+      requiresIssue: true,
+    },
+    issueNumber: 123,
+    core: { info: () => {} },
+  });
+
+  assert.strictEqual(updated, true);
+  assert.strictEqual(calls.update, 1);
+  assert.ok(calls.body.includes('Linked GitHub issue #123 detected for this PR.'));
+  assert.ok(!calls.body.includes('No linked GitHub issue is required'));
 });
 
 test('resolveSourceContextRepairComment skips when no warning exists', async () => {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -979,14 +979,20 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
   );
 }
 
-function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+function buildSourceContextResolvedCommentBody(prNumber, sourceContext, issueNumber = null) {
+  const resolutionDetail = issueNumber
+    ? `Linked GitHub issue #${issueNumber} detected for this PR.`
+    : sourceContext?.isValid && !sourceContext?.requiresIssue
+      ? 'No linked GitHub issue is required for this PR.'
+      : 'Workflow source context has been resolved for this PR.';
+
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    'No linked GitHub issue is required for this PR.',
+    resolutionDetail,
   ].join('\n');
 }
 
@@ -1023,8 +1029,9 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
   };
 }
 
-function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
-  return issueNumber ? null : resolveExplicitNonIssueWorkflowSourceContext(pr);
+function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, sourceContext = {}) {
+  const strictIssueNumber = sourceContext?.requiresIssue ? sourceContext.issueNumber : null;
+  return strictIssueNumber ? null : resolveExplicitNonIssueWorkflowSourceContext(pr);
 }
 
 async function resolveSourceContextRepairComment({
@@ -1034,6 +1041,7 @@ async function resolveSourceContextRepairComment({
   prNumber,
   comments,
   sourceContext,
+  issueNumber = null,
   core,
 }) {
   const marker = '<!-- missing-issue-warning -->';
@@ -1042,7 +1050,7 @@ async function resolveSourceContextRepairComment({
     return false;
   }
 
-  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext);
+  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext, issueNumber);
   if (existingWarning.body === resolvedBody) {
     core?.info?.(`Workflow source repair comment already resolved (id: ${existingWarning.id})`);
     return false;
@@ -1360,9 +1368,16 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const issueNumber = extractIssueNumberFromPull(pr);
   const sourceContext = resolvePrSourceContext(pr);
-  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, issueNumber);
+  const strictIssueNumber = sourceContext.requiresIssue ? sourceContext.issueNumber : null;
+  const broadIssueNumber = extractIssueNumberFromPull(pr);
+  if (broadIssueNumber && !strictIssueNumber) {
+    core.info(
+      `Ignoring broad issue-like reference #${broadIssueNumber} for PR #${pr.number}; strict workflow source context did not identify an issue source.`,
+    );
+  }
+  const issueNumber = strictIssueNumber;
+  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, sourceContext);
   if (explicitNonIssueSourceContext) {
     core.info(
       `PR #${pr.number} has explicit non-issue workflow source context (${formatSourceContextForLog(explicitNonIssueSourceContext)}); skipping issue-sourced body sync.`,
@@ -1471,6 +1486,7 @@ async function run({github: rawGithub, context, core, inputs}) {
       prNumber: pr.number,
       comments,
       sourceContext,
+      issueNumber,
       core,
     });
   } catch (error) {

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -979,14 +979,20 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
   );
 }
 
-function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+function buildSourceContextResolvedCommentBody(prNumber, sourceContext, issueNumber = null) {
+  const resolutionDetail = issueNumber
+    ? `Linked GitHub issue #${issueNumber} detected for this PR.`
+    : sourceContext?.isValid && !sourceContext?.requiresIssue
+      ? 'No linked GitHub issue is required for this PR.'
+      : 'Workflow source context has been resolved for this PR.';
+
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    'No linked GitHub issue is required for this PR.',
+    resolutionDetail,
   ].join('\n');
 }
 
@@ -1023,8 +1029,9 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
   };
 }
 
-function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
-  return issueNumber ? null : resolveExplicitNonIssueWorkflowSourceContext(pr);
+function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, sourceContext = {}) {
+  const strictIssueNumber = sourceContext?.requiresIssue ? sourceContext.issueNumber : null;
+  return strictIssueNumber ? null : resolveExplicitNonIssueWorkflowSourceContext(pr);
 }
 
 async function resolveSourceContextRepairComment({
@@ -1034,6 +1041,7 @@ async function resolveSourceContextRepairComment({
   prNumber,
   comments,
   sourceContext,
+  issueNumber = null,
   core,
 }) {
   const marker = '<!-- missing-issue-warning -->';
@@ -1042,7 +1050,7 @@ async function resolveSourceContextRepairComment({
     return false;
   }
 
-  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext);
+  const resolvedBody = buildSourceContextResolvedCommentBody(prNumber, sourceContext, issueNumber);
   if (existingWarning.body === resolvedBody) {
     core?.info?.(`Workflow source repair comment already resolved (id: ${existingWarning.id})`);
     return false;
@@ -1360,9 +1368,16 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const issueNumber = extractIssueNumberFromPull(pr);
   const sourceContext = resolvePrSourceContext(pr);
-  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, issueNumber);
+  const strictIssueNumber = sourceContext.requiresIssue ? sourceContext.issueNumber : null;
+  const broadIssueNumber = extractIssueNumberFromPull(pr);
+  if (broadIssueNumber && !strictIssueNumber) {
+    core.info(
+      `Ignoring broad issue-like reference #${broadIssueNumber} for PR #${pr.number}; strict workflow source context did not identify an issue source.`,
+    );
+  }
+  const issueNumber = strictIssueNumber;
+  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, sourceContext);
   if (explicitNonIssueSourceContext) {
     core.info(
       `PR #${pr.number} has explicit non-issue workflow source context (${formatSourceContextForLog(explicitNonIssueSourceContext)}); skipping issue-sourced body sync.`,
@@ -1471,6 +1486,7 @@ async function run({github: rawGithub, context, core, inputs}) {
       prNumber: pr.number,
       comments,
       sourceContext,
+      issueNumber,
       core,
     });
   } catch (error) {


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1937 -->
> **Source:** Issue #1937

Closes #1937

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake sync PR #315 is blocked by unresolved Copilot review threads on Workflows-synced files from `sync/workflows-9a8064d02f64`.

Consumer PR: https://github.com/stranske/Inv-Man-Intake/pull/315  
Source sync branch: `sync/workflows-9a8064d02f64`  
Head: `c1eff4d6f3a05ed020992b990038862509f4068a`

The comments are source-of-truth Workflows concerns, not Inv-Man-Intake product work. The consumer repo should not patch synced files locally.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Inv-Man-Intake#315](https://github.com/stranske/Inv-Man-Intake/issues/315)
- [stranske/Travel-Plan-Permission#965](https://github.com/stranske/Travel-Plan-Permission/issues/965)
- [stranske/Travel-Plan-Permission#963](https://github.com/stranske/Travel-Plan-Permission/issues/963)
- [stranske/Travel-Plan-Permission#962](https://github.com/stranske/Travel-Plan-Permission/issues/962)
- [stranske/Travel-Plan-Permission#961](https://github.com/stranske/Travel-Plan-Permission/issues/961)
- [stranske/Travel-Plan-Permission#960](https://github.com/stranske/Travel-Plan-Permission/issues/960)
- [stranske/Travel-Plan-Permission#959](https://github.com/stranske/Travel-Plan-Permission/issues/959)
- [stranske/Travel-Plan-Permission#958](https://github.com/stranske/Travel-Plan-Permission/issues/958)
- [stranske/Travel-Plan-Permission#957](https://github.com/stranske/Travel-Plan-Permission/issues/957)
- [stranske/Template#639](https://github.com/stranske/Template/issues/639)
- [stranske/Template#637](https://github.com/stranske/Template/issues/637)
- [#315](https://github.com/stranske/Workflows/issues/315)
- [#123](https://github.com/stranske/Workflows/issues/123)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Reproduce the seven review concerns against current Workflows `main` or commit `c1eff4d6f3a05ed020992b990038862509f4068a`.
  - [ ] Define scope for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
- [ ] Update `.github/scripts/source_context.js` to stop treating arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PRs.
- [ ] Update `scripts/aggregate_agent_metrics.py` to avoid counting missing verifier model metadata when `verifier_mode` is empty or unknown, or add a dedicated unknown-mode counter.
- [ ] Update `.github/scripts/coverage_monitor_summary.js` so PR source context coverage is not required when the workflow does not generate the report.
- [ ] Fix the Markdown table rows in `docs/LABELS.md` so they do not render an extra empty column.
- [ ] Add or update focused tests covering source-context issue detection behavior in `.github/scripts/source_context.js`.
- [ ] Add or update focused tests covering optional-report behavior in `.github/scripts/coverage_monitor_summary.js`.
- [ ] Add or update focused tests covering verifier-mode handling in `scripts/aggregate_agent_metrics.py`.
- [ ] Test the changed Workflows scripts and related test suites locally and ensure CI passes for the updated files.
  - [ ] Run the changed Workflows scripts (verify: confirm completion in repo) related test suites locally to verify functionality
  - [ ] Verify that CI passes for all updated files after pushing changes
- [ ] Update the Workflows follow-up PR description or comments with explicit disposition for any review thread that is intentionally not code-actionable.
- [ ] Add a comment on Inv-Man-Intake PR #315 linking to the Workflows follow-up before the downstream lane is paused.
- [ ] Wait for or regenerate the refreshed consumer sync PR through the normal sync flow without making consumer-local patches to synced files.

#### Acceptance criteria
- [ ] `.github/scripts/source_context.js` no longer classifies arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PR references in the added or updated tests.
- [ ] `scripts/aggregate_agent_metrics.py` added or updated tests verify that empty or unknown `verifier_mode` values do not inflate missing verifier model metadata counts, or that a dedicated unknown-mode counter is emitted instead.
- [ ] `.github/scripts/coverage_monitor_summary.js` added or updated tests verify that coverage checks do not fail when the PR source context report is absent and the workflow does not generate it.
- [ ] `docs/LABELS.md` renders the updated table rows without an extra empty column when inspected as valid Markdown table syntax.
- [ ] The Workflows PR contains code changes or explicit documented dispositions for all seven review threads linked from Inv-Man-Intake PR #315.
- [ ] No changes are made in Inv-Man-Intake to patch synced Workflows files locally.
- [ ] The updated Workflows tests pass locally or in CI for the modified scripts.
- [ ] Inv-Man-Intake PR #315 includes a comment linking to the Workflows follow-up PR or commit.

**Head SHA:** f93ba94de2b1128b99d8a4dbbbb082efa7691e7f
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24975095752) |
| Agents Bot Comment Handler | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975095807) |
| Agents Keepalive Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975095829) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975095912) |
| CI Autofix Loop | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975095948) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975076295) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24975095869) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/24975095888) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24975095815) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24975074037) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975095871) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975074041) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975074112) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975074113) |
<!-- auto-status-summary:end -->