### PR TITLE
Fix issue-backed source repair handling

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -446,6 +446,20 @@ test('buildSourceContextResolvedCommentBody explains sync-campaign source contex
   assert.ok(result.includes('No linked GitHub issue is required'));
 });
 
+test('buildSourceContextResolvedCommentBody explains issue-backed source context', () => {
+  const result = buildSourceContextResolvedCommentBody(123, {
+    sourceType: 'github_issue',
+    issueNumber: 456,
+    sourceRef: '#456',
+    requiresIssue: true,
+  });
+
+  assert.ok(result.includes('origin=github_issue'));
+  assert.ok(result.includes('ref=#456'));
+  assert.ok(result.includes('A linked GitHub issue is present'));
+  assert.ok(!result.includes('No linked GitHub issue is required'));
+});
+
 test('resolveExplicitNonIssueWorkflowSourceContext preserves explicit automation source despite stale issue preamble', () => {
   const context = resolveExplicitNonIssueWorkflowSourceContext({
     body: [
@@ -487,7 +501,22 @@ test('resolveExplicitNonIssueWorkflowSourceContext ignores source issue markers'
   assert.equal(context, null);
 });
 
-test('resolveNonIssueWorkflowSourceContextForBodySync preserves issue-sourced sync precedence', () => {
+test('resolveNonIssueWorkflowSourceContextForBodySync preserves explicit issue-sourced sync precedence', () => {
+  const context = resolveNonIssueWorkflowSourceContextForBodySync(
+    {
+      body: [
+        'Closes #123',
+        '<!-- workflow-source:local_request -->',
+        '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+      ].join('\n'),
+    },
+    123,
+  );
+
+  assert.equal(context, null);
+});
+
+test('resolveNonIssueWorkflowSourceContextForBodySync lets explicit non-issue markers replace generated issue metadata', () => {
   const context = resolveNonIssueWorkflowSourceContextForBodySync(
     {
       body: [
@@ -499,7 +528,8 @@ test('resolveNonIssueWorkflowSourceContextForBodySync preserves issue-sourced sy
     123,
   );
 
-  assert.equal(context, null);
+  assert.equal(context.sourceType, 'local_request');
+  assert.equal(context.sourceRef, 'codex-thread-2026-04-26');
 });
 
 test('hasExplicitIssueSyncReference ignores heuristic issue-number sources', () => {
@@ -512,7 +542,11 @@ test('hasExplicitIssueSyncReference ignores heuristic issue-number sources', () 
     false,
   );
   assert.equal(hasExplicitIssueSyncReference({ body: 'Closes #123' }), true);
-  assert.equal(hasExplicitIssueSyncReference({ body: '<!-- meta:issue:123 -->' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'Related to #123' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'source issue #123' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'This issue only mentions review follow-up PR #123' }), false);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'refs in this paragraph mention PR #123' }), false);
+  assert.equal(hasExplicitIssueSyncReference({ body: '<!-- meta:issue:123 -->' }), false);
 });
 
 test('resolveNonIssueWorkflowSourceContextForBodySync honors explicit non-issue markers over heuristics', () => {

--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -543,6 +543,8 @@ test('hasExplicitIssueSyncReference ignores heuristic issue-number sources', () 
   );
   assert.equal(hasExplicitIssueSyncReference({ body: 'Closes #123' }), true);
   assert.equal(hasExplicitIssueSyncReference({ body: 'Related to #123' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'Related to issue #123' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'References issue #123' }), true);
   assert.equal(hasExplicitIssueSyncReference({ body: 'source issue #123' }), true);
   assert.equal(hasExplicitIssueSyncReference({ body: 'This issue only mentions review follow-up PR #123' }), false);
   assert.equal(hasExplicitIssueSyncReference({ body: 'refs in this paragraph mention PR #123' }), false);

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -1029,7 +1029,7 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 function hasExplicitIssueSyncReference(pr = {}) {
   const text = `${pr.title || ''}\n${pr.body || ''}`;
   const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
-  const explicitIssueReference = /\b(?:relate[sd]?\s+to|references?|source\s+issue|github\s+issue|linked\s+issue)\s*[:#-]?\s*#[0-9]+\b/i;
+  const explicitIssueReference = /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#[0-9]+\b/i;
   return explicitClosingReference.test(text) || explicitIssueReference.test(text);
 }
 

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -980,13 +980,16 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+  const isIssueBacked = sourceContext?.requiresIssue || sourceContext?.issueNumber || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE;
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    'No linked GitHub issue is required for this PR.',
+    isIssueBacked
+      ? 'A linked GitHub issue is present for this PR.'
+      : 'No linked GitHub issue is required for this PR.',
   ].join('\n');
 }
 
@@ -1024,13 +1027,10 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 }
 
 function hasExplicitIssueSyncReference(pr = {}) {
-  const body = String(pr.body || '');
-  if (/<!--\s*meta:issue:[0-9]+\s*-->/i.test(body)) {
-    return true;
-  }
-
-  const text = `${pr.title || ''}\n${body}`;
-  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*#[0-9]+\b/i.test(text);
+  const text = `${pr.title || ''}\n${pr.body || ''}`;
+  const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
+  const explicitIssueReference = /\b(?:relate[sd]?\s+to|references?|source\s+issue|github\s+issue|linked\s+issue)\s*[:#-]?\s*#[0-9]+\b/i;
+  return explicitClosingReference.test(text) || explicitIssueReference.test(text);
 }
 
 function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -1029,7 +1029,7 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 function hasExplicitIssueSyncReference(pr = {}) {
   const text = `${pr.title || ''}\n${pr.body || ''}`;
   const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
-  const explicitIssueReference = /\b(?:relate[sd]?\s+to|references?|source\s+issue|github\s+issue|linked\s+issue)\s*[:#-]?\s*#[0-9]+\b/i;
+  const explicitIssueReference = /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#[0-9]+\b/i;
   return explicitClosingReference.test(text) || explicitIssueReference.test(text);
 }
 

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -980,13 +980,16 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
+  const isIssueBacked = sourceContext?.requiresIssue || sourceContext?.issueNumber || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE;
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    'No linked GitHub issue is required for this PR.',
+    isIssueBacked
+      ? 'A linked GitHub issue is present for this PR.'
+      : 'No linked GitHub issue is required for this PR.',
   ].join('\n');
 }
 
@@ -1024,13 +1027,10 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 }
 
 function hasExplicitIssueSyncReference(pr = {}) {
-  const body = String(pr.body || '');
-  if (/<!--\s*meta:issue:[0-9]+\s*-->/i.test(body)) {
-    return true;
-  }
-
-  const text = `${pr.title || ''}\n${body}`;
-  return /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing|relate[sd]?\s+to|refs?|references?|issue|source\s+issue|github\s+issue)\s*[:#-]?\s*#[0-9]+\b/i.test(text);
+  const text = `${pr.title || ''}\n${pr.body || ''}`;
+  const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
+  const explicitIssueReference = /\b(?:relate[sd]?\s+to|references?|source\s+issue|github\s+issue|linked\s+issue)\s*[:#-]?\s*#[0-9]+\b/i;
+  return explicitClosingReference.test(text) || explicitIssueReference.test(text);
 }
 
 function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1937 -->
> **Source:** Issue #1937

Closes #1937

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake sync PR #315 is blocked by unresolved Copilot review threads on Workflows-synced files from `sync/workflows-9a8064d02f64`.

Consumer PR: https://github.com/stranske/Inv-Man-Intake/pull/315  
Source sync branch: `sync/workflows-9a8064d02f64`  
Head: `c1eff4d6f3a05ed020992b990038862509f4068a`

The comments are source-of-truth Workflows concerns, not Inv-Man-Intake product work. The consumer repo should not patch synced files locally.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Inv-Man-Intake#315](https://github.com/stranske/Inv-Man-Intake/issues/315)
- [stranske/Travel-Plan-Permission#965](https://github.com/stranske/Travel-Plan-Permission/issues/965)
- [stranske/Travel-Plan-Permission#963](https://github.com/stranske/Travel-Plan-Permission/issues/963)
- [stranske/Travel-Plan-Permission#962](https://github.com/stranske/Travel-Plan-Permission/issues/962)
- [stranske/Travel-Plan-Permission#961](https://github.com/stranske/Travel-Plan-Permission/issues/961)
- [stranske/Travel-Plan-Permission#960](https://github.com/stranske/Travel-Plan-Permission/issues/960)
- [stranske/Travel-Plan-Permission#959](https://github.com/stranske/Travel-Plan-Permission/issues/959)
- [stranske/Travel-Plan-Permission#958](https://github.com/stranske/Travel-Plan-Permission/issues/958)
- [stranske/Travel-Plan-Permission#957](https://github.com/stranske/Travel-Plan-Permission/issues/957)
- [stranske/Template#639](https://github.com/stranske/Template/issues/639)
- [stranske/Template#637](https://github.com/stranske/Template/issues/637)
- [#315](https://github.com/stranske/Workflows/issues/315)
- [#123](https://github.com/stranske/Workflows/issues/123)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Reproduce the seven review concerns against current Workflows `main` or commit `c1eff4d6f3a05ed020992b990038862509f4068a`.
  - [ ] Define scope for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
- [ ] Update `.github/scripts/source_context.js` to stop treating arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PRs.
- [ ] Update `scripts/aggregate_agent_metrics.py` to avoid counting missing verifier model metadata when `verifier_mode` is empty or unknown, or add a dedicated unknown-mode counter.
- [ ] Update `.github/scripts/coverage_monitor_summary.js` so PR source context coverage is not required when the workflow does not generate the report.
- [ ] Fix the Markdown table rows in `docs/LABELS.md` so they do not render an extra empty column.
- [ ] Add or update focused tests covering source-context issue detection behavior in `.github/scripts/source_context.js`.
- [ ] Add or update focused tests covering optional-report behavior in `.github/scripts/coverage_monitor_summary.js`.
- [ ] Add or update focused tests covering verifier-mode handling in `scripts/aggregate_agent_metrics.py`.
- [ ] Test the changed Workflows scripts and related test suites locally and ensure CI passes for the updated files.
  - [ ] Run the changed Workflows scripts (verify: confirm completion in repo) related test suites locally to verify functionality
  - [ ] Verify that CI passes for all updated files after pushing changes
- [ ] Update the Workflows follow-up PR description or comments with explicit disposition for any review thread that is intentionally not code-actionable.
- [ ] Add a comment on Inv-Man-Intake PR #315 linking to the Workflows follow-up before the downstream lane is paused.
- [ ] Wait for or regenerate the refreshed consumer sync PR through the normal sync flow without making consumer-local patches to synced files.

#### Acceptance criteria
- [ ] `.github/scripts/source_context.js` no longer classifies arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PR references in the added or updated tests.
- [ ] `scripts/aggregate_agent_metrics.py` added or updated tests verify that empty or unknown `verifier_mode` values do not inflate missing verifier model metadata counts, or that a dedicated unknown-mode counter is emitted instead.
- [ ] `.github/scripts/coverage_monitor_summary.js` added or updated tests verify that coverage checks do not fail when the PR source context report is absent and the workflow does not generate it.
- [ ] `docs/LABELS.md` renders the updated table rows without an extra empty column when inspected as valid Markdown table syntax.
- [ ] The Workflows PR contains code changes or explicit documented dispositions for all seven review threads linked from Inv-Man-Intake PR #315.
- [ ] No changes are made in Inv-Man-Intake to patch synced Workflows files locally.
- [ ] The updated Workflows tests pass locally or in CI for the modified scripts.
- [ ] Inv-Man-Intake PR #315 includes a comment linking to the Workflows follow-up PR or commit.

**Head SHA:** 0a7b60d9df9d0f7d7448239588978b8307c9dde1
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634139) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634141) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/24975634135) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634133) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634130) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634132) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634138) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634142) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634134) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24975634152) |
<!-- auto-status-summary:end -->