### PR TITLE
Fix issue-reference source override matching

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -18,6 +18,7 @@ const {
   buildSourceContextRepairCommentBody,
   buildSourceContextResolvedCommentBody,
   resolveExplicitNonIssueWorkflowSourceContext,
+  extractExplicitIssueSyncNumbers,
   hasExplicitIssueSyncReference,
   resolveNonIssueWorkflowSourceContextForBodySync,
   resolveSourceContextRepairComment,
@@ -551,6 +552,16 @@ test('hasExplicitIssueSyncReference ignores heuristic issue-number sources', () 
   assert.equal(hasExplicitIssueSyncReference({ body: '<!-- meta:issue:123 -->' }), false);
 });
 
+test('extractExplicitIssueSyncNumbers returns only explicit issue references', () => {
+  assert.deepEqual(
+    Array.from(extractExplicitIssueSyncNumbers({
+      title: 'Review follow-up',
+      body: 'Closes #123\nReferences issue #456\nReview follow-up from PR #789',
+    })).sort((a, b) => a - b),
+    [123, 456],
+  );
+});
+
 test('resolveNonIssueWorkflowSourceContextForBodySync honors explicit non-issue markers over heuristics', () => {
   const branchHeuristicContext = resolveNonIssueWorkflowSourceContextForBodySync(
     {
@@ -595,6 +606,23 @@ test('resolveNonIssueWorkflowSourceContextForBodySync yields to explicit issue r
   );
 
   assert.equal(context, null);
+});
+
+test('resolveNonIssueWorkflowSourceContextForBodySync preserves non-issue context when explicit issue differs from heuristic', () => {
+  const context = resolveNonIssueWorkflowSourceContextForBodySync(
+    {
+      body: [
+        'Closes #123',
+        '<!-- workflow-source:local_request -->',
+        '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+      ].join('\n'),
+      head: { ref: 'codex/issue-99' },
+    },
+    99,
+  );
+
+  assert.equal(context.sourceType, 'local_request');
+  assert.equal(context.sourceRef, 'codex-thread-2026-04-26');
 });
 
 test('resolveSourceContextRepairComment updates an existing warning once', async () => {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -1026,11 +1026,23 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
   };
 }
 
-function hasExplicitIssueSyncReference(pr = {}) {
+function extractExplicitIssueSyncNumbers(pr = {}) {
   const text = `${pr.title || ''}\n${pr.body || ''}`;
-  const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
-  const explicitIssueReference = /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#[0-9]+\b/i;
-  return explicitClosingReference.test(text) || explicitIssueReference.test(text);
+  const issueNumbers = new Set();
+  const patterns = [
+    /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#([0-9]+)\b/gi,
+    /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#([0-9]+)\b/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      issueNumbers.add(Number(match[1]));
+    }
+  }
+  return issueNumbers;
+}
+
+function hasExplicitIssueSyncReference(pr = {}) {
+  return extractExplicitIssueSyncNumbers(pr).size > 0;
 }
 
 function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
@@ -1038,7 +1050,8 @@ function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = 
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (issueNumber && hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueNumbers = extractExplicitIssueSyncNumbers(pr);
+  if (issueNumber && explicitIssueNumbers.has(Number(issueNumber))) {
     return null;
   }
   return explicitNonIssueSourceContext;
@@ -1669,6 +1682,7 @@ module.exports = {
   buildSourceContextRepairCommentBody,
   buildSourceContextResolvedCommentBody,
   resolveExplicitNonIssueWorkflowSourceContext,
+  extractExplicitIssueSyncNumbers,
   hasExplicitIssueSyncReference,
   resolveNonIssueWorkflowSourceContextForBodySync,
   resolveSourceContextRepairComment,

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -468,9 +468,9 @@ def _verifier_mode_requires_model_metadata(entry: dict[str, Any]) -> bool:
 
 
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    stop_reasons = Counter()
-    actions = Counter()
-    gate_results = Counter()
+    stop_reasons: Counter[str] = Counter()
+    actions: Counter[str] = Counter()
+    gate_results: Counter[str] = Counter()
     iterations: list[int] = []
     prs: set[int] = set()
     tasks_complete = 0
@@ -513,8 +513,8 @@ def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _summarise_autofix(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    triggers = Counter()
-    gate_results = Counter()
+    triggers: Counter[str] = Counter()
+    gate_results: Counter[str] = Counter()
     prs: set[int] = set()
     fixes_applied = 0
     for entry in entries:
@@ -542,28 +542,28 @@ def _summarise_verifier(
     entries: list[dict[str, Any]],
     ledger_entries: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    verdicts = Counter()
-    terminal_dispositions = Counter()
-    terminal_sources = Counter()
-    verifier_models = Counter()
-    model_selection_reasons = Counter()
-    verifier_cli_versions = Counter()
-    unsupported_verifier_models = Counter()
-    unsupported_model_dispositions = Counter()
-    missing_verifier_model_metadata = Counter()
+    verdicts: Counter[str] = Counter()
+    terminal_dispositions: Counter[str] = Counter()
+    terminal_sources: Counter[str] = Counter()
+    verifier_models: Counter[str] = Counter()
+    model_selection_reasons: Counter[str] = Counter()
+    verifier_cli_versions: Counter[str] = Counter()
+    unsupported_verifier_models: Counter[str] = Counter()
+    unsupported_model_dispositions: Counter[str] = Counter()
+    missing_verifier_model_metadata: Counter[str] = Counter()
     unsupported_models = _unsupported_verifier_models()
     model_metadata_required = _verifier_model_metadata_required()
     model_metadata_required_after = _verifier_model_metadata_required_after()
-    legacy_missing_verifier_model_metadata = Counter()
-    verifier_modes = Counter()
-    ledger_dispositions = Counter()
+    legacy_missing_verifier_model_metadata: Counter[str] = Counter()
+    verifier_modes: Counter[str] = Counter()
+    ledger_dispositions: Counter[str] = Counter()
     ledger_followup_issues: set[int] = set()
     ledger_prs: set[int] = set()
     ledger_needs_human = 0
     ledger_chain_depths: list[int] = []
     ledger_policy_records = 0
-    ledger_policy_actions = Counter()
-    ledger_policy_triggers = Counter()
+    ledger_policy_actions: Counter[str] = Counter()
+    ledger_policy_triggers: Counter[str] = Counter()
     ledger_policy_depth_limit_exceeded = 0
     verifier_run_keys: set[str] = set()
     prs: set[int] = set()
@@ -702,9 +702,9 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     step_durations: dict[str, list[float]] = {}
     step_successes: dict[str, int] = {}
     step_failures: dict[str, int] = {}
-    cycle_counts = Counter()
-    failure_reasons = Counter()
-    escalation_reasons = Counter()
+    cycle_counts: Counter[str] = Counter()
+    failure_reasons: Counter[str] = Counter()
+    escalation_reasons: Counter[str] = Counter()
     cycle_records = 0
     cycle_steps_attempted = 0
     cycle_steps_completed = 0
@@ -782,14 +782,14 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _summarise_codex_cli_freshness(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    statuses = Counter()
-    packages = Counter()
-    pinned_versions = Counter()
-    latest_versions = Counter()
+    statuses: Counter[str] = Counter()
+    packages: Counter[str] = Counter()
+    pinned_versions: Counter[str] = Counter()
+    latest_versions: Counter[str] = Counter()
     max_major_delta = 0
     max_minor_delta = 0
     max_patch_delta = 0
-    update_targets = Counter()
+    update_targets: Counter[str] = Counter()
     for entry in entries:
         status = _normalize_counter_token(entry.get("status"))
         statuses[status] += 1

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -1026,11 +1026,23 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
   };
 }
 
-function hasExplicitIssueSyncReference(pr = {}) {
+function extractExplicitIssueSyncNumbers(pr = {}) {
   const text = `${pr.title || ''}\n${pr.body || ''}`;
-  const explicitClosingReference = /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#[0-9]+\b/i;
-  const explicitIssueReference = /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#[0-9]+\b/i;
-  return explicitClosingReference.test(text) || explicitIssueReference.test(text);
+  const issueNumbers = new Set();
+  const patterns = [
+    /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)\s*[:#-]?\s*#([0-9]+)\b/gi,
+    /\b(?:(?:relate[sd]?\s+to|references?)\s+(?:issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#([0-9]+)\b/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      issueNumbers.add(Number(match[1]));
+    }
+  }
+  return issueNumbers;
+}
+
+function hasExplicitIssueSyncReference(pr = {}) {
+  return extractExplicitIssueSyncNumbers(pr).size > 0;
 }
 
 function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
@@ -1038,7 +1050,8 @@ function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = 
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (issueNumber && hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueNumbers = extractExplicitIssueSyncNumbers(pr);
+  if (issueNumber && explicitIssueNumbers.has(Number(issueNumber))) {
     return null;
   }
   return explicitNonIssueSourceContext;
@@ -1669,6 +1682,7 @@ module.exports = {
   buildSourceContextRepairCommentBody,
   buildSourceContextResolvedCommentBody,
   resolveExplicitNonIssueWorkflowSourceContext,
+  extractExplicitIssueSyncNumbers,
   hasExplicitIssueSyncReference,
   resolveNonIssueWorkflowSourceContextForBodySync,
   resolveSourceContextRepairComment,

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -468,9 +468,9 @@ def _verifier_mode_requires_model_metadata(entry: dict[str, Any]) -> bool:
 
 
 def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    stop_reasons = Counter()
-    actions = Counter()
-    gate_results = Counter()
+    stop_reasons: Counter[str] = Counter()
+    actions: Counter[str] = Counter()
+    gate_results: Counter[str] = Counter()
     iterations: list[int] = []
     prs: set[int] = set()
     tasks_complete = 0
@@ -513,8 +513,8 @@ def _summarise_keepalive(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _summarise_autofix(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    triggers = Counter()
-    gate_results = Counter()
+    triggers: Counter[str] = Counter()
+    gate_results: Counter[str] = Counter()
     prs: set[int] = set()
     fixes_applied = 0
     for entry in entries:
@@ -542,28 +542,28 @@ def _summarise_verifier(
     entries: list[dict[str, Any]],
     ledger_entries: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    verdicts = Counter()
-    terminal_dispositions = Counter()
-    terminal_sources = Counter()
-    verifier_models = Counter()
-    model_selection_reasons = Counter()
-    verifier_cli_versions = Counter()
-    unsupported_verifier_models = Counter()
-    unsupported_model_dispositions = Counter()
-    missing_verifier_model_metadata = Counter()
+    verdicts: Counter[str] = Counter()
+    terminal_dispositions: Counter[str] = Counter()
+    terminal_sources: Counter[str] = Counter()
+    verifier_models: Counter[str] = Counter()
+    model_selection_reasons: Counter[str] = Counter()
+    verifier_cli_versions: Counter[str] = Counter()
+    unsupported_verifier_models: Counter[str] = Counter()
+    unsupported_model_dispositions: Counter[str] = Counter()
+    missing_verifier_model_metadata: Counter[str] = Counter()
     unsupported_models = _unsupported_verifier_models()
     model_metadata_required = _verifier_model_metadata_required()
     model_metadata_required_after = _verifier_model_metadata_required_after()
-    legacy_missing_verifier_model_metadata = Counter()
-    verifier_modes = Counter()
-    ledger_dispositions = Counter()
+    legacy_missing_verifier_model_metadata: Counter[str] = Counter()
+    verifier_modes: Counter[str] = Counter()
+    ledger_dispositions: Counter[str] = Counter()
     ledger_followup_issues: set[int] = set()
     ledger_prs: set[int] = set()
     ledger_needs_human = 0
     ledger_chain_depths: list[int] = []
     ledger_policy_records = 0
-    ledger_policy_actions = Counter()
-    ledger_policy_triggers = Counter()
+    ledger_policy_actions: Counter[str] = Counter()
+    ledger_policy_triggers: Counter[str] = Counter()
     ledger_policy_depth_limit_exceeded = 0
     verifier_run_keys: set[str] = set()
     prs: set[int] = set()
@@ -702,9 +702,9 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     step_durations: dict[str, list[float]] = {}
     step_successes: dict[str, int] = {}
     step_failures: dict[str, int] = {}
-    cycle_counts = Counter()
-    failure_reasons = Counter()
-    escalation_reasons = Counter()
+    cycle_counts: Counter[str] = Counter()
+    failure_reasons: Counter[str] = Counter()
+    escalation_reasons: Counter[str] = Counter()
     cycle_records = 0
     cycle_steps_attempted = 0
     cycle_steps_completed = 0
@@ -782,14 +782,14 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _summarise_codex_cli_freshness(entries: list[dict[str, Any]]) -> dict[str, Any]:
-    statuses = Counter()
-    packages = Counter()
-    pinned_versions = Counter()
-    latest_versions = Counter()
+    statuses: Counter[str] = Counter()
+    packages: Counter[str] = Counter()
+    pinned_versions: Counter[str] = Counter()
+    latest_versions: Counter[str] = Counter()
     max_major_delta = 0
     max_minor_delta = 0
     max_patch_delta = 0
-    update_targets = Counter()
+    update_targets: Counter[str] = Counter()
     for entry in entries:
         status = _normalize_counter_token(entry.get("status"))
         statuses[status] += 1


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1937 -->
> **Source:** Issue #1937

Closes #1937

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake sync PR #315 is blocked by unresolved Copilot review threads on Workflows-synced files from `sync/workflows-9a8064d02f64`.

Consumer PR: https://github.com/stranske/Inv-Man-Intake/pull/315  
Source sync branch: `sync/workflows-9a8064d02f64`  
Head: `c1eff4d6f3a05ed020992b990038862509f4068a`

The comments are source-of-truth Workflows concerns, not Inv-Man-Intake product work. The consumer repo should not patch synced files locally.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Inv-Man-Intake#315](https://github.com/stranske/Inv-Man-Intake/issues/315)
- [stranske/Travel-Plan-Permission#965](https://github.com/stranske/Travel-Plan-Permission/issues/965)
- [stranske/Travel-Plan-Permission#963](https://github.com/stranske/Travel-Plan-Permission/issues/963)
- [stranske/Travel-Plan-Permission#962](https://github.com/stranske/Travel-Plan-Permission/issues/962)
- [stranske/Travel-Plan-Permission#961](https://github.com/stranske/Travel-Plan-Permission/issues/961)
- [stranske/Travel-Plan-Permission#960](https://github.com/stranske/Travel-Plan-Permission/issues/960)
- [stranske/Travel-Plan-Permission#959](https://github.com/stranske/Travel-Plan-Permission/issues/959)
- [stranske/Travel-Plan-Permission#958](https://github.com/stranske/Travel-Plan-Permission/issues/958)
- [stranske/Travel-Plan-Permission#957](https://github.com/stranske/Travel-Plan-Permission/issues/957)
- [stranske/Template#639](https://github.com/stranske/Template/issues/639)
- [stranske/Template#637](https://github.com/stranske/Template/issues/637)
- [#315](https://github.com/stranske/Workflows/issues/315)
- [#123](https://github.com/stranske/Workflows/issues/123)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Reproduce the seven review concerns against current Workflows `main` or commit `c1eff4d6f3a05ed020992b990038862509f4068a`.
  - [ ] Define scope for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the source_context.js review concern about arbitrary #123 references being treated as issue-sourced PRs (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the aggregate_agent_metrics.py review concern about inflating missing verifier model metadata when verifier_mode is empty (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the coverage_monitor_summary.js review concern about mandatory PR source context coverage (verify: confirm completion in repo)
  - [ ] Define scope for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Reproduce the LABELS.md review concern about extra empty columns in Markdown table rendering (verify: confirm completion in repo)
- [ ] Update `.github/scripts/source_context.js` to stop treating arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PRs.
- [ ] Update `scripts/aggregate_agent_metrics.py` to avoid counting missing verifier model metadata when `verifier_mode` is empty or unknown, or add a dedicated unknown-mode counter.
- [ ] Update `.github/scripts/coverage_monitor_summary.js` so PR source context coverage is not required when the workflow does not generate the report.
- [ ] Fix the Markdown table rows in `docs/LABELS.md` so they do not render an extra empty column.
- [ ] Add or update focused tests covering source-context issue detection behavior in `.github/scripts/source_context.js`.
- [ ] Add or update focused tests covering optional-report behavior in `.github/scripts/coverage_monitor_summary.js`.
- [ ] Add or update focused tests covering verifier-mode handling in `scripts/aggregate_agent_metrics.py`.
- [ ] Test the changed Workflows scripts and related test suites locally and ensure CI passes for the updated files.
  - [ ] Run the changed Workflows scripts (verify: confirm completion in repo) related test suites locally to verify functionality
  - [ ] Verify that CI passes for all updated files after pushing changes
- [ ] Update the Workflows follow-up PR description or comments with explicit disposition for any review thread that is intentionally not code-actionable.
- [ ] Add a comment on Inv-Man-Intake PR #315 linking to the Workflows follow-up before the downstream lane is paused.
- [ ] Wait for or regenerate the refreshed consumer sync PR through the normal sync flow without making consumer-local patches to synced files.

#### Acceptance criteria
- [ ] `.github/scripts/source_context.js` no longer classifies arbitrary `#123` references, including `Review follow-up from PR #...`, as issue-sourced PR references in the added or updated tests.
- [ ] `scripts/aggregate_agent_metrics.py` added or updated tests verify that empty or unknown `verifier_mode` values do not inflate missing verifier model metadata counts, or that a dedicated unknown-mode counter is emitted instead.
- [ ] `.github/scripts/coverage_monitor_summary.js` added or updated tests verify that coverage checks do not fail when the PR source context report is absent and the workflow does not generate it.
- [ ] `docs/LABELS.md` renders the updated table rows without an extra empty column when inspected as valid Markdown table syntax.
- [ ] The Workflows PR contains code changes or explicit documented dispositions for all seven review threads linked from Inv-Man-Intake PR #315.
- [ ] No changes are made in Inv-Man-Intake to patch synced Workflows files locally.
- [ ] The updated Workflows tests pass locally or in CI for the modified scripts.
- [ ] Inv-Man-Intake PR #315 includes a comment linking to the Workflows follow-up PR or commit.

**Head SHA:** 5ab2c2476e63a280ca07bfc36e948cd439472245
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315447) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315454) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315444) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315434) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315432) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315435) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315449) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315446) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315442) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/24976315438) |
<!-- auto-status-summary:end -->