### PR TITLE
fix: preserve explicit non-issue PR meta sources

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -556,13 +556,14 @@ test('hasExplicitIssueSyncReference ignores heuristic issue-number sources', () 
   assert.equal(hasExplicitIssueSyncReference({ body: 'This issue only mentions review follow-up PR #123' }), false);
   assert.equal(hasExplicitIssueSyncReference({ body: 'refs in this paragraph mention PR #123' }), false);
   assert.equal(hasExplicitIssueSyncReference({ body: '<!-- meta:issue:123 -->' }), true);
+  assert.equal(hasExplicitIssueSyncReference({ body: 'Closes #0' }), false);
 });
 
 test('extractExplicitIssueSyncNumbers returns only explicit issue references', () => {
   assert.deepEqual(
     Array.from(extractExplicitIssueSyncNumbers({
       title: 'Review follow-up',
-      body: 'Closes #123\nReferences issue #456\nRefs #234\nRelated to campaign issue #345\n> **Source:** Issue #678\n<!-- meta:issue:567 -->\nReview follow-up from PR #789',
+      body: 'Closes #123\nCloses #0\nReferences issue #456\nRefs #234\nRelated to campaign issue #345\n> **Source:** Issue #678\n<!-- meta:issue:567 -->\n<!-- meta:issue:0 -->\nReview follow-up from PR #789',
     })).sort((a, b) => a - b),
     [123, 234, 345, 456, 567, 678],
   );
@@ -631,7 +632,7 @@ test('resolveNonIssueWorkflowSourceContextForBodySync yields to explicit issue r
   assert.equal(context, null);
 });
 
-test('resolveNonIssueWorkflowSourceContextForBodySync yields to issue numbers even when explicit issue differs', () => {
+test('resolveNonIssueWorkflowSourceContextForBodySync preserves non-issue markers when explicit issue differs', () => {
   const context = resolveNonIssueWorkflowSourceContextForBodySync(
     {
       body: [
@@ -644,7 +645,8 @@ test('resolveNonIssueWorkflowSourceContextForBodySync yields to issue numbers ev
     99,
   );
 
-  assert.equal(context, null);
+  assert.equal(context.sourceType, 'local_request');
+  assert.equal(context.sourceRef, 'codex-thread-2026-04-26');
 });
 
 test('resolveSourceContextRepairComment updates an existing warning once', async () => {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -1060,7 +1060,8 @@ function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = 
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueSyncNumbers = extractExplicitIssueSyncNumbers(pr);
+  if (explicitIssueSyncNumbers.has(Number(issueNumber))) {
     return null;
   }
   return explicitNonIssueSourceContext;

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -1060,7 +1060,8 @@ function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = 
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueSyncNumbers = extractExplicitIssueSyncNumbers(pr);
+  if (explicitIssueSyncNumbers.has(Number(issueNumber))) {
     return null;
   }
   return explicitNonIssueSourceContext;


### PR DESCRIPTION
## Summary
- suppress explicit non-issue workflow-source body sync only when the extracted issue number is explicitly referenced by the PR
- keep explicit issue extraction limited to positive issue numbers in regression coverage
- update the consumer template mirror for agents_pr_meta_update_body.js

## Validation
- node --test .github/scripts/__tests__/agents-pr-meta-update-body.test.js
- python scripts/validate_template_sync.py

Addresses review feedback from stranske/Counter_Risk#501.