### PR TITLE
Prevent cross-repo refs becoming source issues

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
@@ -849,6 +849,32 @@ test('extractIssueNumberFromPull treats "Task #N" as a valid issue ref', () => {
   assert.equal(extractIssueNumberFromPull(pull), 42);
 });
 
+test('extractIssueNumberFromPull ignores cross-repo consumer issue references', () => {
+  for (const body of [
+    'Addresses consumer sync review comments on Counter_Risk #502 and Travel-Plan-Permission #980.',
+    'Addresses consumer sync review comments on Counter_Risk#502 and owner/repo#980.',
+    'Portable-Alpha-Extension-Model #1710 exposed the same source-owned blocker.',
+  ]) {
+    assert.equal(extractIssueNumberFromPull({ body, head: { ref: 'feature' }, title: 'stuff' }), null, body);
+  }
+});
+
+test('extractIssueNumberFromPull still accepts explicit local issue references', () => {
+  assert.equal(
+    extractIssueNumberFromPull({
+      body: 'Counter_Risk #502 exposed a blocker. Source issue #1937 tracks the Workflows fix.',
+      head: { ref: 'feature' },
+      title: 'stuff',
+    }),
+    1937,
+  );
+  assert.equal(extractIssueNumberFromPull({ body: 'Fixes issue #123', head: { ref: 'feature' }, title: 'stuff' }), 123);
+  assert.equal(extractIssueNumberFromPull({ body: 'Some text\nIssue #123', head: { ref: 'feature' }, title: 'stuff' }), 123);
+  assert.equal(extractIssueNumberFromPull({ body: '- Issue #123', head: { ref: 'feature' }, title: 'stuff' }), 123);
+  assert.equal(extractIssueNumberFromPull({ body: '> Issue #123', head: { ref: 'feature' }, title: 'stuff' }), 123);
+  assert.equal(extractIssueNumberFromPull({ body: '- **Source issue** #123', head: { ref: 'feature' }, title: 'stuff' }), 123);
+});
+
 test('extractIssueNumberFromPull skips "version #N" in body', () => {
   const pull = { body: 'Upgraded to version #4', head: { ref: 'feature' }, title: 'stuff' };
   assert.equal(extractIssueNumberFromPull(pull), null);

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -204,6 +204,28 @@ function parseAllowedLogins(env) {
   return new Set(raw);
 }
 
+function hasExplicitIssueReferencePrefix(value) {
+  const rawPrefix = String(value || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[_[\]()`~]/g, ' ');
+  const prefix = rawPrefix
+    .trim()
+    .replace(/[>*]/g, ' ')
+    .replace(/\s+/g, ' ');
+  const explicitIssuePrefix =
+    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+
+  if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
+    return false;
+  }
+
+  if (new RegExp(`\\b${explicitIssuePrefix}\\s*[:#-]?\\s*$`, 'i').test(prefix)) {
+    return true;
+  }
+
+  return new RegExp(`(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${explicitIssuePrefix}(?:\\*\\*)?\\s*[:#-]?\\s*$`, 'i').test(rawPrefix);
+}
+
 function extractIssueNumberFromPull(pull) {
   if (!pull) {
     return null;
@@ -247,6 +269,9 @@ function extractIssueNumberFromPull(pull) {
     // Skip non-issue refs like "Run #123", "run #123", "attempt #2"
     const preceding = bodyText.slice(Math.max(0, match.index - 20), match.index);
     if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    if (!hasExplicitIssueReferencePrefix(bodyText.slice(Math.max(0, match.index - 80), match.index))) {
       continue;
     }
     candidates.push(match[1]);

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -204,6 +204,28 @@ function parseAllowedLogins(env) {
   return new Set(raw);
 }
 
+function hasExplicitIssueReferencePrefix(value) {
+  const rawPrefix = String(value || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[_[\]()`~]/g, ' ');
+  const prefix = rawPrefix
+    .trim()
+    .replace(/[>*]/g, ' ')
+    .replace(/\s+/g, ' ');
+  const explicitIssuePrefix =
+    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+
+  if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
+    return false;
+  }
+
+  if (new RegExp(`\\b${explicitIssuePrefix}\\s*[:#-]?\\s*$`, 'i').test(prefix)) {
+    return true;
+  }
+
+  return new RegExp(`(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${explicitIssuePrefix}(?:\\*\\*)?\\s*[:#-]?\\s*$`, 'i').test(rawPrefix);
+}
+
 function extractIssueNumberFromPull(pull) {
   if (!pull) {
     return null;
@@ -247,6 +269,9 @@ function extractIssueNumberFromPull(pull) {
     // Skip non-issue refs like "Run #123", "run #123", "attempt #2"
     const preceding = bodyText.slice(Math.max(0, match.index - 20), match.index);
     if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    if (!hasExplicitIssueReferencePrefix(bodyText.slice(Math.max(0, match.index - 80), match.index))) {
       continue;
     }
     candidates.push(match[1]);


### PR DESCRIPTION
## Summary
- Tighten PR source issue extraction used by PR meta keepalive so body references need explicit local issue wording.
- Ignore consumer repo references such as Counter_Risk PR 502, Travel-Plan-Permission PR 980, and owner/repo references when no local source issue is declared.
- Keep explicit local references such as Source issue 1937, Fixes issue 123, and Task 42 working.
- Sync the consumer template copy.

## Why this is bounded
Workflows PR 1962 was evaluated against unrelated old Workflows issue 502 because consumer review text mentioned Counter_Risk PR 502. That polluted the PR body source metadata and caused the verifier to judge unrelated acceptance criteria. This fixes that root cause directly.

## Testing
- `scripts/sync_templates.sh`
- `node --test .github/scripts/__tests__/agents-pr-meta-keepalive.test.js .github/scripts/__tests__/agents-pr-meta-update-body.test.js .github/scripts/__tests__/source-context.test.js`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py --manifest .github/sync-manifest.yml --source sync-manifest`
- `git diff --check`