### PR TITLE
Fix no-automation source context handling

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
@@ -819,6 +819,17 @@ test('extractIssueNumberFromPull extracts from title', () => {
   assert.equal(extractIssueNumberFromPull(pull), 55);
 });
 
+test('extractIssueNumberFromPull ignores incidental title refs', () => {
+  assert.equal(
+    extractIssueNumberFromPull({ body: '', head: { ref: 'feature' }, title: 'bump dependency (#55)' }),
+    null,
+  );
+  assert.equal(
+    extractIssueNumberFromPull({ body: '', head: { ref: 'feature' }, title: 'sync from Counter_Risk #502' }),
+    null,
+  );
+});
+
 test('extractIssueNumberFromPull extracts from body hash ref', () => {
   const pull = { body: 'Fixes #123', head: { ref: 'feature' }, title: 'stuff' };
   assert.equal(extractIssueNumberFromPull(pull), 123);

--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -462,6 +462,16 @@ test('buildSourceContextResolvedCommentBody explains issue-backed source context
   assert.ok(!result.includes('No linked GitHub issue is required'));
 });
 
+test('buildSourceContextResolvedCommentBody does not claim missing issue is present', () => {
+  const result = buildSourceContextResolvedCommentBody(123, {
+    sourceType: 'github_issue',
+    requiresIssue: true,
+  });
+
+  assert.ok(!result.includes('A linked GitHub issue is present'));
+  assert.ok(result.includes('A linked GitHub issue is required but was not detected'));
+});
+
 test('resolveExplicitNonIssueWorkflowSourceContext preserves explicit automation source despite stale issue preamble', () => {
   const context = resolveExplicitNonIssueWorkflowSourceContext({
     body: [
@@ -679,6 +689,164 @@ test('resolveSourceContextRepairComment skips when no warning exists', async () 
   });
 
   assert.strictEqual(updated, false);
+});
+
+test('run resolves stale repair warning for valid no-automation workflow source', async () => {
+  const calls = {
+    listComments: 0,
+    updateComment: 0,
+    updateCommentBody: '',
+    issueGet: 0,
+    pullUpdate: 0,
+  };
+  const github = {
+    paginate: async () => {
+      calls.listComments += 1;
+      return [{ id: 99, body: '<!-- missing-issue-warning -->\nstale warning' }];
+    },
+    rest: {
+      pulls: {
+        get: async () => ({
+          data: {
+            number: 55,
+            state: 'open',
+            title: 'Manual workflow source',
+            body: [
+              '## Workflow Source',
+              '',
+              'Started from:',
+              '- [x] Do not automate',
+            ].join('\n'),
+            head: { sha: 'abc123', ref: 'manual/no-automation' },
+            labels: [],
+          },
+        }),
+        update: async () => {
+          calls.pullUpdate += 1;
+        },
+      },
+      issues: {
+        get: async () => {
+          calls.issueGet += 1;
+          throw new Error('should not fetch an issue');
+        },
+        listComments: {},
+        updateComment: async ({ body }) => {
+          calls.updateComment += 1;
+          calls.updateCommentBody = body;
+        },
+      },
+    },
+  };
+  const failures = [];
+  const core = {
+    info: () => {},
+    debug: () => {},
+    warning: () => {},
+    error: () => {},
+    setFailed: (message) => failures.push(message),
+  };
+
+  await run({
+    github,
+    context: {
+      repo: { owner: 'octo', repo: 'demo' },
+      eventName: 'pull_request',
+      payload: {
+        pull_request: {
+          number: 55,
+          head: { sha: 'abc123' },
+        },
+      },
+    },
+    core,
+    inputs: {},
+  });
+
+  assert.deepEqual(failures, []);
+  assert.strictEqual(calls.listComments, 1);
+  assert.strictEqual(calls.updateComment, 1);
+  assert.strictEqual(calls.issueGet, 0);
+  assert.strictEqual(calls.pullUpdate, 0);
+  assert.match(calls.updateCommentBody, /origin=manual_remote/);
+  assert.match(calls.updateCommentBody, /no_automation=true/);
+});
+
+test('run resolves stale repair warning for no-automation PRs with linked issues', async () => {
+  const calls = {
+    listComments: 0,
+    updateComment: 0,
+    updateCommentBody: '',
+    issueGet: 0,
+    pullUpdate: 0,
+  };
+  const github = {
+    paginate: async () => {
+      calls.listComments += 1;
+      return [{ id: 99, body: '<!-- missing-issue-warning -->\nstale warning' }];
+    },
+    rest: {
+      pulls: {
+        get: async () => ({
+          data: {
+            number: 55,
+            state: 'open',
+            title: 'Manual issue follow-up',
+            body: 'Closes #123',
+            head: { sha: 'abc123', ref: 'manual/no-automation' },
+            labels: [{ name: 'workflow:no-automation' }],
+          },
+        }),
+        update: async () => {
+          calls.pullUpdate += 1;
+        },
+      },
+      issues: {
+        get: async () => {
+          calls.issueGet += 1;
+          throw new Error('should not fetch an issue');
+        },
+        listComments: {},
+        updateComment: async ({ body }) => {
+          calls.updateComment += 1;
+          calls.updateCommentBody = body;
+        },
+      },
+    },
+  };
+  const failures = [];
+  const core = {
+    info: () => {},
+    debug: () => {},
+    warning: () => {},
+    error: () => {},
+    setFailed: (message) => failures.push(message),
+  };
+
+  await run({
+    github,
+    context: {
+      repo: { owner: 'octo', repo: 'demo' },
+      eventName: 'pull_request',
+      payload: {
+        pull_request: {
+          number: 55,
+          head: { sha: 'abc123' },
+        },
+      },
+    },
+    core,
+    inputs: {},
+  });
+
+  assert.deepEqual(failures, []);
+  assert.strictEqual(calls.listComments, 1);
+  assert.strictEqual(calls.updateComment, 1);
+  assert.strictEqual(calls.issueGet, 0);
+  assert.strictEqual(calls.pullUpdate, 0);
+  assert.match(calls.updateCommentBody, /origin=github_issue/);
+  assert.match(calls.updateCommentBody, /A linked GitHub issue is present/);
+  assert.match(calls.updateCommentBody, /no_automation=true/);
 });
 
 test('run leaves source repair warning unresolved when issue fetch fails', async () => {

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -120,10 +120,17 @@ test('extractIssueNumberFromPull requires explicit issue wording for body refere
   assert.equal(extractIssueNumberFromPull({ body: 'Related to issue #456' }), 456);
   assert.equal(extractIssueNumberFromPull({ body: 'Closes #789' }), 789);
   assert.equal(extractIssueNumberFromPull({ body: 'Issue #123' }), 123);
+  assert.equal(extractIssueNumberFromPull({ body: 'Task #124 is ready' }), 124);
   assert.equal(extractIssueNumberFromPull({ body: 'Resolve issue #123' }), 123);
   assert.equal(extractIssueNumberFromPull({ body: '> **Source:** Issue #123' }), 123);
   assert.equal(extractIssueNumberFromPull({ body: 'Known issue #123 blocks this PR' }), null);
   assert.equal(extractIssueNumberFromPull({ body: 'No issue #123 is linked' }), null);
+});
+
+test('extractIssueNumberFromPull requires explicit issue wording for title references', () => {
+  assert.equal(extractIssueNumberFromPull({ title: 'fix: resolve #55' }), 55);
+  assert.equal(extractIssueNumberFromPull({ title: 'bump dependency (#55)' }), null);
+  assert.equal(extractIssueNumberFromPull({ title: 'sync from Counter_Risk #502' }), null);
 });
 
 test('resolvePrSourceContext does not classify bare and PR-only mentions as issue-sourced', () => {
@@ -187,7 +194,7 @@ Automation intent:
   assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.LOCAL_REQUEST);
 });
 
-test('sourceTypeFromCheckedTemplate preserves source choice while automation intent disables automation', () => {
+test('sourceTypeFromCheckedTemplate preserves source choice without automation intent opt-out', () => {
   const body = `
 ## Workflow Source
 
@@ -202,7 +209,21 @@ Automation intent:
   assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.LOCAL_REQUEST);
   const context = resolvePrSourceContext({ body });
   assert.equal(context.sourceType, SOURCE_TYPES.LOCAL_REQUEST);
-  assert.equal(context.noAutomation, true);
+  assert.equal(context.noAutomation, false);
+});
+
+test('automation intent checkboxes do not disable automation without started-from source', () => {
+  const body = `
+## Workflow Source
+
+Automation intent:
+- [x] Human-only unless checks fail
+`;
+
+  const context = resolvePrSourceContext({ body });
+  assert.equal(sourceTypeFromCheckedTemplate(body), SOURCE_TYPES.UNKNOWN);
+  assert.equal(context.sourceType, SOURCE_TYPES.UNKNOWN);
+  assert.equal(context.noAutomation, false);
 });
 
 test('sourceTypeFromCheckedTemplate treats human-only PRs as manual remote work', () => {
@@ -245,6 +266,22 @@ automation: no_automation
 <!-- workflow-source:end -->
 `,
   }), true);
+});
+
+test('resolvePrSourceContext normalizes explicit no-automation to a valid manual source', () => {
+  const context = resolvePrSourceContext({
+    body: `
+<!-- workflow-source:start -->
+automation: no_automation
+<!-- workflow-source:end -->
+`,
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.MANUAL_REMOTE);
+  assert.equal(context.noAutomation, true);
+  assert.equal(context.isExplicit, true);
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, false);
 });
 
 test('resolvePrSourceContext preserves legacy human-only no-automation wording', () => {

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -188,6 +188,16 @@ try {
 const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
+const EXPLICIT_ISSUE_PREFIX_PATTERN =
+  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
+  `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
+  'i',
+);
+const EXPLICIT_ISSUE_LINE_PREFIX_REGEX = new RegExp(
+  `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${EXPLICIT_ISSUE_PREFIX_PATTERN}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
+  'i',
+);
 
 function normaliseLogin(login) {
   return String(login || '')
@@ -212,18 +222,42 @@ function hasExplicitIssueReferencePrefix(value) {
     .trim()
     .replace(/[>*]/g, ' ')
     .replace(/\s+/g, ' ');
-  const explicitIssuePrefix =
-    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
 
   if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
     return false;
   }
 
-  if (new RegExp(`\\b${explicitIssuePrefix}\\s*[:#-]?\\s*$`, 'i').test(prefix)) {
+  if (EXPLICIT_ISSUE_INLINE_PREFIX_REGEX.test(prefix)) {
     return true;
   }
 
-  return new RegExp(`(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${explicitIssuePrefix}(?:\\*\\*)?\\s*[:#-]?\\s*$`, 'i').test(rawPrefix);
+  return EXPLICIT_ISSUE_LINE_PREFIX_REGEX.test(rawPrefix);
+}
+
+function extractExplicitIssueNumberFromText(text) {
+  const value = String(text || '');
+  for (const match of value.matchAll(/#([0-9]+)/g)) {
+    if (!match[1]) {
+      continue;
+    }
+    const before = value.slice(Math.max(0, match.index - 200), match.index);
+    const token = before.split(/\s/).pop() || '';
+    if (token.includes('/')) {
+      continue;
+    }
+    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
+      continue;
+    }
+    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
+    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    if (!hasExplicitIssueReferencePrefix(value.slice(Math.max(0, match.index - 80), match.index))) {
+      continue;
+    }
+    return match[1];
+  }
+  return null;
 }
 
 function extractIssueNumberFromPull(pull) {
@@ -247,34 +281,14 @@ function extractIssueNumberFromPull(pull) {
   }
 
   const title = pull?.title || '';
-  const titleMatch = title.match(/#([0-9]+)/);
+  const titleMatch = extractExplicitIssueNumberFromText(title);
   if (titleMatch) {
-    candidates.push(titleMatch[1]);
+    candidates.push(titleMatch);
   }
 
-  for (const match of bodyText.matchAll(/#([0-9]+)/g)) {
-    if (!match[1]) {
-      continue;
-    }
-    // Skip cross-repo refs like owner/repo#123
-    const before = bodyText.slice(Math.max(0, match.index - 200), match.index);
-    const token = before.split(/\s/).pop() || '';
-    if (token.includes('/')) {
-      continue;
-    }
-    // Skip cross-repo shorthand like RepoName#123 or PR#123
-    if (match.index > 0 && /\w/.test(bodyText[match.index - 1])) {
-      continue;
-    }
-    // Skip non-issue refs like "Run #123", "run #123", "attempt #2"
-    const preceding = bodyText.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
-      continue;
-    }
-    if (!hasExplicitIssueReferencePrefix(bodyText.slice(Math.max(0, match.index - 80), match.index))) {
-      continue;
-    }
-    candidates.push(match[1]);
+  const bodyMatch = extractExplicitIssueNumberFromText(bodyText);
+  if (bodyMatch) {
+    candidates.push(bodyMatch);
   }
 
   for (const value of candidates) {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -980,20 +980,19 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
-  const isIssueBacked = Boolean(
-    sourceContext?.requiresIssue
-      || sourceContext?.issueNumber
-      || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE
-  );
+  const hasLinkedIssue = Boolean(sourceContext?.issueNumber);
+  const issueRequired = Boolean(sourceContext?.requiresIssue || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE);
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    isIssueBacked
+    hasLinkedIssue
       ? 'A linked GitHub issue is present for this PR.'
-      : 'No linked GitHub issue is required for this PR.',
+      : issueRequired
+        ? 'A linked GitHub issue is required but was not detected for this PR.'
+        : 'No linked GitHub issue is required for this PR.',
   ].join('\n');
 }
 
@@ -1349,26 +1348,17 @@ async function run({github: rawGithub, context, core, inputs}) {
   const scriptsBase = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE || process.cwd();
   
   // Load external helper scripts
-  let extractIssueNumberFromPull;
   let parseScopeTasksAcceptanceSections;
 
   try {
-    const keepalivePath = path.resolve(scriptsBase, '.github/scripts/agents_pr_meta_keepalive.js');
     const parserPath = path.resolve(scriptsBase, '.github/scripts/issue_scope_parser.js');
 
-    if (!fs.existsSync(keepalivePath)) {
-      throw new Error(`Keepalive script not found at ${keepalivePath}`);
-    }
     if (!fs.existsSync(parserPath)) {
       throw new Error(`Parser script not found at ${parserPath}`);
     }
 
-    extractIssueNumberFromPull = require(keepalivePath).extractIssueNumberFromPull;
     parseScopeTasksAcceptanceSections = require(parserPath).parseScopeTasksAcceptanceSections;
     
-    if (typeof extractIssueNumberFromPull !== 'function') {
-      throw new Error('extractIssueNumberFromPull is not exported from keepalive script');
-    }
     if (typeof parseScopeTasksAcceptanceSections !== 'function') {
       throw new Error('parseScopeTasksAcceptanceSections is not exported from parser script');
     }
@@ -1399,29 +1389,35 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const issueNumber = extractIssueNumberFromPull(pr);
   const sourceContext = resolvePrSourceContext(pr);
+  const issueNumber = sourceContext.issueNumber;
   if (sourceContext.noAutomation) {
     core.info(
-      `PR #${pr.number} has automation disabled (${formatSourceContextForLog(sourceContext)}); skipping PR body update while resolving stale workflow source repair comments.`,
+      `PR #${pr.number} has automation disabled (${formatSourceContextForLog(sourceContext)}); skipping PR body update.`,
     );
-    try {
-      const comments = await github.paginate(github.rest.issues.listComments, {
-        owner,
-        repo,
-        issue_number: pr.number,
-      });
-      await resolveSourceContextRepairComment({
-        github,
-        owner,
-        repo,
-        prNumber: pr.number,
-        comments,
-        sourceContext,
-        core,
-      });
-    } catch (error) {
-      core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+    if (sourceContext.isValid && (!sourceContext.requiresIssue || sourceContext.issueNumber)) {
+      try {
+        const comments = await github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pr.number,
+        });
+        await resolveSourceContextRepairComment({
+          github,
+          owner,
+          repo,
+          prNumber: pr.number,
+          comments,
+          sourceContext,
+          core,
+        });
+      } catch (error) {
+        core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+      }
+    } else {
+      core.warning(
+        `PR #${pr.number} has automation disabled but lacks valid non-issue workflow source context (${formatSourceContextForLog(sourceContext)}); leaving repair comment unresolved.`,
+      );
     }
     return;
   }

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -137,7 +137,8 @@ function workflowSourceSectionLines(body) {
 function startedFromLines(sectionLines) {
   const start = sectionLines.findIndex((line) => /^\s*Started from:\s*$/i.test(line));
   if (start < 0) {
-    return sectionLines;
+    const firstSubsection = sectionLines.findIndex((line) => /^\s*(Automation intent|Notes):\s*$/i.test(line));
+    return firstSubsection < 0 ? sectionLines : sectionLines.slice(0, firstSubsection);
   }
 
   const result = [];
@@ -155,7 +156,9 @@ function hasCheckedNoAutomationTemplate(body) {
   if (!sectionLines.length) {
     return false;
   }
-  return checkedLabels(sectionLines).some((label) => NO_AUTOMATION_CHECKBOX_PATTERN.test(label));
+  return checkedLabels(startedFromLines(sectionLines)).some((label) =>
+    NO_AUTOMATION_CHECKBOX_PATTERN.test(label)
+  );
 }
 
 function hasExplicitIssueReferencePrefix(value) {
@@ -167,7 +170,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
+  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue|task)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
     prefix
   );
 }
@@ -333,10 +336,13 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const sourceType = issueNumber
+  const detectedSourceType = issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
     : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
       || SOURCE_TYPES.UNKNOWN;
+  const sourceType = noAutomation && detectedSourceType === SOURCE_TYPES.UNKNOWN
+    ? SOURCE_TYPES.MANUAL_REMOTE
+    : detectedSourceType;
 
   const sourceRef =
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
@@ -362,7 +368,8 @@ function resolvePrSourceContext(pull = {}) {
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||
-        labelType !== SOURCE_TYPES.UNKNOWN
+        labelType !== SOURCE_TYPES.UNKNOWN ||
+        noAutomation
     ),
     requiresIssue: sourceType === SOURCE_TYPES.GITHUB_ISSUE,
     noAutomation,

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -188,6 +188,16 @@ try {
 const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
+const EXPLICIT_ISSUE_PREFIX_PATTERN =
+  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
+  `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
+  'i',
+);
+const EXPLICIT_ISSUE_LINE_PREFIX_REGEX = new RegExp(
+  `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${EXPLICIT_ISSUE_PREFIX_PATTERN}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
+  'i',
+);
 
 function normaliseLogin(login) {
   return String(login || '')
@@ -212,18 +222,42 @@ function hasExplicitIssueReferencePrefix(value) {
     .trim()
     .replace(/[>*]/g, ' ')
     .replace(/\s+/g, ' ');
-  const explicitIssuePrefix =
-    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
 
   if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
     return false;
   }
 
-  if (new RegExp(`\\b${explicitIssuePrefix}\\s*[:#-]?\\s*$`, 'i').test(prefix)) {
+  if (EXPLICIT_ISSUE_INLINE_PREFIX_REGEX.test(prefix)) {
     return true;
   }
 
-  return new RegExp(`(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${explicitIssuePrefix}(?:\\*\\*)?\\s*[:#-]?\\s*$`, 'i').test(rawPrefix);
+  return EXPLICIT_ISSUE_LINE_PREFIX_REGEX.test(rawPrefix);
+}
+
+function extractExplicitIssueNumberFromText(text) {
+  const value = String(text || '');
+  for (const match of value.matchAll(/#([0-9]+)/g)) {
+    if (!match[1]) {
+      continue;
+    }
+    const before = value.slice(Math.max(0, match.index - 200), match.index);
+    const token = before.split(/\s/).pop() || '';
+    if (token.includes('/')) {
+      continue;
+    }
+    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
+      continue;
+    }
+    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
+    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
+      continue;
+    }
+    if (!hasExplicitIssueReferencePrefix(value.slice(Math.max(0, match.index - 80), match.index))) {
+      continue;
+    }
+    return match[1];
+  }
+  return null;
 }
 
 function extractIssueNumberFromPull(pull) {
@@ -247,34 +281,14 @@ function extractIssueNumberFromPull(pull) {
   }
 
   const title = pull?.title || '';
-  const titleMatch = title.match(/#([0-9]+)/);
+  const titleMatch = extractExplicitIssueNumberFromText(title);
   if (titleMatch) {
-    candidates.push(titleMatch[1]);
+    candidates.push(titleMatch);
   }
 
-  for (const match of bodyText.matchAll(/#([0-9]+)/g)) {
-    if (!match[1]) {
-      continue;
-    }
-    // Skip cross-repo refs like owner/repo#123
-    const before = bodyText.slice(Math.max(0, match.index - 200), match.index);
-    const token = before.split(/\s/).pop() || '';
-    if (token.includes('/')) {
-      continue;
-    }
-    // Skip cross-repo shorthand like RepoName#123 or PR#123
-    if (match.index > 0 && /\w/.test(bodyText[match.index - 1])) {
-      continue;
-    }
-    // Skip non-issue refs like "Run #123", "run #123", "attempt #2"
-    const preceding = bodyText.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
-      continue;
-    }
-    if (!hasExplicitIssueReferencePrefix(bodyText.slice(Math.max(0, match.index - 80), match.index))) {
-      continue;
-    }
-    candidates.push(match[1]);
+  const bodyMatch = extractExplicitIssueNumberFromText(bodyText);
+  if (bodyMatch) {
+    candidates.push(bodyMatch);
   }
 
   for (const value of candidates) {

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -980,20 +980,19 @@ async function createIssueCommentWithRetry({ github, owner, repo, issueNumber, b
 }
 
 function buildSourceContextResolvedCommentBody(prNumber, sourceContext) {
-  const isIssueBacked = Boolean(
-    sourceContext?.requiresIssue
-      || sourceContext?.issueNumber
-      || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE
-  );
+  const hasLinkedIssue = Boolean(sourceContext?.issueNumber);
+  const issueRequired = Boolean(sourceContext?.requiresIssue || sourceContext?.sourceType === SOURCE_TYPES.GITHUB_ISSUE);
   return [
     '<!-- missing-issue-warning -->',
     '### Workflow source detected',
     '',
     `PR #${prNumber} now has valid workflow source context (${formatSourceContextForLog(sourceContext)}).`,
     '',
-    isIssueBacked
+    hasLinkedIssue
       ? 'A linked GitHub issue is present for this PR.'
-      : 'No linked GitHub issue is required for this PR.',
+      : issueRequired
+        ? 'A linked GitHub issue is required but was not detected for this PR.'
+        : 'No linked GitHub issue is required for this PR.',
   ].join('\n');
 }
 
@@ -1349,26 +1348,17 @@ async function run({github: rawGithub, context, core, inputs}) {
   const scriptsBase = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE || process.cwd();
   
   // Load external helper scripts
-  let extractIssueNumberFromPull;
   let parseScopeTasksAcceptanceSections;
 
   try {
-    const keepalivePath = path.resolve(scriptsBase, '.github/scripts/agents_pr_meta_keepalive.js');
     const parserPath = path.resolve(scriptsBase, '.github/scripts/issue_scope_parser.js');
 
-    if (!fs.existsSync(keepalivePath)) {
-      throw new Error(`Keepalive script not found at ${keepalivePath}`);
-    }
     if (!fs.existsSync(parserPath)) {
       throw new Error(`Parser script not found at ${parserPath}`);
     }
 
-    extractIssueNumberFromPull = require(keepalivePath).extractIssueNumberFromPull;
     parseScopeTasksAcceptanceSections = require(parserPath).parseScopeTasksAcceptanceSections;
     
-    if (typeof extractIssueNumberFromPull !== 'function') {
-      throw new Error('extractIssueNumberFromPull is not exported from keepalive script');
-    }
     if (typeof parseScopeTasksAcceptanceSections !== 'function') {
       throw new Error('parseScopeTasksAcceptanceSections is not exported from parser script');
     }
@@ -1399,29 +1389,35 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const issueNumber = extractIssueNumberFromPull(pr);
   const sourceContext = resolvePrSourceContext(pr);
+  const issueNumber = sourceContext.issueNumber;
   if (sourceContext.noAutomation) {
     core.info(
-      `PR #${pr.number} has automation disabled (${formatSourceContextForLog(sourceContext)}); skipping PR body update while resolving stale workflow source repair comments.`,
+      `PR #${pr.number} has automation disabled (${formatSourceContextForLog(sourceContext)}); skipping PR body update.`,
     );
-    try {
-      const comments = await github.paginate(github.rest.issues.listComments, {
-        owner,
-        repo,
-        issue_number: pr.number,
-      });
-      await resolveSourceContextRepairComment({
-        github,
-        owner,
-        repo,
-        prNumber: pr.number,
-        comments,
-        sourceContext,
-        core,
-      });
-    } catch (error) {
-      core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+    if (sourceContext.isValid && (!sourceContext.requiresIssue || sourceContext.issueNumber)) {
+      try {
+        const comments = await github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pr.number,
+        });
+        await resolveSourceContextRepairComment({
+          github,
+          owner,
+          repo,
+          prNumber: pr.number,
+          comments,
+          sourceContext,
+          core,
+        });
+      } catch (error) {
+        core.warning(`Failed to resolve workflow source repair comment: ${error.message}`);
+      }
+    } else {
+      core.warning(
+        `PR #${pr.number} has automation disabled but lacks valid non-issue workflow source context (${formatSourceContextForLog(sourceContext)}); leaving repair comment unresolved.`,
+      );
     }
     return;
   }

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -137,7 +137,8 @@ function workflowSourceSectionLines(body) {
 function startedFromLines(sectionLines) {
   const start = sectionLines.findIndex((line) => /^\s*Started from:\s*$/i.test(line));
   if (start < 0) {
-    return sectionLines;
+    const firstSubsection = sectionLines.findIndex((line) => /^\s*(Automation intent|Notes):\s*$/i.test(line));
+    return firstSubsection < 0 ? sectionLines : sectionLines.slice(0, firstSubsection);
   }
 
   const result = [];
@@ -155,7 +156,9 @@ function hasCheckedNoAutomationTemplate(body) {
   if (!sectionLines.length) {
     return false;
   }
-  return checkedLabels(sectionLines).some((label) => NO_AUTOMATION_CHECKBOX_PATTERN.test(label));
+  return checkedLabels(startedFromLines(sectionLines)).some((label) =>
+    NO_AUTOMATION_CHECKBOX_PATTERN.test(label)
+  );
 }
 
 function hasExplicitIssueReferencePrefix(value) {
@@ -167,7 +170,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
+  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue|task)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
     prefix
   );
 }
@@ -333,10 +336,13 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const sourceType = issueNumber
+  const detectedSourceType = issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
     : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
       || SOURCE_TYPES.UNKNOWN;
+  const sourceType = noAutomation && detectedSourceType === SOURCE_TYPES.UNKNOWN
+    ? SOURCE_TYPES.MANUAL_REMOTE
+    : detectedSourceType;
 
   const sourceRef =
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
@@ -362,7 +368,8 @@ function resolvePrSourceContext(pull = {}) {
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||
-        labelType !== SOURCE_TYPES.UNKNOWN
+        labelType !== SOURCE_TYPES.UNKNOWN ||
+        noAutomation
     ),
     requiresIssue: sourceType === SOURCE_TYPES.GITHUB_ISSUE,
     noAutomation,


### PR DESCRIPTION
## Summary
- Limit no-automation template checkbox detection to the Started from source choices so Automation intent checkboxes do not produce invalid unknown source contexts.
- Normalize explicit no-automation contexts to a valid manual source when no other source type is present.
- Resolve stale workflow source repair comments only when the no-automation context is a valid non-issue source.
- Sync the managed consumer template script copies.

## Validation
- node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/agents-pr-meta-update-body.test.js
- python scripts/validate_template_sync.py

Source work item: stranske/Pension-Data#348 review threads.