### PR TITLE
Fix keepalive no-automation sync follow-ups

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-keepalive.test.js
@@ -855,9 +855,9 @@ test('extractIssueNumberFromPull skips "step #N" in body', () => {
   assert.equal(extractIssueNumberFromPull(pull), null);
 });
 
-test('extractIssueNumberFromPull treats "Task #N" as a valid issue ref', () => {
+test('extractIssueNumberFromPull ignores task numbering', () => {
   const pull = { body: 'Task #42 is ready for review', head: { ref: 'feature' }, title: 'stuff' };
-  assert.equal(extractIssueNumberFromPull(pull), 42);
+  assert.equal(extractIssueNumberFromPull(pull), null);
 });
 
 test('extractIssueNumberFromPull ignores cross-repo consumer issue references', () => {

--- a/.github/scripts/__tests__/keepalive-worker-gate.test.js
+++ b/.github/scripts/__tests__/keepalive-worker-gate.test.js
@@ -42,7 +42,7 @@ function buildStateComment({ commentId, headSha, trace }) {
   };
 }
 
-function makeGithubStub({ prNumber, headSha, comments }) {
+function makeGithubStub({ prNumber, headSha, comments, pull = {} }) {
   const commentsByIssue = new Map([[prNumber, comments]]);
   return {
     rest: {
@@ -53,8 +53,20 @@ function makeGithubStub({ prNumber, headSha, comments }) {
           }
           return {
             data: {
-              head: { sha: headSha, ref: 'codex/issue-1' },
-              base: { ref: 'main' },
+              body: pull.body || '',
+              title: pull.title || 'Keepalive test PR',
+              labels: pull.labels || [],
+              head: {
+                sha: headSha,
+                ref: 'codex/issue-1',
+                repo: { fork: false, owner: { login: 'stranske' } },
+                ...(pull.head || {}),
+              },
+              base: {
+                ref: 'main',
+                repo: { owner: { login: 'stranske' } },
+                ...(pull.base || {}),
+              },
             },
           };
         },
@@ -150,6 +162,49 @@ test('keepalive worker gate executes when head changed despite matching instruct
   assert.equal(result.action, 'execute');
   assert.equal(result.reason, 'head-changed');
   assert.equal(result.headSha, currentHead);
+});
+
+test('keepalive worker gate skips no-automation keepalive comments', async () => {
+  const instructionId = 200;
+  const headSha = 'abc123';
+  const instructionComment = buildInstructionComment({ id: instructionId, trace: 'trace-no-auto', createdAt: '2024-01-01T01:00:00Z' });
+  const github = makeGithubStub({
+    prNumber: 123,
+    headSha,
+    comments: [instructionComment],
+    pull: {
+      body: [
+        '## Workflow Source',
+        '',
+        'Started from:',
+        '- [x] Do not automate',
+      ].join('\n'),
+    },
+  });
+  const result = await evaluateKeepaliveWorkerGate({ core: makeCore(), github, context: baseContext, env: baseEnv });
+  assert.equal(result.action, 'skip');
+  assert.equal(result.reason, 'no-automation-source-context');
+  assert.equal(result.instructionId, String(instructionId));
+});
+
+test('keepalive worker gate skips fork-pr keepalive comments', async () => {
+  const instructionId = 200;
+  const headSha = 'abc123';
+  const instructionComment = buildInstructionComment({ id: instructionId, trace: 'trace-fork', createdAt: '2024-01-01T01:00:00Z' });
+  const github = makeGithubStub({
+    prNumber: 123,
+    headSha,
+    comments: [instructionComment],
+    pull: {
+      head: {
+        repo: { fork: true, owner: { login: 'external-contributor' } },
+      },
+    },
+  });
+  const result = await evaluateKeepaliveWorkerGate({ core: makeCore(), github, context: baseContext, env: baseEnv });
+  assert.equal(result.action, 'skip');
+  assert.equal(result.reason, 'fork-pr');
+  assert.equal(result.instructionId, String(instructionId));
 });
 
 test('keepalive worker gate executes when keepalive disabled', async () => {

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -120,7 +120,7 @@ test('extractIssueNumberFromPull requires explicit issue wording for body refere
   assert.equal(extractIssueNumberFromPull({ body: 'Related to issue #456' }), 456);
   assert.equal(extractIssueNumberFromPull({ body: 'Closes #789' }), 789);
   assert.equal(extractIssueNumberFromPull({ body: 'Issue #123' }), 123);
-  assert.equal(extractIssueNumberFromPull({ body: 'Task #124 is ready' }), 124);
+  assert.equal(extractIssueNumberFromPull({ body: 'Task #124 is ready' }), null);
   assert.equal(extractIssueNumberFromPull({ body: 'Resolve issue #123' }), 123);
   assert.equal(extractIssueNumberFromPull({ body: '> **Source:** Issue #123' }), 123);
   assert.equal(extractIssueNumberFromPull({ body: 'Known issue #123 blocks this PR' }), null);

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -189,7 +189,7 @@ const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
 const EXPLICIT_ISSUE_PREFIX_PATTERN =
-  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|issue)';
 const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
   `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
   'i',

--- a/.github/scripts/keepalive_worker_gate.js
+++ b/.github/scripts/keepalive_worker_gate.js
@@ -135,7 +135,12 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
 
   const dispatch = normaliseLower(result.dispatch);
   const reason = normaliseLower(result.reason);
-  const isValid = dispatch === 'true' || reason === 'duplicate-keepalive' || reason === 'keepalive-detected';
+  const isValid =
+    dispatch === 'true' ||
+    reason === 'duplicate-keepalive' ||
+    reason === 'keepalive-detected' ||
+    reason === 'no-automation-source-context' ||
+    reason === 'fork-pr';
   if (!isValid) {
     return null;
   }
@@ -148,6 +153,7 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
     commentIdRaw: result.comment_id || String(comment.id || ''),
     trace: normalise(result.trace || comment.trace || ''),
     round: normalise(result.round || ''),
+    reason,
     url: comment.html_url || '',
     createdAt: Number.isFinite(createdAt) ? createdAt : 0,
   };
@@ -297,7 +303,13 @@ async function evaluateKeepaliveWorkerGate({ core, github, context, env = proces
   let action = 'execute';
   let reason;
 
-  if (!latestInstruction) {
+  if (latestInstruction?.reason === 'no-automation-source-context') {
+    action = 'skip';
+    reason = 'no-automation-source-context';
+  } else if (latestInstruction?.reason === 'fork-pr') {
+    action = 'skip';
+    reason = 'fork-pr';
+  } else if (!latestInstruction) {
     reason = 'missing-instruction';
   } else if (lastProcessed.commentId === 0n || !lastProcessed.headSha || !headSha) {
     reason = 'missing-history';

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -170,7 +170,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue|task)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
+  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
     prefix
   );
 }

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -189,7 +189,7 @@ const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
 const EXPLICIT_ISSUE_PREFIX_PATTERN =
-  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|task|issue)';
+  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|issue)';
 const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
   `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
   'i',

--- a/templates/consumer-repo/.github/scripts/keepalive_worker_gate.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_worker_gate.js
@@ -135,7 +135,12 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
 
   const dispatch = normaliseLower(result.dispatch);
   const reason = normaliseLower(result.reason);
-  const isValid = dispatch === 'true' || reason === 'duplicate-keepalive' || reason === 'keepalive-detected';
+  const isValid =
+    dispatch === 'true' ||
+    reason === 'duplicate-keepalive' ||
+    reason === 'keepalive-detected' ||
+    reason === 'no-automation-source-context' ||
+    reason === 'fork-pr';
   if (!isValid) {
     return null;
   }
@@ -148,6 +153,7 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
     commentIdRaw: result.comment_id || String(comment.id || ''),
     trace: normalise(result.trace || comment.trace || ''),
     round: normalise(result.round || ''),
+    reason,
     url: comment.html_url || '',
     createdAt: Number.isFinite(createdAt) ? createdAt : 0,
   };
@@ -297,7 +303,13 @@ async function evaluateKeepaliveWorkerGate({ core, github, context, env = proces
   let action = 'execute';
   let reason;
 
-  if (!latestInstruction) {
+  if (latestInstruction?.reason === 'no-automation-source-context') {
+    action = 'skip';
+    reason = 'no-automation-source-context';
+  } else if (latestInstruction?.reason === 'fork-pr') {
+    action = 'skip';
+    reason = 'fork-pr';
+  } else if (!latestInstruction) {
     reason = 'missing-instruction';
   } else if (lastProcessed.commentId === 0n || !lastProcessed.headSha || !headSha) {
     reason = 'missing-history';

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -170,7 +170,7 @@ function hasExplicitIssueReferencePrefix(value) {
     return false;
   }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue|task)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
+  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*issue\s*[:#-]?\s*$/i.test(
     prefix
   );
 }


### PR DESCRIPTION
## Summary
- stop treating `Task #N` task-list numbering as a GitHub issue link in source-context extraction
- make keepalive worker gate treat no-automation detection as a valid skip signal instead of falling back to missing-instruction execution
- sync consumer template script copies

## Validation
- node --test .github/scripts/__tests__/agents-pr-meta-keepalive.test.js .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/keepalive-worker-gate.test.js
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py --manifest .github/sync-manifest.yml --source sync-manifest
- git diff --check