### PR TITLE
fix: bound priority artifact page scans

### DIFF
--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -431,6 +431,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
   assert.match(markdown, /Weekly Metrics Artifact Selection/);
   assert.match(markdown, /Scan cap: 5 pages x 100 artifacts/);
   assert.match(markdown, /Priority producer scan cap: 10 runs per source workflow/);
+  assert.match(markdown, /Priority artifact page cap: 2 pages per run/);
   assert.match(markdown, /Selected artifacts: 2/);
   assert.match(
     markdown,
@@ -456,12 +457,30 @@ test('normalizes invalid environment-like limits to defaults', () => {
   assert.equal(options.max_per_family, 20);
   assert.equal(options.max_scan_pages, 5);
   assert.equal(options.priority_workflow_runs_per_source, 10);
+  assert.equal(options.priority_workflow_artifact_pages_per_run, 2);
 
   const disabledPriorityOptions = normalizeSelectionOptions({
     now_ms: NOW,
     priority_workflow_runs_per_source: '0',
   });
   assert.equal(disabledPriorityOptions.priority_workflow_runs_per_source, 0);
+});
+
+test('normalizes priority workflow artifact page cap independently from repo scan cap', () => {
+  const options = normalizeSelectionOptions({
+    now_ms: NOW,
+    max_scan_pages: 9,
+    priority_workflow_artifact_pages_per_run: '3',
+  });
+
+  assert.equal(options.max_scan_pages, 9);
+  assert.equal(options.priority_workflow_artifact_pages_per_run, 3);
+
+  const defaulted = normalizeSelectionOptions({
+    now_ms: NOW,
+    priority_workflow_artifact_pages_per_run: '0',
+  });
+  assert.equal(defaulted.priority_workflow_artifact_pages_per_run, 2);
 });
 
 test('deduplicates artifacts by stable id before selection', () => {
@@ -597,7 +616,8 @@ test('collects priority artifacts across paginated workflow run artifacts', asyn
       now_ms: NOW,
       priority_workflow_runs_per_source: 1,
       per_page: 1,
-      max_scan_pages: 2,
+      max_scan_pages: 5,
+      priority_workflow_artifact_pages_per_run: 2,
     },
     sources: [
       {
@@ -616,6 +636,54 @@ test('collects priority artifacts across paginated workflow run artifacts', asyn
     ['artifacts', 101, 1, 1],
     ['artifacts', 101, 1, 2],
   ]);
+});
+
+test('bounds priority artifact pagination with the per-run page cap', async () => {
+  const calls = [];
+  const client = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: {
+            workflow_runs: [
+              { id: 101, created_at: '2026-04-25T11:00:00Z', updated_at: '2026-04-25T11:00:00Z' },
+            ],
+          },
+        }),
+        listWorkflowRunArtifacts: async (params) => {
+          calls.push(params.page);
+          return {
+            data: {
+              artifacts: [artifact(params.page, `unrelated-${params.page}`, '2026-04-25T11:00:00Z')],
+            },
+          };
+        },
+      },
+    },
+  };
+
+  const artifacts = await collectPriorityWorkflowArtifacts({
+    github: client,
+    owner: 'owner',
+    repo: 'repo',
+    options: {
+      now_ms: NOW,
+      priority_workflow_runs_per_source: 1,
+      per_page: 1,
+      max_scan_pages: 5,
+      priority_workflow_artifact_pages_per_run: 2,
+    },
+    sources: [
+      {
+        workflow_id: 'reusable-bot-comment-handler.yml',
+        families: ['bot-comment-auth-coverage-reusable'],
+      },
+    ],
+    withRetry: (fn) => fn(client),
+  });
+
+  assert.deepEqual(artifacts, []);
+  assert.deepEqual(calls, [1, 2]);
 });
 
 test('collects priority artifacts until each source satisfies its own families', async () => {

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -7,6 +7,7 @@ const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
+const DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN = 2;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -153,6 +154,12 @@ function normalizeSelectionOptions(options = {}) {
       process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
     DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
   );
+  const priorityWorkflowArtifactPagesPerRun = parsePositiveInt(
+    options.priority_workflow_artifact_pages_per_run ??
+      options.priorityWorkflowArtifactPagesPerRun ??
+      process.env.METRICS_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
+    DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -162,6 +169,7 @@ function normalizeSelectionOptions(options = {}) {
     max_scan_pages: maxScanPages,
     per_page: perPage,
     priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
+    priority_workflow_artifact_pages_per_run: priorityWorkflowArtifactPagesPerRun,
     cutoff_ms: cutoffMs,
   };
 }
@@ -349,6 +357,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -385,6 +394,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -423,6 +433,7 @@ function formatSelectionMarkdown(report) {
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
     `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
+    `- Priority artifact page cap: ${report.config.priority_workflow_artifact_pages_per_run} pages per run`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -533,7 +544,7 @@ async function collectPriorityWorkflowArtifacts({
       if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
         continue;
       }
-      for (let page = 1; page <= config.max_scan_pages; page += 1) {
+      for (let page = 1; page <= config.priority_workflow_artifact_pages_per_run; page += 1) {
         let artifactResponse;
         try {
           artifactResponse = await withRetry((client) =>
@@ -636,6 +647,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--priority-workflow-runs-per-source') {
       options.priority_workflow_runs_per_source = next;
+      index += 1;
+    } else if (arg === '--priority-workflow-artifact-pages-per-run') {
+      options.priority_workflow_artifact_pages_per_run = next;
       index += 1;
     }
   }

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -7,6 +7,7 @@ const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
+const DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN = 2;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -153,6 +154,12 @@ function normalizeSelectionOptions(options = {}) {
       process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
     DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
   );
+  const priorityWorkflowArtifactPagesPerRun = parsePositiveInt(
+    options.priority_workflow_artifact_pages_per_run ??
+      options.priorityWorkflowArtifactPagesPerRun ??
+      process.env.METRICS_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
+    DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -162,6 +169,7 @@ function normalizeSelectionOptions(options = {}) {
     max_scan_pages: maxScanPages,
     per_page: perPage,
     priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
+    priority_workflow_artifact_pages_per_run: priorityWorkflowArtifactPagesPerRun,
     cutoff_ms: cutoffMs,
   };
 }
@@ -349,6 +357,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -385,6 +394,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -423,6 +433,7 @@ function formatSelectionMarkdown(report) {
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
     `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
+    `- Priority artifact page cap: ${report.config.priority_workflow_artifact_pages_per_run} pages per run`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -533,7 +544,7 @@ async function collectPriorityWorkflowArtifacts({
       if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
         continue;
       }
-      for (let page = 1; page <= config.max_scan_pages; page += 1) {
+      for (let page = 1; page <= config.priority_workflow_artifact_pages_per_run; page += 1) {
         let artifactResponse;
         try {
           artifactResponse = await withRetry((client) =>
@@ -636,6 +647,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--priority-workflow-runs-per-source') {
       options.priority_workflow_runs_per_source = next;
+      index += 1;
+    } else if (arg === '--priority-workflow-artifact-pages-per-run') {
+      options.priority_workflow_artifact_pages_per_run = next;
       index += 1;
     }
   }


### PR DESCRIPTION
## Summary\n- add a dedicated per-run page cap for priority workflow artifact scans\n- surface the cap in selection reports and CLI options\n- sync the consumer template copy and add regression coverage\n\n## Verification\n- node --test .github/scripts/__tests__/weekly-metrics-artifacts.test.js\n- scripts/validate_template_sync.py\n\nAddresses active Template sync review feedback from stranske/Template#657.