### PR TITLE
fix: address sync review blockers

### DIFF
--- a/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
+++ b/.github/scripts/__tests__/agents-pr-meta-update-body.test.js
@@ -625,17 +625,21 @@ test('resolveNonIssueWorkflowSourceContextForBodySync yields to explicit issue r
   assert.equal(context, null);
 });
 
-test('resolveNonIssueWorkflowSourceContextForBodySync yields to issue numbers even when explicit issue differs', () => {
-  const context = resolveNonIssueWorkflowSourceContextForBodySync({
-    body: [
-      'Closes #123',
-      '<!-- workflow-source:local_request -->',
-      '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
-    ].join('\n'),
-    head: { ref: 'codex/issue-99' },
-  });
+test('resolveNonIssueWorkflowSourceContextForBodySync preserves non-issue markers when explicit issue differs', () => {
+  const context = resolveNonIssueWorkflowSourceContextForBodySync(
+    {
+      body: [
+        'Closes #123',
+        '<!-- workflow-source:local_request -->',
+        '<!-- workflow-source-ref:codex-thread-2026-04-26 -->',
+      ].join('\n'),
+      head: { ref: 'codex/issue-99' },
+    },
+    99,
+  );
 
-  assert.equal(context, null);
+  assert.equal(context.sourceType, 'local_request');
+  assert.equal(context.sourceRef, 'codex-thread-2026-04-26');
 });
 
 test('resolveSourceContextRepairComment updates an existing warning once', async () => {

--- a/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
+++ b/.github/scripts/__tests__/weekly-metrics-artifacts.test.js
@@ -430,7 +430,7 @@ test('formats a human-visible selector summary for weekly metrics', () => {
 
   assert.match(markdown, /Weekly Metrics Artifact Selection/);
   assert.match(markdown, /Scan cap: 5 pages x 100 artifacts/);
-  assert.match(markdown, /Priority producer scan cap: 10 runs per source workflow/);
+  assert.match(markdown, /Priority producer scan cap: 3 runs per source workflow, 2 artifact pages per run/);
   assert.match(markdown, /Selected artifacts: 2/);
   assert.match(
     markdown,
@@ -455,7 +455,8 @@ test('normalizes invalid environment-like limits to defaults', () => {
   assert.equal(options.max_total, 80);
   assert.equal(options.max_per_family, 20);
   assert.equal(options.max_scan_pages, 5);
-  assert.equal(options.priority_workflow_runs_per_source, 10);
+  assert.equal(options.priority_workflow_runs_per_source, 3);
+  assert.equal(options.priority_workflow_artifact_pages_per_run, 2);
 
   const disabledPriorityOptions = normalizeSelectionOptions({
     now_ms: NOW,

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -4,6 +4,7 @@ const { createGithubApiCache } = require('./github-api-cache-client');
 const { makeTrace } = require('./keepalive_contract.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
 const {
+  extractIssueNumberFromPull,
   formatSourceContextForLog,
   resolvePrSourceContext,
 } = require('./source_context.js');
@@ -188,17 +189,6 @@ try {
 const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
-const EXPLICIT_ISSUE_PREFIX_PATTERN =
-  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|linked\\s+issue|issue)';
-const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
-  `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
-  'i',
-);
-const EXPLICIT_ISSUE_LINE_PREFIX_REGEX = new RegExp(
-  `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${EXPLICIT_ISSUE_PREFIX_PATTERN}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
-  'i',
-);
-
 function normaliseLogin(login) {
   return String(login || '')
     .trim()
@@ -212,93 +202,6 @@ function parseAllowedLogins(env) {
     .map((value) => normaliseLogin(value))
     .filter(Boolean);
   return new Set(raw);
-}
-
-function hasExplicitIssueReferencePrefix(value) {
-  const rawPrefix = String(value || '')
-    .replace(/\r\n?/g, '\n')
-    .replace(/[_[\]()`~]/g, ' ');
-  const prefix = rawPrefix
-    .trim()
-    .replace(/[>*]/g, ' ')
-    .replace(/\s+/g, ' ');
-
-  if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
-    return false;
-  }
-
-  if (EXPLICIT_ISSUE_INLINE_PREFIX_REGEX.test(prefix)) {
-    return true;
-  }
-
-  return EXPLICIT_ISSUE_LINE_PREFIX_REGEX.test(rawPrefix);
-}
-
-function extractExplicitIssueNumberFromText(text) {
-  const value = String(text || '');
-  for (const match of value.matchAll(/#([0-9]+)/g)) {
-    if (!match[1]) {
-      continue;
-    }
-    const before = value.slice(Math.max(0, match.index - 200), match.index);
-    const token = before.split(/\s/).pop() || '';
-    if (token.includes('/')) {
-      continue;
-    }
-    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
-      continue;
-    }
-    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
-      continue;
-    }
-    if (!hasExplicitIssueReferencePrefix(value.slice(Math.max(0, match.index - 80), match.index))) {
-      continue;
-    }
-    return match[1];
-  }
-  return null;
-}
-
-function extractIssueNumberFromPull(pull) {
-  if (!pull) {
-    return null;
-  }
-
-  const candidates = [];
-
-  const bodyText = pull?.body || '';
-  const metaMatch = bodyText.match(/<!--\s*meta:issue:([0-9]+)\s*-->/i);
-  if (metaMatch) {
-    candidates.push(metaMatch[1]);
-  }
-
-  const branch = pull?.head?.ref || '';
-  // Match issue-XX, issue-#XX, or -issue-#XX patterns (handles Codex verbose branch names)
-  const branchMatch = branch.match(/issue-#?([0-9]+)/i) || branch.match(/-issue-#([0-9]+)(?:$|[^0-9])/i);
-  if (branchMatch) {
-    candidates.push(branchMatch[1]);
-  }
-
-  const title = pull?.title || '';
-  const titleMatch = extractExplicitIssueNumberFromText(title);
-  if (titleMatch) {
-    candidates.push(titleMatch);
-  }
-
-  const bodyMatch = extractExplicitIssueNumberFromText(bodyText);
-  if (bodyMatch) {
-    candidates.push(bodyMatch);
-  }
-
-  for (const value of candidates) {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsed)) {
-      return parsed;
-    }
-  }
-
-  return null;
 }
 
 async function detectKeepalive({ core, github, context, env = process.env }) {

--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -16,6 +16,7 @@ const os = require('os');
 const childProcess = require('child_process');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
 const {
+  extractIssueNumbersFromText,
   formatSourceContextForLog,
   normalizeSourceType,
   resolvePrSourceContext,
@@ -1030,21 +1031,10 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 }
 
 function extractExplicitIssueSyncNumbers(pr = {}) {
-  const text = `${pr.title || ''}\n${pr.body || ''}`;
   const issueNumbers = new Set();
-  const patterns = [
-    /<!--\s*meta:issue\s*:\s*([0-9]+)\s*-->/gi,
-    /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?\s*[:#-]?\s*#([0-9]+)\b/gi,
-    /(?:^|\n)\s*>?\s*(?:[-*]\s*)?(?:\*\*)?(?:issue|source\s+issue|github\s+issue)(?:\*\*)?\s*[:#-]?\s*#([0-9]+)\b/gi,
-    /(?:^|\n)\s*>?\s*(?:[-*]\s*)?(?:\*\*)?source\s*:\s*(?:\*\*)?\s*(?:\*\*)?issue(?:\*\*)?\s*#([0-9]+)\b/gi,
-    /\b(?:(?:relate[sd]?\s+to|refs?|references?)\s+(?:(?:[a-z-]+\s+)?issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#([0-9]+)\b/gi,
-  ];
-  for (const pattern of patterns) {
-    for (const match of text.matchAll(pattern)) {
-      const issueNumber = Number.parseInt(match[1], 10);
-      if (Number.isFinite(issueNumber) && issueNumber > 0) {
-        issueNumbers.add(issueNumber);
-      }
+  for (const text of [pr.title, pr.body]) {
+    for (const issueNumber of extractIssueNumbersFromText(text)) {
+      issueNumbers.add(issueNumber);
     }
   }
   return issueNumbers;
@@ -1054,12 +1044,19 @@ function hasExplicitIssueSyncReference(pr = {}) {
   return extractExplicitIssueSyncNumbers(pr).size > 0;
 }
 
-function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}) {
+function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
   const explicitNonIssueSourceContext = resolveExplicitNonIssueWorkflowSourceContext(pr);
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueSyncNumbers = extractExplicitIssueSyncNumbers(pr);
+  const targetIssueNumber = Number.parseInt(issueNumber, 10);
+  if (
+    explicitIssueSyncNumbers.size > 0 &&
+    (!Number.isFinite(targetIssueNumber) ||
+      targetIssueNumber <= 0 ||
+      explicitIssueSyncNumbers.has(targetIssueNumber))
+  ) {
     return null;
   }
   return explicitNonIssueSourceContext;
@@ -1422,7 +1419,7 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr);
+  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, issueNumber);
   if (explicitNonIssueSourceContext) {
     core.info(
       `PR #${pr.number} has explicit non-issue workflow source context (${formatSourceContextForLog(explicitNonIssueSourceContext)}); skipping issue-sourced body sync.`,

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -162,21 +162,43 @@ function hasCheckedNoAutomationTemplate(body) {
 }
 
 function hasExplicitIssueReferencePrefix(value) {
-  const prefix = cleanString(value)
-    .replace(/[>_[\]()`*~]/g, ' ')
+  const rawPrefix = String(value || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[_[\]()`~]/g, ' ');
+  const prefix = rawPrefix
+    .trim()
+    .replace(/[>*]/g, ' ')
     .replace(/\s+/g, ' ');
 
   if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
     return false;
   }
+  if (/\b(?:known|no)\s+(?:linked\s+)?issue\s*[:#-]?\s*$/i.test(prefix)) {
+    return false;
+  }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*(?:issue|linked\s+issue)\s*[:#-]?\s*$/i.test(
-    prefix
+  const issuePrefixPattern =
+    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:(?:[a-z-]+\\s+)?issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|linked\\s+issue|issue)';
+  const inlinePattern = new RegExp(`\\b${issuePrefixPattern}\\s*[:#-]?\\s*$`, 'i');
+  if (inlinePattern.test(prefix)) {
+    return true;
+  }
+  const linePattern = new RegExp(
+    `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${issuePrefixPattern}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
+    'i',
   );
+  return linePattern.test(rawPrefix);
 }
 
-function extractIssueNumberFromText(text) {
+function extractIssueNumbersFromText(text) {
   const value = String(text || '');
+  const issueNumbers = new Set();
+  for (const match of value.matchAll(/<!--\s*meta:issue:([0-9]+)\s*-->/gi)) {
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(parsed)) {
+      issueNumbers.add(parsed);
+    }
+  }
   for (const match of value.matchAll(/#([0-9]+)/g)) {
     if (!match[1]) {
       continue;
@@ -198,10 +220,15 @@ function extractIssueNumberFromText(text) {
     }
     const parsed = Number.parseInt(match[1], 10);
     if (!Number.isNaN(parsed)) {
-      return parsed;
+      issueNumbers.add(parsed);
     }
   }
-  return null;
+  return issueNumbers;
+}
+
+function extractIssueNumberFromText(text) {
+  const issueNumbers = extractIssueNumbersFromText(text);
+  return issueNumbers.size > 0 ? Array.from(issueNumbers)[0] : null;
 }
 
 function extractIssueNumberFromPull(pull = {}) {
@@ -402,6 +429,8 @@ module.exports = {
   SOURCE_TYPES,
   VALID_SOURCE_TYPES,
   normalizeSourceType,
+  extractIssueNumberFromText,
+  extractIssueNumbersFromText,
   extractIssueNumberFromPull,
   parseWorkflowSourceBlock,
   sourceTypeFromCheckedTemplate,

--- a/.github/scripts/weekly_metrics_artifacts.js
+++ b/.github/scripts/weekly_metrics_artifacts.js
@@ -6,7 +6,8 @@ const DEFAULT_MAX_TOTAL = 80;
 const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
-const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
+const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 3;
+const DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN = 2;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -153,6 +154,12 @@ function normalizeSelectionOptions(options = {}) {
       process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
     DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
   );
+  const priorityWorkflowArtifactPagesPerRun = parseNonNegativeInt(
+    options.priority_workflow_artifact_pages_per_run ??
+      options.priorityWorkflowArtifactPagesPerRun ??
+      process.env.METRICS_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
+    DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -162,6 +169,7 @@ function normalizeSelectionOptions(options = {}) {
     max_scan_pages: maxScanPages,
     per_page: perPage,
     priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
+    priority_workflow_artifact_pages_per_run: priorityWorkflowArtifactPagesPerRun,
     cutoff_ms: cutoffMs,
   };
 }
@@ -349,6 +357,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -385,6 +394,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -422,7 +432,8 @@ function formatSelectionMarkdown(report) {
     `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
-    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
+    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow, ` +
+      `${report.config.priority_workflow_artifact_pages_per_run} artifact pages per run`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -533,7 +544,7 @@ async function collectPriorityWorkflowArtifacts({
       if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
         continue;
       }
-      for (let page = 1; page <= config.max_scan_pages; page += 1) {
+      for (let page = 1; page <= config.priority_workflow_artifact_pages_per_run; page += 1) {
         let artifactResponse;
         try {
           artifactResponse = await withRetry((client) =>
@@ -562,6 +573,9 @@ async function collectPriorityWorkflowArtifacts({
       if (familiesSatisfied(sourceArtifacts, families, config)) {
         break;
       }
+    }
+    if (familiesSatisfied(artifacts, PRIORITY_METRICS_FAMILIES, config)) {
+      break;
     }
   }
   return dedupeArtifacts(artifacts);
@@ -699,6 +713,7 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
   DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
   PRIORITY_METRICS_FAMILIES,
   PRIORITY_WORKFLOW_ARTIFACT_SOURCE_CANDIDATES,

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -4,6 +4,7 @@ const { createGithubApiCache } = require('./github-api-cache-client');
 const { makeTrace } = require('./keepalive_contract.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
 const {
+  extractIssueNumberFromPull,
   formatSourceContextForLog,
   resolvePrSourceContext,
 } = require('./source_context.js');
@@ -188,17 +189,6 @@ try {
 const INSTRUCTION_REACTION = 'hooray';
 // Valid GitHub reactions: +1, -1, laugh, confused, heart, hooray, rocket, eyes
 const LOCK_REACTION = 'rocket';
-const EXPLICIT_ISSUE_PREFIX_PATTERN =
-  '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|linked\\s+issue|issue)';
-const EXPLICIT_ISSUE_INLINE_PREFIX_REGEX = new RegExp(
-  `\\b${EXPLICIT_ISSUE_PREFIX_PATTERN}\\s*[:#-]?\\s*$`,
-  'i',
-);
-const EXPLICIT_ISSUE_LINE_PREFIX_REGEX = new RegExp(
-  `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${EXPLICIT_ISSUE_PREFIX_PATTERN}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
-  'i',
-);
-
 function normaliseLogin(login) {
   return String(login || '')
     .trim()
@@ -212,93 +202,6 @@ function parseAllowedLogins(env) {
     .map((value) => normaliseLogin(value))
     .filter(Boolean);
   return new Set(raw);
-}
-
-function hasExplicitIssueReferencePrefix(value) {
-  const rawPrefix = String(value || '')
-    .replace(/\r\n?/g, '\n')
-    .replace(/[_[\]()`~]/g, ' ');
-  const prefix = rawPrefix
-    .trim()
-    .replace(/[>*]/g, ' ')
-    .replace(/\s+/g, ' ');
-
-  if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
-    return false;
-  }
-
-  if (EXPLICIT_ISSUE_INLINE_PREFIX_REGEX.test(prefix)) {
-    return true;
-  }
-
-  return EXPLICIT_ISSUE_LINE_PREFIX_REGEX.test(rawPrefix);
-}
-
-function extractExplicitIssueNumberFromText(text) {
-  const value = String(text || '');
-  for (const match of value.matchAll(/#([0-9]+)/g)) {
-    if (!match[1]) {
-      continue;
-    }
-    const before = value.slice(Math.max(0, match.index - 200), match.index);
-    const token = before.split(/\s/).pop() || '';
-    if (token.includes('/')) {
-      continue;
-    }
-    if (match.index > 0 && /\w/.test(value[match.index - 1])) {
-      continue;
-    }
-    const preceding = value.slice(Math.max(0, match.index - 20), match.index);
-    if (/\b(?:run|attempt|step|job|check|version|v)\s*$/i.test(preceding)) {
-      continue;
-    }
-    if (!hasExplicitIssueReferencePrefix(value.slice(Math.max(0, match.index - 80), match.index))) {
-      continue;
-    }
-    return match[1];
-  }
-  return null;
-}
-
-function extractIssueNumberFromPull(pull) {
-  if (!pull) {
-    return null;
-  }
-
-  const candidates = [];
-
-  const bodyText = pull?.body || '';
-  const metaMatch = bodyText.match(/<!--\s*meta:issue:([0-9]+)\s*-->/i);
-  if (metaMatch) {
-    candidates.push(metaMatch[1]);
-  }
-
-  const branch = pull?.head?.ref || '';
-  // Match issue-XX, issue-#XX, or -issue-#XX patterns (handles Codex verbose branch names)
-  const branchMatch = branch.match(/issue-#?([0-9]+)/i) || branch.match(/-issue-#([0-9]+)(?:$|[^0-9])/i);
-  if (branchMatch) {
-    candidates.push(branchMatch[1]);
-  }
-
-  const title = pull?.title || '';
-  const titleMatch = extractExplicitIssueNumberFromText(title);
-  if (titleMatch) {
-    candidates.push(titleMatch);
-  }
-
-  const bodyMatch = extractExplicitIssueNumberFromText(bodyText);
-  if (bodyMatch) {
-    candidates.push(bodyMatch);
-  }
-
-  for (const value of candidates) {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsed)) {
-      return parsed;
-    }
-  }
-
-  return null;
 }
 
 async function detectKeepalive({ core, github, context, env = process.env }) {

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_update_body.js
@@ -16,6 +16,7 @@ const os = require('os');
 const childProcess = require('child_process');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
 const {
+  extractIssueNumbersFromText,
   formatSourceContextForLog,
   normalizeSourceType,
   resolvePrSourceContext,
@@ -1030,21 +1031,10 @@ function resolveExplicitNonIssueWorkflowSourceContext(pr = {}) {
 }
 
 function extractExplicitIssueSyncNumbers(pr = {}) {
-  const text = `${pr.title || ''}\n${pr.body || ''}`;
   const issueNumbers = new Set();
-  const patterns = [
-    /<!--\s*meta:issue\s*:\s*([0-9]+)\s*-->/gi,
-    /\b(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?\s*[:#-]?\s*#([0-9]+)\b/gi,
-    /(?:^|\n)\s*>?\s*(?:[-*]\s*)?(?:\*\*)?(?:issue|source\s+issue|github\s+issue)(?:\*\*)?\s*[:#-]?\s*#([0-9]+)\b/gi,
-    /(?:^|\n)\s*>?\s*(?:[-*]\s*)?(?:\*\*)?source\s*:\s*(?:\*\*)?\s*(?:\*\*)?issue(?:\*\*)?\s*#([0-9]+)\b/gi,
-    /\b(?:(?:relate[sd]?\s+to|refs?|references?)\s+(?:(?:[a-z-]+\s+)?issue\s+)?|(?:source|github|linked)\s+issue\s*)[:#-]?\s*#([0-9]+)\b/gi,
-  ];
-  for (const pattern of patterns) {
-    for (const match of text.matchAll(pattern)) {
-      const issueNumber = Number.parseInt(match[1], 10);
-      if (Number.isFinite(issueNumber) && issueNumber > 0) {
-        issueNumbers.add(issueNumber);
-      }
+  for (const text of [pr.title, pr.body]) {
+    for (const issueNumber of extractIssueNumbersFromText(text)) {
+      issueNumbers.add(issueNumber);
     }
   }
   return issueNumbers;
@@ -1054,12 +1044,19 @@ function hasExplicitIssueSyncReference(pr = {}) {
   return extractExplicitIssueSyncNumbers(pr).size > 0;
 }
 
-function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}) {
+function resolveNonIssueWorkflowSourceContextForBodySync(pr = {}, issueNumber = null) {
   const explicitNonIssueSourceContext = resolveExplicitNonIssueWorkflowSourceContext(pr);
   if (!explicitNonIssueSourceContext) {
     return null;
   }
-  if (hasExplicitIssueSyncReference(pr)) {
+  const explicitIssueSyncNumbers = extractExplicitIssueSyncNumbers(pr);
+  const targetIssueNumber = Number.parseInt(issueNumber, 10);
+  if (
+    explicitIssueSyncNumbers.size > 0 &&
+    (!Number.isFinite(targetIssueNumber) ||
+      targetIssueNumber <= 0 ||
+      explicitIssueSyncNumbers.has(targetIssueNumber))
+  ) {
     return null;
   }
   return explicitNonIssueSourceContext;
@@ -1422,7 +1419,7 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
-  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr);
+  const explicitNonIssueSourceContext = resolveNonIssueWorkflowSourceContextForBodySync(pr, issueNumber);
   if (explicitNonIssueSourceContext) {
     core.info(
       `PR #${pr.number} has explicit non-issue workflow source context (${formatSourceContextForLog(explicitNonIssueSourceContext)}); skipping issue-sourced body sync.`,

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -162,21 +162,43 @@ function hasCheckedNoAutomationTemplate(body) {
 }
 
 function hasExplicitIssueReferencePrefix(value) {
-  const prefix = cleanString(value)
-    .replace(/[>_[\]()`*~]/g, ' ')
+  const rawPrefix = String(value || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[_[\]()`~]/g, ' ');
+  const prefix = rawPrefix
+    .trim()
+    .replace(/[>*]/g, ' ')
     .replace(/\s+/g, ' ');
 
   if (/\b(?:pr|pull\s+request)\s*[:#-]?\s*$/i.test(prefix)) {
     return false;
   }
+  if (/\b(?:known|no)\s+(?:linked\s+)?issue\s*[:#-]?\s*$/i.test(prefix)) {
+    return false;
+  }
 
-  return /\b(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\s+(?:issue|source\s+issue|github\s+issue))?|relate[sd]?\s+to(?:\s+(?:issue|source\s+issue|github\s+issue))?|refs?(?:\s+(?:issue|source\s+issue|github\s+issue))?|references?(?:\s+(?:issue|source\s+issue|github\s+issue))?|source(?:\s*:\s*|\s+)issue|github\s+issue)\s*[:#-]?\s*$|^\s*(?:issue|linked\s+issue)\s*[:#-]?\s*$/i.test(
-    prefix
+  const issuePrefixPattern =
+    '(?:(?:close[sd]?|closing|fix(?:e[sd])?|fixing|resolve[sd]?|resolving|address(?:e[sd])?|addressing)(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|relate[sd]?\\s+to(?:\\s+(?:(?:[a-z-]+\\s+)?issue|source\\s+issue|github\\s+issue))?|refs?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|references?(?:\\s+(?:issue|source\\s+issue|github\\s+issue))?|source(?:\\s*:\\s*|\\s+)issue|github\\s+issue|linked\\s+issue|issue)';
+  const inlinePattern = new RegExp(`\\b${issuePrefixPattern}\\s*[:#-]?\\s*$`, 'i');
+  if (inlinePattern.test(prefix)) {
+    return true;
+  }
+  const linePattern = new RegExp(
+    `(?:^|\\n)\\s*>?\\s*(?:[-*]\\s*)?(?:\\*\\*)?${issuePrefixPattern}(?:\\*\\*)?\\s*[:#-]?\\s*$`,
+    'i',
   );
+  return linePattern.test(rawPrefix);
 }
 
-function extractIssueNumberFromText(text) {
+function extractIssueNumbersFromText(text) {
   const value = String(text || '');
+  const issueNumbers = new Set();
+  for (const match of value.matchAll(/<!--\s*meta:issue:([0-9]+)\s*-->/gi)) {
+    const parsed = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(parsed)) {
+      issueNumbers.add(parsed);
+    }
+  }
   for (const match of value.matchAll(/#([0-9]+)/g)) {
     if (!match[1]) {
       continue;
@@ -198,10 +220,15 @@ function extractIssueNumberFromText(text) {
     }
     const parsed = Number.parseInt(match[1], 10);
     if (!Number.isNaN(parsed)) {
-      return parsed;
+      issueNumbers.add(parsed);
     }
   }
-  return null;
+  return issueNumbers;
+}
+
+function extractIssueNumberFromText(text) {
+  const issueNumbers = extractIssueNumbersFromText(text);
+  return issueNumbers.size > 0 ? Array.from(issueNumbers)[0] : null;
 }
 
 function extractIssueNumberFromPull(pull = {}) {
@@ -402,6 +429,8 @@ module.exports = {
   SOURCE_TYPES,
   VALID_SOURCE_TYPES,
   normalizeSourceType,
+  extractIssueNumberFromText,
+  extractIssueNumbersFromText,
   extractIssueNumberFromPull,
   parseWorkflowSourceBlock,
   sourceTypeFromCheckedTemplate,

--- a/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
+++ b/templates/consumer-repo/.github/scripts/weekly_metrics_artifacts.js
@@ -6,7 +6,8 @@ const DEFAULT_MAX_TOTAL = 80;
 const DEFAULT_MAX_PER_FAMILY = 20;
 const DEFAULT_MAX_SCAN_PAGES = 5;
 const DEFAULT_PER_PAGE = 100;
-const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 10;
+const DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE = 3;
+const DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN = 2;
 
 const EXACT_METRICS_ARTIFACTS = new Set([
   'keepalive-metrics',
@@ -153,6 +154,12 @@ function normalizeSelectionOptions(options = {}) {
       process.env.METRICS_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
     DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE
   );
+  const priorityWorkflowArtifactPagesPerRun = parseNonNegativeInt(
+    options.priority_workflow_artifact_pages_per_run ??
+      options.priorityWorkflowArtifactPagesPerRun ??
+      process.env.METRICS_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
+    DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN
+  );
   const cutoffMs = nowMs - lookbackDays * 24 * 60 * 60 * 1000;
   return {
     now_ms: nowMs,
@@ -162,6 +169,7 @@ function normalizeSelectionOptions(options = {}) {
     max_scan_pages: maxScanPages,
     per_page: perPage,
     priority_workflow_runs_per_source: priorityWorkflowRunsPerSource,
+    priority_workflow_artifact_pages_per_run: priorityWorkflowArtifactPagesPerRun,
     cutoff_ms: cutoffMs,
   };
 }
@@ -349,6 +357,7 @@ function selectMetricsArtifacts(artifacts = [], options = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     ...stats,
@@ -385,6 +394,7 @@ function buildSelectionErrorReport(options = {}, error = {}) {
       max_scan_pages: config.max_scan_pages,
       per_page: config.per_page,
       priority_workflow_runs_per_source: config.priority_workflow_runs_per_source,
+      priority_workflow_artifact_pages_per_run: config.priority_workflow_artifact_pages_per_run,
       cutoff_iso: new Date(config.cutoff_ms).toISOString(),
     },
     scanned_count: 0,
@@ -422,7 +432,8 @@ function formatSelectionMarkdown(report) {
     `- Status: ${report.status || 'pass'}`,
     `- Lookback days: ${report.config.lookback_days}`,
     `- Scan cap: ${report.config.max_scan_pages} pages x ${report.config.per_page} artifacts`,
-    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow`,
+    `- Priority producer scan cap: ${report.config.priority_workflow_runs_per_source} runs per source workflow, ` +
+      `${report.config.priority_workflow_artifact_pages_per_run} artifact pages per run`,
     `- Download cap: ${report.config.max_total} total, ${report.config.max_per_family} per family`,
     `- Scanned artifacts: ${report.scanned_count}`,
     `- Candidate artifacts: ${report.candidate_count}`,
@@ -533,7 +544,7 @@ async function collectPriorityWorkflowArtifacts({
       if (runTimestamp > 0 && runTimestamp < config.cutoff_ms) {
         continue;
       }
-      for (let page = 1; page <= config.max_scan_pages; page += 1) {
+      for (let page = 1; page <= config.priority_workflow_artifact_pages_per_run; page += 1) {
         let artifactResponse;
         try {
           artifactResponse = await withRetry((client) =>
@@ -562,6 +573,9 @@ async function collectPriorityWorkflowArtifacts({
       if (familiesSatisfied(sourceArtifacts, families, config)) {
         break;
       }
+    }
+    if (familiesSatisfied(artifacts, PRIORITY_METRICS_FAMILIES, config)) {
+      break;
     }
   }
   return dedupeArtifacts(artifacts);
@@ -699,6 +713,7 @@ module.exports = {
   DEFAULT_MAX_PER_FAMILY,
   DEFAULT_MAX_SCAN_PAGES,
   DEFAULT_MAX_TOTAL,
+  DEFAULT_PRIORITY_WORKFLOW_ARTIFACT_PAGES_PER_RUN,
   DEFAULT_PRIORITY_WORKFLOW_RUNS_PER_SOURCE,
   PRIORITY_METRICS_FAMILIES,
   PRIORITY_WORKFLOW_ARTIFACT_SOURCE_CANDIDATES,


### PR DESCRIPTION
## Summary
- centralize explicit issue-reference parsing in source_context for PR meta and keepalive scripts
- bound weekly metrics priority workflow artifact scans by runs per source and artifact pages per run
- keep consumer template copies aligned with the source scripts

## Testing
- node --test .github/scripts/__tests__/agents-pr-meta-update-body.test.js .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/agents-pr-meta-keepalive.test.js .github/scripts/__tests__/weekly-metrics-artifacts.test.js

Source fix for active sync review threads on Template #657.