### PR TITLE
fix: skip trip-planner vendored node_modules sync

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -273,6 +273,9 @@ scripts:
 
   - source: .github/scripts/package.json
     description: "Node package manifest for .github scripts (vendored minimatch)"
+    skip_repos:
+      - repo: stranske/trip-planner
+        reason: "Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules"
 
   - source: .github/agents/registry.yml
     description: "Agent registry - source of truth for agent keys and runner workflow mapping"
@@ -286,14 +289,23 @@ scripts:
   - source: .github/scripts/node_modules/minimatch/
     is_directory: true
     description: "Vendored minimatch dependency for .github scripts"
+    skip_repos:
+      - repo: stranske/trip-planner
+        reason: "Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules"
 
   - source: .github/scripts/node_modules/brace-expansion/
     is_directory: true
     description: "Vendored brace-expansion dependency (transitive dep of minimatch)"
+    skip_repos:
+      - repo: stranske/trip-planner
+        reason: "Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules"
 
   - source: .github/scripts/node_modules/balanced-match/
     is_directory: true
     description: "Vendored balanced-match dependency (transitive dep of brace-expansion)"
+    skip_repos:
+      - repo: stranske/trip-planner
+        reason: "Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules"
 
   # JavaScript scripts for issue/PR handling
   - source: .github/scripts/issue_pr_locator.js

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -26,17 +26,24 @@ Some repos cannot use the template `pr-00-gate.yml` because:
 - **Trend_Model_Project**: Keeps the historical `Agents.md` filename, so syncing
   `AGENTS.md` would create a case-only path collision on case-insensitive
   filesystems
+- **trip-planner**: Installs `.github/scripts` dependencies from
+  `.github/scripts/package-lock.json` with `npm ci` and has an explicit hygiene
+  check that forbids tracked `node_modules/` anywhere in the repo.
 
 For these repos:
 - The Gate workflow (`pr-00-gate.yml`) is maintained locally and excluded from sync.
 - `Trend_Model_Project` skips the synced `AGENTS.md` file and keeps its local
   `Agents.md`.
+- `trip-planner` skips the synced `.github/scripts/package.json` and vendored
+  `.github/scripts/node_modules/` entries so its lockfile-based dependency
+  policy remains intact.
 - Other files listed in the sync manifest continue to sync normally.
 
 Maint 68 currently implements this by keeping an internal `custom_gate_repos` list in
 its sync script and skipping any manifest entry whose `source` contains
 `pr-00-gate` for those repos, plus a repo-specific `AGENTS.md` skip for
-`Trend_Model_Project`.
+`Trend_Model_Project` and manifest-level package/dependency skips for
+`trip-planner`.
 
 ---
 


### PR DESCRIPTION
## Summary
- skip syncing the Workflows vendored minimatch package manifest and node_modules directories into stranske/trip-planner
- document the trip-planner exception because that repo installs .github/scripts deps from package-lock.json and forbids tracked node_modules

## Verification
- python scripts/validate_template_sync.py
- parsed .github/sync-manifest.yml with PyYAML

## Follow-up
After this merges, dispatch Maint 68 for stranske/trip-planner and close/replace trip-planner#1032.