### PR TITLE
fix: bump synced Claude Code action pin

### DIFF
--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Summary
- update the synced consumer maint-76 Claude Code Review workflow to the Dependabot-proposed anthropics/claude-code-action pin
- centralize the action bump in Workflows instead of merging per-consumer Dependabot PRs

## Verification
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py

## Follow-up
After this merges, let Maint 68 produce replacement sync PRs and close the per-consumer Dependabot action-bump PRs as superseded.