### PR TITLE
fix: align autofix tool pin ownership

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
 # Dependabot configuration for Workflows repo
 # 
 # ARCHITECTURE:
-# 1. Dependabot updates pyproject.toml [project.optional-dependencies].dev
-# 2. A post-merge workflow syncs pyproject.toml -> autofix-versions.env
-# 3. maint-52 syncs autofix-versions.env -> consumer repos
-#
-# This keeps the .env file (source of truth for consumers) automatically updated.
+# 1. .github/workflows/autofix-versions.env is the source of truth for shared
+#    autofix/dev-tool pins that are synced to consumers.
+# 2. maint-auto-update-pypi-versions.yml and maint-51-dependency-refresh.yml open
+#    bounded Workflows PRs that update the env file, pyproject.toml, templates,
+#    and requirements.lock together.
+# 3. Dependabot stays responsible for runtime dependency and GitHub Actions bumps.
 
 version: 2
 updates:
-  # Python dev tools - updates pyproject.toml
-  # After merge, a workflow syncs versions to autofix-versions.env
+  # Python dependencies. Shared autofix/dev-tool pins are ignored here because
+  # they must move through the Workflows canonical pin file first.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -24,20 +25,23 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    ignore:
+      - dependency-name: "ruff"
+      - dependency-name: "black"
+      - dependency-name: "mypy"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-xdist"
+      - dependency-name: "coverage"
+      - dependency-name: "isort"
+      - dependency-name: "docformatter"
     commit-message:
       prefix: "deps"
       include: "scope"
     groups:
-      # Group dev tools together for batch review (minor/patch only)
-      dev-tools:
+      # Group test/runtime support that is not controlled by autofix-versions.env.
+      runtime-test-support:
         patterns:
-          - "ruff"
-          - "black"
-          - "mypy"
-          - "pytest*"
-          - "coverage"
-          - "isort"
-          - "docformatter"
           - "hypothesis"
         update-types:
           - "minor"

--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,10 +5,10 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.11
+RUFF_VERSION=0.15.12
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
-MYPY_VERSION=1.20.1
+MYPY_VERSION=1.20.2
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0

--- a/.github/workflows/maint-auto-update-pypi-versions.yml
+++ b/.github/workflows/maint-auto-update-pypi-versions.yml
@@ -76,7 +76,6 @@ jobs:
           echo "🔄 Syncing pyproject.toml + requirements.lock + templates"
           python scripts/sync_tool_versions.py --apply
           python scripts/sync_dev_dependencies.py --apply --lockfile
-          cp .github/workflows/autofix-versions.env templates/integration-repo/.github/workflows/autofix-versions.env
 
       - name: Create PR
         if: steps.check.outputs.has_updates == 'true' && inputs.dry_run != true
@@ -88,7 +87,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Check if there are actual changes
-          if git diff --quiet .github/workflows/autofix-versions.env; then
+          if git diff --quiet -- \
+            .github/workflows/autofix-versions.env \
+            pyproject.toml \
+            requirements.lock \
+            templates/consumer-repo/.github/workflows/autofix-versions.env \
+            templates/integration-repo/.github/workflows/autofix-versions.env; then
             echo "No changes to commit"
             exit 0
           fi

--- a/.github/workflows/maint-sync-env-from-pyproject.yml
+++ b/.github/workflows/maint-sync-env-from-pyproject.yml
@@ -1,164 +1,63 @@
-# Syncs dev tool versions from pyproject.toml to autofix-versions.env
-# Triggered when Dependabot PRs merge to keep the .env file in sync
-#
-# Flow: Dependabot -> pyproject.toml -> this workflow -> autofix-versions.env
+# Keeps pyproject.toml, templates, and requirements.lock aligned to the
+# canonical Workflows autofix pin file.
 
-name: Maint - Sync versions.env from pyproject.toml
+name: Maint - Sync pyproject from versions.env
 
 on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/autofix-versions.env'
+      - 'templates/consumer-repo/.github/workflows/autofix-versions.env'
+      - 'templates/integration-repo/.github/workflows/autofix-versions.env'
       - 'pyproject.toml'
+      - 'requirements.lock'
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  sync-env:
+  sync-source-files:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Extract versions from pyproject.toml
-        id: extract
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Align source files from canonical pin file
         run: |
-          # Parse pyproject.toml and extract pinned dev tool versions
-          python3 << 'PYTHON'
-          import re
-          import sys
-
-          with open('pyproject.toml', 'r') as f:
-              content = f.read()
-
-          # Find the dev dependencies section
-            dev_pattern = (
-              r'\[project\.optional-dependencies\]'
-              r'\s*\n'
-              r'dev\s*=\s*\[(.*?)\]'
-            )
-            dev_match = re.search(dev_pattern, content, re.DOTALL)
-          if not dev_match:
-              print("ERROR: Could not find dev dependencies in pyproject.toml", file=sys.stderr)
-              sys.exit(1)
-
-          dev_section = dev_match.group(1)
-
-          # Map package names to env var names
-          package_to_env = {
-              'black': 'BLACK_VERSION',
-              'ruff': 'RUFF_VERSION',
-              'isort': 'ISORT_VERSION',
-              'docformatter': 'DOCFORMATTER_VERSION',
-              'mypy': 'MYPY_VERSION',
-              'pytest': 'PYTEST_VERSION',
-              'pytest-cov': 'PYTEST_COV_VERSION',
-              'pytest-xdist': 'PYTEST_XDIST_VERSION',
-              'coverage': 'COVERAGE_VERSION',
-              'pyyaml': 'PYYAML_VERSION',
-              'pydantic': 'PYDANTIC_VERSION',
-              'hypothesis': 'HYPOTHESIS_VERSION',
-              'jsonschema': 'JSONSCHEMA_VERSION',
-          }
-
-          versions = {}
-
-          # Extract pinned versions (package==version format)
-          for match in re.finditer(r'"([a-zA-Z0-9_-]+)==([^"]+)"', dev_section):
-              pkg, ver = match.groups()
-              pkg_lower = pkg.lower()
-              if pkg_lower in package_to_env:
-                  versions[package_to_env[pkg_lower]] = ver
-
-          # Output for GitHub Actions
-          for env_var, version in sorted(versions.items()):
-              print(f"{env_var}={version}")
-          PYTHON
-
-      - name: Update autofix-versions.env
-        run: |
-          ENV_FILE=".github/workflows/autofix-versions.env"
-
-          # Read current pyproject versions
-          declare -A NEW_VERSIONS
-          while IFS='=' read -r key value; do
-              NEW_VERSIONS[$key]=$value
-          done < <(python3 << 'PYTHON'
-          import re
-
-          with open('pyproject.toml', 'r') as f:
-              content = f.read()
-
-            dev_pattern = (
-              r'\[project\.optional-dependencies\]'
-              r'\s*\n'
-              r'dev\s*=\s*\[(.*?)\]'
-            )
-            dev_match = re.search(dev_pattern, content, re.DOTALL)
-          dev_section = dev_match.group(1) if dev_match else ""
-
-          package_to_env = {
-              'black': 'BLACK_VERSION',
-              'ruff': 'RUFF_VERSION',
-              'isort': 'ISORT_VERSION',
-              'docformatter': 'DOCFORMATTER_VERSION',
-              'mypy': 'MYPY_VERSION',
-              'pytest': 'PYTEST_VERSION',
-              'pytest-cov': 'PYTEST_COV_VERSION',
-              'pytest-xdist': 'PYTEST_XDIST_VERSION',
-              'coverage': 'COVERAGE_VERSION',
-              'pyyaml': 'PYYAML_VERSION',
-              'pydantic': 'PYDANTIC_VERSION',
-              'hypothesis': 'HYPOTHESIS_VERSION',
-              'jsonschema': 'JSONSCHEMA_VERSION',
-          }
-
-          for match in re.finditer(r'"([a-zA-Z0-9_-]+)==([^"]+)"', dev_section):
-              pkg, ver = match.groups()
-              pkg_lower = pkg.lower()
-              if pkg_lower in package_to_env:
-                  print(f"{package_to_env[pkg_lower]}={ver}")
-          PYTHON
-          )
-
-          # Update each version in the .env file
-          CHANGES=0
-          for key in "${!NEW_VERSIONS[@]}"; do
-              value="${NEW_VERSIONS[$key]}"
-              if grep -q "^${key}=" "$ENV_FILE"; then
-                  OLD_VALUE=$(grep "^${key}=" "$ENV_FILE" | cut -d= -f2)
-                  if [ "$OLD_VALUE" != "$value" ]; then
-                      sed -i "s/^${key}=.*/${key}=${value}/" "$ENV_FILE"
-                      echo "Updated $key: $OLD_VALUE -> $value"
-                      CHANGES=$((CHANGES + 1))
-                  fi
-              fi
-          done
-
-          echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
-
-          if [ $CHANGES -eq 0 ]; then
-              echo "No version changes detected"
-          else
-              echo "Updated $CHANGES version(s)"
-          fi
+          set -euo pipefail
+          python scripts/sync_tool_versions.py --apply
+          python scripts/sync_dev_dependencies.py --apply --lockfile
 
       - name: Commit and push if changed
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet .github/workflows/autofix-versions.env; then
-              echo "No changes to commit"
+          if git diff --quiet -- \
+            .github/workflows/autofix-versions.env \
+            pyproject.toml \
+            requirements.lock \
+            templates/consumer-repo/.github/workflows/autofix-versions.env \
+            templates/integration-repo/.github/workflows/autofix-versions.env; then
+              echo "No source alignment changes to commit"
               exit 0
           fi
 
-          git add .github/workflows/autofix-versions.env
-          git commit -m "chore: sync autofix-versions.env from pyproject.toml
-
-          Auto-generated by maint-sync-env-from-pyproject workflow"
+          git add \
+            .github/workflows/autofix-versions.env \
+            pyproject.toml \
+            requirements.lock \
+            templates/consumer-repo/.github/workflows/autofix-versions.env \
+            templates/integration-repo/.github/workflows/autofix-versions.env
+          git commit -m "chore: align autofix source pins"
           git push

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -85,7 +85,7 @@ The gate uses the shared `.github/scripts/detect-changes.js` helper to decide wh
 ## Coverage Guardrails & Follow-ups
 
 * Gate's `summary` job now emits the consolidated PR comment, uploads `gate-summary.md`, and publishes `gate-coverage.json` / `gate-coverage-delta.json` for downstream consumers.
-* [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) syncs dev tool versions from `pyproject.toml` to `autofix-versions.env` after Dependabot merges.
+* [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) keeps `pyproject.toml`, templates, and `requirements.lock` aligned to the canonical `autofix-versions.env` file.
 * [`maint-coverage-guard.yml`](../../.github/workflows/maint-coverage-guard.yml) periodically verifies that the latest Gate run meets baseline coverage expectations.
 * [`maint-46-post-ci.yml`](../../.github/workflows/maint-46-post-ci.yml) wakes up after Gate completes, validates the workflow syntax with `actionlint`, downloads the Gate artifacts, renders the consolidated CI summary (including coverage deltas), and republishes the Gate commit status while saving a markdown preview for evidence capture.
 
@@ -108,7 +108,7 @@ The gate uses the shared `.github/scripts/detect-changes.js` helper to decide wh
 * [`maint-50-tool-version-check.yml`](../../.github/workflows/maint-50-tool-version-check.yml) checks PyPI weekly for new versions of CI/autofix tools (black, ruff, mypy, pytest) and creates an issue when updates are available.
 * [`maint-51-dependency-refresh.yml`](../../.github/workflows/maint-51-dependency-refresh.yml) regenerates `requirements.lock` using `uv pip compile`, validates tool-pin alignment, and opens a refresh pull request when dependency updates are detected (dry-run friendly).
 * [`maint-39-test-llm-providers.yml`](../../.github/workflows/maint-39-test-llm-providers.yml) verifies LLM provider API keys (GitHub Models, OpenAI) are configured correctly for task completion analysis.
-* [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) syncs dev tool version pins from `pyproject.toml` to `autofix-versions.env` after Dependabot updates land.
+* [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) syncs `pyproject.toml`, templates, and direct `requirements.lock` pins from the canonical `autofix-versions.env` file after source pin changes land.
 * [`maint-52-validate-workflows.yml`](../../.github/workflows/maint-52-validate-workflows.yml) dry-parses every workflow with `yq`, runs `actionlint` with the repository allowlist, and fails fast when malformed YAML or unapproved actionlint findings slip in.
 * [`maint-52-sync-dev-versions.yml`](../../.github/workflows/maint-52-sync-dev-versions.yml) syncs dev tool versions (ruff, mypy, black, isort, pytest) from `autofix-versions.env` to consumer repository `pyproject.toml` files weekly or on version changes.
 * [`maint-auto-update-pypi-versions.yml`](../../.github/workflows/maint-auto-update-pypi-versions.yml) checks PyPI daily for latest dev tool versions and creates a PR to update `autofix-versions.env` when versions are outdated.

--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -491,9 +491,9 @@ Keep this table handy when you are triaging automation: it confirms which workfl
 - **Gate summary job** – the `summary` job within `pr-00-gate.yml` consolidates
   CI results, uploads artifacts, and applies small, low-risk fixes (for example,
   syncing generated docs or updating the failure tracker).
-- **Maint Sync Env from Pyproject** – `.github/workflows/maint-sync-env-from-pyproject.yml`
-  syncs dev tool versions from `pyproject.toml` to `autofix-versions.env` after
-  Dependabot PRs merge, keeping the version pins in sync for downstream consumers.
+- **Maint Sync Pyproject from Env** – `.github/workflows/maint-sync-env-from-pyproject.yml`
+  keeps `pyproject.toml`, templates, and direct `requirements.lock` pins aligned
+  to the canonical `autofix-versions.env` source used by downstream consumers.
 - **Maint Coverage Guard** – `.github/workflows/maint-coverage-guard.yml`
   downloads the latest Gate coverage payload plus the trend artifact and
   compares them against `config/coverage-baseline.json`, surfacing notices when
@@ -522,10 +522,9 @@ Keep this table handy when you are triaging automation: it confirms which workfl
 - **Maint 39 Test LLM Providers** – `.github/workflows/maint-39-test-llm-providers.yml`
   is a manual workflow that verifies LLM provider API keys (GitHub Models, OpenAI)
   are configured correctly. Used to test the task completion analysis fallback chain.
-- **Maint Sync versions.env from pyproject.toml** – `.github/workflows/maint-sync-env-from-pyproject.yml`
-  syncs dev tool version pins from `pyproject.toml` into `autofix-versions.env`
-  on main-branch updates (or on manual dispatch) so Dependabot updates propagate
-  into the workflow toolchain.
+- **Maint Sync pyproject.toml from versions.env** – `.github/workflows/maint-sync-env-from-pyproject.yml`
+  syncs `pyproject.toml`, templates, and direct `requirements.lock` pins from
+  canonical `autofix-versions.env` on main-branch updates or manual dispatch.
 - **Maint 52 Validate Workflows** – `.github/workflows/maint-52-validate-workflows.yml`
   dry-parses every workflow YAML using `yq`, hydrates the shared actionlint
   allowlist, and runs `actionlint` so malformed syntax or unapproved action
@@ -693,7 +692,7 @@ Keep this table handy when you are triaging automation: it confirms which workfl
 | **Auto-label Dependabot PRs** (`maint-dependabot-auto-label.yml`, maintenance bucket) | `pull_request_target` (`opened`) | Apply the `agents:allow-change` label to Dependabot PRs so protected-workflow changes can be reviewed without manual label work. | ⚪ Automatic on PR open | [Dependabot auto-label runs](https://github.com/stranske/Workflows/actions/workflows/maint-dependabot-auto-label.yml) |
 | **Dependabot Auto-Lock** (`maint-dependabot-auto-lock.yml`, maintenance bucket) | `pull_request` (Dependabot branches, `pyproject.toml` changes) | Regenerate `requirements.lock` when Dependabot updates `pyproject.toml`, commit the updated lockfile back to the Dependabot PR branch, and keep dependency pins in sync. | ⚪ Automatic on Dependabot PRs | [Dependabot auto-lock runs](https://github.com/stranske/Workflows/actions/workflows/maint-dependabot-auto-lock.yml) |
 | **Dependabot Weekly Sweep (Consumers)** (`maint-dependabot-weekly-sweep.yml`, maintenance bucket) | `schedule` (Mondays 09:00 UTC), `workflow_dispatch` | Sweep registered consumer repos weekly to enable Dependabot auto-merge and merge eligible PRs when checks are green. | ⚪ Scheduled/manual | [Dependabot weekly sweep runs](https://github.com/stranske/Workflows/actions/workflows/maint-dependabot-weekly-sweep.yml) |
-| **Maint Sync versions.env from pyproject.toml** (`maint-sync-env-from-pyproject.yml`, maintenance bucket) | `push` (`main`, `pyproject.toml`), `workflow_dispatch` | Sync dev tool version pins from `pyproject.toml` into `autofix-versions.env` after changes land. | ⚪ Automatic on main | [Maint sync env runs](https://github.com/stranske/Workflows/actions/workflows/maint-sync-env-from-pyproject.yml) |
+| **Maint Sync pyproject.toml from versions.env** (`maint-sync-env-from-pyproject.yml`, maintenance bucket) | `push` (`main`, autofix pin/template/lock paths), `workflow_dispatch` | Sync `pyproject.toml`, templates, and direct `requirements.lock` pins from canonical `autofix-versions.env` after changes land. | ⚪ Automatic on main | [Maint sync env runs](https://github.com/stranske/Workflows/actions/workflows/maint-sync-env-from-pyproject.yml) |
 | **Maint 52 Validate Workflows** (`maint-52-validate-workflows.yml`, maintenance bucket) | `pull_request`, `push` (`main`) | Parse every workflow file with `yq`, honour the Actionlint allowlist, and fail fast when syntax errors or lint violations appear. | ⚪ Automatic on PR/main | [Maint 52 workflow validations](https://github.com/stranske/Workflows/actions/workflows/maint-52-validate-workflows.yml) |
 | **Maint 52 Sync Dev Versions** (`maint-52-sync-dev-versions.yml`, maintenance bucket) | `schedule` (Sundays 01:00 UTC), `push` (`autofix-versions.env`), `workflow_dispatch` | Sync dev tool versions from `autofix-versions.env` to consumer repository `pyproject.toml` files. | ⚪ Scheduled/manual | [Sync dev versions runs](https://github.com/stranske/Workflows/actions/workflows/maint-52-sync-dev-versions.yml) |
 | **Maint Auto-Update PyPI Versions** (`maint-auto-update-pypi-versions.yml`, maintenance bucket) | `schedule` (daily 03:00 UTC), `workflow_dispatch` | Check PyPI for latest dev tool versions and create a PR to update `autofix-versions.env` when versions are outdated. | ⚪ Scheduled | [Auto-update PyPI versions runs](https://github.com/stranske/Workflows/actions/workflows/maint-auto-update-pypi-versions.yml) |

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -183,6 +183,18 @@ of following the first-party default.
 If a reusable workflow fix must ship immediately, trigger:
 - `Maint 68 Sync Consumer Repos` only if template files changed
 
+### Autofix Tool Version Ownership
+
+Workflows owns shared autofix/dev-tool pins in
+`.github/workflows/autofix-versions.env`. Treat that file as the source of truth
+for `ruff`, `black`, `mypy`, `pytest`, `coverage`, `isort`, and `docformatter`.
+The matching `pyproject.toml`, consumer template, integration template, and
+direct `requirements.lock` pins must move in the same Workflows PR.
+
+Dependabot should not be merged when it only bumps one of those shared tool pins
+in `pyproject.toml`; route that change through the Workflows source pin update
+path instead. Runtime dependency bumps remain normal Dependabot work.
+
 ### Manual Sync Trigger
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel>=0.46.3"]
+requires = ["setuptools>=82.0.1", "wheel>=0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -29,12 +29,12 @@ Issues = "https://github.com/stranske/Workflows/issues"
 [project.optional-dependencies]
 app = []
 dev = [
-    "pre-commit==4.5.1",
+    "pre-commit==4.6.0",
     "black==26.3.1",
-    "ruff==0.15.11",
+    "ruff==0.15.12",
     "isort==8.0.1",
     "docformatter==1.7.7",
-    "mypy==1.20.1",
+    "mypy==1.20.2",
     "flake8==7.3.0",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
@@ -46,7 +46,7 @@ dev = [
     "hypothesis>=6.152.2",
     "pandas",
     "numpy<3.0",
-    "pydantic>=2.13.2",
+    "pydantic>=2.13.3",
     "requests>=2.33.1",
     "jsonschema>=4.26.0",
     "PyYAML>=6.0.0",
@@ -60,9 +60,9 @@ dev = [
 # Versions auto-updated by scripts/update_langchain_versions.py
 langchain = [
     "langchain>=1.2.15,<1.3",
-    "langchain-core>=1.3.0,<1.4",
+    "langchain-core>=1.3.2,<1.4",
     "langchain-community>=0.4,<0.5",
-    "langchain-openai>=1.1.14,<1.2",
+    "langchain-openai>=1.2.1,<1.3",
     "langchain-anthropic>=1.4.1,<1.5",
     "faiss-cpu>=1.13.2,<2.0",  # Vector store for dedup workflow
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -126,7 +126,7 @@ langchain-community==0.4.1
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-core==1.3.0
+langchain-core==1.3.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -139,10 +139,12 @@ langchain-core==1.3.0
     #   langgraph
     #   langgraph-checkpoint
     #   langgraph-prebuilt
-langchain-openai==1.1.14
+langchain-openai==1.2.1
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
+langchain-protocol==0.0.13
+    # via langchain-core
 langchain-text-splitters==1.1.1
     # via langchain-classic
 langgraph==1.1.6
@@ -170,7 +172,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==1.20.1
+mypy==1.20.2
     # via workflows (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -220,7 +222,7 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pre-commit==4.5.1
+pre-commit==4.6.0
     # via workflows (pyproject.toml)
 propcache==0.4.1
     # via
@@ -228,7 +230,7 @@ propcache==0.4.1
     #   yarl
 pycodestyle==2.14.0
     # via flake8
-pydantic==2.13.2
+pydantic==2.13.3
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -241,7 +243,7 @@ pydantic==2.13.2
     #   langsmith
     #   openai
     #   pydantic-settings
-pydantic-core==2.46.2
+pydantic-core==2.46.3
     # via pydantic
 pydantic-settings==2.13.1
     # via langchain-community
@@ -296,7 +298,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.11
+ruff==0.15.12
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil
@@ -328,6 +330,7 @@ typing-extensions==4.15.0
     #   anthropic
     #   anyio
     #   langchain-core
+    #   langchain-protocol
     #   mypy
     #   openai
     #   pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,15 @@
 requests==2.33.1
 pytest==9.0.3
 pyyaml==6.0.3
-pydantic==2.13.2
+pydantic==2.13.3
 numpy==2.4.4
 pandas==3.0.2
 tomlkit==0.14.0
 
 # LangChain integration
 langchain==1.2.15
-langchain-core==1.3.0
+langchain-core==1.3.2
 langchain-community==0.4.1
-langchain-openai==1.1.14
+langchain-openai==1.2.1
 langchain-anthropic==1.4.1
 faiss-cpu==1.13.2

--- a/scripts/sync_tool_versions.py
+++ b/scripts/sync_tool_versions.py
@@ -15,6 +15,13 @@ from re import Pattern
 PIN_FILE = Path(".github/workflows/autofix-versions.env")
 PYPROJECT_FILE = Path("pyproject.toml")
 TEMPLATE_FILE = Path("templates/consumer-repo/.github/workflows/autofix-versions.env")
+INTEGRATION_TEMPLATE_FILE = Path(
+    "templates/integration-repo/.github/workflows/autofix-versions.env"
+)
+LOCKFILE_FILE = Path("requirements.lock")
+LOCKFILE_PATTERN = re.compile(
+    r"^(?P<lead>\s*)(?P<name>[A-Za-z0-9_.-]+)==(?P<version>[^\s#]+)(?P<trail>\s*(?:#.*)?)$"
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -138,6 +145,69 @@ def ensure_pyproject(
     return updated_content, mismatches
 
 
+def ensure_template(
+    source_content: str, template_file: Path, apply: bool
+) -> tuple[dict[str, str], bool]:
+    """Ensure a template env file mirrors the canonical pin file."""
+    if not template_file.exists():
+        return {}, False
+
+    template_content = template_file.read_text(encoding="utf-8")
+    if template_content == source_content:
+        return {}, False
+
+    if apply:
+        template_file.write_text(source_content, encoding="utf-8")
+    return {str(template_file): f"{template_file} differs from source pin file"}, True
+
+
+def ensure_lockfile(
+    lockfile_file: Path,
+    configs: Iterable[ToolConfig],
+    env: dict[str, str],
+    apply: bool,
+) -> dict[str, str]:
+    """Ensure direct tool pins in requirements.lock match the canonical pin file."""
+    if not lockfile_file.exists():
+        return {}
+
+    targets = {cfg.package_name.lower(): env[cfg.env_key] for cfg in configs}
+    content = lockfile_file.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    mismatches: dict[str, str] = {}
+    updated_lines: list[str] = []
+
+    for line in lines:
+        match = LOCKFILE_PATTERN.match(line)
+        if not match:
+            updated_lines.append(line)
+            continue
+
+        name = match.group("name")
+        current = match.group("version")
+        expected = targets.get(name.lower())
+        if expected and current != expected:
+            mismatches[f"requirements.lock:{name}"] = (
+                f"requirements.lock has {current}, pin file requires {expected}"
+            )
+            if apply:
+                updated_lines.append(
+                    f"{match.group('lead')}{name}=={expected}{match.group('trail')}"
+                )
+            else:
+                updated_lines.append(line)
+        else:
+            updated_lines.append(line)
+
+    if apply and mismatches:
+        updated_content = "\n".join(updated_lines)
+        if content.endswith("\n"):
+            updated_content += "\n"
+        lockfile_file.write_text(updated_content, encoding="utf-8")
+
+    return mismatches
+
+
 def main(argv: Iterable[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Synchronise tool version pins with pyproject.toml",
@@ -168,19 +238,17 @@ def main(argv: Iterable[str]) -> int:
         pyproject_content, TOOL_CONFIGS, env_values, apply_changes
     )
 
-    # Check template file is in sync with source
+    source_content = PIN_FILE.read_text(encoding="utf-8")
     template_mismatches: dict[str, str] = {}
-    if TEMPLATE_FILE.exists():
-        template_content = TEMPLATE_FILE.read_text(encoding="utf-8")
-        source_content = PIN_FILE.read_text(encoding="utf-8")
-        if template_content != source_content:
-            template_mismatches["template"] = (
-                "templates/consumer-repo autofix-versions.env differs from source"
-            )
-            if apply_changes:
-                TEMPLATE_FILE.write_text(source_content, encoding="utf-8")
+    template_updates = False
+    for template_file in (TEMPLATE_FILE, INTEGRATION_TEMPLATE_FILE):
+        mismatches, updated = ensure_template(source_content, template_file, apply_changes)
+        template_mismatches.update(mismatches)
+        template_updates = template_updates or updated
 
-    all_mismatches = {**project_mismatches, **template_mismatches}
+    lockfile_mismatches = ensure_lockfile(LOCKFILE_FILE, TOOL_CONFIGS, env_values, apply_changes)
+
+    all_mismatches = {**project_mismatches, **template_mismatches, **lockfile_mismatches}
     if all_mismatches and not apply_changes:
         for package, message in all_mismatches.items():
             print(f"✗ {package}: {message}", file=sys.stderr)
@@ -194,8 +262,10 @@ def main(argv: Iterable[str]) -> int:
         if pyproject_updated != pyproject_content:
             PYPROJECT_FILE.write_text(pyproject_updated, encoding="utf-8")
             print("✓ tool pins synced to pyproject.toml")
-        if template_mismatches:
-            print("✓ template autofix-versions.env synced from source")
+        if template_updates:
+            print("✓ template autofix-versions.env files synced from source")
+        if lockfile_mismatches:
+            print("✓ requirements.lock direct tool pins synced from source")
 
     return 0
 

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,10 +5,10 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.11
+RUFF_VERSION=0.15.12
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
-MYPY_VERSION=1.20.1
+MYPY_VERSION=1.20.2
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,10 +5,10 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.10
+RUFF_VERSION=0.15.12
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
-MYPY_VERSION=1.20.1
+MYPY_VERSION=1.20.2
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0

--- a/tests/scripts/test_sync_tool_versions.py
+++ b/tests/scripts/test_sync_tool_versions.py
@@ -13,6 +13,12 @@ def _disable_template_sync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         sync_tool_versions, "TEMPLATE_FILE", tmp_path / "nonexistent" / "template.env"
     )
+    monkeypatch.setattr(
+        sync_tool_versions,
+        "INTEGRATION_TEMPLATE_FILE",
+        tmp_path / "nonexistent" / "integration-template.env",
+    )
+    monkeypatch.setattr(sync_tool_versions, "LOCKFILE_FILE", tmp_path / "nonexistent.lock")
 
 
 def _write_env_file(path: Path, versions: dict[str, str]) -> None:
@@ -332,3 +338,74 @@ def test_template_sync_apply_updates_template(
     assert "template" in captured.out
     # Template should now match source
     assert template_path.read_text() == env_path.read_text()
+
+
+def test_integration_template_sync_detects_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    env_path = tmp_path / "pins.env"
+    pyproject_path = tmp_path / "pyproject.toml"
+    integration_template = tmp_path / "integration" / "autofix-versions.env"
+    integration_template.parent.mkdir(parents=True)
+
+    env_versions = {cfg.env_key: "14.0" for cfg in sync_tool_versions.TOOL_CONFIGS}
+    _write_env_file(env_path, env_versions)
+    pyproject_path.write_text(_make_pyproject_content(env_versions), encoding="utf-8")
+    integration_template.write_text("OLD_CONTENT\n", encoding="utf-8")
+
+    monkeypatch.setattr(sync_tool_versions, "PIN_FILE", env_path)
+    monkeypatch.setattr(sync_tool_versions, "PYPROJECT_FILE", pyproject_path)
+    monkeypatch.setattr(sync_tool_versions, "INTEGRATION_TEMPLATE_FILE", integration_template)
+
+    exit_code = sync_tool_versions.main(["--check"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert str(integration_template) in captured.err
+
+
+def test_lockfile_sync_detects_direct_pin_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    env_path = tmp_path / "pins.env"
+    pyproject_path = tmp_path / "pyproject.toml"
+    lockfile_path = tmp_path / "requirements.lock"
+
+    env_versions = {cfg.env_key: "15.0" for cfg in sync_tool_versions.TOOL_CONFIGS}
+    _write_env_file(env_path, env_versions)
+    pyproject_path.write_text(_make_pyproject_content(env_versions), encoding="utf-8")
+    lockfile_path.write_text("ruff==1.0\nmypy==15.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(sync_tool_versions, "PIN_FILE", env_path)
+    monkeypatch.setattr(sync_tool_versions, "PYPROJECT_FILE", pyproject_path)
+    monkeypatch.setattr(sync_tool_versions, "LOCKFILE_FILE", lockfile_path)
+
+    exit_code = sync_tool_versions.main(["--check"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "requirements.lock:ruff" in captured.err
+
+
+def test_lockfile_sync_apply_updates_direct_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    env_path = tmp_path / "pins.env"
+    pyproject_path = tmp_path / "pyproject.toml"
+    lockfile_path = tmp_path / "requirements.lock"
+
+    env_versions = {cfg.env_key: "16.0" for cfg in sync_tool_versions.TOOL_CONFIGS}
+    _write_env_file(env_path, env_versions)
+    pyproject_path.write_text(_make_pyproject_content(env_versions), encoding="utf-8")
+    lockfile_path.write_text("ruff==1.0\nmypy==16.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(sync_tool_versions, "PIN_FILE", env_path)
+    monkeypatch.setattr(sync_tool_versions, "PYPROJECT_FILE", pyproject_path)
+    monkeypatch.setattr(sync_tool_versions, "LOCKFILE_FILE", lockfile_path)
+
+    exit_code = sync_tool_versions.main(["--apply"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "requirements.lock direct tool pins synced" in captured.out
+    assert "ruff==16.0" in lockfile_path.read_text(encoding="utf-8")

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -9,7 +9,7 @@
 #   release resolve a mutually compatible core version.
 langchain==1.2.15
 langchain-community==0.4.1
-langchain-openai==1.1.15
+langchain-openai==1.2.1
 langchain-anthropic==1.4.1
-pydantic==2.13.2
+pydantic==2.13.3
 requests==2.33.1

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,3 @@
 # LLM Provider dependencies for Codex session analysis
 # These are optional - the provider falls back to regex if not available
-langchain-openai>=0.1.0
+langchain-openai>=1.2.1


### PR DESCRIPTION
## Summary
- route shared autofix/dev-tool pins through canonical autofix-versions.env instead of pyproject-only Dependabot bumps
- align current Workflows dependency bumps across env files, pyproject, requirements inputs, and requirements.lock
- extend sync_tool_versions.py to check consumer/integration templates and direct lockfile pins
- update the local Dependabot/sync campaign automation prompt to supersede partial autofix pin PRs with one Workflows source fix

## Validation
- python -m pytest tests/scripts/test_sync_tool_versions.py tests/scripts/test_sync_dev_dependencies.py tests/test_dependency_version_alignment.py
- python scripts/sync_tool_versions.py --check
- python scripts/sync_dev_dependencies.py --check --lockfile
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/validate_version_pins.py --check-all-templates
- ruff check scripts/sync_tool_versions.py tests/scripts/test_sync_tool_versions.py
- black --check --target-version py312 scripts/sync_tool_versions.py tests/scripts/test_sync_tool_versions.py
- workflow YAML parse smoke