### PR TITLE
docs: surface durable-tracker pointer in regenerated issue bodies

### DIFF
--- a/.github/scripts/consumer_sync_drift_issue_body.js
+++ b/.github/scripts/consumer_sync_drift_issue_body.js
@@ -125,6 +125,8 @@ function formatIssueBody(report, options = {}) {
   const lines = [
     '## Consumer Repo Drift Detected',
     '',
+    '> **Durable tracker** — see [`docs/ops/DURABLE_TRACKING_ISSUES.md`](https://github.com/stranske/Workflows/blob/main/docs/ops/DURABLE_TRACKING_ISSUES.md). The body below is regenerated each cycle by `health-68-consumer-sync-drift.yml`; auto-resolves on the next clean run.',
+    '',
     'One or more consumer repos have drifted from the Workflows templates or manifest entries.',
     '',
     `**Check Details:** ${runLink}`,

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -922,6 +922,8 @@ function formatCampaignBody(state) {
   const lines = [
     '# Sync/Dependabot Campaign Queue',
     '',
+    '> **Durable tracker** — see [`docs/ops/DURABLE_TRACKING_ISSUES.md`](https://github.com/stranske/Workflows/blob/main/docs/ops/DURABLE_TRACKING_ISSUES.md). The body below is regenerated each cycle by `maint-82-sync-dependabot-campaign.yml`; do not close as part of routine triage.',
+    '',
     'Remote GitHub Actions owns discovery for sync-generated and Dependabot PR rounds. Local Codex should only claim items from this issue when `needs-local-codex` work is queued.',
     '',
     '## Summary',


### PR DESCRIPTION
## Summary
- Follow-up to #1978 ([\`docs/ops/DURABLE_TRACKING_ISSUES.md\`](https://github.com/stranske/Workflows/blob/main/docs/ops/DURABLE_TRACKING_ISSUES.md)). The durable-tracker convention is now documented and labeled, but the bodies of #1836 and #1868 are regenerated each cycle by their owning bot, which would clobber any header added by hand. This PR moves the header into the body builders so it survives regeneration.
- `.github/scripts/sync_dependabot_campaign.js` (formatCampaignBody) — adds a one-line blockquote pointer at the top of the `#1836` body, before the existing summary.
- `.github/scripts/consumer_sync_drift_issue_body.js` (formatIssueBody) — adds the same pointer at the top of the `#1868` body, before the "One or more consumer repos have drifted" lead.

`#1796` already has a stable, human-managed body (the bot only appends comments), so it's covered by the comment posted in #1978's follow-up and doesn't need a code change here.

## Test plan
- [x] `node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js` — 6/6 pass
- [x] `node --test .github/scripts/__tests__/sync_dependabot_campaign.test.js` — 24/24 pass (including the body-size cap test)
- [x] `pytest tests/workflows/test_maint82_sync_campaign_contract.py -q` — 2/2 pass
- [ ] Existing CI gates pass on the small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)