### PR TITLE
fix: clarify draft ready GraphQL mutation

### DIFF
--- a/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
+++ b/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
@@ -69,6 +69,7 @@ function createGithub(options = {}) {
     combinedStatus = { state: 'success', statuses: [] },
     comments = [],
     graphqlError,
+    graphqlUnavailable = false,
   } = options;
   const calls = {
     labelAdds: [],
@@ -113,15 +114,17 @@ function createGithub(options = {}) {
     async paginate() {
       return comments;
     },
-    async graphql(query, variables) {
+    __calls: calls,
+  };
+  if (!graphqlUnavailable) {
+    github.graphql = async function graphql(query, variables) {
       calls.graphql.push({ query, variables });
       if (graphqlError) {
         throw graphqlError;
       }
       return { markPullRequestReadyForReview: { pullRequest: { number: pull?.number || 17, isDraft: false } } };
-    },
-    __calls: calls,
-  };
+    };
+  }
   return github;
 }
 
@@ -413,7 +416,21 @@ test('runKeepaliveGate converts checklist-complete draft PRs to ready for review
   const pr = makePullRequest({
     draft: true,
     labels: ['agents:keepalive', 'agent:codex'],
-    body: '- [x] Acceptance covered\n- [x] Tests pass',
+    body: [
+      '## Review Checklist',
+      '- [ ] CI passes with updated workflows',
+      '- [x] No repo-specific customizations were overwritten',
+      '',
+      '<!-- auto-status-summary:start -->',
+      '## Automated Status Summary',
+      '',
+      '#### Tasks',
+      '- [x] Acceptance covered',
+      '',
+      '#### Acceptance Criteria',
+      '- [x] Tests pass',
+      '<!-- auto-status-summary:end -->',
+    ].join('\n'),
   });
   const github = createGithub({
     pull: pr,
@@ -454,7 +471,17 @@ test('runKeepaliveGate routes incomplete draft PRs to human', async () => {
   const pr = makePullRequest({
     draft: true,
     labels: ['agents:keepalive', 'agent:codex'],
-    body: '- [x] Implementation started\n- [ ] Acceptance complete',
+    body: [
+      '<!-- auto-status-summary:start -->',
+      '## Automated Status Summary',
+      '',
+      '#### Tasks',
+      '- [x] Implementation started',
+      '',
+      '#### Acceptance Criteria',
+      '- [ ] Acceptance complete',
+      '<!-- auto-status-summary:end -->',
+    ].join('\n'),
   });
   const github = createGithub({ pull: pr });
 
@@ -472,5 +499,135 @@ test('runKeepaliveGate routes incomplete draft PRs to human', async () => {
   ]);
   assert.equal(github.__calls.commentsCreated.length, 1);
   assert.match(github.__calls.commentsCreated[0].body, /Draft PR requires human disposition/);
+  assert.match(github.__calls.commentsCreated[0].body, /remove `agents:paused` to resume keepalive/);
+  restore();
+});
+
+test('runKeepaliveGate routes draft PRs with no keepalive checklist to human with explicit reason', async () => {
+  const { core, outputs, summary } = createCore();
+  const gateStub = async () => createGateResult();
+  const { runKeepaliveGate, restore } = loadRunnerWithGate(gateStub);
+
+  const pr = makePullRequest({
+    draft: true,
+    labels: ['agents:keepalive', 'agent:codex'],
+    body: [
+      '<!-- auto-status-summary:start -->',
+      '## Automated Status Summary',
+      '',
+      '#### Scope',
+      'Draft was opened before tasks were written.',
+      '<!-- auto-status-summary:end -->',
+    ].join('\n'),
+  });
+  const github = createGithub({ pull: pr });
+
+  await runKeepaliveGate({
+    core,
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' }, runId: 44 },
+    env: makeEnv({ KEEPALIVE_MAX_RETRIES: '5' }),
+  });
+
+  assert.equal(outputs.proceed, 'false');
+  assert.equal(outputs.reason, 'pr-draft-no-checklist');
+  assert.equal(github.__calls.graphql.length, 0);
+  assert.equal(github.__calls.commentsCreated.length, 1);
+  assert.match(github.__calls.commentsCreated[0].body, /no keepalive checklist items were found/);
+  assert.doesNotMatch(github.__calls.commentsCreated[0].body, /with 0 unchecked checklist item/);
+  assert.ok(
+    summary.entries.some((entry) =>
+      entry.text?.includes('no keepalive checklist items were found')
+    )
+  );
+  restore();
+});
+
+test('runKeepaliveGate explains draft ready conversion failures without claiming unchecked items remain', async () => {
+  const { core, outputs } = createCore();
+  const gateStub = async () => createGateResult();
+  const { runKeepaliveGate, restore } = loadRunnerWithGate(gateStub);
+
+  const pr = makePullRequest({
+    draft: true,
+    labels: ['agents:keepalive', 'agent:codex'],
+    body: [
+      '<!-- auto-status-summary:start -->',
+      '## Automated Status Summary',
+      '',
+      '#### Tasks',
+      '- [x] Implementation complete',
+      '',
+      '#### Acceptance Criteria',
+      '- [x] Verified behavior',
+      '<!-- auto-status-summary:end -->',
+    ].join('\n'),
+  });
+  const github = createGithub({
+    pull: pr,
+    graphqlError: new Error('mutation blocked'),
+  });
+
+  await runKeepaliveGate({
+    core,
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' }, runId: 44 },
+    env: makeEnv({ KEEPALIVE_MAX_RETRIES: '5' }),
+  });
+
+  assert.equal(outputs.proceed, 'false');
+  assert.equal(outputs.reason, 'pr-draft-ready-failed');
+  assert.equal(github.__calls.graphql.length, 1);
+  assert.equal(github.__calls.commentsCreated.length, 1);
+  assert.match(github.__calls.commentsCreated[0].body, /automatic ready-for-review conversion failed/);
+  assert.doesNotMatch(github.__calls.commentsCreated[0].body, /with 0 unchecked checklist item/);
+  restore();
+});
+
+test('runKeepaliveGate distinguishes unavailable GraphQL client from missing PR node id', async () => {
+  const { core, outputs, summary } = createCore();
+  const gateStub = async () => createGateResult();
+  const { runKeepaliveGate, restore } = loadRunnerWithGate(gateStub);
+
+  const pr = makePullRequest({
+    draft: true,
+    labels: ['agents:keepalive', 'agent:codex'],
+    body: [
+      '<!-- auto-status-summary:start -->',
+      '## Automated Status Summary',
+      '',
+      '#### Tasks',
+      '- [x] Implementation complete',
+      '',
+      '#### Acceptance Criteria',
+      '- [x] Verified behavior',
+      '<!-- auto-status-summary:end -->',
+    ].join('\n'),
+  });
+  const github = createGithub({
+    pull: pr,
+    graphqlUnavailable: true,
+  });
+
+  await runKeepaliveGate({
+    core,
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' }, runId: 44 },
+    env: makeEnv({ KEEPALIVE_MAX_RETRIES: '5' }),
+  });
+
+  assert.equal(outputs.proceed, 'false');
+  assert.equal(outputs.reason, 'pr-draft-ready-failed');
+  assert.equal(github.__calls.graphql.length, 0);
+  assert.ok(
+    summary.entries.some((entry) =>
+      entry.text?.includes('GitHub GraphQL client is unavailable')
+    )
+  );
+  assert.ok(
+    !summary.entries.some((entry) =>
+      entry.text?.includes('missing GraphQL PR node id')
+    )
+  );
   restore();
 });

--- a/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
+++ b/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
@@ -434,6 +434,13 @@ test('runKeepaliveGate converts checklist-complete draft PRs to ready for review
   assert.equal(outputs.proceed, 'true');
   assert.equal(outputs.reason, '');
   assert.equal(github.__calls.graphql.length, 1);
+  assert.match(github.__calls.graphql[0].query, /mutation MarkDraftReadyForReview/);
+  assert.match(github.__calls.graphql[0].query, /markPullRequestReadyForReview/);
+  const braceBalance = [...github.__calls.graphql[0].query].reduce(
+    (balance, char) => balance + (char === '{' ? 1 : char === '}' ? -1 : 0),
+    0
+  );
+  assert.equal(braceBalance, 0);
   assert.equal(github.__calls.graphql[0].variables.pullRequestId, 'PR_node_17');
   assert.ok(summary.entries.some((entry) => entry.text?.includes('marked ready for review')));
   restore();

--- a/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -14,6 +14,16 @@ const PAUSE_LABEL = 'agents:paused';
 const NEEDS_HUMAN_LABEL = 'needs-human';
 const NEEDS_ATTENTION_LABEL = 'agent:needs-attention';
 const DRAFT_DISPOSITION_MARKER = '<!-- keepalive-draft-disposition -->';
+const MARK_DRAFT_READY_FOR_REVIEW_MUTATION = `
+mutation MarkDraftReadyForReview($pullRequestId: ID!) {
+  markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
+    pullRequest {
+      number
+      isDraft
+    }
+  }
+}
+`;
 
 function normaliseLabelName(label) {
   if (!label) {
@@ -112,14 +122,7 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
 
   try {
     await github.graphql(
-      `mutation($pullRequestId: ID!) {
-        markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
-          pullRequest {
-            number
-            isDraft
-          }
-        }
-      }`,
+      MARK_DRAFT_READY_FOR_REVIEW_MUTATION,
       { pullRequestId: nodeId }
     );
     summary.addRaw('Draft PR had no unchecked checklist items; marked ready for review.').addEOL();

--- a/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -8,6 +8,7 @@ const {
 } = require('./keepalive_guard_utils.js');
 const { evaluateKeepaliveGate } = require('./keepalive_gate.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const { parseScopeTasksAcceptanceSections } = require('./issue_scope_parser.js');
 
 const KEEPALIVE_LABEL = 'agents:keepalive';
 const PAUSE_LABEL = 'agents:paused';
@@ -89,6 +90,14 @@ function countMarkdownCheckboxes(body) {
   return counts;
 }
 
+function countDraftDispositionCheckboxes(body) {
+  const sections = parseScopeTasksAcceptanceSections(body || '');
+  const scopedChecklist = [sections?.tasks, sections?.acceptance]
+    .filter(Boolean)
+    .join('\n');
+  return countMarkdownCheckboxes(scopedChecklist);
+}
+
 async function addLabelsIfMissing({ github, owner, repo, prNumber, labels, currentLabels, core, summary }) {
   const toAdd = labels.filter((label) => label && !currentLabels.has(label.toLowerCase()));
   if (!toAdd.length) {
@@ -115,8 +124,12 @@ async function addLabelsIfMissing({ github, owner, repo, prNumber, labels, curre
 
 async function markDraftReadyForReview({ github, pr, core, summary }) {
   const nodeId = String(pr?.node_id || '').trim();
-  if (!nodeId || typeof github.graphql !== 'function') {
+  if (!nodeId) {
     summary.addRaw('Draft PR could not be converted automatically: missing GraphQL PR node id.').addEOL();
+    return false;
+  }
+  if (typeof github.graphql !== 'function') {
+    summary.addRaw('Draft PR could not be converted automatically: GitHub GraphQL client is unavailable.').addEOL();
     return false;
   }
 
@@ -135,7 +148,41 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
   }
 }
 
-async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary }) {
+function draftDispositionText(checkboxCounts, dispositionReason) {
+  const checked = Number(checkboxCounts?.checked || 0);
+  const unchecked = Number(checkboxCounts?.unchecked || 0);
+  const total = checked + unchecked;
+
+  if (total === 0 || dispositionReason === 'no-checklist') {
+    return {
+      summary: 'no keepalive checklist items were found',
+      detail:
+        'Keepalive found this PR still in draft, but no keepalive checklist items were found in the Tasks or Acceptance Criteria sections. Draft PRs must not occupy automation capacity silently.',
+      nextAction:
+        `Next human action: add or restore the keepalive checklist, disposition the draft, and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+    };
+  }
+
+  if (unchecked === 0) {
+    return {
+      summary: 'the keepalive checklist is complete, but automatic draft conversion failed',
+      detail:
+        'Keepalive found this PR still in draft and the keepalive checklist has no unchecked items, but automatic ready-for-review conversion failed. Draft PRs must not occupy automation capacity silently.',
+      nextAction:
+        `Next human action: mark the PR ready for review manually and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+    };
+  }
+
+  return {
+    summary: `${unchecked} unchecked keepalive checklist item(s) remain`,
+    detail:
+      `Keepalive found this PR still in draft with ${unchecked} unchecked keepalive checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    nextAction:
+      `Next human action: finish the unchecked acceptance items, mark the PR ready for review, and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+  };
+}
+
+async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, dispositionReason = '', core, summary }) {
   await addLabelsIfMissing({
     github,
     owner,
@@ -147,9 +194,10 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     summary,
   });
 
+  const disposition = draftDispositionText(checkboxCounts, dispositionReason);
   summary
     .addRaw(
-      `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
+      `Draft PR requires human disposition: ${disposition.summary} (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
     )
     .addEOL();
 
@@ -178,11 +226,11 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     DRAFT_DISPOSITION_MARKER,
     '### Draft PR requires human disposition',
     '',
-    `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    disposition.detail,
     '',
     `Applied \`${NEEDS_ATTENTION_LABEL}\`, \`${NEEDS_HUMAN_LABEL}\`, and \`${PAUSE_LABEL}\` so this is visible in automation summaries and human queues.`,
     '',
-    'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.',
+    disposition.nextAction,
   ].join('\n');
 
   try {
@@ -397,26 +445,61 @@ async function runKeepaliveGate({ core, github, context, env }) {
     }
     let draftRequiresHuman = false;
     if (pr.draft) {
-      const checkboxCounts = countMarkdownCheckboxes(pr.body || '');
+      const checkboxCounts = countDraftDispositionCheckboxes(pr.body || '');
       summary
         .addRaw(
-          `Pull request is draft; evaluating disposition (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
+          `Pull request is draft; evaluating keepalive checklist disposition (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
         )
         .addEOL();
 
-      const allChecklistWorkComplete = checkboxCounts.checked > 0 && checkboxCounts.unchecked === 0;
+      const totalChecklistItems = checkboxCounts.checked + checkboxCounts.unchecked;
+      const allChecklistWorkComplete = totalChecklistItems > 0 && checkboxCounts.unchecked === 0;
       if (allChecklistWorkComplete) {
         const ready = await markDraftReadyForReview({ github, pr, core, summary });
         if (ready) {
           pr.draft = false;
         } else {
           draftRequiresHuman = true;
-          await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+          await routeDraftToHuman({
+            github,
+            owner,
+            repo,
+            prNumber,
+            currentLabels,
+            checkboxCounts,
+            dispositionReason: 'ready-failed',
+            core,
+            summary,
+          });
           addReason('pr-draft-ready-failed');
         }
+      } else if (totalChecklistItems === 0) {
+        draftRequiresHuman = true;
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          dispositionReason: 'no-checklist',
+          core,
+          summary,
+        });
+        addReason('pr-draft-no-checklist');
       } else {
         draftRequiresHuman = true;
-        await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          dispositionReason: 'unchecked-items',
+          core,
+          summary,
+        });
         addReason('pr-draft-needs-human');
       }
     }

--- a/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -14,6 +14,16 @@ const PAUSE_LABEL = 'agents:paused';
 const NEEDS_HUMAN_LABEL = 'needs-human';
 const NEEDS_ATTENTION_LABEL = 'agent:needs-attention';
 const DRAFT_DISPOSITION_MARKER = '<!-- keepalive-draft-disposition -->';
+const MARK_DRAFT_READY_FOR_REVIEW_MUTATION = `
+mutation MarkDraftReadyForReview($pullRequestId: ID!) {
+  markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
+    pullRequest {
+      number
+      isDraft
+    }
+  }
+}
+`;
 
 function normaliseLabelName(label) {
   if (!label) {
@@ -112,14 +122,7 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
 
   try {
     await github.graphql(
-      `mutation($pullRequestId: ID!) {
-        markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
-          pullRequest {
-            number
-            isDraft
-          }
-        }
-      }`,
+      MARK_DRAFT_READY_FOR_REVIEW_MUTATION,
       { pullRequestId: nodeId }
     );
     summary.addRaw('Draft PR had no unchecked checklist items; marked ready for review.').addEOL();

--- a/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -8,6 +8,7 @@ const {
 } = require('./keepalive_guard_utils.js');
 const { evaluateKeepaliveGate } = require('./keepalive_gate.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
+const { parseScopeTasksAcceptanceSections } = require('./issue_scope_parser.js');
 
 const KEEPALIVE_LABEL = 'agents:keepalive';
 const PAUSE_LABEL = 'agents:paused';
@@ -89,6 +90,14 @@ function countMarkdownCheckboxes(body) {
   return counts;
 }
 
+function countDraftDispositionCheckboxes(body) {
+  const sections = parseScopeTasksAcceptanceSections(body || '');
+  const scopedChecklist = [sections?.tasks, sections?.acceptance]
+    .filter(Boolean)
+    .join('\n');
+  return countMarkdownCheckboxes(scopedChecklist);
+}
+
 async function addLabelsIfMissing({ github, owner, repo, prNumber, labels, currentLabels, core, summary }) {
   const toAdd = labels.filter((label) => label && !currentLabels.has(label.toLowerCase()));
   if (!toAdd.length) {
@@ -115,8 +124,12 @@ async function addLabelsIfMissing({ github, owner, repo, prNumber, labels, curre
 
 async function markDraftReadyForReview({ github, pr, core, summary }) {
   const nodeId = String(pr?.node_id || '').trim();
-  if (!nodeId || typeof github.graphql !== 'function') {
+  if (!nodeId) {
     summary.addRaw('Draft PR could not be converted automatically: missing GraphQL PR node id.').addEOL();
+    return false;
+  }
+  if (typeof github.graphql !== 'function') {
+    summary.addRaw('Draft PR could not be converted automatically: GitHub GraphQL client is unavailable.').addEOL();
     return false;
   }
 
@@ -135,7 +148,41 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
   }
 }
 
-async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary }) {
+function draftDispositionText(checkboxCounts, dispositionReason) {
+  const checked = Number(checkboxCounts?.checked || 0);
+  const unchecked = Number(checkboxCounts?.unchecked || 0);
+  const total = checked + unchecked;
+
+  if (total === 0 || dispositionReason === 'no-checklist') {
+    return {
+      summary: 'no keepalive checklist items were found',
+      detail:
+        'Keepalive found this PR still in draft, but no keepalive checklist items were found in the Tasks or Acceptance Criteria sections. Draft PRs must not occupy automation capacity silently.',
+      nextAction:
+        `Next human action: add or restore the keepalive checklist, disposition the draft, and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+    };
+  }
+
+  if (unchecked === 0) {
+    return {
+      summary: 'the keepalive checklist is complete, but automatic draft conversion failed',
+      detail:
+        'Keepalive found this PR still in draft and the keepalive checklist has no unchecked items, but automatic ready-for-review conversion failed. Draft PRs must not occupy automation capacity silently.',
+      nextAction:
+        `Next human action: mark the PR ready for review manually and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+    };
+  }
+
+  return {
+    summary: `${unchecked} unchecked keepalive checklist item(s) remain`,
+    detail:
+      `Keepalive found this PR still in draft with ${unchecked} unchecked keepalive checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    nextAction:
+      `Next human action: finish the unchecked acceptance items, mark the PR ready for review, and remove \`${PAUSE_LABEL}\` to resume keepalive; or close/supersede the PR.`,
+  };
+}
+
+async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, dispositionReason = '', core, summary }) {
   await addLabelsIfMissing({
     github,
     owner,
@@ -147,9 +194,10 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     summary,
   });
 
+  const disposition = draftDispositionText(checkboxCounts, dispositionReason);
   summary
     .addRaw(
-      `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
+      `Draft PR requires human disposition: ${disposition.summary} (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
     )
     .addEOL();
 
@@ -178,11 +226,11 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     DRAFT_DISPOSITION_MARKER,
     '### Draft PR requires human disposition',
     '',
-    `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    disposition.detail,
     '',
     `Applied \`${NEEDS_ATTENTION_LABEL}\`, \`${NEEDS_HUMAN_LABEL}\`, and \`${PAUSE_LABEL}\` so this is visible in automation summaries and human queues.`,
     '',
-    'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.',
+    disposition.nextAction,
   ].join('\n');
 
   try {
@@ -397,26 +445,61 @@ async function runKeepaliveGate({ core, github, context, env }) {
     }
     let draftRequiresHuman = false;
     if (pr.draft) {
-      const checkboxCounts = countMarkdownCheckboxes(pr.body || '');
+      const checkboxCounts = countDraftDispositionCheckboxes(pr.body || '');
       summary
         .addRaw(
-          `Pull request is draft; evaluating disposition (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
+          `Pull request is draft; evaluating keepalive checklist disposition (checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}).`
         )
         .addEOL();
 
-      const allChecklistWorkComplete = checkboxCounts.checked > 0 && checkboxCounts.unchecked === 0;
+      const totalChecklistItems = checkboxCounts.checked + checkboxCounts.unchecked;
+      const allChecklistWorkComplete = totalChecklistItems > 0 && checkboxCounts.unchecked === 0;
       if (allChecklistWorkComplete) {
         const ready = await markDraftReadyForReview({ github, pr, core, summary });
         if (ready) {
           pr.draft = false;
         } else {
           draftRequiresHuman = true;
-          await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+          await routeDraftToHuman({
+            github,
+            owner,
+            repo,
+            prNumber,
+            currentLabels,
+            checkboxCounts,
+            dispositionReason: 'ready-failed',
+            core,
+            summary,
+          });
           addReason('pr-draft-ready-failed');
         }
+      } else if (totalChecklistItems === 0) {
+        draftRequiresHuman = true;
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          dispositionReason: 'no-checklist',
+          core,
+          summary,
+        });
+        addReason('pr-draft-no-checklist');
       } else {
         draftRequiresHuman = true;
-        await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          dispositionReason: 'unchecked-items',
+          core,
+          summary,
+        });
         addReason('pr-draft-needs-human');
       }
     }


### PR DESCRIPTION
## Summary
- Moves the draft ready-for-review GraphQL mutation into a named constant with the outer selection set explicit.
- Adds a focused runner test assertion that the emitted mutation is the ready-for-review mutation and has balanced braces.

## Validation
- node --test .github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
- git diff --check

Source fix for sync-generated consumer PR review thread: stranske/Travel-Plan-Permission#1004.