### PR TITLE
docs: tighten rubric tier triggers after Phase 2 round 1 over-tiering

### DIFF
--- a/docs/ops/WORKFLOW_REVIEW_RUBRIC.md
+++ b/docs/ops/WORKFLOW_REVIEW_RUBRIC.md
@@ -47,15 +47,26 @@ minor gains.
 
 | Dimension | Threshold |
 |---|---|
-| Token cost | ≥10% reduction **and** the workflow consumes ≥1M tokens/month, **OR** the change addresses a recurring failure mode (≥3 occurrences in 90 days) |
+| Token cost | The workflow consumes ≥1M tokens/month (whether attributed directly via LangSmith or estimated by the heuristic). The "≥10% reduction lever available" question is a Phase 3 judgment, not a tier gate — Tier A means worth investigating for a lever, not proof a lever exists. |
 | CI time | ≥30s/run × ≥40 runs/month, **OR** ≥1m/run × ≥10 runs/month — both yield ~10–20 min/month saved as the floor |
-| Code quality | Only intervene if there is concrete evidence of harm: ≥2 incidents traced to this workflow OR ≥3 closed bug issues citing it OR associated script LOC > 500 with no test coverage |
+| Code quality | ≥2 incidents traced to this workflow in the 90-day window, **OR** ≥3 closed bug issues citing it. Script LOC stays in the inventory and informs Phase 3 prioritization but does not gate tier placement on its own — most load-bearing workflows have large scripts, and absence of an exact-name-match test file is not a reliable proxy for "no test coverage." |
 | Automation gap | ≥1 human intervention/month required by this workflow, **OR** ≥1 multi-day stuck window in last 90 days traced here |
 
 Thresholds are deliberately strict. They are the operationalization of "skip
 minor gains." If a threshold is wrong for the fleet's context, this document
 gets updated *first* — never adjust a threshold mid-review to justify a
 particular workflow.
+
+**History note**: an earlier version of the token-cost rule included a
+"recurring failure mode (≥3 occurrences in 90 days)" trigger and the
+code-quality rule included a "script LOC > 500 with no test coverage"
+trigger. Both were dropped in 2026-04-30 after Phase 2 round 1
+mechanically applied them and produced 83 Tier A workflows (vs the
+expected 15-25). The failure-mode phrasing was ambiguous between
+"per-workflow" and "across the inventory" and the inventory data didn't
+support either; the LOC+test trigger fired on every non-trivial workflow
+because exact-name-match test files are rare. The simpler dimension
+rules above replace them.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2 round 1 of the workflow fleet review produced 83 Tier A workflows vs the rubric's expected 15-25. Per the rubric's own guardrail (\"Either signal triggers a rubric-update review before the deep work proceeds\"), this PR tightens two over-firing triggers before Phase 2 round 2.

### What changed

- **Token cost** — dropped the \"recurring failure mode (≥3 occurrences in 90 days)\" trigger. The phrasing was ambiguous between per-workflow and fleet-wide, and the inventory's \`recent_failure_modes\` column doesn't carry per-workflow counts to support either. Codex applied it fleet-wide, which fired on every workflow with any cancellation. Now: just \`≥1M tokens/month\`.
- **Code quality** — dropped the \"script_loc > 500 with no test coverage\" trigger. \"No test coverage\" was implemented as strict filename matching (\`test_*<workflow>*.py\`), which fires on most workflows regardless of actual coverage. Now: just \`≥2 incidents\` OR \`≥3 closed bug issues citing it\`.
- Added a **History note** in the rubric explaining the change so future quarterly refreshes know why these triggers were dropped.

CI-time and automation-gap thresholds are unchanged — those rules worked correctly in round 1.

### Why this is the right move

After dropping the two over-firing triggers, the remaining tier signals (CI time, ≥1M tokens, ≥2 incidents, automation gap) are all backed by concrete thresholds the inventory data can support. Estimating from the round 1 data, Tier A round 2 should land roughly **20-25 workflows** — within the rubric's expected range.

The round 1 Phase 2 output (83 Tier A) is preserved at \`~/Library/CloudStorage/Dropbox/Learning/Code/Workflows-fleet-review/archive/\` for posterity.

## Test plan
- [x] Markdown renders cleanly
- [x] History note explains the trigger removal so future reviewers don't re-introduce them
- [ ] Existing CI gates pass on the docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)