### PR TITLE
fix(maint-65): idempotent label-doc sync with fixture coverage

### DIFF
--- a/.github/workflows/maint-65-sync-label-docs.yml
+++ b/.github/workflows/maint-65-sync-label-docs.yml
@@ -35,6 +35,7 @@ jobs:
             docs/LABELS.md
             .github/workflows/maint-68-sync-consumer-repos.yml
             scripts/list_registered_consumer_repos.py
+            scripts/sync_label_docs.py
           sparse-checkout-cone-mode: false
 
       - name: Verify source file exists
@@ -80,7 +81,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Determine repos to sync
           if [ -n "${CUSTOM_REPOS:-}" ]; then
             repos="${CUSTOM_REPOS}"
           else
@@ -88,63 +88,7 @@ jobs:
           fi
 
           echo "Syncing to repos: ${repos}"
-
-          # Process each repo
-          IFS=',' read -ra REPO_ARRAY <<< "$repos"
-          for repo in "${REPO_ARRAY[@]}"; do
-            repo=$(echo "$repo" | xargs)  # Trim whitespace
-            [ -z "$repo" ] && continue
-
-            echo "## Syncing to ${repo}"
-
-            # Create a temporary directory for the clone
-            tmpdir=$(mktemp -d)
-            trap 'rm -rf "$tmpdir"' EXIT
-
-            # Clone the target repo
-            clone_url="https://x-access-token:${SYNC_TOKEN}@github.com/${repo}.git"
-            if ! git clone --depth 1 "$clone_url" "$tmpdir" 2>/dev/null; then
-              echo "WARNING: Failed to clone ${repo} - skipping"
-              continue
-            fi
-
-            # Ensure docs directory exists
-            mkdir -p "$tmpdir/docs"
-
-            # Copy the labels file
-            cp docs/LABELS.md "$tmpdir/docs/LABELS.md"
-
-            # Check for changes
-            cd "$tmpdir"
-            if git diff --quiet docs/LABELS.md 2>/dev/null; then
-              echo "No changes needed for ${repo}"
-              cd - > /dev/null
-              continue
-            fi
-
-            # Commit and push if not dry run
-            if [ "${DRY_RUN}" = "true" ]; then
-              echo "DRY RUN: Would update docs/LABELS.md in ${repo}"
-              git diff docs/LABELS.md || true
-            else
-              git config user.name "github-actions[bot]"
-              git config user.email "github-actions[bot]@users.noreply.github.com"
-              git add docs/LABELS.md
-              git commit -m "docs: sync LABELS.md from Workflows repository"
-
-              if git push; then
-                echo "Successfully synced to ${repo}"
-              else
-                echo "WARNING: Failed to push to ${repo}"
-              fi
-            fi
-
-            cd - > /dev/null
-            rm -rf "$tmpdir"
-            trap - EXIT
-
-            echo "Processing complete for ${repo}"
-          done
+          python scripts/sync_label_docs.py --repos "${repos}" --source docs/LABELS.md
 
       - name: Summary
         run: |

--- a/scripts/sync_label_docs.py
+++ b/scripts/sync_label_docs.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Sync docs/LABELS.md to registered consumer repositories."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote
+
+DEFAULT_SOURCE = Path("docs/LABELS.md")
+TARGET_PATH = Path("docs/LABELS.md")
+COMMIT_MESSAGE = "docs: sync LABELS.md from Workflows repository"
+
+
+class SyncLabelDocsError(RuntimeError):
+    """Raised when a label docs sync cannot be completed safely."""
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    repo: str
+    status: str
+    message: str
+
+
+CommandRunner = Callable[[Sequence[str], Path | None], None]
+
+
+def parse_repos(value: str) -> list[str]:
+    return [repo.strip() for repo in value.split(",") if repo.strip()]
+
+
+def file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def redact_command(command: Sequence[str], redactions: Sequence[str] = ()) -> str:
+    parts: list[str] = []
+    for part in command:
+        safe_part = part
+        for secret in redactions:
+            if secret:
+                safe_part = safe_part.replace(secret, "***")
+        parts.append(safe_part)
+    return " ".join(parts)
+
+
+def run_command(
+    command: Sequence[str],
+    cwd: Path | None = None,
+    *,
+    redactions: Sequence[str] = (),
+) -> None:
+    completed = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    if completed.returncode == 0:
+        return
+
+    details = (completed.stderr or completed.stdout).strip()
+    safe_command = redact_command(command, redactions)
+    if details:
+        raise SyncLabelDocsError(
+            f"{safe_command} failed with exit {completed.returncode}: {details}"
+        )
+    raise SyncLabelDocsError(f"{safe_command} failed with exit {completed.returncode}")
+
+
+def build_clone_url(repo: str, token: str) -> str:
+    return f"https://x-access-token:{quote(token, safe='')}@github.com/{repo}.git"
+
+
+def sync_checkout(
+    *,
+    repo: str,
+    source_file: Path,
+    checkout_dir: Path,
+    dry_run: bool = False,
+    run: CommandRunner = run_command,
+) -> SyncResult:
+    source_file = source_file.resolve()
+    checkout_dir = checkout_dir.resolve()
+    docs_dir = checkout_dir / TARGET_PATH.parent
+    target_file = checkout_dir / TARGET_PATH
+
+    if not source_file.is_file():
+        raise SyncLabelDocsError(f"Source file not found: {source_file}")
+    if not docs_dir.is_dir():
+        raise SyncLabelDocsError(f"{repo}: target docs directory not found: {TARGET_PATH.parent}")
+
+    source_hash = file_sha256(source_file)
+    target_hash = file_sha256(target_file)
+    if source_hash == target_hash:
+        return SyncResult(repo=repo, status="skipped", message=f"No changes needed for {repo}")
+
+    if dry_run:
+        return SyncResult(
+            repo=repo,
+            status="changed",
+            message=f"DRY RUN: Would update {TARGET_PATH} in {repo}",
+        )
+
+    shutil.copyfile(source_file, target_file)
+    run(["git", "config", "user.name", "github-actions[bot]"], checkout_dir)
+    run(
+        ["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"],
+        checkout_dir,
+    )
+    run(["git", "add", str(TARGET_PATH)], checkout_dir)
+    run(["git", "commit", "-m", COMMIT_MESSAGE], checkout_dir)
+    run(["git", "push"], checkout_dir)
+    return SyncResult(repo=repo, status="updated", message=f"Successfully synced to {repo}")
+
+
+def sync_repo(
+    *,
+    repo: str,
+    token: str,
+    source_file: Path,
+    dry_run: bool = False,
+    run: CommandRunner = run_command,
+) -> SyncResult:
+    with tempfile.TemporaryDirectory(prefix="sync-label-docs-") as tmp:
+        checkout_dir = Path(tmp) / "repo"
+        clone_url = build_clone_url(repo, token)
+        try:
+            run(["git", "clone", "--depth", "1", clone_url, str(checkout_dir)], None)
+        except SyncLabelDocsError as exc:
+            raise SyncLabelDocsError(f"{repo}: clone failed") from exc
+
+        return sync_checkout(
+            repo=repo,
+            source_file=source_file,
+            checkout_dir=checkout_dir,
+            dry_run=dry_run,
+            run=run,
+        )
+
+
+def sync_repos(
+    *,
+    repos: Sequence[str],
+    token: str,
+    source_file: Path = DEFAULT_SOURCE,
+    dry_run: bool = False,
+) -> list[SyncResult]:
+    results: list[SyncResult] = []
+    failures: list[str] = []
+
+    for repo in repos:
+        print(f"## Syncing to {repo}", flush=True)
+        try:
+            result = sync_repo(repo=repo, token=token, source_file=source_file, dry_run=dry_run)
+        except SyncLabelDocsError as exc:
+            message = str(exc)
+            if not message.startswith(f"{repo}:"):
+                message = f"{repo}: {message}"
+            print(f"::error::{message}", flush=True)
+            failures.append(message)
+            continue
+
+        print(result.message, flush=True)
+        results.append(result)
+
+    if failures:
+        raise SyncLabelDocsError("; ".join(failures))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repos", required=True, help="Comma-separated owner/repo names")
+    parser.add_argument("--source", default=str(DEFAULT_SOURCE), help="Source LABELS.md path")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=os.environ.get("DRY_RUN", "false").lower() == "true",
+        help="Preview changes without committing or pushing",
+    )
+    parser.add_argument(
+        "--token-env",
+        default="SYNC_TOKEN",
+        help="Environment variable containing a push-capable GitHub token",
+    )
+    args = parser.parse_args()
+
+    repos = parse_repos(args.repos)
+    if not repos:
+        raise SystemExit("No repositories supplied")
+
+    token = os.environ.get(args.token_env, "")
+    if not token:
+        raise SystemExit(f"Missing sync token in ${args.token_env}")
+
+    try:
+        sync_repos(repos=repos, token=token, source_file=Path(args.source), dry_run=args.dry_run)
+    except SyncLabelDocsError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_sync_label_docs.py
+++ b/tests/scripts/test_sync_label_docs.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+from scripts import sync_label_docs
+
+
+def write_label_doc(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_source_unchanged_skips_cleanly(tmp_path: Path) -> None:
+    source = tmp_path / "source" / "LABELS.md"
+    checkout = tmp_path / "checkout"
+    write_label_doc(source, "# Labels\n\nSame content\n")
+    write_label_doc(checkout / "docs" / "LABELS.md", "# Labels\n\nSame content\n")
+
+    commands: list[list[str]] = []
+
+    def run(command: list[str], cwd: Path | None) -> None:
+        commands.append(command)
+
+    result = sync_label_docs.sync_checkout(
+        repo="owner/repo",
+        source_file=source,
+        checkout_dir=checkout,
+        run=run,
+    )
+
+    assert result.status == "skipped"
+    assert result.message == "No changes needed for owner/repo"
+    assert commands == []
+
+
+def test_source_changed_writes_doc_and_pushes_commit(tmp_path: Path) -> None:
+    source = tmp_path / "source" / "LABELS.md"
+    checkout = tmp_path / "checkout"
+    write_label_doc(source, "# Labels\n\nNew content\n")
+    write_label_doc(checkout / "docs" / "LABELS.md", "# Labels\n\nOld content\n")
+
+    commands: list[tuple[list[str], Path | None]] = []
+
+    def run(command: list[str], cwd: Path | None) -> None:
+        commands.append((command, cwd))
+
+    result = sync_label_docs.sync_checkout(
+        repo="owner/repo",
+        source_file=source,
+        checkout_dir=checkout,
+        run=run,
+    )
+
+    assert result.status == "updated"
+    assert (checkout / "docs" / "LABELS.md").read_text(encoding="utf-8") == (
+        "# Labels\n\nNew content\n"
+    )
+    assert [command for command, _cwd in commands] == [
+        ["git", "config", "user.name", "github-actions[bot]"],
+        ["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"],
+        ["git", "add", "docs/LABELS.md"],
+        ["git", "commit", "-m", "docs: sync LABELS.md from Workflows repository"],
+        ["git", "push"],
+    ]
+    assert all(cwd == checkout.resolve() for _command, cwd in commands)
+
+
+def test_missing_target_docs_directory_fails_clearly(tmp_path: Path) -> None:
+    source = tmp_path / "source" / "LABELS.md"
+    checkout = tmp_path / "checkout"
+    write_label_doc(source, "# Labels\n")
+    checkout.mkdir()
+
+    with pytest.raises(sync_label_docs.SyncLabelDocsError) as excinfo:
+        sync_label_docs.sync_checkout(
+            repo="owner/repo",
+            source_file=source,
+            checkout_dir=checkout,
+        )
+
+    assert "owner/repo: target docs directory not found: docs" in str(excinfo.value)


### PR DESCRIPTION
## Motivation

Phase 3 fleet review `workflow-reviews/maint-65-sync-label-docs.md` flagged `maint-65-sync-label-docs.yml` as the highest incident-rate Tier A workflow: 20 incidents in 90 days across roughly 18 runs. The review recommended making the label-doc sync idempotent with fixture tests so the critical sync paths are covered.

## Diagnosis

Recent failed runs `24969113849`, `22535375332`, `22293363571`, and `22289173208` failed before syncing because the sparse checkout did not include `.github/workflows/maint-68-sync-consumer-repos.yml`, causing `scripts/list_registered_consumer_repos.py` to raise `Manifest not found`. Current `main` already includes that sparse-checkout manifest fix and the latest dry-run is green, but the sync/push behavior still lived as inline shell with no fixture coverage.

This PR keeps the maint-65 scope focused by extracting only the label-doc sync mechanism into `scripts/sync_label_docs.py` and wiring the workflow to call it.

## What Changed

- Adds `scripts/sync_label_docs.py` with content-hash idempotency before any commit work.
- Skips cleanly when the target `docs/LABELS.md` hash already matches the source.
- Commits and pushes only when the source hash differs.
- Fails clearly for malformed target checkouts, including missing `docs/` directories, instead of silently manufacturing the target shape.
- Adds fixture-style tests for unchanged, changed, and error paths.

## Test Plan

- [x] `pytest tests/scripts/test_sync_label_docs.py`
- [x] `pytest tests/workflows/test_registered_consumer_repos_helper.py`
- [x] `python -m ruff check scripts/sync_label_docs.py tests/scripts/test_sync_label_docs.py`
- [x] `python scripts/validate_workflow_yaml.py .github/workflows/maint-65-sync-label-docs.yml`
- [x] `scripts/sync_templates.sh && python scripts/validate_template_completeness.py`
- [ ] Existing GitHub CI gates pass on this PR
