### PR TITLE
feat: add path-classifier composite action with classification config

### DIFF
--- a/.github/actions/path-classifier/action.yml
+++ b/.github/actions/path-classifier/action.yml
@@ -1,0 +1,54 @@
+name: Path Classifier
+description: Classify changed PR paths into workflow relevance categories.
+
+inputs:
+  base-ref:
+    description: Base ref or SHA to diff against. Defaults to PR base or push before SHA.
+    required: false
+  config-path:
+    description: Path classification config file.
+    required: false
+    default: .github/path-classification.yml
+  force-full:
+    description: Set true to force every category output to true.
+    required: false
+    default: 'false'
+
+outputs:
+  is-docs-only:
+    description: True when every changed path matches the docs-only category.
+    value: ${{ steps.classify.outputs.is-docs-only }}
+  is-python-code:
+    description: True when any changed path is Python-code relevant.
+    value: ${{ steps.classify.outputs.is-python-code }}
+  is-workflow-change:
+    description: True when any changed path affects GitHub workflows or actions.
+    value: ${{ steps.classify.outputs.is-workflow-change }}
+  is-security-relevant:
+    description: True when any changed path is security-scan relevant.
+    value: ${{ steps.classify.outputs.is-security-relevant }}
+  is-template-change:
+    description: True when any changed path affects consumer templates.
+    value: ${{ steps.classify.outputs.is-template-change }}
+  is-test-only:
+    description: True when every changed path matches the test-only category.
+    value: ${{ steps.classify.outputs.is-test-only }}
+  affected-consumers:
+    description: JSON list of affected consumers. Reserved for Wave 2.
+    value: ${{ steps.classify.outputs.affected-consumers }}
+  classification-rationale:
+    description: Human-readable classification rationale.
+    value: ${{ steps.classify.outputs.classification-rationale }}
+
+runs:
+  using: composite
+  steps:
+    - name: Classify changed paths
+      id: classify
+      shell: bash
+      env:
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_CONFIG_PATH: ${{ inputs.config-path }}
+        INPUT_FORCE_FULL: ${{ inputs.force-full }}
+        GITHUB_CONTEXT_JSON: ${{ toJSON(github) }}
+      run: node "$GITHUB_ACTION_PATH/classify.js"

--- a/.github/actions/path-classifier/classify.js
+++ b/.github/actions/path-classifier/classify.js
@@ -1,0 +1,348 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const OUTPUT_NAMES = {
+  'docs-only': 'is-docs-only',
+  'python-code': 'is-python-code',
+  'workflow-change': 'is-workflow-change',
+  'security-relevant': 'is-security-relevant',
+  'template-change': 'is-template-change',
+  'test-only': 'is-test-only',
+};
+
+const DEFAULT_CATEGORIES = {
+  'docs-only': { paths: ['docs/**', '*.md', 'README.md'], requireAll: true },
+  'python-code': { paths: ['**/*.py', 'pyproject.toml', 'requirements*.txt'], requireAll: false },
+  'workflow-change': { paths: ['.github/workflows/**', '.github/actions/**'], requireAll: false },
+  'security-relevant': {
+    paths: ['scripts/**', 'tools/**', '.github/workflows/**', 'pyproject.toml'],
+    requireAll: false,
+  },
+  'template-change': { paths: ['templates/**'], requireAll: false },
+  'test-only': { paths: ['tests/**', '**/test_*.py', '**/*.test.js'], requireAll: true },
+};
+
+function normalizePath(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\/+/, '');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function globToRegExp(glob) {
+  const pattern = normalizePath(glob);
+  let out = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+    if (char === '*') {
+      if (next === '*') {
+        const after = pattern[index + 2];
+        if (after === '/') {
+          out += '(?:.*/)?';
+          index += 2;
+        } else {
+          out += '.*';
+          index += 1;
+        }
+      } else {
+        out += '[^/]*';
+      }
+    } else if (char === '?') {
+      out += '[^/]';
+    } else {
+      out += escapeRegExp(char);
+    }
+  }
+  out += '$';
+  return new RegExp(out);
+}
+
+function matchesAny(filePath, patterns) {
+  const normalized = normalizePath(filePath);
+  return patterns.some((pattern) => globToRegExp(pattern).test(normalized));
+}
+
+function parseScalar(value) {
+  const trimmed = String(value || '').trim();
+  if (trimmed === 'true') {
+    return true;
+  }
+  if (trimmed === 'false') {
+    return false;
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseInlineList(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return null;
+  }
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) {
+    return [];
+  }
+  return body.split(',').map((entry) => parseScalar(entry));
+}
+
+function parseClassificationConfig(raw) {
+  const categories = {};
+  const lines = String(raw || '').split(/\r?\n/);
+  let section = null;
+  let category = null;
+  let listKey = null;
+
+  for (const line of lines) {
+    const withoutComment = line.replace(/\s+#.*$/, '');
+    if (!withoutComment.trim()) {
+      continue;
+    }
+    const indent = withoutComment.match(/^ */)[0].length;
+    const trimmed = withoutComment.trim();
+
+    if (indent === 0 && trimmed.endsWith(':')) {
+      section = trimmed.slice(0, -1);
+      category = null;
+      listKey = null;
+      continue;
+    }
+
+    if (section !== 'categories') {
+      continue;
+    }
+
+    if (indent === 2 && trimmed.endsWith(':')) {
+      category = trimmed.slice(0, -1);
+      categories[category] = categories[category] || {};
+      listKey = null;
+      continue;
+    }
+
+    if (!category) {
+      continue;
+    }
+
+    if (indent === 4 && trimmed.includes(':')) {
+      const [key, ...rest] = trimmed.split(':');
+      const value = rest.join(':').trim();
+      const normalizedKey = key === 'require-all' ? 'requireAll' : key;
+      if (!value) {
+        categories[category][normalizedKey] = [];
+        listKey = normalizedKey;
+        continue;
+      }
+      const inlineList = parseInlineList(value);
+      categories[category][normalizedKey] = inlineList === null ? parseScalar(value) : inlineList;
+      listKey = null;
+      continue;
+    }
+
+    if (indent >= 6 && listKey && trimmed.startsWith('- ')) {
+      categories[category][listKey].push(parseScalar(trimmed.slice(2)));
+    }
+  }
+
+  return { categories };
+}
+
+function loadConfig(configPath) {
+  const resolved = path.resolve(process.env.GITHUB_WORKSPACE || process.cwd(), configPath);
+  if (!fs.existsSync(resolved)) {
+    return { categories: DEFAULT_CATEGORIES, configPath: resolved, usedDefault: true };
+  }
+  const parsed = parseClassificationConfig(fs.readFileSync(resolved, 'utf8'));
+  const categories = {};
+  for (const [name, fallback] of Object.entries(DEFAULT_CATEGORIES)) {
+    const configured = parsed.categories[name] || {};
+    categories[name] = {
+      paths: Array.isArray(configured.paths) ? configured.paths : fallback.paths,
+      requireAll:
+        typeof configured.requireAll === 'boolean' ? configured.requireAll : fallback.requireAll,
+    };
+  }
+  return { categories, configPath: resolved, usedDefault: false };
+}
+
+function parseGithubContext() {
+  try {
+    return JSON.parse(process.env.GITHUB_CONTEXT_JSON || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function runGit(args) {
+  return execFileSync('git', args, {
+    cwd: process.env.GITHUB_WORKSPACE || process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function tryGit(args) {
+  try {
+    return runGit(args);
+  } catch {
+    return '';
+  }
+}
+
+function resolveBaseRef(inputBaseRef, githubContext) {
+  if (inputBaseRef) {
+    return inputBaseRef;
+  }
+  if (githubContext.event_name === 'pull_request' && githubContext.base_ref) {
+    return `origin/${githubContext.base_ref}`;
+  }
+  const event = githubContext.event || {};
+  if (event.before && !/^0+$/.test(event.before)) {
+    return event.before;
+  }
+  return '';
+}
+
+function fetchBaseRef(baseRef, githubContext) {
+  if (!baseRef || !baseRef.startsWith('origin/')) {
+    return;
+  }
+  const branch = baseRef.slice('origin/'.length);
+  tryGit(['fetch', '--no-tags', '--depth=1', 'origin', branch]);
+  const prBaseSha = githubContext.event?.pull_request?.base?.sha;
+  if (prBaseSha) {
+    tryGit(['fetch', '--no-tags', '--depth=1', 'origin', prBaseSha]);
+  }
+}
+
+function listChangedFiles({ baseRef, githubContext } = {}) {
+  const envFiles = process.env.PATH_CLASSIFIER_FILES_JSON;
+  if (envFiles) {
+    const parsed = JSON.parse(envFiles);
+    if (!Array.isArray(parsed)) {
+      throw new Error('PATH_CLASSIFIER_FILES_JSON must be a JSON array');
+    }
+    return parsed.map(normalizePath).filter(Boolean);
+  }
+
+  fetchBaseRef(baseRef, githubContext);
+  const head = githubContext.sha || 'HEAD';
+  const ranges = [];
+  if (baseRef) {
+    ranges.push(`${baseRef}...${head}`);
+    ranges.push(`${baseRef}..${head}`);
+  }
+  const prBaseSha = githubContext.event?.pull_request?.base?.sha;
+  if (prBaseSha) {
+    ranges.push(`${prBaseSha}...${head}`);
+    ranges.push(`${prBaseSha}..${head}`);
+  }
+
+  for (const range of ranges) {
+    const output = tryGit(['diff', '--name-only', range]);
+    if (output) {
+      return output.split(/\r?\n/).map(normalizePath).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function classifyFiles(files, config, { forceFull = false, conservativeFull = false } = {}) {
+  const changedFiles = Array.from(new Set((files || []).map(normalizePath).filter(Boolean)));
+  const outputs = {};
+  const matched = {};
+
+  for (const [category, rule] of Object.entries(config.categories)) {
+    const outputName = OUTPUT_NAMES[category] || `is-${category}`;
+    const patterns = Array.isArray(rule.paths) ? rule.paths : [];
+    const matches = changedFiles.filter((filePath) => matchesAny(filePath, patterns));
+    let enabled;
+    if (forceFull || conservativeFull) {
+      enabled = true;
+    } else if (changedFiles.length === 0) {
+      enabled = false;
+    } else if (rule.requireAll) {
+      enabled = matches.length === changedFiles.length;
+    } else {
+      enabled = matches.length > 0;
+    }
+    outputs[outputName] = enabled ? 'true' : 'false';
+    matched[category] = matches;
+  }
+
+  outputs['affected-consumers'] = '[]';
+  const trueOutputs = Object.entries(outputs)
+    .filter(([key, value]) => key.startsWith('is-') && value === 'true')
+    .map(([key]) => key.replace(/^is-/, ''));
+  const mode = forceFull ? 'force-full' : conservativeFull ? 'conservative-full' : 'classified';
+  outputs['classification-rationale'] =
+    `${mode}: ${changedFiles.length} changed file(s); ` +
+    (trueOutputs.length ? `matched ${trueOutputs.join(', ')}` : 'no categories matched');
+
+  return { outputs, changedFiles, matched };
+}
+
+function writeOutputs(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  for (const [key, value] of Object.entries(outputs)) {
+    console.log(`${key}=${value}`);
+  }
+  if (!outputPath) {
+    return;
+  }
+  const lines = [];
+  for (const [key, value] of Object.entries(outputs)) {
+    if (String(value).includes('\n')) {
+      lines.push(`${key}<<PATH_CLASSIFIER_EOF\n${value}\nPATH_CLASSIFIER_EOF`);
+    } else {
+      lines.push(`${key}=${value}`);
+    }
+  }
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function main() {
+  const githubContext = parseGithubContext();
+  const forceFull = String(process.env.INPUT_FORCE_FULL || '').toLowerCase() === 'true';
+  const configPath = process.env.INPUT_CONFIG_PATH || '.github/path-classification.yml';
+  const baseRef = resolveBaseRef(process.env.INPUT_BASE_REF || '', githubContext);
+  const config = loadConfig(configPath);
+  let files = [];
+  let conservativeFull = false;
+
+  try {
+    files = listChangedFiles({ baseRef, githubContext });
+  } catch (error) {
+    conservativeFull = true;
+    console.warn(`::warning::Unable to list changed files; forcing full classification: ${error.message}`);
+  }
+
+  const result = classifyFiles(files, config, { forceFull, conservativeFull });
+  writeOutputs(result.outputs);
+  console.log(`Changed files: ${result.changedFiles.join(', ') || '(none)'}`);
+  console.log(`Config: ${config.configPath}${config.usedDefault ? ' (default fallback)' : ''}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  DEFAULT_CATEGORIES,
+  OUTPUT_NAMES,
+  classifyFiles,
+  globToRegExp,
+  loadConfig,
+  matchesAny,
+  normalizePath,
+  parseClassificationConfig,
+};

--- a/.github/path-classification.yml
+++ b/.github/path-classification.yml
@@ -1,0 +1,35 @@
+categories:
+  docs-only:
+    require-all: true
+    paths:
+      - docs/**
+      - "*.md"
+      - README.md
+  python-code:
+    require-all: false
+    paths:
+      - "**/*.py"
+      - pyproject.toml
+      - requirements*.txt
+  workflow-change:
+    require-all: false
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  security-relevant:
+    require-all: false
+    paths:
+      - scripts/**
+      - tools/**
+      - .github/workflows/**
+      - pyproject.toml
+  template-change:
+    require-all: false
+    paths:
+      - templates/**
+  test-only:
+    require-all: true
+    paths:
+      - tests/**
+      - "**/test_*.py"
+      - "**/*.test.js"

--- a/.github/scripts/__tests__/path-classifier-replay.test.js
+++ b/.github/scripts/__tests__/path-classifier-replay.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+
+const {
+  DEFAULT_CATEGORIES,
+  classifyFiles,
+  matchesAny,
+} = require('../../actions/path-classifier/classify.js');
+
+const CONFIG = { categories: DEFAULT_CATEGORIES };
+const SINCE = '2026-02-03';
+
+function runGh(args) {
+  return execFileSync('gh', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function requireGh() {
+  try {
+    runGh(['auth', 'status']);
+  } catch (error) {
+    throw new Error(`gh authentication is required for path-classifier replay: ${error.message}`);
+  }
+}
+
+function listRecentMergedPullRequests() {
+  const raw = runGh([
+    'pr',
+    'list',
+    '--repo',
+    'stranske/Workflows',
+    '--state',
+    'merged',
+    '--limit',
+    '200',
+    '--search',
+    `merged:>=${SINCE}`,
+    '--json',
+    'number,mergedAt,files',
+  ]);
+  return JSON.parse(raw);
+}
+
+function expectRequireAll(files, patterns) {
+  return files.length > 0 && files.every((filePath) => matchesAny(filePath, patterns));
+}
+
+function expectAny(files, patterns) {
+  return files.some((filePath) => matchesAny(filePath, patterns));
+}
+
+test('historical merged PR replay matches classification expectations for last 90 days', {
+  skip: process.env.PATH_CLASSIFIER_REPLAY !== '1'
+    ? 'set PATH_CLASSIFIER_REPLAY=1 to run live GitHub replay'
+    : false,
+}, () => {
+  requireGh();
+  const pullRequests = listRecentMergedPullRequests();
+  assert.ok(pullRequests.length > 0, 'expected at least one merged PR in replay window');
+
+  const failures = [];
+  for (const pr of pullRequests) {
+    const files = (pr.files || []).map((file) => file.path).filter(Boolean);
+    const outputs = classifyFiles(files, CONFIG).outputs;
+    const expected = {
+      'is-docs-only': expectRequireAll(files, CONFIG.categories['docs-only'].paths),
+      'is-python-code': expectAny(files, CONFIG.categories['python-code'].paths),
+      'is-workflow-change': expectAny(files, CONFIG.categories['workflow-change'].paths),
+      'is-security-relevant': expectAny(files, CONFIG.categories['security-relevant'].paths),
+      'is-template-change': expectAny(files, CONFIG.categories['template-change'].paths),
+      'is-test-only': expectRequireAll(files, CONFIG.categories['test-only'].paths),
+    };
+
+    for (const [name, expectedValue] of Object.entries(expected)) {
+      if (outputs[name] !== String(expectedValue)) {
+        failures.push(
+          `PR #${pr.number} ${name}: expected ${expectedValue}, got ${outputs[name]} for ${files.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/.github/scripts/__tests__/path-classifier.test.js
+++ b/.github/scripts/__tests__/path-classifier.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_CATEGORIES,
+  classifyFiles,
+  globToRegExp,
+  matchesAny,
+  parseClassificationConfig,
+} = require('../../actions/path-classifier/classify.js');
+
+const CONFIG = { categories: DEFAULT_CATEGORIES };
+
+function outputsFor(files, options) {
+  return classifyFiles(files, CONFIG, options).outputs;
+}
+
+test('glob matcher handles root and nested patterns', () => {
+  assert.match('README.md', globToRegExp('*.md'));
+  assert.doesNotMatch('docs/README.md', globToRegExp('*.md'));
+  assert.equal(matchesAny('pkg/module.py', ['**/*.py']), true);
+  assert.equal(matchesAny('module.py', ['**/*.py']), true);
+  assert.equal(matchesAny('.github/actions/path-classifier/action.yml', ['.github/actions/**']), true);
+});
+
+test('classifies docs-only changes when every path matches docs rules', () => {
+  const outputs = outputsFor(['README.md', 'docs/usage.md']);
+  assert.equal(outputs['is-docs-only'], 'true');
+  assert.equal(outputs['is-python-code'], 'false');
+  assert.equal(outputs['is-security-relevant'], 'false');
+});
+
+test('classifies python code changes', () => {
+  const outputs = outputsFor(['src/app.py', 'requirements-dev.txt']);
+  assert.equal(outputs['is-python-code'], 'true');
+  assert.equal(outputs['is-docs-only'], 'false');
+});
+
+test('classifies workflow and security relevant changes', () => {
+  const outputs = outputsFor(['.github/workflows/pr-00-gate.yml']);
+  assert.equal(outputs['is-workflow-change'], 'true');
+  assert.equal(outputs['is-security-relevant'], 'true');
+});
+
+test('classifies security relevant tool and pyproject changes', () => {
+  const outputs = outputsFor(['tools/enforce_gate_branch_protection.py', 'pyproject.toml']);
+  assert.equal(outputs['is-security-relevant'], 'true');
+  assert.equal(outputs['is-python-code'], 'true');
+});
+
+test('classifies template changes', () => {
+  const outputs = outputsFor(['templates/consumer-repo/.github/workflows/pr-00-gate.yml']);
+  assert.equal(outputs['is-template-change'], 'true');
+  assert.equal(outputs['is-workflow-change'], 'false');
+});
+
+test('classifies test-only changes when every path is a test', () => {
+  const outputs = outputsFor([
+    'tests/workflows/test_gate.py',
+    '.github/scripts/__tests__/path-classifier.test.js',
+  ]);
+  assert.equal(outputs['is-test-only'], 'true');
+  assert.equal(outputs['is-python-code'], 'true');
+});
+
+test('mixed docs and code changes are not docs-only or test-only', () => {
+  const outputs = outputsFor(['docs/usage.md', 'scripts/sync_dev_dependencies.py']);
+  assert.equal(outputs['is-docs-only'], 'false');
+  assert.equal(outputs['is-test-only'], 'false');
+  assert.equal(outputs['is-python-code'], 'true');
+  assert.equal(outputs['is-security-relevant'], 'true');
+});
+
+test('empty diff does not enable categories', () => {
+  const outputs = outputsFor([]);
+  assert.equal(outputs['is-docs-only'], 'false');
+  assert.equal(outputs['is-python-code'], 'false');
+  assert.equal(outputs['is-workflow-change'], 'false');
+  assert.equal(outputs['is-security-relevant'], 'false');
+  assert.equal(outputs['is-template-change'], 'false');
+  assert.equal(outputs['is-test-only'], 'false');
+  assert.equal(outputs['affected-consumers'], '[]');
+});
+
+test('force-full override enables every category output', () => {
+  const outputs = outputsFor(['README.md'], { forceFull: true });
+  assert.equal(outputs['is-docs-only'], 'true');
+  assert.equal(outputs['is-python-code'], 'true');
+  assert.equal(outputs['is-workflow-change'], 'true');
+  assert.equal(outputs['is-security-relevant'], 'true');
+  assert.equal(outputs['is-template-change'], 'true');
+  assert.equal(outputs['is-test-only'], 'true');
+});
+
+test('parses classification YAML config', () => {
+  const parsed = parseClassificationConfig(`
+categories:
+  docs-only:
+    require-all: true
+    paths:
+      - docs/**
+      - "*.md"
+  python-code:
+    require-all: false
+    paths: ["**/*.py", pyproject.toml]
+`);
+  assert.deepEqual(parsed.categories['docs-only'], {
+    requireAll: true,
+    paths: ['docs/**', '*.md'],
+  });
+  assert.deepEqual(parsed.categories['python-code'], {
+    requireAll: false,
+    paths: ['**/*.py', 'pyproject.toml'],
+  });
+});

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -567,6 +567,9 @@ templates:
   - source: .github/PULL_REQUEST_TEMPLATE.md
     description: "Pull request template with Workflow Source fields for direct GitHub and non-issue work"
 
+  - source: .github/path-classification.yml
+    description: "Path classification config used by the path-classifier composite action"
+
 # Actions required by reusable workflows
 actions:
   - source: .github/actions/setup-api-client/
@@ -576,6 +579,10 @@ actions:
   - source: .github/actions/export-load-balancer-tokens/
     is_directory: true
     description: "Export load balancer tokens action - required by reusable-10-ci-python.yml (deprecated, use setup-api-client)"
+
+  - source: .github/actions/path-classifier/
+    is_directory: true
+    description: "Classifies changed PR paths for path-aware expensive job gating"
 
 # Configuration files for LLM providers and workflows
 llm_config:

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -23,6 +23,8 @@ on:
       - '.github/codex/**'
       - '.github/actions/setup-api-client/**'
       - '.github/actions/export-load-balancer-tokens/**'
+      - '.github/actions/path-classifier/**'
+      - '.github/path-classification.yml'
       - '.github/copilot-instructions.md'
       - '.github/copilot-skills/**'
       - '.github/dependabot.yml'

--- a/.github/workflows/selftest-ci.yml
+++ b/.github/workflows/selftest-ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: selftest-ci-${{ github.repository }}-${{ github.ref }}
@@ -27,6 +28,12 @@ jobs:
 
       - name: Run JavaScript tests
         run: node --test .github/scripts/__tests__/*.test.js
+
+      - name: Replay path classifier against recent merged PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PATH_CLASSIFIER_REPLAY: '1'
+        run: node --test .github/scripts/__tests__/path-classifier-replay.test.js
 
   test-python:
     name: Python Tests

--- a/templates/consumer-repo/.github/actions/path-classifier/action.yml
+++ b/templates/consumer-repo/.github/actions/path-classifier/action.yml
@@ -1,0 +1,54 @@
+name: Path Classifier
+description: Classify changed PR paths into workflow relevance categories.
+
+inputs:
+  base-ref:
+    description: Base ref or SHA to diff against. Defaults to PR base or push before SHA.
+    required: false
+  config-path:
+    description: Path classification config file.
+    required: false
+    default: .github/path-classification.yml
+  force-full:
+    description: Set true to force every category output to true.
+    required: false
+    default: 'false'
+
+outputs:
+  is-docs-only:
+    description: True when every changed path matches the docs-only category.
+    value: ${{ steps.classify.outputs.is-docs-only }}
+  is-python-code:
+    description: True when any changed path is Python-code relevant.
+    value: ${{ steps.classify.outputs.is-python-code }}
+  is-workflow-change:
+    description: True when any changed path affects GitHub workflows or actions.
+    value: ${{ steps.classify.outputs.is-workflow-change }}
+  is-security-relevant:
+    description: True when any changed path is security-scan relevant.
+    value: ${{ steps.classify.outputs.is-security-relevant }}
+  is-template-change:
+    description: True when any changed path affects consumer templates.
+    value: ${{ steps.classify.outputs.is-template-change }}
+  is-test-only:
+    description: True when every changed path matches the test-only category.
+    value: ${{ steps.classify.outputs.is-test-only }}
+  affected-consumers:
+    description: JSON list of affected consumers. Reserved for Wave 2.
+    value: ${{ steps.classify.outputs.affected-consumers }}
+  classification-rationale:
+    description: Human-readable classification rationale.
+    value: ${{ steps.classify.outputs.classification-rationale }}
+
+runs:
+  using: composite
+  steps:
+    - name: Classify changed paths
+      id: classify
+      shell: bash
+      env:
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_CONFIG_PATH: ${{ inputs.config-path }}
+        INPUT_FORCE_FULL: ${{ inputs.force-full }}
+        GITHUB_CONTEXT_JSON: ${{ toJSON(github) }}
+      run: node "$GITHUB_ACTION_PATH/classify.js"

--- a/templates/consumer-repo/.github/actions/path-classifier/classify.js
+++ b/templates/consumer-repo/.github/actions/path-classifier/classify.js
@@ -1,0 +1,348 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const OUTPUT_NAMES = {
+  'docs-only': 'is-docs-only',
+  'python-code': 'is-python-code',
+  'workflow-change': 'is-workflow-change',
+  'security-relevant': 'is-security-relevant',
+  'template-change': 'is-template-change',
+  'test-only': 'is-test-only',
+};
+
+const DEFAULT_CATEGORIES = {
+  'docs-only': { paths: ['docs/**', '*.md', 'README.md'], requireAll: true },
+  'python-code': { paths: ['**/*.py', 'pyproject.toml', 'requirements*.txt'], requireAll: false },
+  'workflow-change': { paths: ['.github/workflows/**', '.github/actions/**'], requireAll: false },
+  'security-relevant': {
+    paths: ['scripts/**', 'tools/**', '.github/workflows/**', 'pyproject.toml'],
+    requireAll: false,
+  },
+  'template-change': { paths: ['templates/**'], requireAll: false },
+  'test-only': { paths: ['tests/**', '**/test_*.py', '**/*.test.js'], requireAll: true },
+};
+
+function normalizePath(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\/+/, '');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function globToRegExp(glob) {
+  const pattern = normalizePath(glob);
+  let out = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+    if (char === '*') {
+      if (next === '*') {
+        const after = pattern[index + 2];
+        if (after === '/') {
+          out += '(?:.*/)?';
+          index += 2;
+        } else {
+          out += '.*';
+          index += 1;
+        }
+      } else {
+        out += '[^/]*';
+      }
+    } else if (char === '?') {
+      out += '[^/]';
+    } else {
+      out += escapeRegExp(char);
+    }
+  }
+  out += '$';
+  return new RegExp(out);
+}
+
+function matchesAny(filePath, patterns) {
+  const normalized = normalizePath(filePath);
+  return patterns.some((pattern) => globToRegExp(pattern).test(normalized));
+}
+
+function parseScalar(value) {
+  const trimmed = String(value || '').trim();
+  if (trimmed === 'true') {
+    return true;
+  }
+  if (trimmed === 'false') {
+    return false;
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseInlineList(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return null;
+  }
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) {
+    return [];
+  }
+  return body.split(',').map((entry) => parseScalar(entry));
+}
+
+function parseClassificationConfig(raw) {
+  const categories = {};
+  const lines = String(raw || '').split(/\r?\n/);
+  let section = null;
+  let category = null;
+  let listKey = null;
+
+  for (const line of lines) {
+    const withoutComment = line.replace(/\s+#.*$/, '');
+    if (!withoutComment.trim()) {
+      continue;
+    }
+    const indent = withoutComment.match(/^ */)[0].length;
+    const trimmed = withoutComment.trim();
+
+    if (indent === 0 && trimmed.endsWith(':')) {
+      section = trimmed.slice(0, -1);
+      category = null;
+      listKey = null;
+      continue;
+    }
+
+    if (section !== 'categories') {
+      continue;
+    }
+
+    if (indent === 2 && trimmed.endsWith(':')) {
+      category = trimmed.slice(0, -1);
+      categories[category] = categories[category] || {};
+      listKey = null;
+      continue;
+    }
+
+    if (!category) {
+      continue;
+    }
+
+    if (indent === 4 && trimmed.includes(':')) {
+      const [key, ...rest] = trimmed.split(':');
+      const value = rest.join(':').trim();
+      const normalizedKey = key === 'require-all' ? 'requireAll' : key;
+      if (!value) {
+        categories[category][normalizedKey] = [];
+        listKey = normalizedKey;
+        continue;
+      }
+      const inlineList = parseInlineList(value);
+      categories[category][normalizedKey] = inlineList === null ? parseScalar(value) : inlineList;
+      listKey = null;
+      continue;
+    }
+
+    if (indent >= 6 && listKey && trimmed.startsWith('- ')) {
+      categories[category][listKey].push(parseScalar(trimmed.slice(2)));
+    }
+  }
+
+  return { categories };
+}
+
+function loadConfig(configPath) {
+  const resolved = path.resolve(process.env.GITHUB_WORKSPACE || process.cwd(), configPath);
+  if (!fs.existsSync(resolved)) {
+    return { categories: DEFAULT_CATEGORIES, configPath: resolved, usedDefault: true };
+  }
+  const parsed = parseClassificationConfig(fs.readFileSync(resolved, 'utf8'));
+  const categories = {};
+  for (const [name, fallback] of Object.entries(DEFAULT_CATEGORIES)) {
+    const configured = parsed.categories[name] || {};
+    categories[name] = {
+      paths: Array.isArray(configured.paths) ? configured.paths : fallback.paths,
+      requireAll:
+        typeof configured.requireAll === 'boolean' ? configured.requireAll : fallback.requireAll,
+    };
+  }
+  return { categories, configPath: resolved, usedDefault: false };
+}
+
+function parseGithubContext() {
+  try {
+    return JSON.parse(process.env.GITHUB_CONTEXT_JSON || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function runGit(args) {
+  return execFileSync('git', args, {
+    cwd: process.env.GITHUB_WORKSPACE || process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function tryGit(args) {
+  try {
+    return runGit(args);
+  } catch {
+    return '';
+  }
+}
+
+function resolveBaseRef(inputBaseRef, githubContext) {
+  if (inputBaseRef) {
+    return inputBaseRef;
+  }
+  if (githubContext.event_name === 'pull_request' && githubContext.base_ref) {
+    return `origin/${githubContext.base_ref}`;
+  }
+  const event = githubContext.event || {};
+  if (event.before && !/^0+$/.test(event.before)) {
+    return event.before;
+  }
+  return '';
+}
+
+function fetchBaseRef(baseRef, githubContext) {
+  if (!baseRef || !baseRef.startsWith('origin/')) {
+    return;
+  }
+  const branch = baseRef.slice('origin/'.length);
+  tryGit(['fetch', '--no-tags', '--depth=1', 'origin', branch]);
+  const prBaseSha = githubContext.event?.pull_request?.base?.sha;
+  if (prBaseSha) {
+    tryGit(['fetch', '--no-tags', '--depth=1', 'origin', prBaseSha]);
+  }
+}
+
+function listChangedFiles({ baseRef, githubContext } = {}) {
+  const envFiles = process.env.PATH_CLASSIFIER_FILES_JSON;
+  if (envFiles) {
+    const parsed = JSON.parse(envFiles);
+    if (!Array.isArray(parsed)) {
+      throw new Error('PATH_CLASSIFIER_FILES_JSON must be a JSON array');
+    }
+    return parsed.map(normalizePath).filter(Boolean);
+  }
+
+  fetchBaseRef(baseRef, githubContext);
+  const head = githubContext.sha || 'HEAD';
+  const ranges = [];
+  if (baseRef) {
+    ranges.push(`${baseRef}...${head}`);
+    ranges.push(`${baseRef}..${head}`);
+  }
+  const prBaseSha = githubContext.event?.pull_request?.base?.sha;
+  if (prBaseSha) {
+    ranges.push(`${prBaseSha}...${head}`);
+    ranges.push(`${prBaseSha}..${head}`);
+  }
+
+  for (const range of ranges) {
+    const output = tryGit(['diff', '--name-only', range]);
+    if (output) {
+      return output.split(/\r?\n/).map(normalizePath).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function classifyFiles(files, config, { forceFull = false, conservativeFull = false } = {}) {
+  const changedFiles = Array.from(new Set((files || []).map(normalizePath).filter(Boolean)));
+  const outputs = {};
+  const matched = {};
+
+  for (const [category, rule] of Object.entries(config.categories)) {
+    const outputName = OUTPUT_NAMES[category] || `is-${category}`;
+    const patterns = Array.isArray(rule.paths) ? rule.paths : [];
+    const matches = changedFiles.filter((filePath) => matchesAny(filePath, patterns));
+    let enabled;
+    if (forceFull || conservativeFull) {
+      enabled = true;
+    } else if (changedFiles.length === 0) {
+      enabled = false;
+    } else if (rule.requireAll) {
+      enabled = matches.length === changedFiles.length;
+    } else {
+      enabled = matches.length > 0;
+    }
+    outputs[outputName] = enabled ? 'true' : 'false';
+    matched[category] = matches;
+  }
+
+  outputs['affected-consumers'] = '[]';
+  const trueOutputs = Object.entries(outputs)
+    .filter(([key, value]) => key.startsWith('is-') && value === 'true')
+    .map(([key]) => key.replace(/^is-/, ''));
+  const mode = forceFull ? 'force-full' : conservativeFull ? 'conservative-full' : 'classified';
+  outputs['classification-rationale'] =
+    `${mode}: ${changedFiles.length} changed file(s); ` +
+    (trueOutputs.length ? `matched ${trueOutputs.join(', ')}` : 'no categories matched');
+
+  return { outputs, changedFiles, matched };
+}
+
+function writeOutputs(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  for (const [key, value] of Object.entries(outputs)) {
+    console.log(`${key}=${value}`);
+  }
+  if (!outputPath) {
+    return;
+  }
+  const lines = [];
+  for (const [key, value] of Object.entries(outputs)) {
+    if (String(value).includes('\n')) {
+      lines.push(`${key}<<PATH_CLASSIFIER_EOF\n${value}\nPATH_CLASSIFIER_EOF`);
+    } else {
+      lines.push(`${key}=${value}`);
+    }
+  }
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function main() {
+  const githubContext = parseGithubContext();
+  const forceFull = String(process.env.INPUT_FORCE_FULL || '').toLowerCase() === 'true';
+  const configPath = process.env.INPUT_CONFIG_PATH || '.github/path-classification.yml';
+  const baseRef = resolveBaseRef(process.env.INPUT_BASE_REF || '', githubContext);
+  const config = loadConfig(configPath);
+  let files = [];
+  let conservativeFull = false;
+
+  try {
+    files = listChangedFiles({ baseRef, githubContext });
+  } catch (error) {
+    conservativeFull = true;
+    console.warn(`::warning::Unable to list changed files; forcing full classification: ${error.message}`);
+  }
+
+  const result = classifyFiles(files, config, { forceFull, conservativeFull });
+  writeOutputs(result.outputs);
+  console.log(`Changed files: ${result.changedFiles.join(', ') || '(none)'}`);
+  console.log(`Config: ${config.configPath}${config.usedDefault ? ' (default fallback)' : ''}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  DEFAULT_CATEGORIES,
+  OUTPUT_NAMES,
+  classifyFiles,
+  globToRegExp,
+  loadConfig,
+  matchesAny,
+  normalizePath,
+  parseClassificationConfig,
+};

--- a/templates/consumer-repo/.github/path-classification.yml
+++ b/templates/consumer-repo/.github/path-classification.yml
@@ -1,0 +1,35 @@
+categories:
+  docs-only:
+    require-all: true
+    paths:
+      - docs/**
+      - "*.md"
+      - README.md
+  python-code:
+    require-all: false
+    paths:
+      - "**/*.py"
+      - pyproject.toml
+      - requirements*.txt
+  workflow-change:
+    require-all: false
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  security-relevant:
+    require-all: false
+    paths:
+      - scripts/**
+      - tools/**
+      - .github/workflows/**
+      - pyproject.toml
+  template-change:
+    require-all: false
+    paths:
+      - templates/**
+  test-only:
+    require-all: true
+    paths:
+      - tests/**
+      - "**/test_*.py"
+      - "**/*.test.js"


### PR DESCRIPTION
## Summary
- Add the `path-classifier` composite action and path classification config.
- Sync the action/config into consumer templates and the sync manifest.
- Add unit coverage plus a live historical replay test for merged PRs since 2026-02-03.

## Validation
- `node --test .github/scripts/__tests__/*.test.js`
- `PATH_CLASSIFIER_REPLAY=1 node --test .github/scripts/__tests__/path-classifier-replay.test.js`
- `scripts/sync_templates.sh`
- `python scripts/validate_template_completeness.py --strict`
- `python scripts/validate_template_sync.py`
- `python -m pytest tests/workflows/ -q`

## Notes
- `affected-consumers` intentionally returns `[]`; Wave 2 will populate it.
- The replay found no classification mismatches across the recent merged PR window.
