### PR TITLE
test: guard issue 2 workflow test inclusion

### DIFF
--- a/scripts/fix_cosmetic_aggregate.py
+++ b/scripts/fix_cosmetic_aggregate.py
@@ -11,7 +11,7 @@ TARGET = ROOT / "automation_multifailure.py"
 def _rewrite(text: str) -> tuple[str, bool]:
     if '" | ".join' in text or "' | '.join" in text:
         return text, False
-    replaced = text.replace('",".join', '" | ".join').replace("',' .join", '" | ".join')
+    replaced = text.replace('",".join', '" | ".join').replace("','.join", '" | ".join')
     changed = replaced != text
     return replaced, changed
 

--- a/tests/workflows/test_issue2_excluded_tests_enabled.py
+++ b/tests/workflows/test_issue2_excluded_tests_enabled.py
@@ -1,10 +1,37 @@
 from __future__ import annotations
 
 import importlib
+import re
 import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_issue2_excluded_autofix_tests_only_depend_on_local_scripts() -> None:
+    excluded_test_files = (
+        "tests/workflows/test_autofix_full_pipeline.py",
+        "tests/workflows/test_autofix_pipeline.py",
+        "tests/workflows/test_autofix_pipeline_diverse.py",
+        "tests/workflows/test_autofix_pr_comment.py",
+    )
+    expected_imports = {
+        "scripts.auto_type_hygiene",
+        "scripts.build_autofix_pr_comment",
+        "scripts.fix_cosmetic_aggregate",
+        "scripts.fix_numpy_asserts",
+        "scripts.mypy_autofix",
+        "scripts.mypy_return_autofix",
+        "scripts.update_autofix_expectations",
+    }
+
+    observed_imports: set[str] = set()
+    pattern = re.compile(r"(?:from|import)\s+(scripts\.[a-zA-Z0-9_\.]+)")
+    for relative_path in excluded_test_files:
+        text = (ROOT / relative_path).read_text(encoding="utf-8")
+        observed_imports.update(pattern.findall(text))
+
+    assert observed_imports == expected_imports
 
 
 def test_issue2_autofix_stub_modules_are_importable() -> None:

--- a/tests/workflows/test_issue2_excluded_tests_enabled.py
+++ b/tests/workflows/test_issue2_excluded_tests_enabled.py
@@ -49,14 +49,19 @@ def test_issue2_autofix_stub_modules_are_importable() -> None:
 def test_issue2_workflow_tests_are_not_excluded_from_ruff() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
-    ruff_excludes = config["tool"]["ruff"].get("exclude", [])
-    assert "tests/workflows" not in ruff_excludes
-    assert not any(str(path).startswith("tests/workflows/") for path in ruff_excludes)
+    ruff_config = config["tool"]["ruff"]
+    ruff_excludes = [
+        str(path).rstrip("/")
+        for key in ("exclude", "extend-exclude")
+        for path in ruff_config.get(key, [])
+    ]
+    assert not any(
+        path == "tests/workflows" or path.startswith("tests/workflows/") for path in ruff_excludes
+    )
 
 
 def test_issue2_selftest_ci_runs_all_workflow_tests() -> None:
     workflow = (ROOT / ".github/workflows/selftest-ci.yml").read_text(encoding="utf-8")
 
     assert "python -m pytest tests/workflows/ -v" in workflow
-    assert "--ignore tests/workflows" not in workflow
-    assert "--ignore=tests/workflows" not in workflow
+    assert not re.search(r"--ignore(?:=|\s+)tests/workflows/?(?:\s|$)", workflow)

--- a/tests/workflows/test_issue2_excluded_tests_enabled.py
+++ b/tests/workflows/test_issue2_excluded_tests_enabled.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_issue2_autofix_stub_modules_are_importable() -> None:
+    expected_modules = (
+        "scripts.fix_cosmetic_aggregate",
+        "scripts.mypy_return_autofix",
+        "scripts.update_autofix_expectations",
+    )
+
+    for module_name in expected_modules:
+        module = importlib.import_module(module_name)
+        assert callable(module.main)
+
+
+def test_issue2_workflow_tests_are_not_excluded_from_ruff() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    ruff_excludes = config["tool"]["ruff"].get("exclude", [])
+    assert "tests/workflows" not in ruff_excludes
+    assert not any(str(path).startswith("tests/workflows/") for path in ruff_excludes)
+
+
+def test_issue2_selftest_ci_runs_all_workflow_tests() -> None:
+    workflow = (ROOT / ".github/workflows/selftest-ci.yml").read_text(encoding="utf-8")
+
+    assert "python -m pytest tests/workflows/ -v" in workflow
+    assert "--ignore tests/workflows" not in workflow
+    assert "--ignore=tests/workflows" not in workflow

--- a/tests/workflows/test_issue2_stub_module_interfaces.py
+++ b/tests/workflows/test_issue2_stub_module_interfaces.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.fix_cosmetic_aggregate as fix_cosmetic_aggregate
+import scripts.mypy_return_autofix as mypy_return_autofix
+import scripts.update_autofix_expectations as update_autofix_expectations
+
+
+def test_fix_cosmetic_aggregate_rewrites_supported_join_variants() -> None:
+    rewritten, changed = fix_cosmetic_aggregate._rewrite('return ",".join(items)')
+    assert changed is True
+    assert '" | ".join(items)' in rewritten
+
+    rewritten_single, changed_single = fix_cosmetic_aggregate._rewrite("return ','.join(items)")
+    assert changed_single is True
+    assert '" | ".join(items)' in rewritten_single
+
+
+def test_mypy_return_autofix_main_noops_when_targets_missing(tmp_path: Path, monkeypatch) -> None:
+    missing = tmp_path / "missing-src"
+    monkeypatch.setattr(mypy_return_autofix, "ROOT", tmp_path, raising=False)
+    monkeypatch.setattr(mypy_return_autofix, "PROJECT_DIRS", [missing], raising=False)
+    assert mypy_return_autofix.main() == 0
+
+
+def test_update_autofix_expectations_main_noops_with_empty_targets() -> None:
+    assert update_autofix_expectations.main([]) == 0


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2 -->
> **Source:** Issue #2

Closes #2

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
10 Python test files in `tests/workflows/` are excluded from CI and local runs because they import modules from Trend_Model_Project that don't exist in this repository (e.g., `scripts.mypy_return_autofix`, `scripts.fix_cosmetic_aggregate`, `scripts.update_autofix_expectations`). This represents ~50% of the Python test suite being skipped.

#### Tasks
- [x] Identify the exact imports needed by examining the excluded test files.
- [x] Create minimal stub modules that provide the expected interfaces (functions that return sensible defaults or raise NotImplementedError).
- [ ] Remove the corresponding entries from `[tool.ruff] exclude` in pyproject.toml.
- [ ] Remove the `--ignore` flags from selftest-ci.yml Python test step.
- [ ] Run the full test suite and fix any remaining import or interface issues.

#### Acceptance criteria
- [ ] All 10 previously excluded test files are now included in CI runs.
- [x] `python -m pytest tests/workflows/ -v` runs without collection errors.
- [ ] Test count increases from ~196 to include the previously skipped tests.
- [ ] CI workflow passes with expanded test coverage.

<!-- auto-status-summary:end -->