### PR TITLE
fix: keepalive no-checklist handling + state-fingerprint 401/403 fallback

### DIFF
--- a/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -132,7 +132,17 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
   }
 }
 
-async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary }) {
+async function routeDraftToHuman({
+  github,
+  owner,
+  repo,
+  prNumber,
+  currentLabels,
+  checkboxCounts,
+  noChecklist,
+  core,
+  summary,
+}) {
   await addLabelsIfMissing({
     github,
     owner,
@@ -144,11 +154,19 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     summary,
   });
 
-  summary
-    .addRaw(
-      `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
-    )
-    .addEOL();
+  if (noChecklist) {
+    summary
+      .addRaw(
+        'Draft PR requires human disposition: no acceptance checklist found in PR body.'
+      )
+      .addEOL();
+  } else {
+    summary
+      .addRaw(
+        `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
+      )
+      .addEOL();
+  }
 
   let comments = [];
   try {
@@ -171,15 +189,23 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     return;
   }
 
+  const draftReason = noChecklist
+    ? 'Keepalive found this PR still in draft with no acceptance checklist in the PR body. Draft PRs must not occupy automation capacity silently.'
+    : `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`;
+
+  const nextAction = noChecklist
+    ? 'Next human action: add an acceptance checklist to the PR body and mark it ready for review, or close/supersede the PR.'
+    : 'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.';
+
   const body = [
     DRAFT_DISPOSITION_MARKER,
     '### Draft PR requires human disposition',
     '',
-    `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    draftReason,
     '',
     `Applied \`${NEEDS_ATTENTION_LABEL}\`, \`${NEEDS_HUMAN_LABEL}\`, and \`${PAUSE_LABEL}\` so this is visible in automation summaries and human queues.`,
     '',
-    'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.',
+    nextAction,
   ].join('\n');
 
   try {
@@ -401,6 +427,7 @@ async function runKeepaliveGate({ core, github, context, env }) {
         )
         .addEOL();
 
+      const noChecklist = checkboxCounts.checked === 0 && checkboxCounts.unchecked === 0;
       const allChecklistWorkComplete = checkboxCounts.checked > 0 && checkboxCounts.unchecked === 0;
       if (allChecklistWorkComplete) {
         const ready = await markDraftReadyForReview({ github, pr, core, summary });
@@ -408,13 +435,33 @@ async function runKeepaliveGate({ core, github, context, env }) {
           pr.draft = false;
         } else {
           draftRequiresHuman = true;
-          await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+          await routeDraftToHuman({
+            github,
+            owner,
+            repo,
+            prNumber,
+            currentLabels,
+            checkboxCounts,
+            noChecklist,
+            core,
+            summary,
+          });
           addReason('pr-draft-ready-failed');
         }
       } else {
         draftRequiresHuman = true;
-        await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
-        addReason('pr-draft-needs-human');
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          noChecklist,
+          core,
+          summary,
+        });
+        addReason(noChecklist ? 'pr-draft-no-checklist' : 'pr-draft-needs-human');
       }
     }
     if (!draftRequiresHuman && headSha) {

--- a/.github/workflows/health-44-gate-branch-protection.yml
+++ b/.github/workflows/health-44-gate-branch-protection.yml
@@ -53,8 +53,12 @@ jobs:
       - name: Compute state fingerprint
         id: fingerprint
         env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
+          # Repo-variable storage requires a token with Variables permission.
+          # GITHUB_TOKEN can't access actions/variables even with actions: write.
+          # Prefer BRANCH_PROTECTION_TOKEN (already used downstream); fall back to
+          # GITHUB_TOKEN — the helper handles 401/403 by skipping the optimization.
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN || github.token }}
           DEFAULT_BRANCH: >-
             ${{
               github.event.repository.default_branch ||

--- a/scripts/state_fingerprint.py
+++ b/scripts/state_fingerprint.py
@@ -235,13 +235,28 @@ class RepoVariableStorage:
                 f"/repos/{self.api.repo}/actions/variables/{variable_name}",
             )
         except RuntimeError as exc:
-            if " failed: 404 " in str(exc):
+            message = str(exc)
+            if " failed: 404 " in message:
+                return None
+            if " failed: 401 " in message or " failed: 403 " in message:
+                # Token can't read repo variables. Treat as "no prior fingerprint"
+                # so the caller decides should_run=true; emit a warning so the
+                # operator sees the misconfiguration in workflow logs.
+                print(
+                    f"warning: state-fingerprint storage unavailable for "
+                    f"{variable_name}: {message}",
+                    file=sys.stderr,
+                )
+                self._storage_unavailable = True
                 return None
             raise
         value = payload.get("value") if isinstance(payload, dict) else None
         return _extract_hash(value if isinstance(value, str) else None, workflow_name)
 
     def write_fingerprint(self, workflow_name: str, fingerprint_hash: str) -> None:
+        if getattr(self, "_storage_unavailable", False):
+            # Read failed with 401/403; skip write rather than failing the workflow.
+            return
         variable_name = self.variable_name or _variable_name(workflow_name)
         value = json.dumps({"hash": fingerprint_hash, "ts": _utc_now()}, sort_keys=True)
         try:
@@ -251,13 +266,22 @@ class RepoVariableStorage:
                 {"name": variable_name, "value": value},
             )
         except RuntimeError as exc:
-            if " failed: 404 " not in str(exc):
-                raise
-            self.api.request(
-                "POST",
-                f"/repos/{self.api.repo}/actions/variables",
-                {"name": variable_name, "value": value},
-            )
+            message = str(exc)
+            if " failed: 404 " in message:
+                self.api.request(
+                    "POST",
+                    f"/repos/{self.api.repo}/actions/variables",
+                    {"name": variable_name, "value": value},
+                )
+                return
+            if " failed: 401 " in message or " failed: 403 " in message:
+                print(
+                    f"warning: state-fingerprint write skipped for "
+                    f"{variable_name}: {message}",
+                    file=sys.stderr,
+                )
+                return
+            raise
 
 
 def _variable_name(workflow_name: str) -> str:

--- a/scripts/state_fingerprint.py
+++ b/scripts/state_fingerprint.py
@@ -276,8 +276,7 @@ class RepoVariableStorage:
                 return
             if " failed: 401 " in message or " failed: 403 " in message:
                 print(
-                    f"warning: state-fingerprint write skipped for "
-                    f"{variable_name}: {message}",
+                    f"warning: state-fingerprint write skipped for " f"{variable_name}: {message}",
                     file=sys.stderr,
                 )
                 return

--- a/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -132,7 +132,17 @@ async function markDraftReadyForReview({ github, pr, core, summary }) {
   }
 }
 
-async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary }) {
+async function routeDraftToHuman({
+  github,
+  owner,
+  repo,
+  prNumber,
+  currentLabels,
+  checkboxCounts,
+  noChecklist,
+  core,
+  summary,
+}) {
   await addLabelsIfMissing({
     github,
     owner,
@@ -144,11 +154,19 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     summary,
   });
 
-  summary
-    .addRaw(
-      `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
-    )
-    .addEOL();
+  if (noChecklist) {
+    summary
+      .addRaw(
+        'Draft PR requires human disposition: no acceptance checklist found in PR body.'
+      )
+      .addEOL();
+  } else {
+    summary
+      .addRaw(
+        `Draft PR requires human disposition: checked=${checkboxCounts.checked}, unchecked=${checkboxCounts.unchecked}.`
+      )
+      .addEOL();
+  }
 
   let comments = [];
   try {
@@ -171,15 +189,23 @@ async function routeDraftToHuman({ github, owner, repo, prNumber, currentLabels,
     return;
   }
 
+  const draftReason = noChecklist
+    ? 'Keepalive found this PR still in draft with no acceptance checklist in the PR body. Draft PRs must not occupy automation capacity silently.'
+    : `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`;
+
+  const nextAction = noChecklist
+    ? 'Next human action: add an acceptance checklist to the PR body and mark it ready for review, or close/supersede the PR.'
+    : 'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.';
+
   const body = [
     DRAFT_DISPOSITION_MARKER,
     '### Draft PR requires human disposition',
     '',
-    `Keepalive found this PR still in draft with ${checkboxCounts.unchecked} unchecked checklist item(s). Draft PRs must not occupy automation capacity silently.`,
+    draftReason,
     '',
     `Applied \`${NEEDS_ATTENTION_LABEL}\`, \`${NEEDS_HUMAN_LABEL}\`, and \`${PAUSE_LABEL}\` so this is visible in automation summaries and human queues.`,
     '',
-    'Next human action: finish the unchecked acceptance items and mark the PR ready for review, or close/supersede the PR.',
+    nextAction,
   ].join('\n');
 
   try {
@@ -401,6 +427,7 @@ async function runKeepaliveGate({ core, github, context, env }) {
         )
         .addEOL();
 
+      const noChecklist = checkboxCounts.checked === 0 && checkboxCounts.unchecked === 0;
       const allChecklistWorkComplete = checkboxCounts.checked > 0 && checkboxCounts.unchecked === 0;
       if (allChecklistWorkComplete) {
         const ready = await markDraftReadyForReview({ github, pr, core, summary });
@@ -408,13 +435,33 @@ async function runKeepaliveGate({ core, github, context, env }) {
           pr.draft = false;
         } else {
           draftRequiresHuman = true;
-          await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
+          await routeDraftToHuman({
+            github,
+            owner,
+            repo,
+            prNumber,
+            currentLabels,
+            checkboxCounts,
+            noChecklist,
+            core,
+            summary,
+          });
           addReason('pr-draft-ready-failed');
         }
       } else {
         draftRequiresHuman = true;
-        await routeDraftToHuman({ github, owner, repo, prNumber, currentLabels, checkboxCounts, core, summary });
-        addReason('pr-draft-needs-human');
+        await routeDraftToHuman({
+          github,
+          owner,
+          repo,
+          prNumber,
+          currentLabels,
+          checkboxCounts,
+          noChecklist,
+          core,
+          summary,
+        });
+        addReason(noChecklist ? 'pr-draft-no-checklist' : 'pr-draft-needs-human');
       }
     }
     if (!draftRequiresHuman && headSha) {


### PR DESCRIPTION
## Summary

Two related sync-review-fallout fixes from reviewing the consumer-repo sync PRs after Wave 1:

### 1. Keepalive orchestrator no-checklist handling (commit f8606b4b)

Copilot review on multiple stranske/* sync PRs flagged that \`routeDraftToHuman()\` emits *"this PR still in draft with 0 unchecked checklist item(s)"* when a PR has no checkboxes at all. The branching at line 404 also fell through to the same "needs human" path for both genuine missing-acceptance-items cases and PRs that legitimately have no checklist.

End-to-end fix: a \`noChecklist\` flag (\`checked === 0 && unchecked === 0\`) computed at the call site and threaded through \`routeDraftToHuman\`. Comment body, summary line, and reason key all branch on it. New reason key \`pr-draft-no-checklist\` (alongside existing \`pr-draft-needs-human\`) for weekly metrics. Lockstep canonical + template.

The \"missing closing brace\" Copilot also flagged was already fixed by PR #1985 / #1986 on 2026-04-30 — the GraphQL mutation block has correct three closing braces. \`isConcreteAgentLabel()\` rate-limited/retry concern deferred to a separate review.

### 2. State-fingerprint 401/403 graceful fallback + Health 44 token fix (commit 38006bb4)

Wave 1's state-fingerprint helper (#1998 + #2002 wireup) broke Health 44 \`enforce\` because the workflow's \`GITHUB_TOKEN\` can't access the \`actions/variables\` endpoint even with \`actions: write\` set — that endpoint requires a token with Variables permission. Result: every PR running Health 44 enforce has been failing since #2002 merged (incl. PR #2006 / PR #2007 today).

Two-part fix:

- **\`scripts/state_fingerprint.py\`** — \`RepoVariableStorage\` now treats 401/403 from the variables API as \"storage unavailable\" rather than fatal. Read returns None (no prior fingerprint), write skips silently, warning goes to stderr. The 404 (no prior) path is unchanged. Effect: any workflow that adopts \`--storage repo-variable\` but doesn't have the right token degrades gracefully instead of failing outright.
- **\`.github/workflows/health-44-gate-branch-protection.yml\`** — uses \`BRANCH_PROTECTION_TOKEN\` (already used downstream by enforce) when present, falling back to \`GITHUB_TOKEN\`. Now the fingerprint optimization actually works when the secret is configured.

## Test plan
- [x] Both files pass \`node --check\` / \`py_compile\`
- [x] Existing 6 tests in \`tests/scripts/test_state_fingerprint.py\` still pass
- [x] Lockstep diff confirms canonical and template versions of \`keepalive_orchestrator_gate_runner.js\` are identical post-change
- [ ] Existing CI gates pass on this PR (specifically: this PR's \`enforce\` check should pass thanks to the fix included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)