### PR TITLE
fix: address sync review workflow guards

### DIFF
--- a/.github/actions/path-classifier/classify.js
+++ b/.github/actions/path-classifier/classify.js
@@ -266,8 +266,10 @@ function classifyFiles(files, config, { forceFull = false, conservativeFull = fa
     const patterns = Array.isArray(rule.paths) ? rule.paths : [];
     const matches = changedFiles.filter((filePath) => matchesAny(filePath, patterns));
     let enabled;
-    if (forceFull || conservativeFull) {
+    if (forceFull) {
       enabled = true;
+    } else if (conservativeFull) {
+      enabled = rule.requireAll ? false : true;
     } else if (changedFiles.length === 0) {
       enabled = false;
     } else if (rule.requireAll) {

--- a/.github/scripts/__tests__/path-classifier.test.js
+++ b/.github/scripts/__tests__/path-classifier.test.js
@@ -94,6 +94,16 @@ test('force-full override enables every category output', () => {
   assert.equal(outputs['is-test-only'], 'true');
 });
 
+test('conservative fallback keeps only-category outputs disabled', () => {
+  const outputs = outputsFor(['README.md'], { conservativeFull: true });
+  assert.equal(outputs['is-docs-only'], 'false');
+  assert.equal(outputs['is-python-code'], 'true');
+  assert.equal(outputs['is-workflow-change'], 'true');
+  assert.equal(outputs['is-security-relevant'], 'true');
+  assert.equal(outputs['is-template-change'], 'true');
+  assert.equal(outputs['is-test-only'], 'false');
+});
+
 test('parses classification YAML config', () => {
   const parsed = parseClassificationConfig(`
 categories:

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -35,10 +35,7 @@ jobs:
         id: eligibility
         uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
         with:
-          expected-labels: >-
-            agent:auto,agent:codex,agent:claude,agent:copilot,
-            agents:auto-pilot,agents:keepalive
-          expected-actions: opened,synchronize,labeled
+          expected-actions: opened,reopened,synchronize,ready_for_review,labeled,unlabeled
           custom-predicate: pull_request
 
       - name: Checkout base ref for safety validation

--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -2,7 +2,7 @@ name: Keepalive Loop Reporter
 
 on:
   workflow_run:
-    workflows: ["Agents Keepalive Loop"]
+    workflows: ["Agents Gate Followups", "Agents Keepalive Loop"]
     types: [completed]
 
 permissions:
@@ -20,7 +20,6 @@ concurrency:
 jobs:
   report:
     name: Report keepalive completion
-    if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout keepalive scripts

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -216,6 +216,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          VERIFIER_MODE: ${{ steps.check.outputs.mode }}
+          VERIFIER_MODEL: ${{ steps.check.outputs.model }}
+          VERIFIER_MODEL2: ${{ steps.check.outputs.model2 }}
+          VERIFIER_PROVIDER: ${{ steps.check.outputs.provider }}
         run: |
           python - <<'PY' > /tmp/state-fingerprint-inputs.json
           import hashlib
@@ -244,7 +249,8 @@ jobs:
               page = 1
               while True:
                   separator = "&" if "?" in path else "?"
-                  batch = api(f"{path}{separator}{urllib.parse.urlencode({'per_page': 100, 'page': page})}")
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
                   results.extend(batch)
                   if len(batch) < 100:
                       return results
@@ -269,8 +275,15 @@ jobs:
           ).hexdigest()
           payload = {
               "pr_number": int(pr_number),
+              "event_name": os.environ.get("EVENT_NAME", ""),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "diff_hash": diff_hash,
+              "verifier_settings": {
+                  "mode": os.environ.get("VERIFIER_MODE", ""),
+                  "model": os.environ.get("VERIFIER_MODEL", ""),
+                  "model2": os.environ.get("VERIFIER_MODEL2", ""),
+                  "provider": os.environ.get("VERIFIER_PROVIDER", ""),
+              },
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/templates/consumer-repo/.github/actions/path-classifier/classify.js
+++ b/templates/consumer-repo/.github/actions/path-classifier/classify.js
@@ -266,8 +266,10 @@ function classifyFiles(files, config, { forceFull = false, conservativeFull = fa
     const patterns = Array.isArray(rule.paths) ? rule.paths : [];
     const matches = changedFiles.filter((filePath) => matchesAny(filePath, patterns));
     let enabled;
-    if (forceFull || conservativeFull) {
+    if (forceFull) {
       enabled = true;
+    } else if (conservativeFull) {
+      enabled = rule.requireAll ? false : true;
     } else if (changedFiles.length === 0) {
       enabled = false;
     } else if (rule.requireAll) {

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -98,6 +98,10 @@ jobs:
               ''
             }}
           GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE_RETRY: ${{ github.event.inputs.force_retry || 'false' }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [ -z "${PR_NUMBER:-}" ]; then
             {
@@ -134,6 +138,8 @@ jobs:
           label_names = sorted(label.get("name", "") for label in labels if label.get("name"))
           payload = {
               "pr_number": int(pr_number),
+              "event_name": os.environ.get("EVENT_NAME", ""),
+              "force_retry": os.environ.get("FORCE_RETRY", "").lower() == "true",
               "head_sha": pr.get("head", {}).get("sha", ""),
               "gate_conclusion": os.environ.get("GATE_CONCLUSION", ""),
               "autofix_label_state": [
@@ -141,6 +147,11 @@ jobs:
                   if name.startswith("autofix") or name == "agent:retry"
               ],
           }
+          if payload["force_retry"]:
+              payload["manual_retry_run"] = {
+                  "run_id": os.environ.get("RUN_ID", ""),
+                  "run_attempt": os.environ.get("RUN_ATTEMPT", ""),
+              }
           print(json.dumps(payload, sort_keys=True))
           PY
 

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -35,10 +35,7 @@ jobs:
         id: eligibility
         uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
         with:
-          expected-labels: >-
-            agent:auto,agent:codex,agent:claude,agent:copilot,
-            agents:auto-pilot,agents:keepalive
-          expected-actions: opened,synchronize,labeled
+          expected-actions: opened,reopened,synchronize,ready_for_review,labeled,unlabeled
           custom-predicate: pull_request
 
       # Mint GitHub App token early to use for API calls (avoids rate limits)

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -2,7 +2,7 @@ name: Keepalive Loop Reporter
 
 on:
   workflow_run:
-    workflows: ["Agents Keepalive Loop"]
+    workflows: ["Agents Gate Followups", "Agents Keepalive Loop"]
     types: [completed]
 
 permissions:
@@ -20,7 +20,6 @@ concurrency:
 jobs:
   report:
     name: Report keepalive completion
-    if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout keepalive scripts

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -210,6 +210,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          VERIFIER_MODE: ${{ steps.check.outputs.mode }}
+          VERIFIER_MODEL: ${{ steps.check.outputs.model }}
+          VERIFIER_MODEL2: ${{ steps.check.outputs.model2 }}
+          VERIFIER_PROVIDER: ${{ steps.check.outputs.provider }}
         run: |
           python - <<'PY' > /tmp/state-fingerprint-inputs.json
           import hashlib
@@ -238,7 +243,8 @@ jobs:
               page = 1
               while True:
                   separator = "&" if "?" in path else "?"
-                  batch = api(f"{path}{separator}{urllib.parse.urlencode({'per_page': 100, 'page': page})}")
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
                   results.extend(batch)
                   if len(batch) < 100:
                       return results
@@ -263,8 +269,15 @@ jobs:
           ).hexdigest()
           payload = {
               "pr_number": int(pr_number),
+              "event_name": os.environ.get("EVENT_NAME", ""),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "diff_hash": diff_hash,
+              "verifier_settings": {
+                  "mode": os.environ.get("VERIFIER_MODE", ""),
+                  "model": os.environ.get("VERIFIER_MODEL", ""),
+                  "model2": os.environ.get("VERIFIER_MODEL2", ""),
+                  "provider": os.environ.get("VERIFIER_PROVIDER", ""),
+              },
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -463,6 +463,51 @@ def test_keepalive_metrics_emit_compact_ndjson():
         assert "metrics_json=$(jq -cn \\" in text, f"{path} must emit one JSON object per line"
 
 
+def test_agents_guard_eligibility_does_not_require_agent_labels():
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-guard.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-guard.yml"),
+    ]
+    for path in workflow_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "expected-labels:" not in text, f"{path} must guard unlabeled workflow PRs"
+        for action in ["opened", "reopened", "synchronize", "ready_for_review", "labeled", "unlabeled"]:
+            assert action in text, f"{path} must allow {action} guard events"
+
+
+def test_keepalive_reporter_watches_consolidated_followups():
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-keepalive-loop-reporter.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml"),
+    ]
+    for path in workflow_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "Agents Gate Followups" in text, f"{path} must report consolidated followup runs"
+        assert (
+            "USE_CONSOLIDATED_WORKFLOWS != 'true'" not in text
+        ), f"{path} must not disable reporting when consolidated workflows are enabled"
+
+
+def test_fingerprint_payloads_include_manual_trigger_settings():
+    followups_text = Path(
+        "templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml"
+    ).read_text(encoding="utf-8")
+    assert '"event_name": os.environ.get("EVENT_NAME", "")' in followups_text
+    assert '"force_retry": os.environ.get("FORCE_RETRY", "").lower() == "true"' in followups_text
+    assert '"manual_retry_run"' in followups_text
+
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-verifier.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-verifier.yml"),
+    ]
+    for path in workflow_paths:
+        text = path.read_text(encoding="utf-8")
+        assert '"event_name": os.environ.get("EVENT_NAME", "")' in text
+        assert '"verifier_settings":' in text
+        for name in ["VERIFIER_MODE", "VERIFIER_MODEL", "VERIFIER_MODEL2", "VERIFIER_PROVIDER"]:
+            assert name in text, f"{path} must fingerprint {name}"
+
+
 def test_terminal_disposition_records_include_artifact_identity():
     workflow_paths = [
         WORKFLOWS_DIR / "agents-verify-to-issue-v2.yml",


### PR DESCRIPTION
## Summary
- keep agents guard running for unlabeled protected workflow PR changes
- point keepalive reporter at consolidated gate followups and keep it enabled under consolidated workflows
- include manual retry/verifier settings in state fingerprints so explicit reruns are not skipped incorrectly
- make path-classifier conservative fallback keep docs-only/test-only false while enabling full checks

## Validation
- node --test .github/scripts/__tests__/path-classifier.test.js .github/scripts/__tests__/agent-event-eligibility.test.js
- python -m pytest tests/workflows/test_workflow_agents_consolidation.py tests/scripts/test_state_fingerprint.py tests/workflows/test_github_api_retry_standard.py -q
- python scripts/validate_workflow_yaml.py .github/workflows/agents-guard.yml .github/workflows/agents-keepalive-loop-reporter.yml .github/workflows/agents-verifier.yml templates/consumer-repo/.github/workflows/agents-guard.yml templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml templates/consumer-repo/.github/workflows/agents-verifier.yml
- python scripts/validate_template_sync.py

Refs: stranske/Manager-Database#956