### PR TITLE
Fix sync review fingerprint gates

### DIFF
--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -38,7 +38,7 @@ jobs:
           expected-labels: >-
             agent:auto,agent:codex,agent:claude,agent:copilot,
             agents:auto-pilot,agents:keepalive
-          expected-actions: opened,synchronize,labeled
+          expected-actions: opened,reopened,synchronize,ready_for_review,labeled,unlabeled
           custom-predicate: pull_request
 
       - name: Checkout base ref for safety validation

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -216,6 +216,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+          VERIFY_MODE: ${{ steps.check.outputs.mode }}
+          VERIFY_MODEL: ${{ steps.check.outputs.model }}
+          VERIFY_MODEL2: ${{ steps.check.outputs.model2 }}
+          VERIFY_PROVIDER: ${{ steps.check.outputs.provider }}
         run: |
           python - <<'PY' > /tmp/state-fingerprint-inputs.json
           import hashlib
@@ -244,7 +248,8 @@ jobs:
               page = 1
               while True:
                   separator = "&" if "?" in path else "?"
-                  batch = api(f"{path}{separator}{urllib.parse.urlencode({'per_page': 100, 'page': page})}")
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
                   results.extend(batch)
                   if len(batch) < 100:
                       return results
@@ -271,6 +276,10 @@ jobs:
               "pr_number": int(pr_number),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "diff_hash": diff_hash,
+              "mode": os.environ.get("VERIFY_MODE", ""),
+              "model": os.environ.get("VERIFY_MODEL", ""),
+              "model2": os.environ.get("VERIFY_MODEL2", ""),
+              "provider": os.environ.get("VERIFY_PROVIDER", ""),
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/scripts/state_fingerprint.py
+++ b/scripts/state_fingerprint.py
@@ -85,6 +85,7 @@ def _marker_re(workflow_name: str) -> re.Pattern[str]:
 def _build_marker(workflow_name: str, fingerprint_hash: str) -> str:
     payload = {"hash": fingerprint_hash, "ts": _utc_now()}
     return (
+        f"Workflow state fingerprint for {workflow_name}. Do not edit.\n\n"
         f"<!-- {MARKER_PREFIX}:{workflow_name}:{MARKER_VERSION} "
         f"{json.dumps(payload, sort_keys=True, separators=(',', ':'))} -->"
     )
@@ -345,7 +346,8 @@ def _compare_command(args: argparse.Namespace) -> int:
         should_run = True
         reason = f"warning-mode:{decision.reason}"
 
-    store_fingerprint(args.workflow, decision.current_hash, storage)
+    if decision.should_run or args.mode == "warning":
+        store_fingerprint(args.workflow, decision.current_hash, storage)
 
     outputs = {
         "should_run": "true" if should_run else "false",

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -98,6 +98,7 @@ jobs:
               ''
             }}
           GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+          FORCE_RETRY: ${{ github.event.inputs.force_retry || 'false' }}
         run: |
           if [ -z "${PR_NUMBER:-}" ]; then
             {
@@ -136,6 +137,7 @@ jobs:
               "pr_number": int(pr_number),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "gate_conclusion": os.environ.get("GATE_CONCLUSION", ""),
+              "force_retry": os.environ.get("FORCE_RETRY", "").lower() == "true",
               "autofix_label_state": [
                   name for name in label_names
                   if name.startswith("autofix") or name == "agent:retry"

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -38,7 +38,7 @@ jobs:
           expected-labels: >-
             agent:auto,agent:codex,agent:claude,agent:copilot,
             agents:auto-pilot,agents:keepalive
-          expected-actions: opened,synchronize,labeled
+          expected-actions: opened,reopened,synchronize,ready_for_review,labeled,unlabeled
           custom-predicate: pull_request
 
       # Mint GitHub App token early to use for API calls (avoids rate limits)

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -210,6 +210,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+          VERIFY_MODE: ${{ steps.check.outputs.mode }}
+          VERIFY_MODEL: ${{ steps.check.outputs.model }}
+          VERIFY_MODEL2: ${{ steps.check.outputs.model2 }}
+          VERIFY_PROVIDER: ${{ steps.check.outputs.provider }}
         run: |
           python - <<'PY' > /tmp/state-fingerprint-inputs.json
           import hashlib
@@ -238,7 +242,8 @@ jobs:
               page = 1
               while True:
                   separator = "&" if "?" in path else "?"
-                  batch = api(f"{path}{separator}{urllib.parse.urlencode({'per_page': 100, 'page': page})}")
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
                   results.extend(batch)
                   if len(batch) < 100:
                       return results
@@ -265,6 +270,10 @@ jobs:
               "pr_number": int(pr_number),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "diff_hash": diff_hash,
+              "mode": os.environ.get("VERIFY_MODE", ""),
+              "model": os.environ.get("VERIFY_MODEL", ""),
+              "model2": os.environ.get("VERIFY_MODEL2", ""),
+              "provider": os.environ.get("VERIFY_PROVIDER", ""),
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/tests/scripts/test_state_fingerprint.py
+++ b/tests/scripts/test_state_fingerprint.py
@@ -90,6 +90,41 @@ def test_warning_mode_bypasses_skip_and_logs_delta(
     assert storage.writes == [prior]
 
 
+def test_enforce_mode_does_not_rewrite_matching_fingerprint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = {"head_sha": "abc"}
+    prior = state_fingerprint.compute_fingerprint("wf", current)
+    storage = MemoryStorage(state_fingerprint._build_marker("wf", prior))
+
+    monkeypatch.setattr(state_fingerprint, "_storage_from_name", lambda _name, _workflow: storage)
+
+    exit_code = state_fingerprint.main(
+        [
+            "compare",
+            "--workflow",
+            "wf",
+            "--inputs",
+            json.dumps(current),
+            "--storage",
+            "pr-comment",
+        ]
+    )
+
+    outputs = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert outputs["should_run"] == "false"
+    assert outputs["reason"] == "fingerprint-match"
+    assert storage.writes == []
+
+
+def test_pr_comment_marker_includes_visible_guidance() -> None:
+    marker = state_fingerprint._build_marker("wf", "a" * 64)
+
+    assert marker.startswith("Workflow state fingerprint for wf. Do not edit.")
+    assert state_fingerprint._extract_hash(marker, "wf") == "a" * 64
+
+
 def test_malformed_prior_marker_is_tolerated() -> None:
     storage = MemoryStorage('<!-- fingerprint:wf:v1 {"hash": -->')
 


### PR DESCRIPTION
## Summary
- align agents-guard event eligibility actions with configured PR triggers
- include force_retry and verifier mode/model/provider overrides in fingerprint payloads
- avoid rewriting matching PR-comment fingerprints and add visible marker text

## Validation
- python -m pytest tests/scripts/test_state_fingerprint.py -q
- python scripts/validate_workflow_yaml.py .github/workflows/agents-guard.yml .github/workflows/agents-verifier.yml templates/consumer-repo/.github/workflows/agents-guard.yml templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml templates/consumer-repo/.github/workflows/agents-verifier.yml
- python -m py_compile scripts/state_fingerprint.py
- git diff --check
- python scripts/validate_template_sync.py

Source fix for consumer sync PR review feedback on stranske/Portable-Alpha-Extension-Model#1733.