### PR TITLE
fix: address current sync review blockers

### DIFF
--- a/.github/actions/agent-event-eligibility/eligibility.js
+++ b/.github/actions/agent-event-eligibility/eligibility.js
@@ -36,7 +36,7 @@ function extractLabels(payload) {
   for (const item of payload?.issue?.labels || []) labels.push(labelName(item));
   for (const item of payload?.pull_request?.labels || []) labels.push(labelName(item));
   for (const item of payload?.discussion?.labels || []) labels.push(labelName(item));
-  if (payload?.label && payload.action !== 'unlabeled') labels.push(labelName(payload.label));
+  if (payload?.label) labels.push(labelName(payload.label));
   return unique(labels.map((item) => item.trim()).filter(Boolean));
 }
 

--- a/.github/scripts/__tests__/agent-event-eligibility.test.js
+++ b/.github/scripts/__tests__/agent-event-eligibility.test.js
@@ -117,14 +117,30 @@ test('warning mode bypasses denied decisions', () => {
   assert.match(result.reason, /warning mode bypassed denial/);
 });
 
-test('unlabeled events do not keep the removed label in the current set', () => {
+test('unlabeled events include the removed label as an event signal', () => {
   const labels = extractLabels(issuePayload({
     action: 'unlabeled',
     label: { name: 'agent:codex' },
     issue: { labels: [{ name: 'agents:auto-pilot' }] },
   }));
 
-  assert.deepEqual(labels, ['agents:auto-pilot']);
+  assert.deepEqual(labels, ['agents:auto-pilot', 'agent:codex']);
+});
+
+test('unlabeled events can match the removed expected label', () => {
+  const result = evaluateEligibility({
+    payload: issuePayload({
+      action: 'unlabeled',
+      label: { name: 'agents:keepalive' },
+      pull_request: { labels: [] },
+    }),
+    eventName: 'pull_request_target',
+    expectedActions: 'unlabeled',
+    expectedLabels: 'agents:keepalive',
+  });
+
+  assert.equal(result.shouldRun, true);
+  assert.equal(result.matchedLabel, 'agents:keepalive');
 });
 
 test('event-name input default stays blank so runtime env fallback is used', () => {

--- a/.github/scripts/__tests__/agents-guard.test.js
+++ b/.github/scripts/__tests__/agents-guard.test.js
@@ -205,6 +205,34 @@ test('blocks renames of allowlisted removal paths', () => {
   assert.ok(result.fatalViolations.some((reason) => reason.includes('was renamed')));
 });
 
+test('allows archive renames of allowlisted removal paths', () => {
+  const result = evaluateGuard({
+    repository: 'stranske/Template',
+    files: [{
+      filename: 'archives/deprecated-workflows/agents-autofix-loop.yml',
+      previous_filename: '.github/workflows/agents-autofix-loop.yml',
+      status: 'renamed',
+    }],
+  });
+
+  assert.equal(result.blocked, false);
+  assert.equal(result.fatalViolations.length, 0);
+});
+
+test('blocks consumer-only archive renames in Workflows repo', () => {
+  const result = evaluateGuard({
+    repository: 'stranske/Workflows',
+    files: [{
+      filename: 'archives/deprecated-workflows/agents-autofix-loop.yml',
+      previous_filename: '.github/workflows/agents-autofix-loop.yml',
+      status: 'renamed',
+    }],
+  });
+
+  assert.equal(result.blocked, true);
+  assert.ok(result.fatalViolations.some((reason) => reason.includes('was renamed')));
+});
+
 test('does not allow label-only bypass without codeowner approval', () => {
   const result = evaluateGuard({
     files: [protectedFile],

--- a/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
+++ b/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
@@ -139,6 +139,34 @@ function makeEnv(overrides = {}) {
   };
 }
 
+test('normal numeric feature branches are not automation signals', async () => {
+  const { core, outputs } = createCore();
+  const pull = {
+    number: 17,
+    draft: false,
+    head: { ref: 'feat/123', sha: 'abc123' },
+    labels: [],
+    body: 'No checklists here.',
+  };
+  const github = createGithub({ pull });
+  const gate = loadRunnerWithGate(() => ({ ok: false, reason: 'not-routed' }));
+
+  try {
+    await gate.runKeepaliveGate({
+      github,
+      context: { repo: { owner: 'stranske', repo: 'Example' } },
+      core,
+      env: makeEnv(),
+    });
+  } finally {
+    gate.restore();
+  }
+
+  assert.equal(outputs.proceed, 'false');
+  assert.match(outputs.reason, /missing-label:agents:keepalive/);
+  assert.deepEqual(github.__calls.labelAdds, []);
+});
+
 function makePullRequest(overrides = {}) {
   return {
     number: 17,

--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -68,6 +68,23 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
   return ALLOW_REMOVED_PATHS.has(normalizedPath) && isConsumerOnlyRemovalAllowed(normalizedPath, repository);
 }
 
+function isArchivePath(filePath) {
+  const normalized = normalizePattern(filePath || '').toLowerCase();
+  return normalized.startsWith('archives/') || normalized.startsWith('.github/workflows/archive/');
+}
+
+function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {
+  if (status !== 'renamed' || !previous || !current || !isArchivePath(current)) {
+    return false;
+  }
+
+  const normalizedPrevious = normalizePattern(previous).toLowerCase();
+  return (
+    ALLOW_REMOVED_PATHS.has(normalizedPrevious) &&
+    isConsumerOnlyRemovalAllowed(normalizedPrevious, repository)
+  );
+}
+
 const PULL_REQUEST_TARGET_EVENT = 'pull_request_target';
 const HEAD_SHA_REF_REGEX = /\bref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/i;
 const SECRETS_EXPRESSION_REGEX = /\$\{\{\s*secrets\.[^}]+\}\}/i;
@@ -429,6 +446,12 @@ function evaluateGuard({
       previous,
       repository,
     });
+    const archiveRenameAllowed = isAllowlistedArchiveRename({
+      status,
+      current,
+      previous,
+      repository,
+    });
 
     if (protectedPath) {
       touchedProtectedPaths.add(protectedPath);
@@ -441,6 +464,9 @@ function evaluateGuard({
       }
 
       if (status === 'renamed' && previous) {
+        if (archiveRenameAllowed) {
+          continue;
+        }
         fatalViolations.push(`• ${previous} was renamed to ${current}.`);
         continue;
       }

--- a/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -68,8 +68,7 @@ function hasAutomationSignal(pr, labels) {
     labels.has('autofix') ||
     Array.from(labels).some((label) => isConcreteAgentLabel(label)) ||
     headRef.startsWith('codex/') ||
-    headRef.startsWith('claude/') ||
-    /^feat\/\d+/.test(headRef)
+    headRef.startsWith('claude/')
   );
 }
 

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -5,7 +5,7 @@ name: Auto-Label Issues
 
 on:
   issues:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, edited]
 
 permissions:
   contents: read
@@ -45,7 +45,7 @@ jobs:
         id: eligibility
         uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
         with:
-          expected-actions: opened,reopened,labeled
+          expected-actions: opened,reopened,edited
           custom-predicate: >-
             sender.type != 'Bot' && !ends_with(sender.login, '[bot]')
 

--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -2,7 +2,7 @@ name: Keepalive Loop Reporter
 
 on:
   workflow_run:
-    workflows: ["Agents Keepalive Loop"]
+    workflows: ["Agents Gate Followups"]
     types: [completed]
 
 permissions:
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   report:
     name: Report keepalive completion
-    if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true'
+    if: vars.USE_CONSOLIDATED_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout keepalive scripts

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -137,9 +137,18 @@ jobs:
               "pr_number": int(pr_number),
               "head_sha": pr.get("head", {}).get("sha", ""),
               "gate_conclusion": os.environ.get("GATE_CONCLUSION", ""),
-              "autofix_label_state": [
+              "automation_label_state": [
                   name for name in label_names
-                  if name.startswith("autofix") or name == "agent:retry"
+                  if (
+                      name.startswith("autofix")
+                      or name.startswith("agent:")
+                      or name in {
+                          "agents:auto-pilot",
+                          "agents:keepalive",
+                          "agents:paused",
+                          "needs-human",
+                      }
+                  )
               ],
           }
           print(json.dumps(payload, sort_keys=True))

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1575,8 +1575,13 @@ def _generate_without_llm(
             task = f"Address: {task}"
         tasks.append(task)
 
-    # Use original unmet acceptance criteria
-    acceptance_criteria = original_issue.acceptance_criteria[:10]
+    # Use original unmet acceptance criteria, but avoid pulling workflow-sync
+    # rollout criteria into repo-local follow-ups when verifier concerns are
+    # focused on the consumer repository behavior.
+    acceptance_criteria = _select_followup_acceptance_criteria(
+        original_issue,
+        verification_data,
+    )
 
     # Build body
     body_parts = [
@@ -1763,12 +1768,74 @@ def _build_why_section(
     if verification_data.structural_issues:
         parts.append("The original issue had structural problems that may have hindered progress.")
 
+    if _has_mixed_repo_and_workflow_acceptance_criteria(original_issue):
+        parts.append(
+            "Workflow-sync acceptance criteria were de-emphasized so this follow-up stays "
+            "focused on the repo-local verifier concerns."
+        )
+
     if needs_human_reason:
         parts.append(needs_human_reason)
 
     parts.append("This follow-up addresses the remaining gaps with improved task structure.")
 
     return " ".join(parts)
+
+
+WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
+    ".github/",
+    "agent",
+    "autofix",
+    "consumer sync",
+    "gate workflow",
+    "maint-68",
+    "sync pr",
+    "sync-generated",
+    "template",
+    "workflow",
+)
+
+
+def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
+    normalized = str(criterion or "").strip().lower()
+    return any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS)
+
+
+def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIssueData) -> bool:
+    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+    if not criteria:
+        return False
+    has_workflow = any(_is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
+    has_repo_local = any(not _is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
+    return has_workflow and has_repo_local
+
+
+def _select_followup_acceptance_criteria(
+    original_issue: OriginalIssueData,
+    verification_data: VerificationData,  # noqa: ARG001 - retained for future signal-aware filtering
+    *,
+    limit: int = 10,
+) -> list[str]:
+    """Select acceptance criteria that keep fallback follow-ups scoped.
+
+    Mixed Workflows/consumer issues can carry rollout criteria about synced
+    workflows next to repo-local behavior checks. When verifier feedback is
+    being converted into a consumer follow-up, keep the repo-local criteria and
+    avoid restating workflow-sync rollout criteria as if they were local tasks.
+    """
+
+    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+    if not criteria:
+        return []
+
+    filtered = [
+        criterion
+        for criterion in criteria
+        if not _is_workflow_sync_acceptance_criterion(criterion)
+    ]
+    if filtered:
+        return filtered[:limit]
+    return criteria[:limit]
 
 
 def main() -> int:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1806,7 +1806,9 @@ def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIss
     if not criteria:
         return False
     has_workflow = any(_is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
-    has_repo_local = any(not _is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
+    has_repo_local = any(
+        not _is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria
+    )
     return has_workflow and has_repo_local
 
 
@@ -1829,9 +1831,7 @@ def _select_followup_acceptance_criteria(
         return []
 
     filtered = [
-        criterion
-        for criterion in criteria
-        if not _is_workflow_sync_acceptance_criterion(criterion)
+        criterion for criterion in criteria if not _is_workflow_sync_acceptance_criterion(criterion)
     ]
     if filtered:
         return filtered[:limit]

--- a/scripts/state_fingerprint.py
+++ b/scripts/state_fingerprint.py
@@ -409,7 +409,9 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--mode", choices=["enforce", "warning"], default="enforce")
     compare.set_defaults(func=_compare_command)
 
-    store = subparsers.add_parser("store", help="persist a fingerprint after workflow work completes")
+    store = subparsers.add_parser(
+        "store", help="persist a fingerprint after workflow work completes"
+    )
     store.add_argument("--workflow", required=True)
     store.add_argument("--hash", required=True)
     store.add_argument("--storage", choices=["pr-comment", "repo-variable"], default="pr-comment")

--- a/scripts/state_fingerprint.py
+++ b/scripts/state_fingerprint.py
@@ -374,15 +374,25 @@ def _compare_command(args: argparse.Namespace) -> int:
         should_run = True
         reason = f"warning-mode:{decision.reason}"
 
-    if decision.should_run or args.mode == "warning":
-        store_fingerprint(args.workflow, decision.current_hash, storage)
-
     outputs = {
         "should_run": "true" if should_run else "false",
         "reason": reason,
         "current_hash": decision.current_hash,
         "prior_hash": decision.prior_hash or "",
     }
+    _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
+def _store_command(args: argparse.Namespace) -> int:
+    if not re.fullmatch(r"[0-9a-f]{64}", args.hash):
+        print("--hash must be a 64-character hex SHA-256 fingerprint", file=sys.stderr)
+        return 2
+
+    storage = _storage_from_name(args.storage, args.workflow)
+    store_fingerprint(args.workflow, args.hash, storage)
+    outputs = {"stored": "true", "hash": args.hash}
     _write_github_output(outputs)
     print(json.dumps(outputs, sort_keys=True))
     return 0
@@ -398,6 +408,12 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--storage", choices=["pr-comment", "repo-variable"], default="pr-comment")
     compare.add_argument("--mode", choices=["enforce", "warning"], default="enforce")
     compare.set_defaults(func=_compare_command)
+
+    store = subparsers.add_parser("store", help="persist a fingerprint after workflow work completes")
+    store.add_argument("--workflow", required=True)
+    store.add_argument("--hash", required=True)
+    store.add_argument("--storage", choices=["pr-comment", "repo-variable"], default="pr-comment")
+    store.set_defaults(func=_store_command)
     return parser
 
 

--- a/templates/consumer-repo/.github/actions/agent-event-eligibility/eligibility.js
+++ b/templates/consumer-repo/.github/actions/agent-event-eligibility/eligibility.js
@@ -36,7 +36,7 @@ function extractLabels(payload) {
   for (const item of payload?.issue?.labels || []) labels.push(labelName(item));
   for (const item of payload?.pull_request?.labels || []) labels.push(labelName(item));
   for (const item of payload?.discussion?.labels || []) labels.push(labelName(item));
-  if (payload?.label && payload.action !== 'unlabeled') labels.push(labelName(payload.label));
+  if (payload?.label) labels.push(labelName(payload.label));
   return unique(labels.map((item) => item.trim()).filter(Boolean));
 }
 

--- a/templates/consumer-repo/.github/scripts/agents-guard.js
+++ b/templates/consumer-repo/.github/scripts/agents-guard.js
@@ -68,6 +68,23 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
   return ALLOW_REMOVED_PATHS.has(normalizedPath) && isConsumerOnlyRemovalAllowed(normalizedPath, repository);
 }
 
+function isArchivePath(filePath) {
+  const normalized = normalizePattern(filePath || '').toLowerCase();
+  return normalized.startsWith('archives/') || normalized.startsWith('.github/workflows/archive/');
+}
+
+function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {
+  if (status !== 'renamed' || !previous || !current || !isArchivePath(current)) {
+    return false;
+  }
+
+  const normalizedPrevious = normalizePattern(previous).toLowerCase();
+  return (
+    ALLOW_REMOVED_PATHS.has(normalizedPrevious) &&
+    isConsumerOnlyRemovalAllowed(normalizedPrevious, repository)
+  );
+}
+
 const PULL_REQUEST_TARGET_EVENT = 'pull_request_target';
 const HEAD_SHA_REF_REGEX = /\bref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/i;
 const SECRETS_EXPRESSION_REGEX = /\$\{\{\s*secrets\.[^}]+\}\}/i;
@@ -429,6 +446,12 @@ function evaluateGuard({
       previous,
       repository,
     });
+    const archiveRenameAllowed = isAllowlistedArchiveRename({
+      status,
+      current,
+      previous,
+      repository,
+    });
 
     if (protectedPath) {
       touchedProtectedPaths.add(protectedPath);
@@ -441,6 +464,9 @@ function evaluateGuard({
       }
 
       if (status === 'renamed' && previous) {
+        if (archiveRenameAllowed) {
+          continue;
+        }
         fatalViolations.push(`• ${previous} was renamed to ${current}.`);
         continue;
       }

--- a/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -68,8 +68,7 @@ function hasAutomationSignal(pr, labels) {
     labels.has('autofix') ||
     Array.from(labels).some((label) => isConcreteAgentLabel(label)) ||
     headRef.startsWith('codex/') ||
-    headRef.startsWith('claude/') ||
-    /^feat\/\d+/.test(headRef)
+    headRef.startsWith('claude/')
   );
 }
 

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -138,9 +138,18 @@ jobs:
               "head_sha": pr.get("head", {}).get("sha", ""),
               "gate_conclusion": os.environ.get("GATE_CONCLUSION", ""),
               "force_retry": os.environ.get("FORCE_RETRY", "").lower() == "true",
-              "autofix_label_state": [
+              "automation_label_state": [
                   name for name in label_names
-                  if name.startswith("autofix") or name == "agent:retry"
+                  if (
+                      name.startswith("autofix")
+                      or name.startswith("agent:")
+                      or name in {
+                          "agents:auto-pilot",
+                          "agents:keepalive",
+                          "agents:paused",
+                          "needs-human",
+                      }
+                  )
               ],
           }
           print(json.dumps(payload, sort_keys=True))
@@ -268,6 +277,27 @@ jobs:
             }
             // Task appendix needs special handling due to multiline content
             core.setOutput('task_appendix', result.taskAppendix || '');
+
+      - name: Persist state fingerprint
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          steps.fingerprint.outputs.current_hash != '' &&
+          steps.evaluate.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: >-
+            ${{
+              github.event.workflow_run.pull_requests[0].number ||
+              github.event.pull_request.number ||
+              github.event.inputs.pr_number ||
+              ''
+            }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
+            --storage pr-comment
 
   preflight:
     name: Verify secrets available

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -5,7 +5,7 @@ name: Auto-Label Issues
 
 on:
   issues:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, edited]
 
 permissions:
   contents: read
@@ -37,7 +37,7 @@ jobs:
         id: eligibility
         uses: stranske/Workflows/.github/actions/agent-event-eligibility@main
         with:
-          expected-actions: opened,reopened,labeled
+          expected-actions: opened,reopened,edited
           custom-predicate: >-
             sender.type != 'Bot' && !ends_with(sender.login, '[bot]')
 

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -2,7 +2,7 @@ name: Keepalive Loop Reporter
 
 on:
   workflow_run:
-    workflows: ["Agents Keepalive Loop"]
+    workflows: ["Agents Gate Followups"]
     types: [completed]
 
 permissions:
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   report:
     name: Report keepalive completion
-    if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true'
+    if: vars.USE_CONSOLIDATED_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout keepalive scripts

--- a/tests/scripts/test_state_fingerprint.py
+++ b/tests/scripts/test_state_fingerprint.py
@@ -117,7 +117,7 @@ def test_warning_mode_bypasses_skip_and_logs_delta(
     outputs = json.loads(captured.out)
     assert outputs["should_run"] == "true"
     assert outputs["reason"] == "warning-mode:fingerprint-match"
-    assert storage.writes == [prior]
+    assert storage.writes == []
 
 
 def test_enforce_mode_does_not_rewrite_matching_fingerprint(
@@ -146,6 +146,32 @@ def test_enforce_mode_does_not_rewrite_matching_fingerprint(
     assert outputs["should_run"] == "false"
     assert outputs["reason"] == "fingerprint-match"
     assert storage.writes == []
+
+
+def test_store_command_persists_current_hash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    storage = MemoryStorage()
+    fingerprint = "d" * 64
+
+    monkeypatch.setattr(state_fingerprint, "_storage_from_name", lambda _name, _workflow: storage)
+
+    exit_code = state_fingerprint.main(
+        [
+            "store",
+            "--workflow",
+            "wf",
+            "--hash",
+            fingerprint,
+            "--storage",
+            "pr-comment",
+        ]
+    )
+
+    outputs = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert outputs["stored"] == "true"
+    assert storage.writes == [fingerprint]
 
 
 def test_pr_comment_marker_includes_visible_guidance() -> None:

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -11,12 +11,59 @@ from scripts.langchain import followup_issue_generator
 from scripts.langchain.followup_issue_generator import (
     OriginalIssueData,
     VerificationData,
+    _select_followup_acceptance_criteria,
     extract_original_issue_data,
     extract_verification_data,
     generate_disposition_comment,
     generate_followup_issue,
     generate_issue_disposition_link_comment,
 )
+
+
+def test_select_followup_acceptance_criteria_drops_workflow_sync_items() -> None:
+    original_issue = OriginalIssueData(
+        title="Database verifier follow-up",
+        number=42,
+        tasks=[],
+        acceptance_criteria=[
+            "Database migrations preserve existing records",
+            "Workflow template sync PRs are merged across consumers",
+            "Pension report rows remain queryable after import",
+        ],
+    )
+    verification_data = VerificationData(concerns=["Database rows were not preserved"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == [
+        "Database migrations preserve existing records",
+        "Pension report rows remain queryable after import",
+    ]
+
+
+def test_build_why_section_explains_mixed_surface_deemphasis() -> None:
+    original_issue = OriginalIssueData(
+        title="Mixed rollout",
+        number=43,
+        tasks=[],
+        acceptance_criteria=[
+            "Workflow template sync PRs are merged across consumers",
+            "Database exports include the new field",
+        ],
+    )
+    verification_data = VerificationData(
+        provider_verdicts={"openai": {"verdict": "CONCERNS", "confidence": 70}},
+        concerns=["Database export omitted the new field"],
+    )
+
+    why = followup_issue_generator._build_why_section(
+        verification_data,
+        original_issue,
+        pr_number=99,
+        verdict="CONCERNS",
+    )
+
+    assert "Workflow-sync acceptance criteria were de-emphasized" in why
 
 
 class TestExtractVerificationData:


### PR DESCRIPTION
## Summary\n- address active sync PR review debt in shared agent event eligibility, keepalive gate routing, guard archive handling, and auto-label triggers\n- keep Gate followup fingerprints sensitive to agent/keepalive labels and persist the fingerprint after evaluation succeeds\n- restore repo-local follow-up issue acceptance-criteria filtering for mixed workflow/consumer issues\n\n## Validation\n- node --test .github/scripts/__tests__/agent-event-eligibility.test.js .github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js .github/scripts/__tests__/agents-guard.test.js\n- python -m pytest tests/scripts/test_state_fingerprint.py tests/test_followup_issue_generator.py tests/workflows/test_agents_guard.py -q\n- python scripts/validate_template_sync.py\n- python scripts/validate_template_completeness.py\n- git diff --check