### PR TITLE
fix: address replacement sync review debt

### DIFF
--- a/.github/actions/agent-event-eligibility/eligibility.js
+++ b/.github/actions/agent-event-eligibility/eligibility.js
@@ -36,7 +36,7 @@ function extractLabels(payload) {
   for (const item of payload?.issue?.labels || []) labels.push(labelName(item));
   for (const item of payload?.pull_request?.labels || []) labels.push(labelName(item));
   for (const item of payload?.discussion?.labels || []) labels.push(labelName(item));
-  if (payload?.label) labels.push(labelName(payload.label));
+  if (payload?.label && payload?.action !== 'unlabeled') labels.push(labelName(payload.label));
   return unique(labels.map((item) => item.trim()).filter(Boolean));
 }
 

--- a/.github/scripts/__tests__/agent-event-eligibility.test.js
+++ b/.github/scripts/__tests__/agent-event-eligibility.test.js
@@ -117,17 +117,17 @@ test('warning mode bypasses denied decisions', () => {
   assert.match(result.reason, /warning mode bypassed denial/);
 });
 
-test('unlabeled events include the removed label as an event signal', () => {
+test('unlabeled events only include labels still present after removal', () => {
   const labels = extractLabels(issuePayload({
     action: 'unlabeled',
     label: { name: 'agent:codex' },
     issue: { labels: [{ name: 'agents:auto-pilot' }] },
   }));
 
-  assert.deepEqual(labels, ['agents:auto-pilot', 'agent:codex']);
+  assert.deepEqual(labels, ['agents:auto-pilot']);
 });
 
-test('unlabeled events can match the removed expected label', () => {
+test('unlabeled events do not match the removed expected label', () => {
   const result = evaluateEligibility({
     payload: issuePayload({
       action: 'unlabeled',
@@ -139,8 +139,8 @@ test('unlabeled events can match the removed expected label', () => {
     expectedLabels: 'agents:keepalive',
   });
 
-  assert.equal(result.shouldRun, true);
-  assert.equal(result.matchedLabel, 'agents:keepalive');
+  assert.equal(result.shouldRun, false);
+  assert.equal(result.reason, 'expected label not present');
 });
 
 test('event-name input default stays blank so runtime env fallback is used', () => {

--- a/.github/scripts/__tests__/agents-guard.test.js
+++ b/.github/scripts/__tests__/agents-guard.test.js
@@ -219,6 +219,20 @@ test('allows archive renames of allowlisted removal paths', () => {
   assert.equal(result.fatalViolations.length, 0);
 });
 
+test('blocks renames into retired workflow archive directory', () => {
+  const result = evaluateGuard({
+    repository: 'stranske/Template',
+    files: [{
+      filename: '.github/workflows/archive/agents-autofix-loop.yml',
+      previous_filename: '.github/workflows/agents-autofix-loop.yml',
+      status: 'renamed',
+    }],
+  });
+
+  assert.equal(result.blocked, true);
+  assert.ok(result.fatalViolations.some((reason) => reason.includes('was renamed')));
+});
+
 test('blocks consumer-only archive renames in Workflows repo', () => {
   const result = evaluateGuard({
     repository: 'stranske/Workflows',

--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -70,7 +70,7 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
 
 function isArchivePath(filePath) {
   const normalized = normalizePattern(filePath || '').toLowerCase();
-  return normalized.startsWith('archives/') || normalized.startsWith('.github/workflows/archive/');
+  return normalized.startsWith('archives/');
 }
 
 function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {

--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -91,6 +91,7 @@ jobs:
         run: echo "Skipped - ${{ steps.fingerprint.outputs.reason }}"
 
       - name: Update summary for cancelled/failed runs
+        id: update-summary
         if: steps.fingerprint.outputs.should_run == 'true'
         uses: actions/github-script@v9
         with:
@@ -141,3 +142,17 @@ jobs:
             };
 
             await updateKeepaliveLoopSummary({ github, context, core, inputs });
+
+      - name: Persist state fingerprint
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          steps.fingerprint.outputs.current_hash != '' &&
+          steps.update-summary.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
+            --storage pr-comment

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -342,6 +342,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.check.outputs.pr_number }}
         run: |
           python scripts/state_fingerprint.py store \
             --workflow "${GITHUB_WORKFLOW}" \

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -88,6 +88,7 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout retry helpers
         uses: actions/checkout@v6
@@ -317,3 +318,32 @@ jobs:
       # Second model for compare mode (empty string uses default)
       model2: ${{ needs.check.outputs.model2 }}
     secrets: inherit
+
+  persist-fingerprint:
+    name: Persist verifier state fingerprint
+    needs:
+      - check
+      - verifier
+    if: >-
+      always() &&
+      needs.check.outputs.should_run == 'true' &&
+      needs.check.outputs.fingerprint_should_run == 'true' &&
+      needs.check.outputs.fingerprint_current_hash != '' &&
+      needs.verifier.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout state fingerprint helper
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: scripts/state_fingerprint.py
+          sparse-checkout-cone-mode: false
+
+      - name: Persist state fingerprint
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ needs.check.outputs.fingerprint_current_hash }}" \
+            --storage pr-comment

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1768,10 +1768,9 @@ def _build_why_section(
     if verification_data.structural_issues:
         parts.append("The original issue had structural problems that may have hindered progress.")
 
-    if (
-        _has_mixed_repo_and_workflow_acceptance_criteria(original_issue)
-        and not _verification_feedback_mentions_workflow_sync(verification_data)
-    ):
+    if _has_mixed_repo_and_workflow_acceptance_criteria(
+        original_issue
+    ) and not _verification_feedback_mentions_workflow_sync(verification_data):
         parts.append(
             "Workflow-sync acceptance criteria were de-emphasized so this follow-up stays "
             "focused on the repo-local verifier concerns."

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1768,7 +1768,10 @@ def _build_why_section(
     if verification_data.structural_issues:
         parts.append("The original issue had structural problems that may have hindered progress.")
 
-    if _has_mixed_repo_and_workflow_acceptance_criteria(original_issue):
+    if (
+        _has_mixed_repo_and_workflow_acceptance_criteria(original_issue)
+        and not _verification_feedback_mentions_workflow_sync(verification_data)
+    ):
         parts.append(
             "Workflow-sync acceptance criteria were de-emphasized so this follow-up stays "
             "focused on the repo-local verifier concerns."
@@ -1783,16 +1786,17 @@ def _build_why_section(
 
 
 WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
-    ".github/",
-    "agent",
-    "autofix",
     "consumer sync",
+    "consumer-sync",
     "gate workflow",
     "maint-68",
+    "synced workflow",
     "sync pr",
     "sync-generated",
-    "template",
-    "workflow",
+    "sync workflow templates",
+    "template sync",
+    "workflow template sync",
+    "workflow-template",
 )
 
 
@@ -1812,9 +1816,19 @@ def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIss
     return has_workflow and has_repo_local
 
 
+def _verification_feedback_mentions_workflow_sync(verification_data: VerificationData) -> bool:
+    parts = [
+        *verification_data.concerns,
+        *verification_data.non_pass_output,
+        *verification_data.non_pass_findings,
+        *verification_data.structural_issues,
+    ]
+    return any(_is_workflow_sync_acceptance_criterion(part) for part in parts)
+
+
 def _select_followup_acceptance_criteria(
     original_issue: OriginalIssueData,
-    verification_data: VerificationData,  # noqa: ARG001 - retained for future signal-aware filtering
+    verification_data: VerificationData,
     *,
     limit: int = 10,
 ) -> list[str]:
@@ -1829,6 +1843,12 @@ def _select_followup_acceptance_criteria(
     criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
     if not criteria:
         return []
+
+    if not _has_mixed_repo_and_workflow_acceptance_criteria(original_issue):
+        return criteria[:limit]
+
+    if _verification_feedback_mentions_workflow_sync(verification_data):
+        return criteria[:limit]
 
     filtered = [
         criterion for criterion in criteria if not _is_workflow_sync_acceptance_criterion(criterion)

--- a/templates/consumer-repo/.github/scripts/agents-guard.js
+++ b/templates/consumer-repo/.github/scripts/agents-guard.js
@@ -70,7 +70,7 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
 
 function isArchivePath(filePath) {
   const normalized = normalizePattern(filePath || '').toLowerCase();
-  return normalized.startsWith('archives/') || normalized.startsWith('.github/workflows/archive/');
+  return normalized.startsWith('archives/');
 }
 
 function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
   actions: write
   models: read
 
@@ -75,6 +76,7 @@ jobs:
       security_reason: ${{ steps.security_gate.outputs.reason }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -277,27 +279,6 @@ jobs:
             }
             // Task appendix needs special handling due to multiline content
             core.setOutput('task_appendix', result.taskAppendix || '');
-
-      - name: Persist state fingerprint
-        if: >-
-          steps.fingerprint.outputs.should_run == 'true' &&
-          steps.fingerprint.outputs.current_hash != '' &&
-          steps.evaluate.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: >-
-            ${{
-              github.event.workflow_run.pull_requests[0].number ||
-              github.event.pull_request.number ||
-              github.event.inputs.pr_number ||
-              ''
-            }}
-        run: |
-          python scripts/state_fingerprint.py store \
-            --workflow "${GITHUB_WORKFLOW}" \
-            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
-            --storage pr-comment
 
   preflight:
     name: Verify secrets available
@@ -634,6 +615,7 @@ jobs:
             core.setOutput('commit_tasks_count', result.sources?.commit || 0);
 
       - name: Update summary comment
+        id: update-summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           AGENT_SUMMARY: >-
@@ -712,6 +694,33 @@ jobs:
               llm_analysis_run: llmAnalysisRun,
             };
             await updateKeepaliveLoopSummary({ github, context, core, inputs });
+
+      - name: Persist state fingerprint
+        if: >-
+          needs.evaluate.outputs.fingerprint_should_run == 'true' &&
+          needs.evaluate.outputs.fingerprint_current_hash != '' &&
+          needs.evaluate.outputs.pr_number != '' &&
+          steps.update-summary.outcome == 'success' &&
+          (
+            (
+              needs.evaluate.outputs.action != 'run' &&
+              needs.evaluate.outputs.action != 'fix' &&
+              needs.evaluate.outputs.action != 'conflict'
+            ) ||
+            (
+              needs.preflight.result == 'success' &&
+              (needs.run-codex.result == 'success' || needs.run-codex.result == 'skipped') &&
+              (needs.run-claude.result == 'success' || needs.run-claude.result == 'skipped')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ needs.evaluate.outputs.fingerprint_current_hash }}" \
+            --storage pr-comment
 
   prepare:
     name: Prepare autofix context

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -716,6 +716,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
         run: |
           python scripts/state_fingerprint.py store \
             --workflow "${GITHUB_WORKFLOW}" \

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -79,6 +79,7 @@ jobs:
         run: echo "Skipped - ${{ steps.fingerprint.outputs.reason }}"
 
       - name: Update summary for cancelled/failed runs
+        id: update-summary
         if: steps.fingerprint.outputs.should_run == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -129,3 +130,17 @@ jobs:
             };
 
             await updateKeepaliveLoopSummary({ github, context, core, inputs });
+
+      - name: Persist state fingerprint
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          steps.fingerprint.outputs.current_hash != '' &&
+          steps.update-summary.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
+            --storage pr-comment

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -338,6 +338,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.check.outputs.pr_number }}
         run: |
           python scripts/state_fingerprint.py store \
             --workflow "${GITHUB_WORKFLOW}" \

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -83,6 +83,7 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout retry helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -313,3 +314,32 @@ jobs:
       # Second model for compare mode (empty string uses default)
       model2: ${{ needs.check.outputs.model2 }}
     secrets: inherit
+
+  persist-fingerprint:
+    name: Persist verifier state fingerprint
+    needs:
+      - check
+      - verifier
+    if: >-
+      always() &&
+      needs.check.outputs.should_run == 'true' &&
+      needs.check.outputs.fingerprint_should_run == 'true' &&
+      needs.check.outputs.fingerprint_current_hash != '' &&
+      needs.verifier.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout state fingerprint helper
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: scripts/state_fingerprint.py
+          sparse-checkout-cone-mode: false
+
+      - name: Persist state fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ needs.check.outputs.fingerprint_current_hash }}" \
+            --storage pr-comment

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -41,6 +41,42 @@ def test_select_followup_acceptance_criteria_drops_workflow_sync_items() -> None
     ]
 
 
+def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:
+    original_issue = OriginalIssueData(
+        title="Mixed verifier follow-up",
+        number=44,
+        tasks=[],
+        acceptance_criteria=[
+            "Database migrations preserve existing records",
+            "Workflow template sync PRs are merged across consumers",
+        ],
+    )
+    verification_data = VerificationData(
+        concerns=["Workflow template sync acceptance was not satisfied"]
+    )
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == original_issue.acceptance_criteria
+
+
+def test_select_followup_acceptance_criteria_keeps_repo_local_agent_items() -> None:
+    original_issue = OriginalIssueData(
+        title="Repo-local agent UI",
+        number=45,
+        tasks=[],
+        acceptance_criteria=[
+            "The portal UI can reopen saved workflow state after refresh",
+            "Update .github/agents/registry.yml with repo-local agent config",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The portal did not reopen saved state"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == original_issue.acceptance_criteria
+
+
 def test_build_why_section_explains_mixed_surface_deemphasis() -> None:
     original_issue = OriginalIssueData(
         title="Mixed rollout",


### PR DESCRIPTION
## Summary
- keep event eligibility label checks tied to currently applied labels on unlabeled events
- persist state fingerprints only after verifier/reporter/consumer follow-up work succeeds
- keep workflow archive rename allowlisting aligned to the active archives/ location
- narrow workflow-sync acceptance filtering and make it verifier-signal aware

## Validation
- node --test .github/scripts/__tests__/agent-event-eligibility.test.js .github/scripts/__tests__/agents-guard.test.js
- python -m pytest tests/scripts/test_state_fingerprint.py tests/test_followup_issue_generator.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- actionlint targeted workflow files
- git diff --check