### PR TITLE
fix: resolve remaining sync review debt

### DIFF
--- a/.github/scripts/__tests__/agents-guard.test.js
+++ b/.github/scripts/__tests__/agents-guard.test.js
@@ -219,7 +219,7 @@ test('allows archive renames of allowlisted removal paths', () => {
   assert.equal(result.fatalViolations.length, 0);
 });
 
-test('blocks renames into retired workflow archive directory', () => {
+test('allows renames into retired workflow archive directory', () => {
   const result = evaluateGuard({
     repository: 'stranske/Template',
     files: [{
@@ -229,8 +229,22 @@ test('blocks renames into retired workflow archive directory', () => {
     }],
   });
 
-  assert.equal(result.blocked, true);
-  assert.ok(result.fatalViolations.some((reason) => reason.includes('was renamed')));
+  assert.equal(result.blocked, false);
+  assert.equal(result.fatalViolations.length, 0);
+});
+
+test('allows renames into legacy workflows-archive directory', () => {
+  const result = evaluateGuard({
+    repository: 'stranske/Travel-Plan-Permission',
+    files: [{
+      filename: '.github/workflows-archive/agents-autofix-loop.yml',
+      previous_filename: '.github/workflows/agents-autofix-loop.yml',
+      status: 'renamed',
+    }],
+  });
+
+  assert.equal(result.blocked, false);
+  assert.equal(result.fatalViolations.length, 0);
 });
 
 test('blocks consumer-only archive renames in Workflows repo', () => {

--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -70,7 +70,11 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
 
 function isArchivePath(filePath) {
   const normalized = normalizePattern(filePath || '').toLowerCase();
-  return normalized.startsWith('archives/');
+  return (
+    normalized.startsWith('archives/') ||
+    normalized.startsWith('.github/workflows/archive/') ||
+    normalized.startsWith('.github/workflows-archive/')
+  );
 }
 
 function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1787,6 +1787,12 @@ def _build_why_section(
 WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "consumer sync",
     "consumer-sync",
+    ".github/workflows/",
+    "workflow file",
+    "workflow files",
+    "workflow-owned",
+    "workflows-owned",
+    "workflows-owned scripts",
     "gate workflow",
     "maint-68",
     "synced workflow",
@@ -1799,13 +1805,25 @@ WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
 )
 
 
+def _acceptance_criteria_from_original_issue(
+    original_issue: OriginalIssueData | list[str],
+) -> list[str]:
+    if isinstance(original_issue, OriginalIssueData):
+        raw_criteria = original_issue.acceptance_criteria
+    else:
+        raw_criteria = original_issue
+    return [criterion for criterion in raw_criteria if criterion]
+
+
 def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     normalized = str(criterion or "").strip().lower()
     return any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS)
 
 
-def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIssueData) -> bool:
-    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+def _has_mixed_repo_and_workflow_acceptance_criteria(
+    original_issue: OriginalIssueData | list[str],
+) -> bool:
+    criteria = _acceptance_criteria_from_original_issue(original_issue)
     if not criteria:
         return False
     has_workflow = any(_is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
@@ -1826,7 +1844,7 @@ def _verification_feedback_mentions_workflow_sync(verification_data: Verificatio
 
 
 def _select_followup_acceptance_criteria(
-    original_issue: OriginalIssueData,
+    original_issue: OriginalIssueData | list[str],
     verification_data: VerificationData,
     *,
     limit: int = 10,
@@ -1839,7 +1857,7 @@ def _select_followup_acceptance_criteria(
     avoid restating workflow-sync rollout criteria as if they were local tasks.
     """
 
-    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+    criteria = _acceptance_criteria_from_original_issue(original_issue)
     if not criteria:
         return []
 

--- a/templates/consumer-repo/.github/scripts/agents-guard.js
+++ b/templates/consumer-repo/.github/scripts/agents-guard.js
@@ -70,7 +70,11 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
 
 function isArchivePath(filePath) {
   const normalized = normalizePattern(filePath || '').toLowerCase();
-  return normalized.startsWith('archives/');
+  return (
+    normalized.startsWith('archives/') ||
+    normalized.startsWith('.github/workflows/archive/') ||
+    normalized.startsWith('.github/workflows-archive/')
+  );
 }
 
 function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -60,6 +60,35 @@ def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_f
     assert selected == original_issue.acceptance_criteria
 
 
+def test_select_followup_acceptance_criteria_accepts_plain_list() -> None:
+    criteria = [
+        "Workflows-owned scripts in Pension-Data stay synced",
+        "Imported records keep their account IDs",
+    ]
+    verification_data = VerificationData(concerns=["Imported records lost account IDs"])
+
+    selected = _select_followup_acceptance_criteria(criteria, verification_data)
+
+    assert selected == ["Imported records keep their account IDs"]
+
+
+def test_select_followup_acceptance_criteria_detects_workflow_file_markers() -> None:
+    original_issue = OriginalIssueData(
+        title="Workflow path rollout",
+        number=46,
+        tasks=[],
+        acceptance_criteria=[
+            "Update .github/workflows/agents-verifier.yml from the template",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == ["The dashboard export renders for the selected account"]
+
+
 def test_select_followup_acceptance_criteria_keeps_repo_local_agent_items() -> None:
     original_issue = OriginalIssueData(
         title="Repo-local agent UI",


### PR DESCRIPTION
## Summary
- keep workflow-sync follow-up filtering compatible with plain criteria lists
- restore generic workflow-file and Workflows-owned markers for sync criterion detection
- allow archived workflow renames under archives/, .github/workflows/archive/, and .github/workflows-archive/ in source and consumer guard copies

## Validation
- python -m black scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- node --test .github/scripts/__tests__/agent-event-eligibility.test.js .github/scripts/__tests__/agents-guard.test.js
- python -m pytest tests/test_followup_issue_generator.py tests/scripts/test_state_fingerprint.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check