### PR TITLE
fix: tighten sync review fingerprint state

### DIFF
--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -65,15 +65,82 @@ jobs:
           import hashlib
           import json
           import os
+          import re
+          import urllib.parse
+          import urllib.request
 
           with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
               event = json.load(handle)
           run = event.get("workflow_run") or {}
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          pr_number = int(os.environ["PR_NUMBER"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          api_root = (os.environ.get("GITHUB_API_URL") or "https://api." + "github.com").rstrip("/")
+          state_re = re.compile(r"<!--\s*keepalive-state(?::[\w.-]+)?\s+(.*?)\s*-->", re.S)
+
+          def api(path):
+              request = urllib.request.Request(f"{api_root}{path}", headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def paged(path):
+              results = []
+              page = 1
+              while True:
+                  separator = "&" if "?" in path else "?"
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
+                  results.extend(batch)
+                  if len(batch) < 100:
+                      return results
+                  page += 1
+
+          def stable_keepalive_state():
+              comments = paged(f"/repos/{repo}/issues/{pr_number}/comments")
+              for comment in reversed(comments):
+                  match = state_re.search(comment.get("body") or "")
+                  if not match:
+                      continue
+                  try:
+                      state = json.loads(match.group(1))
+                  except json.JSONDecodeError:
+                      continue
+                  tasks = state.get("tasks") if isinstance(state.get("tasks"), dict) else {}
+                  failure = state.get("failure") if isinstance(state.get("failure"), dict) else {}
+                  return {
+                      "running": state.get("running"),
+                      "iteration": state.get("iteration"),
+                      "max_iterations": state.get("max_iterations"),
+                      "failure_threshold": state.get("failure_threshold"),
+                      "failure": {
+                          "reason": failure.get("reason"),
+                          "count": failure.get("count"),
+                      },
+                      "tasks": {
+                          "total": tasks.get("total"),
+                          "unchecked": tasks.get("unchecked"),
+                      },
+                      "keepalive_enabled": state.get("keepalive_enabled"),
+                      "autofix_enabled": state.get("autofix_enabled"),
+                      "agent_type": state.get("agent_type"),
+                      "trace": state.get("trace"),
+                      "rounds_without_task_completion": state.get(
+                          "rounds_without_task_completion"
+                      ),
+                  }
+              return {}
+
           run_state = {
-              "pr_number": int(os.environ["PR_NUMBER"]),
+              "pr_number": pr_number,
               "head_sha": run.get("head_sha") or "",
               "status": run.get("status") or "",
               "conclusion": run.get("conclusion") or "",
+              "keepalive_state": stable_keepalive_state(),
           }
           state_hash = hashlib.sha256(
               json.dumps(run_state, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -256,6 +256,73 @@ jobs:
                       return results
                   page += 1
 
+          def graphql(query, variables):
+              payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+              request = urllib.request.Request(
+                  f"{api_root}/graphql",
+                  data=payload,
+                  headers={**headers, "Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def text_hash(value):
+              return hashlib.sha256(
+                  str(value or "").encode("utf-8")
+              ).hexdigest()
+
+          def closing_issue_context():
+              owner, repo_name = repo.split("/", 1)
+              query = """
+              query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    closingIssuesReferences(first: 20) {
+                      nodes {
+                        number
+                        title
+                        body
+                        state
+                        labels(first: 100) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              """
+              data = graphql(
+                  query,
+                  {"owner": owner, "repo": repo_name, "prNumber": int(pr_number)},
+              )
+              issues = (
+                  data.get("data", {})
+                  .get("repository", {})
+                  .get("pullRequest", {})
+                  .get("closingIssuesReferences", {})
+                  .get("nodes", [])
+              )
+              context = []
+              for issue in issues:
+                  if not issue:
+                      continue
+                  labels = issue.get("labels", {}).get("nodes", [])
+                  context.append(
+                      {
+                          "number": issue.get("number"),
+                          "title": issue.get("title") or "",
+                          "state": issue.get("state") or "",
+                          "body_hash": text_hash(issue.get("body") or ""),
+                          "labels": sorted(
+                              label.get("name", "")
+                              for label in labels
+                              if label.get("name")
+                          ),
+                      }
+                  )
+              return sorted(context, key=lambda item: item["number"] or 0)
+
           pr = api(f"/repos/{repo}/pulls/{pr_number}")
           files = paged(f"/repos/{repo}/pulls/{pr_number}/files")
           labels = api(f"/repos/{repo}/issues/{pr_number}/labels")
@@ -282,6 +349,9 @@ jobs:
               "model": os.environ.get("VERIFY_MODEL", ""),
               "model2": os.environ.get("VERIFY_MODEL2", ""),
               "provider": os.environ.get("VERIFY_PROVIDER", ""),
+              "pr_body_hash": text_hash(pr.get("body") or ""),
+              "pr_title": pr.get("title", ""),
+              "closing_issue_context": closing_issue_context(),
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1787,6 +1787,8 @@ def _build_why_section(
 WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "consumer sync",
     "consumer-sync",
+    ".github/scripts",
+    ".github/workflows",
     ".github/workflows/",
     "workflow file",
     "workflow files",

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -53,15 +53,82 @@ jobs:
           import hashlib
           import json
           import os
+          import re
+          import urllib.parse
+          import urllib.request
 
           with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
               event = json.load(handle)
           run = event.get("workflow_run") or {}
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          pr_number = int(os.environ["PR_NUMBER"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          api_root = (os.environ.get("GITHUB_API_URL") or "https://api." + "github.com").rstrip("/")
+          state_re = re.compile(r"<!--\s*keepalive-state(?::[\w.-]+)?\s+(.*?)\s*-->", re.S)
+
+          def api(path):
+              request = urllib.request.Request(f"{api_root}{path}", headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def paged(path):
+              results = []
+              page = 1
+              while True:
+                  separator = "&" if "?" in path else "?"
+                  query = urllib.parse.urlencode({"per_page": 100, "page": page})
+                  batch = api(f"{path}{separator}{query}")
+                  results.extend(batch)
+                  if len(batch) < 100:
+                      return results
+                  page += 1
+
+          def stable_keepalive_state():
+              comments = paged(f"/repos/{repo}/issues/{pr_number}/comments")
+              for comment in reversed(comments):
+                  match = state_re.search(comment.get("body") or "")
+                  if not match:
+                      continue
+                  try:
+                      state = json.loads(match.group(1))
+                  except json.JSONDecodeError:
+                      continue
+                  tasks = state.get("tasks") if isinstance(state.get("tasks"), dict) else {}
+                  failure = state.get("failure") if isinstance(state.get("failure"), dict) else {}
+                  return {
+                      "running": state.get("running"),
+                      "iteration": state.get("iteration"),
+                      "max_iterations": state.get("max_iterations"),
+                      "failure_threshold": state.get("failure_threshold"),
+                      "failure": {
+                          "reason": failure.get("reason"),
+                          "count": failure.get("count"),
+                      },
+                      "tasks": {
+                          "total": tasks.get("total"),
+                          "unchecked": tasks.get("unchecked"),
+                      },
+                      "keepalive_enabled": state.get("keepalive_enabled"),
+                      "autofix_enabled": state.get("autofix_enabled"),
+                      "agent_type": state.get("agent_type"),
+                      "trace": state.get("trace"),
+                      "rounds_without_task_completion": state.get(
+                          "rounds_without_task_completion"
+                      ),
+                  }
+              return {}
+
           run_state = {
-              "pr_number": int(os.environ["PR_NUMBER"]),
+              "pr_number": pr_number,
               "head_sha": run.get("head_sha") or "",
               "status": run.get("status") or "",
               "conclusion": run.get("conclusion") or "",
+              "keepalive_state": stable_keepalive_state(),
           }
           state_hash = hashlib.sha256(
               json.dumps(run_state, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -250,6 +250,73 @@ jobs:
                       return results
                   page += 1
 
+          def graphql(query, variables):
+              payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+              request = urllib.request.Request(
+                  f"{api_root}/graphql",
+                  data=payload,
+                  headers={**headers, "Content-Type": "application/json"},
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def text_hash(value):
+              return hashlib.sha256(
+                  str(value or "").encode("utf-8")
+              ).hexdigest()
+
+          def closing_issue_context():
+              owner, repo_name = repo.split("/", 1)
+              query = """
+              query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    closingIssuesReferences(first: 20) {
+                      nodes {
+                        number
+                        title
+                        body
+                        state
+                        labels(first: 100) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              """
+              data = graphql(
+                  query,
+                  {"owner": owner, "repo": repo_name, "prNumber": int(pr_number)},
+              )
+              issues = (
+                  data.get("data", {})
+                  .get("repository", {})
+                  .get("pullRequest", {})
+                  .get("closingIssuesReferences", {})
+                  .get("nodes", [])
+              )
+              context = []
+              for issue in issues:
+                  if not issue:
+                      continue
+                  labels = issue.get("labels", {}).get("nodes", [])
+                  context.append(
+                      {
+                          "number": issue.get("number"),
+                          "title": issue.get("title") or "",
+                          "state": issue.get("state") or "",
+                          "body_hash": text_hash(issue.get("body") or ""),
+                          "labels": sorted(
+                              label.get("name", "")
+                              for label in labels
+                              if label.get("name")
+                          ),
+                      }
+                  )
+              return sorted(context, key=lambda item: item["number"] or 0)
+
           pr = api(f"/repos/{repo}/pulls/{pr_number}")
           files = paged(f"/repos/{repo}/pulls/{pr_number}/files")
           labels = api(f"/repos/{repo}/issues/{pr_number}/labels")
@@ -276,6 +343,9 @@ jobs:
               "model": os.environ.get("VERIFY_MODEL", ""),
               "model2": os.environ.get("VERIFY_MODEL2", ""),
               "provider": os.environ.get("VERIFY_PROVIDER", ""),
+              "pr_body_hash": text_hash(pr.get("body") or ""),
+              "pr_title": pr.get("title", ""),
+              "closing_issue_context": closing_issue_context(),
               "verifier_trigger_labels": sorted(
                   label.get("name", "")
                   for label in labels

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -78,7 +78,24 @@ def test_select_followup_acceptance_criteria_detects_workflow_file_markers() -> 
         number=46,
         tasks=[],
         acceptance_criteria=[
-            "Update .github/workflows/agents-verifier.yml from the template",
+            "Update .github/workflows from the template",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == ["The dashboard export renders for the selected account"]
+
+
+def test_select_followup_acceptance_criteria_detects_synced_script_markers() -> None:
+    original_issue = OriginalIssueData(
+        title="Workflow script rollout",
+        number=47,
+        tasks=[],
+        acceptance_criteria=[
+            "Update .github/scripts/keepalive_loop.js from Workflows",
             "The dashboard export renders for the selected account",
         ],
     )


### PR DESCRIPTION
## Summary
- classify synced `.github/workflows` and `.github/scripts` acceptance criteria as workflow-sync rollout items
- include stable keepalive loop state in reporter fingerprint inputs
- include PR body and linked issue context hashes in verifier fingerprint inputs
- update consumer templates with the same workflow fingerprint behavior

## Validation
- `python -m pytest tests/test_followup_issue_generator.py tests/scripts/test_state_fingerprint.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- targeted PyYAML parse for changed workflows and templates
- targeted `actionlint` for changed workflows and templates
- `python -m black --check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py`
- `git diff --check`