### PR TITLE
fix: narrow workflow sync acceptance markers

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1784,16 +1784,31 @@ def _build_why_section(
     return " ".join(parts)
 
 
-WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
+WORKFLOW_SYNC_CONTEXT_MARKERS = (
     "consumer sync",
     "consumer-sync",
+    "consumer",
+    "consumers",
+    "from the template",
+    "maint-68",
+    "synced",
+    "sync pr",
+    "sync-generated",
+    "template sync",
+    "workflow template sync",
+    "workflow-template",
+    "workflow-owned",
+    "workflows-owned",
+)
+
+WORKFLOW_SYNC_PATH_MARKERS = (
     ".github/actions",
-    ".github/actions/",
     ".github/scripts",
-    ".github/scripts/",
     ".github/sync-manifest.yml",
     ".github/workflows",
-    ".github/workflows/",
+)
+
+WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "workflow file",
     "workflow files",
     "workflow-owned",
@@ -1826,7 +1841,11 @@ def _acceptance_criteria_from_original_issue(
 
 def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     normalized = str(criterion or "").strip().lower()
-    return any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS)
+    if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
+        return True
+    if any(marker in normalized for marker in WORKFLOW_SYNC_PATH_MARKERS):
+        return any(marker in normalized for marker in WORKFLOW_SYNC_CONTEXT_MARKERS)
+    return False
 
 
 def _has_mixed_repo_and_workflow_acceptance_criteria(

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -123,6 +123,40 @@ def test_select_followup_acceptance_criteria_detects_synced_scripts() -> None:
     assert selected == ["The dashboard export renders for the selected account"]
 
 
+def test_select_followup_acceptance_criteria_detects_synced_actions() -> None:
+    original_issue = OriginalIssueData(
+        title="Action rollout",
+        number=49,
+        tasks=[],
+        acceptance_criteria=[
+            "Synced .github/actions helpers are updated across consumers",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == ["The dashboard export renders for the selected account"]
+
+
+def test_select_followup_acceptance_criteria_keeps_repo_local_actions() -> None:
+    original_issue = OriginalIssueData(
+        title="Repo-local action",
+        number=50,
+        tasks=[],
+        acceptance_criteria=[
+            "The .github/actions/build-dashboard action handles missing config",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == original_issue.acceptance_criteria
+
+
 def test_select_followup_acceptance_criteria_keeps_repo_local_agent_items() -> None:
     original_issue = OriginalIssueData(
         title="Repo-local agent UI",


### PR DESCRIPTION
## Summary
- require sync/template context before path-only .github/actions, .github/scripts, and .github/workflows markers suppress acceptance criteria
- remove redundant trailing-slash path markers under substring matching
- add regression coverage for synced actions versus repo-local action criteria

## Validation
- python -m pytest tests/test_followup_issue_generator.py -q
- python -m black --check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- python scripts/validate_template_sync.py
- git diff --check