### PR TITLE
feat: add sync-tracker-state shared library

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DURABLE_TRACKER_LABEL,
+  clearStuckWindowBody,
+  findOrCreateTracker,
+  isConsumerOpenPr,
+  markStuckWindowBody,
+  parseStuckWindow,
+  preserveDurableTrackerHeader,
+  updateTrackerBody,
+} = require('../sync_tracker_state');
+
+function mockGithub({ issues = [], pulls = [] } = {}) {
+  const calls = {
+    createdIssues: [],
+    updatedIssues: [],
+    comments: [],
+    labels: [],
+  };
+  const api = {
+    paginate: async (method, params) => {
+      if (method === api.rest.issues.listForRepo) {
+        const labelSet = String(params.labels || '')
+          .split(',')
+          .map((label) => label.trim())
+          .filter(Boolean);
+        if (!labelSet.length) {
+          return issues;
+        }
+        return issues.filter((issue) => {
+          const names = (issue.labels || []).map((label) =>
+            typeof label === 'string' ? label : label.name
+          );
+          return labelSet.every((label) => names.includes(label));
+        });
+      }
+      if (method === api.rest.pulls.list) {
+        return pulls;
+      }
+      return [];
+    },
+    rest: {
+      issues: {
+        listForRepo: async () => ({ data: issues }),
+        get: async ({ issue_number }) => ({
+          data: issues.find((issue) => issue.number === issue_number),
+        }),
+        create: async (params) => {
+          calls.createdIssues.push(params);
+          return {
+            data: {
+              number: 99,
+              title: params.title,
+              body: params.body,
+              labels: params.labels.map((name) => ({ name })),
+            },
+          };
+        },
+        update: async (params) => {
+          calls.updatedIssues.push(params);
+          return {
+            data: {
+              number: params.issue_number,
+              title: params.title,
+              body: params.body,
+            },
+          };
+        },
+        addLabels: async (params) => {
+          calls.labels.push(params);
+          return { data: params.labels.map((name) => ({ name })) };
+        },
+        createComment: async (params) => {
+          calls.comments.push(params);
+          return { data: { id: 1, body: params.body } };
+        },
+      },
+      pulls: {
+        list: async () => ({ data: pulls }),
+      },
+    },
+    calls,
+  };
+  return api;
+}
+
+test('findOrCreateTracker discovers a tracker with the durable marker', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 10,
+        title: 'Other issue',
+        body: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+        labels: [{ name: 'automation' }],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'consumer-sync',
+    titlePattern: 'Consumer repo drift detected',
+    markerPattern: /consumer-sync-drift:v1/,
+    title: 'Consumer repo drift detected',
+    body: 'new body',
+  });
+
+  assert.equal(tracker.number, 10);
+  assert.equal(tracker.sync_tracker_created, false);
+  assert.equal(github.calls.createdIssues.length, 0);
+});
+
+test('findOrCreateTracker discovers a tracker by durable label and title', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 11,
+        title: 'Sync/Dependabot campaign queue',
+        body: 'queue body',
+        labels: [{ name: DURABLE_TRACKER_LABEL }, { name: 'campaign:sync-dependabot' }],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'campaign:sync-dependabot',
+    titlePattern: /^Sync\/Dependabot campaign queue$/,
+  });
+
+  assert.equal(tracker.number, 11);
+  assert.equal(github.calls.createdIssues.length, 0);
+});
+
+test('findOrCreateTracker creates a durable tracker when none is found', async () => {
+  const github = mockGithub();
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'consumer-sync',
+    titlePattern: 'Consumer repo drift detected',
+    title: 'Consumer repo drift detected',
+    body: '## Consumer Repo Drift Detected',
+    markerComment: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+  });
+
+  assert.equal(tracker.number, 99);
+  assert.equal(tracker.sync_tracker_created, true);
+  assert.equal(github.calls.createdIssues.length, 1);
+  assert.deepEqual(github.calls.createdIssues[0].labels, [
+    DURABLE_TRACKER_LABEL,
+    'automated',
+    'consumer-sync',
+  ]);
+  assert.match(github.calls.createdIssues[0].body, /consumer-sync-drift:v1/);
+});
+
+test('findOrCreateTracker can return null without creating', async () => {
+  const github = mockGithub();
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'campaign:sync-dependabot',
+    titlePattern: /^Sync\/Dependabot campaign queue$/,
+    createIfMissing: false,
+  });
+
+  assert.equal(tracker, null);
+  assert.equal(github.calls.createdIssues.length, 0);
+});
+
+test('updateTrackerBody preserves the durable-tracker header', async () => {
+  const existingBody = [
+    '## Consumer Repo Drift Detected',
+    '',
+    '> **Durable tracker** - this issue stays open. Do not close it.',
+    '',
+    'Old generated content.',
+  ].join('\n');
+  const nextGeneratedBody = [
+    '## Consumer Repo Drift Detected',
+    '',
+    'New generated content.',
+    '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+  ].join('\n');
+  const github = mockGithub();
+
+  const updated = await updateTrackerBody({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    tracker: { number: 12, body: existingBody },
+    newBody: nextGeneratedBody,
+  });
+
+  assert.match(updated.body, /> \*\*Durable tracker\*\* - this issue stays open/);
+  assert.match(updated.body, /New generated content/);
+  assert.equal(github.calls.updatedIssues[0].issue_number, 12);
+});
+
+test('preserveDurableTrackerHeader does not duplicate an existing generated header', () => {
+  const existingBody = '> **Durable tracker** - old header\n\nOld body';
+  const newBody = '> **Durable tracker** - new header\n\nNew body';
+
+  const merged = preserveDurableTrackerHeader(existingBody, newBody);
+
+  assert.equal((merged.match(/\*\*Durable tracker\*\*/g) || []).length, 1);
+  assert.match(merged, /new header/);
+});
+
+test('isConsumerOpenPr matches open consumer PR branches by pattern', async () => {
+  const github = mockGithub({
+    pulls: [
+      { number: 1, head: { ref: 'feature/manual-change' } },
+      { number: 2, head: { ref: 'sync/workflows-abc123' } },
+    ],
+  });
+
+  assert.equal(
+    await isConsumerOpenPr({
+      github,
+      consumerRepo: 'stranske/Ready',
+      branchPattern: /^sync\/workflows-/,
+    }),
+    true,
+  );
+  assert.equal(
+    await isConsumerOpenPr({
+      github,
+      consumerRepo: 'stranske/Ready',
+      branchPattern: /^dependabot\//,
+    }),
+    false,
+  );
+});
+
+test('markStuckWindowBody and clearStuckWindowBody manage the lifecycle marker', () => {
+  const marked = markStuckWindowBody('## Sync Status\n\nStill failing.', '2026-05-01T00:00:00Z', {
+    updatedAt: '2026-05-02T00:00:00Z',
+    reason: 'missing-token',
+  });
+  const parsed = parseStuckWindow(marked);
+
+  assert.equal(parsed.schema, 'sync-tracker-stuck-window/v1');
+  assert.equal(parsed.since, '2026-05-01T00:00:00Z');
+  assert.equal(parsed.reason, 'missing-token');
+  assert.match(marked, /sync-tracker-stuck-window:v1/);
+
+  const refreshed = markStuckWindowBody(marked, '2026-05-03T00:00:00Z', {
+    updatedAt: '2026-05-04T00:00:00Z',
+  });
+  assert.equal((refreshed.match(/sync-tracker-stuck-window:v1/g) || []).length, 1);
+  assert.equal(parseStuckWindow(refreshed).since, '2026-05-03T00:00:00Z');
+
+  const cleared = clearStuckWindowBody(refreshed);
+  assert.equal(parseStuckWindow(cleared), null);
+  assert.doesNotMatch(cleared, /sync-tracker-stuck-window:v1/);
+  assert.match(cleared, /Still failing/);
+});

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -1,0 +1,464 @@
+'use strict';
+
+// API guard: callers pass createTokenAwareRetry / github-api-with-retry.js
+// `withRetry` wrappers into these helpers; tests use lightweight mock clients.
+const DURABLE_TRACKER_LABEL = 'tracker:durable';
+const AUTOMATED_LABEL = 'automated';
+const DEFAULT_STUCK_WINDOW_SCHEMA = 'sync-tracker-stuck-window/v1';
+const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+({[\s\S]*?})\s*-->/;
+const DURABLE_HEADER_RE = /^>\s*\*\*Durable tracker\*\*[\s\S]*?(?=\n(?!>)|\n*$)/im;
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function cleanArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function unique(values) {
+  return [...new Set(cleanArray(values).map(cleanString).filter(Boolean))];
+}
+
+function labelNames(issue = {}) {
+  return cleanArray(issue.labels).map((label) =>
+    typeof label === 'string' ? label : cleanString(label?.name)
+  );
+}
+
+function normaliseRepo(repoFullName, fallbackOwner = '') {
+  const value = cleanString(repoFullName);
+  if (!value) {
+    return null;
+  }
+  const parts = value.split('/').map(cleanString).filter(Boolean);
+  if (parts.length === 2) {
+    return { owner: parts[0], repo: parts[1], fullName: `${parts[0]}/${parts[1]}` };
+  }
+  if (parts.length === 1 && fallbackOwner) {
+    return { owner: fallbackOwner, repo: parts[0], fullName: `${fallbackOwner}/${parts[0]}` };
+  }
+  return null;
+}
+
+function patternMatches(value, pattern) {
+  const text = cleanString(value);
+  if (!pattern) {
+    return true;
+  }
+  if (pattern instanceof RegExp) {
+    return pattern.test(text);
+  }
+  const patternText = cleanString(pattern);
+  if (!patternText) {
+    return true;
+  }
+  if (patternText.startsWith('/') && patternText.lastIndexOf('/') > 0) {
+    const lastSlash = patternText.lastIndexOf('/');
+    const source = patternText.slice(1, lastSlash);
+    const flags = patternText.slice(lastSlash + 1);
+    return new RegExp(source, flags).test(text);
+  }
+  return text.includes(patternText);
+}
+
+async function callWithRetry(fn, label, { withRetry = null, core = console } = {}) {
+  if (typeof withRetry === 'function') {
+    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries: true });
+  }
+  try {
+    return await fn();
+  } catch (error) {
+    if (core && typeof core.warning === 'function') {
+      core.warning(`${label} failed: ${error.status || error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function paginateIssues({ github, owner, repo, labels = '', core, withRetry }) {
+  const params = { owner, repo, state: 'open', per_page: 100 };
+  if (labels) {
+    params.labels = labels;
+  }
+  const method = github.rest.issues.listForRepo;
+  if (typeof github.paginate === 'function') {
+    return cleanArray(await callWithRetry(
+      () => github.paginate(method, params),
+      `${owner}/${repo} open issues`,
+      { core, withRetry },
+    ));
+  }
+  const response = await callWithRetry(
+    () => method(params),
+    `${owner}/${repo} open issues`,
+    { core, withRetry },
+  );
+  return cleanArray(response?.data);
+}
+
+async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
+  const response = await callWithRetry(
+    () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
+    `${owner}/${repo}#${issueNumber}`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+function issueHasMarker(issue = {}, markerPattern = null) {
+  if (!markerPattern) {
+    return false;
+  }
+  return patternMatches(issue.body || '', markerPattern);
+}
+
+function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+  if (issue.pull_request) {
+    return false;
+  }
+  const names = labelNames(issue);
+  const requiredLabels = unique([label]).filter(Boolean);
+  const hasRequiredLabel = requiredLabels.length === 0 ||
+    requiredLabels.some((name) => names.includes(name));
+  const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
+  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasMarker = issueHasMarker(issue, markerPattern);
+  if (markerPattern && hasTitle && !cleanString(issue.body)) {
+    return true;
+  }
+  return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
+}
+
+async function ensureLabels({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  labels = [],
+  core,
+  withRetry,
+}) {
+  const names = unique(labels);
+  if (!names.length) {
+    return;
+  }
+  await callWithRetry(
+    () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
+    `${owner}/${repo}#${issueNumber} add labels`,
+    { core, withRetry },
+  );
+}
+
+async function findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry }) {
+  const labelQuery = unique([DURABLE_TRACKER_LABEL, label]).join(',');
+  const labeledIssues = await paginateIssues({
+    github,
+    owner,
+    repo,
+    labels: labelQuery,
+    core,
+    withRetry,
+  });
+  const openIssues = markerPattern || !labelQuery
+    ? await paginateIssues({ github, owner, repo, core, withRetry })
+    : [];
+  const byNumber = new Map();
+  for (const issue of [...labeledIssues, ...openIssues]) {
+    byNumber.set(issue.number, issue);
+  }
+  for (const issue of byNumber.values()) {
+    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+      continue;
+    }
+    const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });
+    if (issueMatchesTracker(fullIssue, { label, titlePattern, markerPattern })) {
+      return fullIssue;
+    }
+  }
+  return null;
+}
+
+async function findOrCreateTracker({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  label = '',
+  titlePattern = '',
+  markerPattern = null,
+  title = '',
+  body = '',
+  markerComment = '',
+  labels = [],
+  createIfMissing = true,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo) {
+    throw new Error('findOrCreateTracker requires github, owner, and repo');
+  }
+  const tracker = await findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry });
+  if (tracker) {
+    if (createIfMissing) {
+      await ensureLabels({
+        github,
+        owner,
+        repo,
+        issueNumber: tracker.number,
+        labels: [DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels],
+        core,
+        withRetry,
+      });
+    }
+    tracker.sync_tracker_created = false;
+    return tracker;
+  }
+
+  if (!createIfMissing) {
+    return null;
+  }
+
+  const issueTitle = cleanString(title) || cleanString(titlePattern);
+  if (!issueTitle) {
+    throw new Error('findOrCreateTracker requires title when no tracker exists');
+  }
+  const createBody = markerComment
+    ? `${cleanString(body)}\n\n${cleanString(markerComment)}`.trim()
+    : cleanString(body);
+  const response = await callWithRetry(
+    () => github.rest.issues.create({
+      owner,
+      repo,
+      title: issueTitle,
+      body: createBody,
+      labels: unique([DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels]),
+    }),
+    `${owner}/${repo} create durable tracker`,
+    { core, withRetry },
+  );
+  const created = response?.data || null;
+  if (created) {
+    created.sync_tracker_created = true;
+  }
+  return created;
+}
+
+function extractDurableTrackerHeader(body = '') {
+  const match = cleanString(body).match(DURABLE_HEADER_RE);
+  return match ? match[0].trim() : '';
+}
+
+function bodyHasDurableHeader(body = '') {
+  return Boolean(extractDurableTrackerHeader(body));
+}
+
+function preserveDurableTrackerHeader(existingBody = '', newBody = '') {
+  const nextBody = cleanString(newBody);
+  const existingHeader = extractDurableTrackerHeader(existingBody);
+  if (!existingHeader || bodyHasDurableHeader(nextBody)) {
+    return nextBody;
+  }
+
+  const lines = nextBody.split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+\S/.test(line));
+  if (headingIndex === -1) {
+    return `${existingHeader}\n\n${nextBody}`.trim();
+  }
+  const insertAt = headingIndex + 1;
+  const before = lines.slice(0, insertAt);
+  const after = lines.slice(insertAt);
+  return [...before, '', existingHeader, '', ...after].join('\n').trim();
+}
+
+async function updateTrackerBody({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  newBody,
+  title = null,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('updateTrackerBody requires github, owner, repo, and tracker.number');
+  }
+  const body = preserveDurableTrackerHeader(tracker.body || '', newBody);
+  const params = { owner, repo, issue_number: tracker.number, body };
+  if (title) {
+    params.title = title;
+  }
+  const response = await callWithRetry(
+    () => github.rest.issues.update(params),
+    `${owner}/${repo}#${tracker.number} update durable tracker`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function appendTrackerComment({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  comment,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('appendTrackerComment requires github, owner, repo, and tracker.number');
+  }
+  const response = await callWithRetry(
+    () => github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: tracker.number,
+      body: cleanString(comment),
+    }),
+    `${owner}/${repo}#${tracker.number} append tracker comment`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function isConsumerOpenPr({
+  github,
+  consumerRepo,
+  branchPattern,
+  state = 'open',
+  core = console,
+  withRetry = null,
+  defaultOwner = '',
+} = {}) {
+  const parsed = normaliseRepo(consumerRepo, defaultOwner);
+  if (!github || !parsed) {
+    throw new Error('isConsumerOpenPr requires github and consumerRepo');
+  }
+  const method = github.rest.pulls.list;
+  const params = { owner: parsed.owner, repo: parsed.repo, state, per_page: 100 };
+  const pulls = typeof github.paginate === 'function'
+    ? cleanArray(await callWithRetry(
+        () => github.paginate(method, params),
+        `${parsed.fullName} open pulls`,
+        { core, withRetry },
+      ))
+    : cleanArray((await callWithRetry(
+        () => method(params),
+        `${parsed.fullName} open pulls`,
+        { core, withRetry },
+      ))?.data);
+  return pulls.some((pull) => {
+    const headRef = cleanString(pull?.head?.ref || pull?.headRefName || pull?.head_ref);
+    return patternMatches(headRef, branchPattern);
+  });
+}
+
+function formatStuckWindowMarker(sinceTimestamp, options = {}) {
+  const payload = {
+    schema: DEFAULT_STUCK_WINDOW_SCHEMA,
+    since: cleanString(sinceTimestamp),
+    updated_at: cleanString(options.updatedAt) || new Date().toISOString(),
+  };
+  if (options.reason) {
+    payload.reason = cleanString(options.reason);
+  }
+  return `<!-- sync-tracker-stuck-window:v1 ${JSON.stringify(payload)} -->`;
+}
+
+function parseStuckWindow(body = '') {
+  const match = cleanString(body).match(STUCK_WINDOW_MARKER_RE);
+  if (!match) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(match[1]);
+    return payload && payload.schema === DEFAULT_STUCK_WINDOW_SCHEMA ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function markStuckWindowBody(body = '', sinceTimestamp, options = {}) {
+  const source = cleanString(body);
+  const marker = formatStuckWindowMarker(sinceTimestamp, options);
+  if (STUCK_WINDOW_MARKER_RE.test(source)) {
+    return source.replace(STUCK_WINDOW_MARKER_RE, marker);
+  }
+  return `${source.trimEnd()}\n\n${marker}`.trim();
+}
+
+function clearStuckWindowBody(body = '') {
+  return cleanString(body).replace(STUCK_WINDOW_MARKER_RE, '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function markStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  sinceTimestamp,
+  core = console,
+  withRetry = null,
+  ...options
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: markStuckWindowBody(tracker?.body || '', sinceTimestamp, options),
+    core,
+    withRetry,
+  });
+}
+
+async function clearStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  core = console,
+  withRetry = null,
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: clearStuckWindowBody(tracker?.body || ''),
+    core,
+    withRetry,
+  });
+}
+
+module.exports = {
+  AUTOMATED_LABEL,
+  DEFAULT_STUCK_WINDOW_SCHEMA,
+  DURABLE_TRACKER_LABEL,
+  appendTrackerComment,
+  append_tracker_comment: appendTrackerComment,
+  bodyHasDurableHeader,
+  clearStuckWindow,
+  clearStuckWindowBody,
+  clear_stuck_window: clearStuckWindow,
+  extractDurableTrackerHeader,
+  findOrCreateTracker,
+  find_or_create_tracker: findOrCreateTracker,
+  formatStuckWindowMarker,
+  isConsumerOpenPr,
+  is_consumer_open_pr: isConsumerOpenPr,
+  issueMatchesTracker,
+  markStuckWindow,
+  markStuckWindowBody,
+  mark_stuck_window: markStuckWindow,
+  parseStuckWindow,
+  patternMatches,
+  preserveDurableTrackerHeader,
+  updateTrackerBody,
+  update_tracker_body: updateTrackerBody,
+};

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -386,6 +386,10 @@ scripts:
   - source: .github/scripts/github-api-with-retry.js
     description: "GitHub API retry wrapper with exponential backoff and pagination support - required by agents-auto-pilot.yml"
 
+  - source: .github/scripts/sync_tracker_state/
+    is_directory: true
+    description: "Shared durable tracker and open PR state helpers for consumer sync workflows"
+
   - source: .github/scripts/github-rate-limited-wrapper.js
     description: "Transparent rate-limit proxy - wraps all github.rest.* calls with automatic retry and token switching"
 

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -1,0 +1,464 @@
+'use strict';
+
+// API guard: callers pass createTokenAwareRetry / github-api-with-retry.js
+// `withRetry` wrappers into these helpers; tests use lightweight mock clients.
+const DURABLE_TRACKER_LABEL = 'tracker:durable';
+const AUTOMATED_LABEL = 'automated';
+const DEFAULT_STUCK_WINDOW_SCHEMA = 'sync-tracker-stuck-window/v1';
+const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+({[\s\S]*?})\s*-->/;
+const DURABLE_HEADER_RE = /^>\s*\*\*Durable tracker\*\*[\s\S]*?(?=\n(?!>)|\n*$)/im;
+
+function cleanString(value) {
+  return String(value || '').trim();
+}
+
+function cleanArray(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function unique(values) {
+  return [...new Set(cleanArray(values).map(cleanString).filter(Boolean))];
+}
+
+function labelNames(issue = {}) {
+  return cleanArray(issue.labels).map((label) =>
+    typeof label === 'string' ? label : cleanString(label?.name)
+  );
+}
+
+function normaliseRepo(repoFullName, fallbackOwner = '') {
+  const value = cleanString(repoFullName);
+  if (!value) {
+    return null;
+  }
+  const parts = value.split('/').map(cleanString).filter(Boolean);
+  if (parts.length === 2) {
+    return { owner: parts[0], repo: parts[1], fullName: `${parts[0]}/${parts[1]}` };
+  }
+  if (parts.length === 1 && fallbackOwner) {
+    return { owner: fallbackOwner, repo: parts[0], fullName: `${fallbackOwner}/${parts[0]}` };
+  }
+  return null;
+}
+
+function patternMatches(value, pattern) {
+  const text = cleanString(value);
+  if (!pattern) {
+    return true;
+  }
+  if (pattern instanceof RegExp) {
+    return pattern.test(text);
+  }
+  const patternText = cleanString(pattern);
+  if (!patternText) {
+    return true;
+  }
+  if (patternText.startsWith('/') && patternText.lastIndexOf('/') > 0) {
+    const lastSlash = patternText.lastIndexOf('/');
+    const source = patternText.slice(1, lastSlash);
+    const flags = patternText.slice(lastSlash + 1);
+    return new RegExp(source, flags).test(text);
+  }
+  return text.includes(patternText);
+}
+
+async function callWithRetry(fn, label, { withRetry = null, core = console } = {}) {
+  if (typeof withRetry === 'function') {
+    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries: true });
+  }
+  try {
+    return await fn();
+  } catch (error) {
+    if (core && typeof core.warning === 'function') {
+      core.warning(`${label} failed: ${error.status || error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function paginateIssues({ github, owner, repo, labels = '', core, withRetry }) {
+  const params = { owner, repo, state: 'open', per_page: 100 };
+  if (labels) {
+    params.labels = labels;
+  }
+  const method = github.rest.issues.listForRepo;
+  if (typeof github.paginate === 'function') {
+    return cleanArray(await callWithRetry(
+      () => github.paginate(method, params),
+      `${owner}/${repo} open issues`,
+      { core, withRetry },
+    ));
+  }
+  const response = await callWithRetry(
+    () => method(params),
+    `${owner}/${repo} open issues`,
+    { core, withRetry },
+  );
+  return cleanArray(response?.data);
+}
+
+async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
+  const response = await callWithRetry(
+    () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
+    `${owner}/${repo}#${issueNumber}`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+function issueHasMarker(issue = {}, markerPattern = null) {
+  if (!markerPattern) {
+    return false;
+  }
+  return patternMatches(issue.body || '', markerPattern);
+}
+
+function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+  if (issue.pull_request) {
+    return false;
+  }
+  const names = labelNames(issue);
+  const requiredLabels = unique([label]).filter(Boolean);
+  const hasRequiredLabel = requiredLabels.length === 0 ||
+    requiredLabels.some((name) => names.includes(name));
+  const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
+  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasMarker = issueHasMarker(issue, markerPattern);
+  if (markerPattern && hasTitle && !cleanString(issue.body)) {
+    return true;
+  }
+  return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
+}
+
+async function ensureLabels({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  labels = [],
+  core,
+  withRetry,
+}) {
+  const names = unique(labels);
+  if (!names.length) {
+    return;
+  }
+  await callWithRetry(
+    () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
+    `${owner}/${repo}#${issueNumber} add labels`,
+    { core, withRetry },
+  );
+}
+
+async function findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry }) {
+  const labelQuery = unique([DURABLE_TRACKER_LABEL, label]).join(',');
+  const labeledIssues = await paginateIssues({
+    github,
+    owner,
+    repo,
+    labels: labelQuery,
+    core,
+    withRetry,
+  });
+  const openIssues = markerPattern || !labelQuery
+    ? await paginateIssues({ github, owner, repo, core, withRetry })
+    : [];
+  const byNumber = new Map();
+  for (const issue of [...labeledIssues, ...openIssues]) {
+    byNumber.set(issue.number, issue);
+  }
+  for (const issue of byNumber.values()) {
+    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+      continue;
+    }
+    const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });
+    if (issueMatchesTracker(fullIssue, { label, titlePattern, markerPattern })) {
+      return fullIssue;
+    }
+  }
+  return null;
+}
+
+async function findOrCreateTracker({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  label = '',
+  titlePattern = '',
+  markerPattern = null,
+  title = '',
+  body = '',
+  markerComment = '',
+  labels = [],
+  createIfMissing = true,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo) {
+    throw new Error('findOrCreateTracker requires github, owner, and repo');
+  }
+  const tracker = await findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry });
+  if (tracker) {
+    if (createIfMissing) {
+      await ensureLabels({
+        github,
+        owner,
+        repo,
+        issueNumber: tracker.number,
+        labels: [DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels],
+        core,
+        withRetry,
+      });
+    }
+    tracker.sync_tracker_created = false;
+    return tracker;
+  }
+
+  if (!createIfMissing) {
+    return null;
+  }
+
+  const issueTitle = cleanString(title) || cleanString(titlePattern);
+  if (!issueTitle) {
+    throw new Error('findOrCreateTracker requires title when no tracker exists');
+  }
+  const createBody = markerComment
+    ? `${cleanString(body)}\n\n${cleanString(markerComment)}`.trim()
+    : cleanString(body);
+  const response = await callWithRetry(
+    () => github.rest.issues.create({
+      owner,
+      repo,
+      title: issueTitle,
+      body: createBody,
+      labels: unique([DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels]),
+    }),
+    `${owner}/${repo} create durable tracker`,
+    { core, withRetry },
+  );
+  const created = response?.data || null;
+  if (created) {
+    created.sync_tracker_created = true;
+  }
+  return created;
+}
+
+function extractDurableTrackerHeader(body = '') {
+  const match = cleanString(body).match(DURABLE_HEADER_RE);
+  return match ? match[0].trim() : '';
+}
+
+function bodyHasDurableHeader(body = '') {
+  return Boolean(extractDurableTrackerHeader(body));
+}
+
+function preserveDurableTrackerHeader(existingBody = '', newBody = '') {
+  const nextBody = cleanString(newBody);
+  const existingHeader = extractDurableTrackerHeader(existingBody);
+  if (!existingHeader || bodyHasDurableHeader(nextBody)) {
+    return nextBody;
+  }
+
+  const lines = nextBody.split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+\S/.test(line));
+  if (headingIndex === -1) {
+    return `${existingHeader}\n\n${nextBody}`.trim();
+  }
+  const insertAt = headingIndex + 1;
+  const before = lines.slice(0, insertAt);
+  const after = lines.slice(insertAt);
+  return [...before, '', existingHeader, '', ...after].join('\n').trim();
+}
+
+async function updateTrackerBody({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  newBody,
+  title = null,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('updateTrackerBody requires github, owner, repo, and tracker.number');
+  }
+  const body = preserveDurableTrackerHeader(tracker.body || '', newBody);
+  const params = { owner, repo, issue_number: tracker.number, body };
+  if (title) {
+    params.title = title;
+  }
+  const response = await callWithRetry(
+    () => github.rest.issues.update(params),
+    `${owner}/${repo}#${tracker.number} update durable tracker`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function appendTrackerComment({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  comment,
+  core = console,
+  withRetry = null,
+} = {}) {
+  if (!github || !owner || !repo || !tracker?.number) {
+    throw new Error('appendTrackerComment requires github, owner, repo, and tracker.number');
+  }
+  const response = await callWithRetry(
+    () => github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: tracker.number,
+      body: cleanString(comment),
+    }),
+    `${owner}/${repo}#${tracker.number} append tracker comment`,
+    { core, withRetry },
+  );
+  return response?.data || null;
+}
+
+async function isConsumerOpenPr({
+  github,
+  consumerRepo,
+  branchPattern,
+  state = 'open',
+  core = console,
+  withRetry = null,
+  defaultOwner = '',
+} = {}) {
+  const parsed = normaliseRepo(consumerRepo, defaultOwner);
+  if (!github || !parsed) {
+    throw new Error('isConsumerOpenPr requires github and consumerRepo');
+  }
+  const method = github.rest.pulls.list;
+  const params = { owner: parsed.owner, repo: parsed.repo, state, per_page: 100 };
+  const pulls = typeof github.paginate === 'function'
+    ? cleanArray(await callWithRetry(
+        () => github.paginate(method, params),
+        `${parsed.fullName} open pulls`,
+        { core, withRetry },
+      ))
+    : cleanArray((await callWithRetry(
+        () => method(params),
+        `${parsed.fullName} open pulls`,
+        { core, withRetry },
+      ))?.data);
+  return pulls.some((pull) => {
+    const headRef = cleanString(pull?.head?.ref || pull?.headRefName || pull?.head_ref);
+    return patternMatches(headRef, branchPattern);
+  });
+}
+
+function formatStuckWindowMarker(sinceTimestamp, options = {}) {
+  const payload = {
+    schema: DEFAULT_STUCK_WINDOW_SCHEMA,
+    since: cleanString(sinceTimestamp),
+    updated_at: cleanString(options.updatedAt) || new Date().toISOString(),
+  };
+  if (options.reason) {
+    payload.reason = cleanString(options.reason);
+  }
+  return `<!-- sync-tracker-stuck-window:v1 ${JSON.stringify(payload)} -->`;
+}
+
+function parseStuckWindow(body = '') {
+  const match = cleanString(body).match(STUCK_WINDOW_MARKER_RE);
+  if (!match) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(match[1]);
+    return payload && payload.schema === DEFAULT_STUCK_WINDOW_SCHEMA ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function markStuckWindowBody(body = '', sinceTimestamp, options = {}) {
+  const source = cleanString(body);
+  const marker = formatStuckWindowMarker(sinceTimestamp, options);
+  if (STUCK_WINDOW_MARKER_RE.test(source)) {
+    return source.replace(STUCK_WINDOW_MARKER_RE, marker);
+  }
+  return `${source.trimEnd()}\n\n${marker}`.trim();
+}
+
+function clearStuckWindowBody(body = '') {
+  return cleanString(body).replace(STUCK_WINDOW_MARKER_RE, '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function markStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  sinceTimestamp,
+  core = console,
+  withRetry = null,
+  ...options
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: markStuckWindowBody(tracker?.body || '', sinceTimestamp, options),
+    core,
+    withRetry,
+  });
+}
+
+async function clearStuckWindow({
+  github,
+  context = null,
+  owner = context?.repo?.owner,
+  repo = context?.repo?.repo,
+  tracker,
+  core = console,
+  withRetry = null,
+} = {}) {
+  return updateTrackerBody({
+    github,
+    owner,
+    repo,
+    tracker,
+    newBody: clearStuckWindowBody(tracker?.body || ''),
+    core,
+    withRetry,
+  });
+}
+
+module.exports = {
+  AUTOMATED_LABEL,
+  DEFAULT_STUCK_WINDOW_SCHEMA,
+  DURABLE_TRACKER_LABEL,
+  appendTrackerComment,
+  append_tracker_comment: appendTrackerComment,
+  bodyHasDurableHeader,
+  clearStuckWindow,
+  clearStuckWindowBody,
+  clear_stuck_window: clearStuckWindow,
+  extractDurableTrackerHeader,
+  findOrCreateTracker,
+  find_or_create_tracker: findOrCreateTracker,
+  formatStuckWindowMarker,
+  isConsumerOpenPr,
+  is_consumer_open_pr: isConsumerOpenPr,
+  issueMatchesTracker,
+  markStuckWindow,
+  markStuckWindowBody,
+  mark_stuck_window: markStuckWindow,
+  parseStuckWindow,
+  patternMatches,
+  preserveDurableTrackerHeader,
+  updateTrackerBody,
+  update_tracker_body: updateTrackerBody,
+};


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/sync_tracker_state/` with durable tracker discovery, body updates that preserve durable headers, comment append, consumer open-PR detection, and stuck-window marker helpers.
- Adds focused Node tests for tracker discovery, durable header preservation, open PR detection, and stuck-window mark/clear lifecycle.
- Adds the library to `.github/sync-manifest.yml` and syncs the template copy.

## Validation
- `node --test .github/scripts/__tests__/sync-tracker-state.test.js`
- `scripts/sync_templates.sh`
- `scripts/validate_template_completeness.py`
