### PR TITLE
feat: wire sync-tracker-state library into 4 consumer-sync workflows

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -845,7 +845,7 @@ test('findCampaignIssue falls back to active campaign labels', async () => {
       },
     },
     paginate: async (method, params) => {
-      if (params.labels === 'campaign:sync-dependabot,campaign:active') {
+      if (!params.labels || params.labels === 'campaign:sync-dependabot,campaign:active') {
         return [
           {
             number: 1836,

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const crypto = require('crypto');
+const {
+  findOrCreateTracker,
+  isConsumerOpenPr,
+  updateTrackerBody,
+} = require('./sync_tracker_state');
 
 const CAMPAIGN_SCHEMA = 'sync-dependabot-campaign/v1';
 const CAMPAIGN_MARKER = 'sync-dependabot-campaign:v1';
@@ -1281,6 +1286,17 @@ async function discoverRepoWork({
     dependabotPrsOpen: 0,
   };
 
+  const hasCampaignPr = await isConsumerOpenPr({
+    github,
+    consumerRepo: fullName,
+    branchPattern: /^(sync\/workflows-|dependabot\/)/,
+    core,
+    withRetry,
+  });
+  if (!hasCampaignPr) {
+    return result;
+  }
+
   const prs = cleanArray(await paginateWithRetry({
     github,
     core,
@@ -1320,60 +1336,17 @@ async function discoverRepoWork({
 }
 
 async function findCampaignIssue(github, owner, repo, core, withRetry = null) {
-  const listIssues = async (params, label) => cleanArray(await paginateWithRetry({
+  return findOrCreateTracker({
     github,
+    owner,
+    repo,
+    label: LABEL_CAMPAIGN,
+    titlePattern: /^Sync\/Dependabot campaign queue$/,
+    markerPattern: /sync-dependabot-campaign:v1/,
+    createIfMissing: false,
     core,
     withRetry,
-    method: (client) => client.rest.issues.listForRepo,
-    params,
-    label,
-  }));
-  const titleIssues = await listIssues(
-    { owner, repo, state: 'open', per_page: 100 },
-    `${owner}/${repo} campaign issue list`,
-  );
-  const labeledIssues = await listIssues(
-    {
-      owner,
-      repo,
-      state: 'open',
-      labels: `${LABEL_CAMPAIGN},${LABEL_ACTIVE}`,
-      per_page: 100,
-    },
-    `${owner}/${repo} active campaign issue list`,
-  );
-  const candidatesByNumber = new Map();
-  for (const issue of [...titleIssues, ...labeledIssues]) {
-    if (issue.pull_request) {
-      continue;
-    }
-    const labelNames = labelsForPullRequest(issue);
-    const hasCampaignLabels =
-      labelNames.includes(LABEL_CAMPAIGN) && labelNames.includes(LABEL_ACTIVE);
-    const hasCampaignTitle = cleanString(issue.title).startsWith(CAMPAIGN_TITLE);
-    if (hasCampaignTitle || hasCampaignLabels) {
-      candidatesByNumber.set(issue.number, issue);
-    }
-  }
-
-  for (const issue of candidatesByNumber.values()) {
-    const fullIssue = await callWithRetry(
-      (client) => client.rest.issues.get({ owner, repo, issue_number: issue.number }),
-      `${owner}/${repo}#${issue.number}`,
-      core,
-      3,
-      withRetry,
-      github,
-    );
-    const labelNames = labelsForPullRequest(fullIssue.data);
-    const hasCampaignLabels =
-      labelNames.includes(LABEL_CAMPAIGN) && labelNames.includes(LABEL_ACTIVE);
-    if (parseCampaignMarker(fullIssue.data.body) || hasCampaignLabels) {
-      return fullIssue.data;
-    }
-  }
-
-  return null;
+  });
 }
 
 async function ensureLabel(github, owner, repo, name, color, description, core, withRetry = null) {
@@ -1614,38 +1587,32 @@ async function runCampaign({
       log(core, 'info', '[dry-run] Campaign issue body preview:');
       log(core, 'info', body);
     }
-  } else if (campaignIssue?.number) {
-    const updated = await callWithRetry(
-      (client) => client.rest.issues.update({
-        owner: campaignOwner,
-        repo: campaignRepo,
-        issue_number: campaignIssue.number,
-        title: CAMPAIGN_TITLE,
-        body,
-      }),
-      `${campaignOwner}/${campaignRepo}#${campaignIssue.number} update campaign issue`,
-      core,
-      3,
-      withRetry,
-      api,
-    );
-    campaignIssue = updated.data;
-    await applyCampaignLabels(api, campaignOwner, campaignRepo, campaignIssue.number, needsLocalCodex, core, withRetry);
   } else {
-    const created = await callWithRetry(
-      (client) => client.rest.issues.create({
+    campaignIssue = await findOrCreateTracker({
+      github: api,
+      owner: campaignOwner,
+      repo: campaignRepo,
+      label: LABEL_CAMPAIGN,
+      titlePattern: /^Sync\/Dependabot campaign queue$/,
+      markerPattern: /sync-dependabot-campaign:v1/,
+      title: CAMPAIGN_TITLE,
+      body,
+      labels: [LABEL_ACTIVE],
+      core,
+      withRetry,
+    });
+    if (!campaignIssue.sync_tracker_created) {
+      campaignIssue = await updateTrackerBody({
+        github: api,
         owner: campaignOwner,
         repo: campaignRepo,
+        tracker: campaignIssue,
         title: CAMPAIGN_TITLE,
-        body,
-      }),
-      `${campaignOwner}/${campaignRepo} create campaign issue`,
-      core,
-      3,
-      withRetry,
-      api,
-    );
-    campaignIssue = created.data;
+        newBody: body,
+        core,
+        withRetry,
+      });
+    }
     await applyCampaignLabels(api, campaignOwner, campaignRepo, campaignIssue.number, needsLocalCodex, core, withRetry);
   }
 

--- a/.github/workflows/health-68-consumer-sync-drift.yml
+++ b/.github/workflows/health-68-consumer-sync-drift.yml
@@ -87,8 +87,12 @@ jobs:
             const {
               formatIssueBody,
               formatIssueComment,
-              mergeIssueBody,
             } = require('./.github/scripts/consumer_sync_drift_issue_body.js');
+            const {
+              appendTrackerComment,
+              findOrCreateTracker,
+              updateTrackerBody,
+            } = require('./.github/scripts/sync_tracker_state');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
             const retryHelpers = fs.existsSync(retryHelperPath)
               ? require(retryHelperPath)
@@ -148,61 +152,51 @@ jobs:
               runNumber: process.env.GITHUB_RUN_NUMBER,
             });
 
-            const listResult = await skipOnRateLimit('lookup', () => github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: label,
-              per_page: 5
+            const tracker = await skipOnRateLimit('tracker lookup/create', () => findOrCreateTracker({
+              github,
+              context,
+              label,
+              titlePattern: /^🔄 Consumer repo drift detected$/,
+              markerPattern: /consumer-sync-drift:v1/,
+              title,
+              body,
+              labels: ['automation'],
+              core,
+              withRetry,
             }));
-            if (!listResult) {
+            if (!tracker) {
               return;
             }
-            const { data: issues } = listResult;
 
-            if (issues.length > 0) {
-              const refreshedBody = mergeIssueBody(issues[0].body || '', report, {
-                runUrl,
-                runId: process.env.GITHUB_RUN_ID,
-                runNumber: process.env.GITHUB_RUN_NUMBER,
-              });
-              if (refreshedBody !== (issues[0].body || '')) {
-                const updateResult = await skipOnRateLimit('body update', () => github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issues[0].number,
-                  body: refreshedBody,
-                }));
-                if (!updateResult) {
-                  return;
-                }
-                console.log(`Refreshed drift issue body for #${issues[0].number}`);
+            if (tracker.sync_tracker_created) {
+              console.log(`Created issue #${tracker.number}`);
+            } else {
+              const updateResult = await skipOnRateLimit('body update', () => updateTrackerBody({
+                github,
+                context,
+                tracker,
+                newBody: body,
+                core,
+                withRetry,
+              }));
+              if (!updateResult) {
+                return;
               }
-              const commentResult = await skipOnRateLimit('comment', () => github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: formatIssueComment(report, {
+              console.log(`Refreshed drift issue body for #${tracker.number}`);
+              const commentResult = await skipOnRateLimit('comment', () => appendTrackerComment({
+                github,
+                context,
+                tracker,
+                comment: formatIssueComment(report, {
                   runUrl,
                   runId: process.env.GITHUB_RUN_ID,
                   runNumber: process.env.GITHUB_RUN_NUMBER,
-                })
+                }),
+                core,
+                withRetry,
               }));
               if (!commentResult) {
                 return;
               }
-              console.log(`Added comment to existing issue #${issues[0].number}`);
-            } else {
-              const createResult = await skipOnRateLimit('create', () => github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: [label, 'automation']
-              }));
-              if (!createResult) {
-                return;
-              }
-              const { data: issue } = createResult;
-              console.log(`Created issue #${issue.number}`);
+              console.log(`Added comment to existing issue #${tracker.number}`);
             }

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -776,17 +776,52 @@ jobs:
             --description "Applies optimization suggestions from agents:optimize" \
             --color "0E8A16" --force || true
 
+      - name: Check for existing sync PR
+        id: open_pr
+        if: steps.sync.outputs.has_changes == 'true' && inputs.dry_run != true
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ env.REPO_TOKEN }}
+          script: |
+            const { isConsumerOpenPr } = require('./workflows/.github/scripts/sync_tracker_state');
+            const branchName = 'sync/workflows-${{ needs.prepare.outputs.template_hash }}';
+            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const exists = await isConsumerOpenPr({
+              github,
+              consumerRepo: '${{ matrix.repo }}',
+              branchPattern: new RegExp(`^${escapeRegex(branchName)}$`),
+              core,
+            });
+            core.setOutput('exists', exists ? 'true' : 'false');
+            if (exists) {
+              core.notice(`Existing sync PR is already open for ${branchName}`);
+            }
+
       - name: Create sync PR
         id: create_pr
         if: steps.sync.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
+          EXISTING_SYNC_PR: ${{ steps.open_pr.outputs.exists || 'false' }}
         run: |
           cd consumer
 
           branch_name="sync/workflows-${{ needs.prepare.outputs.template_hash }}"
 
-          # Check if branch/PR already exists
+          if [ "$EXISTING_SYNC_PR" = "true" ]; then
+            existing_pr=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
+            echo "PR #$existing_pr already exists for this sync"
+            echo "::notice::Existing PR: #$existing_pr"
+            {
+              echo "status=existing_pr"
+              echo "pr_number=$existing_pr"
+              echo "pr_url=https://github.com/${{ matrix.repo }}/pull/$existing_pr"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Race-condition backstop: another run may have opened the PR after
+          # the shared open-PR check completed.
           existing_pr=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
           if [ -n "$existing_pr" ]; then
             echo "PR #$existing_pr already exists for this sync"

--- a/.github/workflows/maint-69-sync-integration-repo.yml
+++ b/.github/workflows/maint-69-sync-integration-repo.yml
@@ -42,6 +42,7 @@ jobs:
           sparse-checkout: |
             templates/integration-repo
             .github/workflows/autofix-versions.env
+            .github/scripts/sync_tracker_state
           sparse-checkout-cone-mode: false
 
       - name: Prepare sync token
@@ -214,6 +215,37 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Clear stuck-window status
+        if: steps.token.outputs.token_available == 'true' && success()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const {
+              appendTrackerComment,
+              clearStuckWindow,
+              findOrCreateTracker,
+              parseStuckWindow,
+            } = require('./workflows/.github/scripts/sync_tracker_state');
+            const tracker = await findOrCreateTracker({
+              github,
+              context,
+              label: 'integration-sync-failure',
+              titlePattern: /^🚨 Integration-Tests Sync Failed/,
+              createIfMissing: false,
+              core,
+            });
+            if (!tracker || !parseStuckWindow(tracker.body || '')) {
+              return;
+            }
+            await clearStuckWindow({ github, context, tracker, core });
+            await appendTrackerComment({
+              github,
+              context,
+              tracker,
+              core,
+              comment: `### ✅ Integration sync recovered\n\nThe stuck-window marker was cleared by ${context.workflow} run ${context.runId}.`,
+            });
+
   # ============================================================================
   # FAILURE NOTIFICATION: Create issue when sync fails
   # ============================================================================
@@ -243,103 +275,101 @@ jobs:
             echo "summary=Sync workflow concluded with non-success status" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check for existing open issue
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          existing=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "integration-sync-failure,automated" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-
-          if [ -n "$existing" ]; then
-            echo "existing_issue=$existing" >> "$GITHUB_OUTPUT"
-            echo "Found existing integration sync failure issue: #$existing"
-          else
-            echo "existing_issue=" >> "$GITHUB_OUTPUT"
-            echo "No existing integration sync failure issue found"
-          fi
-
-      - name: Ensure labels exist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh label create "integration-sync-failure" \
-            --repo "${{ github.repository }}" \
-            --description "Integration-Tests sync workflow failed" \
-            --color "B60205" --force || true
-          gh label create "automated" \
-            --repo "${{ github.repository }}" \
-            --description "Automatically created issue" \
-            --color "0e8a16" --force || true
+      - name: Checkout tracker helper
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/scripts/sync_tracker_state
+          sparse-checkout-cone-mode: false
 
       - name: Create or update failure issue
+        uses: actions/github-script@v9
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXISTING_ISSUE: ${{ steps.check.outputs.existing_issue }}
           FAILURE_REASON: ${{ steps.failure.outputs.reason }}
           FAILURE_SUMMARY: ${{ steps.failure.outputs.summary }}
           RUN_URL: >-
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER_SHA: ${{ github.sha }}
           TRIGGER_REF: ${{ github.ref_name }}
-        run: |
-          issue_body="## 🚨 Integration-Tests Sync Failed
+        with:
+          script: |
+            const {
+              appendTrackerComment,
+              findOrCreateTracker,
+              markStuckWindowBody,
+              parseStuckWindow,
+              updateTrackerBody,
+            } = require('./.github/scripts/sync_tracker_state');
+            const title = '🚨 Integration-Tests Sync Failed - Action Required';
+            const now = new Date().toISOString();
+            const baseBody = `## 🚨 Integration-Tests Sync Failed
 
-          The maint-69 sync workflow failed to push template updates to \
-          \`stranske/Workflows-Integration-Tests\`.
+            > **Durable tracker** — see [\`docs/ops/DURABLE_TRACKING_ISSUES.md\`](https://github.com/stranske/Workflows/blob/main/docs/ops/DURABLE_TRACKING_ISSUES.md). The stuck-window marker below is maintained by \`maint-69-sync-integration-repo.yml\`.
 
-          ### Failure Details
-          - **Reason:** ${FAILURE_SUMMARY}
-          - **Trigger:** Push to \`${TRIGGER_REF}\` (${TRIGGER_SHA:0:7})
-          - **Run:** [View workflow run](${RUN_URL})
-          - **Time:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            The maint-69 sync workflow failed to push template updates to \`stranske/Workflows-Integration-Tests\`.
 
-          ### Impact
-          \`Workflows-Integration-Tests\` is NOT receiving the latest templates,
-          autofix version pins, or scripts. Drift will accumulate until this is
-          fixed and the next push to \`templates/integration-repo/**\` or
-          \`.github/workflows/autofix-versions.env\` re-triggers the sync.
+            ### Failure Details
+            - **Reason:** ${process.env.FAILURE_SUMMARY}
+            - **Trigger:** Push to \`${process.env.TRIGGER_REF}\` (${(process.env.TRIGGER_SHA || '').slice(0, 7)})
+            - **Run:** [View workflow run](${process.env.RUN_URL})
+            - **Time:** ${now}
 
-          ### Common Causes
-          1. **Expired PAT** — \`OWNER_PR_PAT\` or \`SERVICE_BOT_PAT\` rotated /
-             expired. Push step fails with \`Authentication failed\`.
-          2. **Missing PAT** — neither secret is set; sync skipped at the
-             \`Prepare sync token\` step (\`token_available=false\`).
-          3. **Lock regeneration error** — \`uv pip compile\` fails on the
-             integration repo's \`pyproject.toml\`.
+            ### Impact
+            \`Workflows-Integration-Tests\` is NOT receiving the latest templates, autofix version pins, or scripts. Drift will accumulate until this is fixed and the next push to \`templates/integration-repo/**\` or \`.github/workflows/autofix-versions.env\` re-triggers the sync.
 
-          ### Resolution Steps
-          1. Open the [failed run](${RUN_URL}) and check the \`Commit and push\`
-             step for the actual error.
-          2. If auth failed: rotate \`OWNER_PR_PAT\` (preferred) or
-             \`SERVICE_BOT_PAT\` in repo secrets.
-          3. Re-trigger:
-             \`gh workflow run 'Maint 69 Sync Integration Repo' --repo ${{ github.repository }}\`
-          4. Close this issue once the next run succeeds.
+            ### Common Causes
+            1. **Expired PAT** — \`OWNER_PR_PAT\` or \`SERVICE_BOT_PAT\` rotated / expired. Push step fails with \`Authentication failed\`.
+            2. **Missing PAT** — neither secret is set; sync skipped at the \`Prepare sync token\` step (\`token_available=false\`).
+            3. **Lock regeneration error** — \`uv pip compile\` fails on the integration repo's \`pyproject.toml\`.
 
-          ---
-          *Automatically created by the maint-69 failure handler.*"
+            ### Resolution Steps
+            1. Open the [failed run](${process.env.RUN_URL}) and check the \`Commit and push\` step for the actual error.
+            2. If auth failed: rotate \`OWNER_PR_PAT\` (preferred) or \`SERVICE_BOT_PAT\` in repo secrets.
+            3. Re-trigger: \`gh workflow run 'Maint 69 Sync Integration Repo' --repo ${context.repo.owner}/${context.repo.repo}\`
+            4. Close this issue once the next run succeeds.
 
-          if [ -n "$EXISTING_ISSUE" ]; then
-            gh issue comment "$EXISTING_ISSUE" \
-              --repo "${{ github.repository }}" \
-              --body "### 🔄 Sync failed again
+            ---
+            *Automatically created by the maint-69 failure handler.*`;
 
-          - **Run:** [View workflow run](${RUN_URL})
-          - **Reason:** ${FAILURE_SUMMARY}
-          - **Time:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            const existing = await findOrCreateTracker({
+              github,
+              context,
+              label: 'integration-sync-failure',
+              titlePattern: /^🚨 Integration-Tests Sync Failed/,
+              createIfMissing: false,
+              core,
+            });
+            const since = parseStuckWindow(existing?.body || '')?.since || now;
+            const body = markStuckWindowBody(baseBody, since, {
+              updatedAt: now,
+              reason: process.env.FAILURE_REASON,
+            });
+            const tracker = await findOrCreateTracker({
+              github,
+              context,
+              label: 'integration-sync-failure',
+              titlePattern: /^🚨 Integration-Tests Sync Failed/,
+              title,
+              body,
+              labels: ['bug'],
+              core,
+            });
+            if (tracker.sync_tracker_created) {
+              core.warning(`Created new integration sync failure tracker #${tracker.number}`);
+              return;
+            }
+            await updateTrackerBody({ github, context, tracker, newBody: body, title, core });
+            await appendTrackerComment({
+              github,
+              context,
+              tracker,
+              core,
+              comment: `### 🔄 Sync failed again
 
-          The sync workflow continues to fail. Please investigate."
-            echo "::warning::Added comment to existing issue #$EXISTING_ISSUE"
-          else
-            gh issue create \
-              --repo "${{ github.repository }}" \
-              --title "🚨 Integration-Tests Sync Failed - Action Required" \
-              --body "$issue_body" \
-              --label "integration-sync-failure,automated,bug"
-            echo "::warning::Created new integration sync failure issue"
-          fi
+            - **Run:** [View workflow run](${process.env.RUN_URL})
+            - **Reason:** ${process.env.FAILURE_SUMMARY}
+            - **Time:** ${now}
+
+            The sync workflow continues to fail. Please investigate.`,
+            });
+            core.warning(`Updated existing integration sync failure tracker #${tracker.number}`);

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -196,7 +196,7 @@ def test_consumer_sync_drift_uploads_machine_readable_report():
         "consumer_sync_drift_issue_body.js" in text
     ), "Health 68 issue payload must use the structured drift report"
     assert (
-        "mergeIssueBody" in text and "github.rest.issues.update" in text
+        "sync_tracker_state" in text and "updateTrackerBody" in text
     ), "Health 68 must refresh the GitHub-visible drift issue checkpoint"
     assert (
         "consumer-sync-drift-report" in text


### PR DESCRIPTION
## Summary
- Wires Health 68 drift issue creation/update through `sync_tracker_state` tracker helpers.
- Adds the shared open-PR check to Maint 68 before sync PR creation while keeping the existing race-condition backstop.
- Routes Maint 82 campaign tracker discovery/update and no-open-campaign-PR skips through the shared helper.
- Adds Maint 69 stuck-window mark/clear lifecycle using the shared tracker helpers.

## Validation
- `node --test .github/scripts/__tests__/sync-tracker-state.test.js .github/scripts/__tests__/sync_dependabot_campaign.test.js`
- `actionlint -oneline .github/workflows/health-68-consumer-sync-drift.yml .github/workflows/maint-68-sync-consumer-repos.yml .github/workflows/maint-69-sync-integration-repo.yml .github/workflows/maint-82-sync-dependabot-campaign.yml`
- `python3 scripts/check_api_wrapper_guard.py --base-ref origin/main`
- YAML parse check for the four changed workflows
