### PR TITLE
feat: wire runner library into 5 dual-provider workflows

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -85,6 +85,8 @@ jobs:
       has_high_privilege: ${{ steps.evaluate.outputs.has_high_privilege }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
@@ -109,6 +111,9 @@ jobs:
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
           sparse-checkout-cone-mode: false
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
@@ -185,7 +190,8 @@ jobs:
             } catch (error) {
               if (isRateLimitError(error)) {
                 core.warning(
-                  `Skipping prompt-injection gate: workflow_run ${manualInputs.runId} lookup was rate-limited.`
+                  `Skipping prompt-injection gate: workflow_run ${manualInputs.runId} ` +
+                  'lookup was rate-limited.'
                 );
                 core.setOutput('blocked', 'false');
                 core.setOutput('reason', 'workflow-run-lookup-rate-limited');
@@ -641,10 +647,35 @@ jobs:
               core.setOutput(key, value);
             }
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.evaluate.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
@@ -669,6 +700,7 @@ jobs:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
     uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
@@ -689,6 +721,64 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+  record-autofix-completion:
+    name: Record autofix dispatch completion
+    needs:
+      - prepare
+      - autofix
+      - autofix-claude
+    if: >-
+      always() &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
+      (needs.autofix.result != 'skipped' || needs.autofix-claude.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVIDER: ${{ needs.prepare.outputs.agent_type || 'codex' }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          SUMMARY: >-
+            ${{ needs.autofix.outputs.final-message-summary ||
+                needs.autofix-claude.outputs.final-message-summary || '' }}
+          EXIT_CODE: >-
+            ${{ needs.autofix.outputs.exit-code ||
+                needs.autofix-claude.outputs.exit-code || '' }}
+          JOB_RESULT: >-
+            ${{ needs.autofix.result != 'skipped' &&
+                needs.autofix.result || needs.autofix-claude.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Runner completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ -z "${EXIT_CODE:-}" ]; then
+            if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          fi
+          python -m scripts.runner_lib record-completion \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "$SUMMARY" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto
 
   needs-human:
     needs: prepare

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -71,6 +71,8 @@ jobs:
       force_retry: ${{ steps.evaluate.outputs.force_retry }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -449,6 +451,34 @@ jobs:
             // the job-output level, so even a step output would re-introduce
             // the "Skip output since it may contain secret" noise.
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: >
+          steps.fingerprint.outputs.should_run == 'true' &&
+          (steps.evaluate.outputs.action == 'run' ||
+          steps.evaluate.outputs.action == 'fix' ||
+          steps.evaluate.outputs.action == 'conflict')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
       - name: Verify task appendix artifact
         if: >
           steps.fingerprint.outputs.should_run == 'true' &&
@@ -478,9 +508,10 @@ jobs:
     name: Verify secrets available
     needs: evaluate
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     environment: >-
       ${{
@@ -524,7 +555,9 @@ jobs:
               fi
               ;;
             *)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || \
+                [ "$HAS_CLAUDE_AUTH" = "true" ] || \
+                [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -535,13 +568,17 @@ jobs:
           if [ "$agent_auth_ok" != "true" ]; then
             case "$AGENT_TYPE" in
               claude)
-                missing_msg="Missing credentials for agent 'claude'. Set CLAUDE_CODE_OAUTH_TOKEN (preferred), CLAUDE_AUTH_JSON, or configure KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent 'claude'. Set "
+                missing_msg+="CLAUDE_CODE_OAUTH_TOKEN (preferred), CLAUDE_AUTH_JSON, "
+                missing_msg+="or configure KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
               codex)
-                missing_msg="Missing credentials for agent 'codex'. Set CODEX_AUTH_JSON, or configure KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent 'codex'. Set CODEX_AUTH_JSON, "
+                missing_msg+="or configure KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
               *)
-                missing_msg="Missing credentials for agent '${AGENT_TYPE}'. Configure that agent's credentials or KEEPALIVE/WORKFLOWS_APP credentials."
+                missing_msg="Missing credentials for agent '${AGENT_TYPE}'. Configure "
+                missing_msg+="that agent's credentials or KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
             esac
             echo "::error::$missing_msg"
@@ -569,9 +606,10 @@ jobs:
       - evaluate
       - preflight
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -622,6 +660,7 @@ jobs:
     # Only run for agent:codex label when action is run/fix/conflict
     if: |
       needs.evaluate.outputs.agent_type == 'codex' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
@@ -654,6 +693,7 @@ jobs:
       - mark-running
     if: |
       needs.evaluate.outputs.agent_type == 'claude' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
@@ -680,6 +720,64 @@ jobs:
 
   # Progress review: LLM-based check when agent is active but not completing tasks
   # This catches "productive but unfocused" patterns where agent works on tangential items
+  record-keepalive-completion:
+    name: Record keepalive dispatch completion
+    needs:
+      - evaluate
+      - run-codex
+      - run-claude
+    if: >-
+      always() &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.run-codex.result != 'skipped' || needs.run-claude.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVIDER: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
+          SUMMARY: >-
+            ${{ needs.run-codex.outputs.final-message-summary ||
+                needs.run-claude.outputs.final-message-summary || '' }}
+          EXIT_CODE: >-
+            ${{ needs.run-codex.outputs.exit-code ||
+                needs.run-claude.outputs.exit-code || '' }}
+          JOB_RESULT: >-
+            ${{ needs.run-codex.result != 'skipped' &&
+                needs.run-codex.result || needs.run-claude.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Runner completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ -z "${EXIT_CODE:-}" ]; then
+            if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          fi
+          python -m scripts.runner_lib record-completion \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "$SUMMARY" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto
+
   progress-review:
     name: Review agent progress alignment
     needs: evaluate

--- a/.github/workflows/agents-pr-meta-v4.yml
+++ b/.github/workflows/agents-pr-meta-v4.yml
@@ -428,6 +428,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
+          AGENTS_AUTOMATION_PAT: ${{ secrets.AGENTS_AUTOMATION_PAT }}
+          ACTIONS_BOT_PAT: ${{ secrets.ACTIONS_BOT_PAT }}
+          SERVICE_BOT_PAT: ${{ secrets.SERVICE_BOT_PAT }}
+          OWNER_PR_PAT: ${{ secrets.OWNER_PR_PAT }}
           PR_NUMBER: >-
             ${{
               inputs.pr_number ||
@@ -454,7 +458,20 @@ jobs:
           import urllib.request
 
           repo = os.environ["GITHUB_REPOSITORY"]
-          token = os.environ["GITHUB_TOKEN"]
+          token = next(
+              (
+                  os.environ.get(name, "")
+                  for name in (
+                      "AGENTS_AUTOMATION_PAT",
+                      "ACTIONS_BOT_PAT",
+                      "SERVICE_BOT_PAT",
+                      "OWNER_PR_PAT",
+                      "GITHUB_TOKEN",
+                  )
+                  if os.environ.get(name, "")
+              ),
+              "",
+          )
           pr_number = os.environ["PR_NUMBER"]
           headers = {
               "Accept": "application/vnd.github+json",

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,6 +32,9 @@ jobs:
       pr_labels_json: ${{ steps.context.outputs.pr_labels_json }}
       same_repo: ${{ steps.context.outputs.same_repo }}
       caller_actor: ${{ steps.context.outputs.caller_actor }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
@@ -53,6 +56,9 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
           sparse-checkout-cone-mode: false
 
       - name: Setup API client
@@ -180,6 +186,7 @@ jobs:
               core.setOutput('pr_labels_json', JSON.stringify(labels));
               core.setOutput('same_repo', sameRepo ? 'true' : 'false');
               core.setOutput('caller_actor', callerActor);
+              core.setOutput('head_sha', pr.head?.sha || '');
             };
 
             // --- workflow_run trigger (after Gate/CI completes) ---
@@ -369,9 +376,38 @@ jobs:
 
             setOutputs({ pr, sameRepo, callerActor: context.actor });
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.context.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          GITHUB_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: resolve
-    if: needs.resolve.outputs.should_run == 'true'
+    if: >-
+      needs.resolve.outputs.should_run == 'true' &&
+      needs.resolve.outputs.dispatch_should_run == 'true'
     uses: ./.github/workflows/reusable-18-autofix.yml
     with:
       pr_number: ${{ fromJson(needs.resolve.outputs.pr_number) }}
@@ -385,3 +421,49 @@ jobs:
       service_bot_pat: ${{ secrets.ACTIONS_BOT_PAT }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+  record-autofix-dispatch:
+    name: Record autofix dispatch completion
+    needs:
+      - resolve
+      - autofix
+    if: >-
+      always() &&
+      needs.resolve.outputs.dispatch_should_run == 'true' &&
+      needs.autofix.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          JOB_RESULT: ${{ needs.autofix.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Autofix completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          python -m scripts.runner_lib record-completion \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "autofix workflow result: ${JOB_RESULT:-unknown}" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto

--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -555,58 +555,14 @@ jobs:
           MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
-          base="${BASE_PROMPT}"
-          if [ -n "${PR_NUMBER}" ]; then
-            output="claude-prompt-${PR_NUMBER}.md"
-          else
-            output="claude-prompt.md"
-          fi
-
-          if [ -z "$base" ] || [ ! -f "$base" ]; then
-            echo "Base prompt file not found: ${base}" >&2
-            exit 1
-          fi
-
-          if [ -f ".github/claude/AGENT_INSTRUCTIONS.md" ]; then
-            {
-              cat ".github/claude/AGENT_INSTRUCTIONS.md"
-              echo
-              echo "---"
-              echo
-              echo "## Task Prompt"
-              echo
-            } > "$output"
-            cat "$base" >> "$output"
-          else
-            cat "$base" > "$output"
-          fi
-
-          if [ "$MODE" = "keepalive" ] && [ -s "/tmp/keepalive-artifacts/task-appendix.txt" ]; then
-            echo "Streaming task appendix from artifact file"
-            {
-              echo
-              echo "## Run context"
-              cat /tmp/keepalive-artifacts/task-appendix.txt
-            } >> "$output"
-          elif [ -n "$APPENDIX" ]; then
-            echo "Using task appendix from input parameter"
-            {
-              echo
-              echo "## Run context"
-              printf '%s\n' "$APPENDIX"
-            } >> "$output"
-          fi
-
-          if [ -f ".reference/REFERENCE_PACKS.md" ]; then
-            echo "Including reference pack content in prompt"
-            {
-              echo
-              echo "## Reference Packs"
-              cat .reference/REFERENCE_PACKS.md
-            } >> "$output"
-          fi
-
-          echo "file=${output}" >> "$GITHUB_OUTPUT"
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib assemble-prompt \
+              --provider claude \
+              --base-prompt "$BASE_PROMPT" \
+              --appendix "$APPENDIX" \
+              --mode "$MODE" \
+              --pr-number "$PR_NUMBER" \
+              --task-appendix-file /tmp/keepalive-artifacts/task-appendix.txt
 
       # Keep workspace shape identical to Codex runner so git status noise doesn't
       # confuse the agent or produce merge conflicts when multiple PRs run.
@@ -904,26 +860,12 @@ jobs:
             git log --oneline -5 2>/dev/null || true
           echo "::endgroup::"
 
-          output=""
-          if [ -f "$output_file" ]; then
-            output="$(cat "$output_file")"
-          fi
-
-          encoded="$(
-            printf '%s' "$output" | base64 -w 0 2>/dev/null || \
-            printf '%s' "$output" | base64 | tr -d '\n'
-          )"
-          summary="$(
-            printf '%s' "$output" | head -c 500 | tr '\n' ' ' | sed 's/  */ /g' || true
-          )"
-          if [ -z "$summary" ]; then
-            summary="No output captured"
-          fi
 
           echo "exit-code=$status" >> "$GITHUB_OUTPUT"
-          echo "error-summary=$summary" >> "$GITHUB_OUTPUT"
-          echo "final-message=${encoded}" >> "$GITHUB_OUTPUT"
-          echo "final-message-summary=${summary}" >> "$GITHUB_OUTPUT"
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib parse-output \
+              --provider claude \
+              --raw-output-file "$output_file" >/tmp/claude-runner-result.json
 
           if [ "$status" -ne 0 ]; then
             exit "$status"

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -592,64 +592,14 @@ jobs:
           MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
-          base="${BASE_PROMPT}"
-          # Use PR-specific filename to avoid merge conflicts when multiple PRs run concurrently
-          if [ -n "${PR_NUMBER}" ]; then
-            output="codex-prompt-${PR_NUMBER}.md"
-          else
-            output="codex-prompt.md"
-          fi
-
-          if [ -z "$base" ] || [ ! -f "$base" ]; then
-            echo "Base prompt file not found: ${base}" >&2
-            exit 1
-          fi
-
-          # Start with agent instructions if available
-          if [ -f ".github/codex/AGENT_INSTRUCTIONS.md" ]; then
-            {
-              cat ".github/codex/AGENT_INSTRUCTIONS.md"
-              echo
-              echo "---"
-              echo
-              echo "## Task Prompt"
-              echo
-            } > "$output"
-            cat "$base" >> "$output"
-          else
-            cat "$base" > "$output"
-          fi
-
-          # For keepalive mode, prefer artifact file to avoid secret scanner blocking
-          # Stream file contents directly to avoid loading large content into memory
-          # Use -s test to skip empty files (preserves previous behavior of no empty section)
-          if [ "$MODE" = "keepalive" ] && [ -s "/tmp/keepalive-artifacts/task-appendix.txt" ]; then
-            echo "Streaming task appendix from artifact file"
-            {
-              echo
-              echo "## Run context"
-              cat /tmp/keepalive-artifacts/task-appendix.txt
-            } >> "$output"
-          elif [ -n "$APPENDIX" ]; then
-            echo "Using task appendix from input parameter"
-            {
-              echo
-              echo "## Run context"
-              printf '%s\n' "$APPENDIX"
-            } >> "$output"
-          fi
-
-          # Append reference pack content if materialized
-          if [ -f ".reference/REFERENCE_PACKS.md" ]; then
-            echo "Including reference pack content in prompt"
-            {
-              echo
-              echo "## Reference Packs"
-              cat .reference/REFERENCE_PACKS.md
-            } >> "$output"
-          fi
-
-          echo "file=${output}" >> "$GITHUB_OUTPUT"
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib assemble-prompt \
+              --provider codex \
+              --base-prompt "$BASE_PROMPT" \
+              --appendix "$APPENDIX" \
+              --mode "$MODE" \
+              --pr-number "$PR_NUMBER" \
+              --task-appendix-file /tmp/keepalive-artifacts/task-appendix.txt
 
       - name: Install Codex CLI
         run: |
@@ -1066,18 +1016,16 @@ jobs:
 
           echo "Codex completed with exit code ${CODEX_EXIT}. Output written to $OUTPUT_FILE"
 
-          # Set outputs for downstream steps
+          # Set outputs for downstream steps through the shared parser.
           if [ -f "$OUTPUT_FILE" ]; then
-            # Base64 encode full message to avoid heredoc delimiter issues
-            encoded=$(base64 -w 0 "$OUTPUT_FILE")
-            echo "final-message=${encoded}" >> "$GITHUB_OUTPUT"
-
-            # Summary (first 500 chars, safe for PR comments)
-            summary=$(head -c 500 "$OUTPUT_FILE" | tr '\n' ' ' | sed 's/"/\\"/g')
-            echo "final-message-summary=${summary}" >> "$GITHUB_OUTPUT"
+            PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+              python -m scripts.runner_lib parse-output \
+                --provider codex \
+                --raw-output-file "$OUTPUT_FILE" >/tmp/codex-runner-result.json
           else
-            echo "final-message=" >> "$GITHUB_OUTPUT"
-            echo "final-message-summary=No output captured" >> "$GITHUB_OUTPUT"
+            printf '' | PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+              python -m scripts.runner_lib parse-output \
+                --provider codex >/tmp/codex-runner-result.json
           fi
 
           # Exit with original code to mark job as failed if Codex failed

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -21,7 +21,8 @@ from scripts.state_fingerprint import GitHubApi, _github_context
 
 MARKER_VERSION = "v1"
 MARKER_PREFIX = "runner-dispatch"
-PROVIDERS = {"codex", "claude"}
+PROVIDERS = {"autofix", "claude", "codex"}
+PROMPT_PROVIDERS = {"claude", "codex"}
 TERMINAL_STATUSES = {"completed", "error"}
 
 
@@ -185,6 +186,8 @@ def assemble_prompt(
 ) -> RunnerPrompt:
     """Assemble a provider-specific prompt from template, context, and references."""
     provider = _validate_provider(provider)
+    if provider not in PROMPT_PROVIDERS:
+        raise ValueError(f"provider does not support prompt assembly: {provider}")
     workspace = Path(str(context.get("workspace", "."))).resolve()
     base_prompt_raw = context.get("base_prompt_file") or context.get("prompt_file")
     if not base_prompt_raw:
@@ -287,6 +290,8 @@ def _parse_jsonl_output(raw_output: str) -> tuple[list[str], list[str]]:
 def parse_runner_output(provider: str, raw_output: str) -> RunnerResult:
     """Parse raw Codex/Claude output into a common result shape."""
     provider = _validate_provider(provider)
+    if provider not in PROMPT_PROVIDERS:
+        raise ValueError(f"provider does not support output parsing: {provider}")
     raw = raw_output or ""
     truncated = len(raw) > 64000 or bool(re.search(r"\btruncated\b", raw, re.IGNORECASE))
     clipped = raw[:64000] if len(raw) > 64000 else raw
@@ -608,7 +613,9 @@ def _cmd_parse(args: argparse.Namespace) -> int:
     outputs = {
         "success": "true" if result.success else "false",
         "summary": result.summary,
+        "final-message-summary": result.summary,
         "error": result.error or "",
+        "error-summary": result.error or result.summary,
         "truncated": "true" if result.truncated else "false",
         "final-message": base64.b64encode(result.final_message.encode("utf-8")).decode("ascii"),
     }
@@ -642,7 +649,17 @@ def _cmd_record_completion(args: argparse.Namespace) -> int:
         path = Path(args.raw_output_file)
         if path.is_file():
             raw = path.read_text(encoding="utf-8")
-    result = parse_runner_output(args.provider, raw or args.summary or "")
+    provider = _validate_provider(args.provider)
+    if provider in PROMPT_PROVIDERS:
+        result = parse_runner_output(provider, raw or args.summary or "")
+    else:
+        summary = args.summary or raw or "No output captured"
+        result = RunnerResult(
+            provider=provider,
+            success=args.exit_code is None or int(args.exit_code) == 0,
+            final_message=summary,
+            summary=re.sub(r"\s+", " ", summary).strip()[:500] or "No output captured",
+        )
     if args.exit_code is not None and int(args.exit_code) != 0 and result.success:
         result = dataclasses.replace(result, success=False, error=result.summary)
     record = record_completion(

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -74,6 +74,8 @@ jobs:
       agent_routing_mode: ${{ steps.evaluate.outputs.agent_routing_mode }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
       fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
@@ -280,13 +282,42 @@ jobs:
             // Task appendix needs special handling due to multiline content
             core.setOutput('task_appendix', result.taskAppendix || '');
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: >
+          steps.fingerprint.outputs.should_run == 'true' &&
+          (steps.evaluate.outputs.action == 'run' ||
+          steps.evaluate.outputs.action == 'fix' ||
+          steps.evaluate.outputs.action == 'conflict')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   preflight:
     name: Verify secrets available
     needs: evaluate
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     environment: agent-standard
     outputs:
@@ -343,9 +374,10 @@ jobs:
       - evaluate
       - preflight
     if: |
-      needs.evaluate.outputs.action == 'run' ||
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.evaluate.outputs.action == 'run' ||
       needs.evaluate.outputs.action == 'fix' ||
-      needs.evaluate.outputs.action == 'conflict'
+      needs.evaluate.outputs.action == 'conflict')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -387,7 +419,9 @@ jobs:
       - preflight
       - mark-running
     # Only run for agent:codex label
-    if: needs.evaluate.outputs.agent_type == 'codex'
+    if: >-
+      needs.evaluate.outputs.agent_type == 'codex' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true'
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
@@ -418,6 +452,7 @@ jobs:
       - mark-running
     if: |
       needs.evaluate.outputs.agent_type == 'claude' &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
@@ -434,6 +469,64 @@ jobs:
       pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
       appendix: ${{ needs.evaluate.outputs.task_appendix }}
       iteration: ${{ needs.evaluate.outputs.iteration }}
+
+  record-keepalive-completion:
+    name: Record keepalive dispatch completion
+    needs:
+      - evaluate
+      - run-codex
+      - run-claude
+    if: >-
+      always() &&
+      needs.evaluate.outputs.dispatch_should_run == 'true' &&
+      (needs.run-codex.result != 'skipped' || needs.run-claude.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVIDER: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
+          SUMMARY: >-
+            ${{ needs.run-codex.outputs.final-message-summary ||
+                needs.run-claude.outputs.final-message-summary || '' }}
+          EXIT_CODE: >-
+            ${{ needs.run-codex.outputs.exit-code ||
+                needs.run-claude.outputs.exit-code || '' }}
+          JOB_RESULT: >-
+            ${{ needs.run-codex.result != 'skipped' &&
+                needs.run-codex.result || needs.run-claude.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Runner completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ -z "${EXIT_CODE:-}" ]; then
+            if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          fi
+          python -m scripts.runner_lib record-completion \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "$SUMMARY" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto
 
   summary:
     name: Update keepalive summary
@@ -746,6 +839,8 @@ jobs:
       gate_run_id: ${{ steps.evaluate.outputs.gate_run_id }}
       security_blocked: ${{ steps.security_gate.outputs.blocked }}
       security_reason: ${{ steps.security_gate.outputs.reason }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout (for security gate + agent registry)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -756,6 +851,9 @@ jobs:
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
             .github/scripts/agent_registry.js
             .github/agents/registry.yml
           sparse-checkout-cone-mode: false
@@ -1110,10 +1208,35 @@ jobs:
               core.setOutput(key, value);
             }
 
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.evaluate.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          PROVIDER: ${{ steps.evaluate.outputs.agent_type || 'codex' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider "$PROVIDER" \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
     uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
@@ -1132,6 +1255,7 @@ jobs:
     needs: prepare
     if: >-
       needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
     uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -64,6 +64,9 @@ jobs:
       pr_labels_json: ${{ steps.context.outputs.pr_labels_json }}
       same_repo: ${{ steps.context.outputs.same_repo }}
       caller_actor: ${{ steps.context.outputs.caller_actor }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      dispatch_should_run: ${{ steps.runner_dispatch.outputs.should_dispatch || 'true' }}
+      dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
@@ -87,6 +90,9 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
           sparse-checkout-cone-mode: false
 
       - name: Setup API client
@@ -216,6 +222,7 @@ jobs:
               core.setOutput('pr_labels_json', JSON.stringify(labels));
               core.setOutput('same_repo', sameRepo ? 'true' : 'false');
               core.setOutput('caller_actor', callerActor);
+              core.setOutput('head_sha', pr.head?.sha || '');
             };
 
             // --- workflow_run trigger (after Gate/CI completes) ---
@@ -560,9 +567,38 @@ jobs:
             });
 
   # Call reusable autofix workflow
+      - name: Check runner dispatch debounce
+        id: runner_dispatch
+        if: steps.context.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          GITHUB_TOKEN: >-
+            ${{ secrets.AGENTS_AUTOMATION_PAT || secrets.ACTIONS_BOT_PAT ||
+                secrets.SERVICE_BOT_PAT || github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            {
+              echo "should_dispatch=true"
+              echo "reason=missing-pr-or-sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python -m scripts.runner_lib should-dispatch \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --storage auto
+
   autofix:
     needs: resolve
-    if: needs.resolve.outputs.should_run == 'true'
+    if: >-
+      needs.resolve.outputs.should_run == 'true' &&
+      needs.resolve.outputs.dispatch_should_run == 'true'
     uses: stranske/Workflows/.github/workflows/reusable-18-autofix.yml@main
     with:
       pr_number: ${{ fromJson(needs.resolve.outputs.pr_number) }}
@@ -576,3 +612,49 @@ jobs:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+  record-autofix-dispatch:
+    name: Record autofix dispatch completion
+    needs:
+      - resolve
+      - autofix
+    if: >-
+      always() &&
+      needs.resolve.outputs.dispatch_should_run == 'true' &&
+      needs.autofix.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runner library
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            scripts/runner_lib
+            scripts/state_fingerprint.py
+            scripts/reference_packs.py
+          sparse-checkout-cone-mode: false
+
+      - name: Record completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          JOB_RESULT: ${{ needs.autofix.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Autofix completion state missing PR or SHA; skipping."
+            exit 0
+          fi
+          if [ "${JOB_RESULT:-}" = "success" ]; then
+              EXIT_CODE=0
+            else
+              EXIT_CODE=1
+            fi
+          python -m scripts.runner_lib record-completion \
+            --provider autofix \
+            --pr-number "$PR_NUMBER" \
+            --head-sha "$HEAD_SHA" \
+            --summary "autofix workflow result: ${JOB_RESULT:-unknown}" \
+            --exit-code "$EXIT_CODE" \
+            --storage auto


### PR DESCRIPTION
## Summary
- wire reusable Codex and Claude runners to `scripts.runner_lib assemble-prompt` and `parse-output`
- add SHA-keyed `should-dispatch` gates before keepalive/autofix runner dispatches
- record completion state after keepalive/autofix runner jobs finish
- add caller-side debounce to canonical and template `autofix.yml`
- wire the current consumer default `templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml`
- make the PR meta-manager fingerprint precheck use the same PAT fallback pattern as its body-update step, avoiding stacked-PR `github.token` 403s

## Notes
- This PR is stacked on #2024 (`feat/runner-library`) because the library must merge first. Retarget to `main` after #2024 lands.
- The repo currently has `agents-81-gate-followups.yml` only under `templates/consumer-repo/.github/workflows/`; there is no canonical `.github/workflows/agents-81-gate-followups.yml` file to edit in lockstep. I wired the template copy and the canonical first-party loop files that exist.
- Existing workflow concurrency groups remain in place. The new debounce runs inside the prepare/evaluate job before reusable runner dispatch, so it suppresses duplicate same-SHA provider runs without changing the concurrency cancellation policy.

## Validation
- `python -m pytest tests/scripts/test_runner_lib.py`
- `python -m ruff check scripts/runner_lib tests/scripts/test_runner_lib.py`
- `python scripts/validate_workflow_yaml.py .github/workflows/agents-pr-meta-v4.yml .github/workflows/agents-autofix-loop.yml .github/workflows/agents-keepalive-loop.yml .github/workflows/autofix.yml templates/consumer-repo/.github/workflows/autofix.yml templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`

## Not run
- `actionlint`: local repo binary is Linux x86_64 and cannot execute on this macOS runner clone.


## Post-rebase CI note (2026-05-06)
- After rebase to `origin/main` and force-push of `adb83013`, fresh Gate run `25434206471` started successfully but failed in the full Python matrix on both 3.12 and 3.13. Failure mode: `tests/scripts/test_issue_formatter.py::test_format_issue_body_caps_oversized_input` asserts `len(result["formatted_body"]) < len(oversized_body)`, but CI reports `64059 < 60000`. Focused local validation for this PR passed (`py_compile`, `tests/scripts/test_runner_lib.py`, and direct YAML parsing of changed workflows).
