### PR TITLE
fix: address sync helper review debt

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -9,6 +9,7 @@ const {
   findOrCreateTracker,
   isConsumerOpenPr,
   markStuckWindowBody,
+  patternMatches,
   parseStuckWindow,
   preserveDurableTrackerHeader,
   updateTrackerBody,
@@ -95,7 +96,7 @@ test('findOrCreateTracker discovers a tracker with the durable marker', async ()
         number: 10,
         title: 'Other issue',
         body: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
-        labels: [{ name: 'automation' }],
+        labels: [{ name: DURABLE_TRACKER_LABEL }, { name: 'consumer-sync' }],
       },
     ],
   });
@@ -114,6 +115,14 @@ test('findOrCreateTracker discovers a tracker with the durable marker', async ()
   assert.equal(tracker.number, 10);
   assert.equal(tracker.sync_tracker_created, false);
   assert.equal(github.calls.createdIssues.length, 0);
+});
+
+test('patternMatches handles invalid and stateful regex patterns deterministically', () => {
+  const globalPattern = /sync\/workflows-/g;
+
+  assert.equal(patternMatches('sync/workflows-abc123', globalPattern), true);
+  assert.equal(patternMatches('sync/workflows-abc123', globalPattern), true);
+  assert.equal(patternMatches('sync/workflows-abc123', '/[/'), false);
 });
 
 test('findOrCreateTracker discovers a tracker by durable label and title', async () => {
@@ -142,6 +151,7 @@ test('findOrCreateTracker discovers a tracker by durable label and title', async
 
 test('findOrCreateTracker creates a durable tracker when none is found', async () => {
   const github = mockGithub();
+  const retryOptions = [];
 
   const tracker = await findOrCreateTracker({
     github,
@@ -152,6 +162,10 @@ test('findOrCreateTracker creates a durable tracker when none is found', async (
     title: 'Consumer repo drift detected',
     body: '## Consumer Repo Drift Detected',
     markerComment: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+    withRetry: async (fn, options) => {
+      retryOptions.push(options);
+      return fn();
+    },
   });
 
   assert.equal(tracker.number, 99);
@@ -163,6 +177,7 @@ test('findOrCreateTracker creates a durable tracker when none is found', async (
     'consumer-sync',
   ]);
   assert.match(github.calls.createdIssues[0].body, /consumer-sync-drift:v1/);
+  assert.equal(retryOptions.at(-1).allowNonIdempotentRetries, false);
 });
 
 test('findOrCreateTracker can return null without creating', async () => {
@@ -241,6 +256,14 @@ test('isConsumerOpenPr matches open consumer PR branches by pattern', async () =
       github,
       consumerRepo: 'stranske/Ready',
       branchPattern: /^dependabot\//,
+    }),
+    false,
+  );
+  assert.equal(
+    await isConsumerOpenPr({
+      github,
+      consumerRepo: 'stranske/Ready',
+      branchPattern: '',
     }),
     false,
   );

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -47,6 +47,7 @@ function patternMatches(value, pattern) {
     return true;
   }
   if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
     return pattern.test(text);
   }
   const patternText = cleanString(pattern);
@@ -57,14 +58,22 @@ function patternMatches(value, pattern) {
     const lastSlash = patternText.lastIndexOf('/');
     const source = patternText.slice(1, lastSlash);
     const flags = patternText.slice(lastSlash + 1);
-    return new RegExp(source, flags).test(text);
+    try {
+      return new RegExp(source, flags).test(text);
+    } catch {
+      return text.includes(patternText);
+    }
   }
   return text.includes(patternText);
 }
 
-async function callWithRetry(fn, label, { withRetry = null, core = console } = {}) {
+async function callWithRetry(
+  fn,
+  label,
+  { withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
+) {
   if (typeof withRetry === 'function') {
-    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries: true });
+    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries });
   }
   try {
     return await fn();
@@ -86,13 +95,13 @@ async function paginateIssues({ github, owner, repo, labels = '', core, withRetr
     return cleanArray(await callWithRetry(
       () => github.paginate(method, params),
       `${owner}/${repo} open issues`,
-      { core, withRetry },
+      { core, withRetry, allowNonIdempotentRetries: true },
     ));
   }
   const response = await callWithRetry(
     () => method(params),
     `${owner}/${repo} open issues`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
   return cleanArray(response?.data);
 }
@@ -101,7 +110,7 @@ async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
   const response = await callWithRetry(
     () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
     `${owner}/${repo}#${issueNumber}`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
   return response?.data || null;
 }
@@ -146,7 +155,7 @@ async function ensureLabels({
   await callWithRetry(
     () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
     `${owner}/${repo}#${issueNumber} add labels`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
 }
 
@@ -160,7 +169,7 @@ async function findTracker({ github, owner, repo, label, titlePattern, markerPat
     core,
     withRetry,
   });
-  const openIssues = markerPattern || !labelQuery
+  const openIssues = !labelQuery
     ? await paginateIssues({ github, owner, repo, core, withRetry })
     : [];
   const byNumber = new Map();
@@ -343,13 +352,16 @@ async function isConsumerOpenPr({
     ? cleanArray(await callWithRetry(
         () => github.paginate(method, params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry },
+        { core, withRetry, allowNonIdempotentRetries: true },
       ))
     : cleanArray((await callWithRetry(
         () => method(params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry },
+        { core, withRetry, allowNonIdempotentRetries: true },
       ))?.data);
+  if (!branchPattern) {
+    return false;
+  }
   return pulls.some((pull) => {
     const headRef = cleanString(pull?.head?.ref || pull?.headRefName || pull?.head_ref);
     return patternMatches(headRef, branchPattern);

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1828,6 +1828,15 @@ WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "workflow-template",
 )
 
+WORKFLOW_SYNC_REPO_LOCAL_MARKERS = (
+    "repo-local",
+    "repository-local",
+    "local-only",
+    "project-specific",
+    "this repository",
+    "this repo",
+)
+
 
 def _acceptance_criteria_from_original_issue(
     original_issue: OriginalIssueData | list[str],
@@ -1844,7 +1853,9 @@ def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
         return True
     if any(marker in normalized for marker in WORKFLOW_SYNC_PATH_MARKERS):
-        return any(marker in normalized for marker in WORKFLOW_SYNC_CONTEXT_MARKERS)
+        if any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS):
+            return False
+        return True
     return False
 
 

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -83,7 +83,7 @@ def build_pr_context(
         body = _text(pr.get("formatted_body") or pr.get("body"))
 
     diff_body = _diff_text(pr) if resolved.include_diff else ""
-    metadata_block = _pr_metadata(pr, resolved)
+    metadata_block = _pr_metadata(pr, resolved, diff_body=diff_body)
     extra_sections = [("## Pull Request Diff", diff_body)] if diff_body else None
     return _build_payload(
         kind="pr",
@@ -179,9 +179,7 @@ def _cap_block(text: str, token_budget: int, *, model: str | None = None) -> tup
         return text, False
 
     marker = "\n[truncated: context exceeded token budget]"
-    marker_tokens = estimate_tokens(marker, model=model)
-    allowed_chars = max(1, (token_budget - marker_tokens) * TOKEN_CHARS)
-    return f"{text[:allowed_chars].rstrip()}{marker}", True
+    return _truncate_with_suffix(text, token_budget, suffix=marker, model=model), True
 
 
 def _cap_sections(
@@ -200,7 +198,6 @@ def _cap_sections(
             model=options.model,
         )
         if remaining <= 0:
-            rendered.append(f"{heading}\n[truncated: token budget exhausted before this section]")
             truncated = True
             continue
 
@@ -210,21 +207,95 @@ def _cap_sections(
             continue
 
         marker = "\n\n[truncated: context exceeded token budget]"
-        marker_tokens = estimate_tokens(f"{heading}{marker}", model=options.model)
-        allowed_tokens = max(1, remaining - marker_tokens)
-        allowed_chars = allowed_tokens * TOKEN_CHARS
-        capped_text = _text(text).strip()[:allowed_chars].rstrip()
-        rendered.append(f"{heading}\n{capped_text}{marker}".rstrip())
+        capped_section = _truncate_section(
+            heading,
+            _text(text).strip(),
+            remaining,
+            suffix=marker,
+            model=options.model,
+        )
+        if capped_section:
+            rendered.append(capped_section)
         truncated = True
 
     context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
     while estimate_tokens(context, model=options.model) > budget and rendered:
         truncated = True
+        previous = context
         heading = rendered[-1].split("\n", 1)[0]
-        rendered[-1] = f"{heading}\n[truncated: token budget exhausted before this section]"
+        remaining = budget - estimate_tokens(
+            "\n\n".join(part for part in [metadata_block, *rendered[:-1]] if part),
+            model=options.model,
+        )
+        rendered[-1] = _truncate_section(
+            heading,
+            "",
+            remaining,
+            suffix="\n[truncated: token budget exhausted before this section]",
+            model=options.model,
+        )
+        if not rendered[-1]:
+            rendered.pop()
         context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
+        if context == previous:
+            rendered.pop()
+            context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
 
     return rendered, truncated
+
+
+def _truncate_with_suffix(
+    text: str,
+    token_budget: int,
+    *,
+    suffix: str = "",
+    model: str | None = None,
+) -> str:
+    budget = max(0, token_budget)
+    source = _text(text).rstrip()
+    suffix_text = suffix if estimate_tokens(suffix, model=model) <= budget else ""
+    low = 0
+    high = len(source)
+    best = ""
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = f"{source[:midpoint].rstrip()}{suffix_text}".rstrip()
+        if estimate_tokens(candidate, model=model) <= budget:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
+
+
+def _truncate_section(
+    heading: str,
+    text: str,
+    token_budget: int,
+    *,
+    suffix: str,
+    model: str | None = None,
+) -> str:
+    budget = max(0, token_budget)
+    prefix = f"{heading}\n"
+    if estimate_tokens(prefix.rstrip(), model=model) > budget:
+        return _truncate_with_suffix(heading, budget, model=model)
+
+    suffix_text = (
+        suffix if estimate_tokens(f"{prefix}{suffix}".rstrip(), model=model) <= budget else ""
+    )
+    low = 0
+    high = len(text)
+    best = prefix.rstrip()
+    while low <= high:
+        midpoint = (low + high) // 2
+        candidate = f"{prefix}{text[:midpoint].rstrip()}{suffix_text}".rstrip()
+        if estimate_tokens(candidate, model=model) <= budget:
+            best = candidate
+            low = midpoint + 1
+        else:
+            high = midpoint - 1
+    return best
 
 
 def _issue_metadata(issue: Mapping[str, Any], options: ContextOptions) -> str:
@@ -245,7 +316,7 @@ def _issue_metadata(issue: Mapping[str, Any], options: ContextOptions) -> str:
     return "\n".join(lines)
 
 
-def _pr_metadata(pr: Mapping[str, Any], options: ContextOptions) -> str:
+def _pr_metadata(pr: Mapping[str, Any], options: ContextOptions, *, diff_body: str = "") -> str:
     lines = ["## Pull Request Metadata"]
     number = pr.get("number")
     if number is not None:
@@ -265,7 +336,7 @@ def _pr_metadata(pr: Mapping[str, Any], options: ContextOptions) -> str:
         labels = _labels(pr.get("labels"))
         if labels:
             lines.append(f"- Labels: {', '.join(labels)}")
-    if options.include_diff and _diff_text(pr):
+    if options.include_diff and diff_body:
         lines.append("- Diff: included")
     return "\n".join(lines)
 

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -47,6 +47,7 @@ function patternMatches(value, pattern) {
     return true;
   }
   if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
     return pattern.test(text);
   }
   const patternText = cleanString(pattern);
@@ -57,14 +58,22 @@ function patternMatches(value, pattern) {
     const lastSlash = patternText.lastIndexOf('/');
     const source = patternText.slice(1, lastSlash);
     const flags = patternText.slice(lastSlash + 1);
-    return new RegExp(source, flags).test(text);
+    try {
+      return new RegExp(source, flags).test(text);
+    } catch {
+      return text.includes(patternText);
+    }
   }
   return text.includes(patternText);
 }
 
-async function callWithRetry(fn, label, { withRetry = null, core = console } = {}) {
+async function callWithRetry(
+  fn,
+  label,
+  { withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
+) {
   if (typeof withRetry === 'function') {
-    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries: true });
+    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries });
   }
   try {
     return await fn();
@@ -86,13 +95,13 @@ async function paginateIssues({ github, owner, repo, labels = '', core, withRetr
     return cleanArray(await callWithRetry(
       () => github.paginate(method, params),
       `${owner}/${repo} open issues`,
-      { core, withRetry },
+      { core, withRetry, allowNonIdempotentRetries: true },
     ));
   }
   const response = await callWithRetry(
     () => method(params),
     `${owner}/${repo} open issues`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
   return cleanArray(response?.data);
 }
@@ -101,7 +110,7 @@ async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
   const response = await callWithRetry(
     () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
     `${owner}/${repo}#${issueNumber}`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
   return response?.data || null;
 }
@@ -146,7 +155,7 @@ async function ensureLabels({
   await callWithRetry(
     () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
     `${owner}/${repo}#${issueNumber} add labels`,
-    { core, withRetry },
+    { core, withRetry, allowNonIdempotentRetries: true },
   );
 }
 
@@ -160,7 +169,7 @@ async function findTracker({ github, owner, repo, label, titlePattern, markerPat
     core,
     withRetry,
   });
-  const openIssues = markerPattern || !labelQuery
+  const openIssues = !labelQuery
     ? await paginateIssues({ github, owner, repo, core, withRetry })
     : [];
   const byNumber = new Map();
@@ -343,13 +352,16 @@ async function isConsumerOpenPr({
     ? cleanArray(await callWithRetry(
         () => github.paginate(method, params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry },
+        { core, withRetry, allowNonIdempotentRetries: true },
       ))
     : cleanArray((await callWithRetry(
         () => method(params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry },
+        { core, withRetry, allowNonIdempotentRetries: true },
       ))?.data);
+  if (!branchPattern) {
+    return false;
+  }
   return pulls.some((pull) => {
     const headRef = cleanString(pull?.head?.ref || pull?.headRefName || pull?.head_ref);
     return patternMatches(headRef, branchPattern);

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -23,8 +23,36 @@ def test_issue_context_enforces_token_budget_with_truncation() -> None:
 
     assert context["truncated"] is True
     assert context["estimated_tokens"] <= 80
-    assert "context exceeded token budget" in context["context"]
+    assert "truncated:" in context["context"]
     assert len(context["formatted_body"]) < len(issue["body"])
+
+
+def test_issue_context_handles_tiny_budget_without_overflow() -> None:
+    issue = {
+        "number": 123,
+        "title": "Oversize metadata and body",
+        "state": "open",
+        "body": "body " * 100,
+    }
+
+    context = build_issue_context(issue, ContextOptions(token_budget=1))
+
+    assert context["truncated"] is True
+    assert context["estimated_tokens"] <= 1
+
+
+def test_pr_context_caps_metadata_only_payload_without_looping() -> None:
+    pr = {
+        "number": 77,
+        "title": "x" * 2000,
+        "state": "open",
+        "body": "body " * 500,
+    }
+
+    context = build_pr_context(pr, ContextOptions(token_budget=3))
+
+    assert context["truncated"] is True
+    assert context["estimated_tokens"] <= 3
 
 
 def test_reuse_formatted_body_returns_embedded_marker_body() -> None:

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -146,7 +146,7 @@ def test_select_followup_acceptance_criteria_keeps_repo_local_actions() -> None:
         number=50,
         tasks=[],
         acceptance_criteria=[
-            "The .github/actions/build-dashboard action handles missing config",
+            "The repo-local .github/actions/build-dashboard action handles missing config",
             "The dashboard export renders for the selected account",
         ],
     )
@@ -155,6 +155,23 @@ def test_select_followup_acceptance_criteria_keeps_repo_local_actions() -> None:
     selected = _select_followup_acceptance_criteria(original_issue, verification_data)
 
     assert selected == original_issue.acceptance_criteria
+
+
+def test_select_followup_acceptance_criteria_treats_workflow_paths_as_sync_by_default() -> None:
+    original_issue = OriginalIssueData(
+        title="Workflow path rollout",
+        number=51,
+        tasks=[],
+        acceptance_criteria=[
+            "Update .github/scripts/sync_tracker_state for tracker reuse",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == ["The dashboard export renders for the selected account"]
 
 
 def test_select_followup_acceptance_criteria_keeps_repo_local_agent_items() -> None:


### PR DESCRIPTION
## Summary
- enforce actual token budgets in issue/PR context truncation and avoid non-converging cap loops
- harden sync tracker regex matching, retry options, and empty branch-pattern handling
- classify workflow-owned path criteria as sync by default while preserving explicit repo-local exceptions

## Validation
- python -m pytest tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py -q
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m black --check scripts/langchain/issue_pr_context.py scripts/langchain/followup_issue_generator.py tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py
- git diff --check