### PR TITLE
fix: satisfy sync criterion ruff lint

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1853,9 +1853,7 @@ def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
         return True
     if any(marker in normalized for marker in WORKFLOW_SYNC_PATH_MARKERS):
-        if any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS):
-            return False
-        return True
+        return not any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS)
     return False
 
 


### PR DESCRIPTION
## Summary
- simplify workflow sync acceptance criterion classification to satisfy Ruff SIM103
- unblock Maint 68 sync validation after Workflows #2028

## Validation
- python -m ruff check scripts/langchain/followup_issue_generator.py
- python -m pytest tests/test_followup_issue_generator.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m black --check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- git diff --check