### PR TITLE
fix: resolve sync helper review debt

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -18,6 +18,7 @@ const {
 function mockGithub({ issues = [], pulls = [] } = {}) {
   const calls = {
     createdIssues: [],
+    issueLists: [],
     updatedIssues: [],
     comments: [],
     labels: [],
@@ -25,6 +26,7 @@ function mockGithub({ issues = [], pulls = [] } = {}) {
   const api = {
     paginate: async (method, params) => {
       if (method === api.rest.issues.listForRepo) {
+        calls.issueLists.push(params);
         const labelSet = String(params.labels || '')
           .split(',')
           .map((label) => label.trim())
@@ -147,6 +149,62 @@ test('findOrCreateTracker discovers a tracker by durable label and title', async
 
   assert.equal(tracker.number, 11);
   assert.equal(github.calls.createdIssues.length, 0);
+});
+
+test('findOrCreateTracker does not require durable and campaign labels together', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 12,
+        title: 'Sync/Dependabot campaign queue',
+        body: 'queue body',
+        labels: [{ name: 'campaign:sync-dependabot' }],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'campaign:sync-dependabot',
+    titlePattern: /^Sync\/Dependabot campaign queue$/,
+  });
+
+  assert.equal(tracker.number, 12);
+  assert.equal(
+    github.calls.issueLists.some(
+      (params) => params.labels === 'tracker:durable,campaign:sync-dependabot'
+    ),
+    false,
+  );
+});
+
+test('findOrCreateTracker discovers an unlabeled tracker by marker', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 13,
+        title: 'Consumer repo drift detected',
+        body: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+        labels: [],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'consumer-sync',
+    markerPattern: /consumer-sync-drift:v1/,
+  });
+
+  assert.equal(tracker.number, 13);
+  assert.equal(
+    github.calls.issueLists.some((params) => !params.labels),
+    true,
+  );
 });
 
 test('findOrCreateTracker creates a durable tracker when none is found', async () => {
@@ -280,6 +338,12 @@ test('markStuckWindowBody and clearStuckWindowBody manage the lifecycle marker',
   assert.equal(parsed.since, '2026-05-01T00:00:00Z');
   assert.equal(parsed.reason, 'missing-token');
   assert.match(marked, /sync-tracker-stuck-window:v1/);
+
+  const reasonWithBrace = markStuckWindowBody(marked, '2026-05-02T00:00:00Z', {
+    updatedAt: '2026-05-02T01:00:00Z',
+    reason: 'payload contained } in a message',
+  });
+  assert.equal(parseStuckWindow(reasonWithBrace).reason, 'payload contained } in a message');
 
   const refreshed = markStuckWindowBody(marked, '2026-05-03T00:00:00Z', {
     updatedAt: '2026-05-04T00:00:00Z',

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -5,7 +5,7 @@
 const DURABLE_TRACKER_LABEL = 'tracker:durable';
 const AUTOMATED_LABEL = 'automated';
 const DEFAULT_STUCK_WINDOW_SCHEMA = 'sync-tracker-stuck-window/v1';
-const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+({[\s\S]*?})\s*-->/;
+const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+([\s\S]*?)\s*-->/;
 const DURABLE_HEADER_RE = /^>\s*\*\*Durable tracker\*\*[\s\S]*?(?=\n(?!>)|\n*$)/im;
 
 function cleanString(value) {
@@ -160,21 +160,26 @@ async function ensureLabels({
 }
 
 async function findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry }) {
-  const labelQuery = unique([DURABLE_TRACKER_LABEL, label]).join(',');
-  const labeledIssues = await paginateIssues({
-    github,
-    owner,
-    repo,
-    labels: labelQuery,
-    core,
-    withRetry,
-  });
-  const openIssues = !labelQuery
+  const labeledIssueGroups = await Promise.all(
+    unique([DURABLE_TRACKER_LABEL, label]).map((labelName) =>
+      paginateIssues({
+        github,
+        owner,
+        repo,
+        labels: labelName,
+        core,
+        withRetry,
+      })
+    )
+  );
+  const openIssues = titlePattern || markerPattern
     ? await paginateIssues({ github, owner, repo, core, withRetry })
     : [];
   const byNumber = new Map();
-  for (const issue of [...labeledIssues, ...openIssues]) {
-    byNumber.set(issue.number, issue);
+  for (const issueGroup of [...labeledIssueGroups, openIssues]) {
+    for (const issue of issueGroup) {
+      byNumber.set(issue.number, issue);
+    }
   }
   for (const issue of byNumber.values()) {
     if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1784,23 +1784,6 @@ def _build_why_section(
     return " ".join(parts)
 
 
-WORKFLOW_SYNC_CONTEXT_MARKERS = (
-    "consumer sync",
-    "consumer-sync",
-    "consumer",
-    "consumers",
-    "from the template",
-    "maint-68",
-    "synced",
-    "sync pr",
-    "sync-generated",
-    "template sync",
-    "workflow template sync",
-    "workflow-template",
-    "workflow-owned",
-    "workflows-owned",
-)
-
 WORKFLOW_SYNC_PATH_MARKERS = (
     ".github/actions",
     ".github/scripts",

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -114,7 +114,14 @@ def reuse_formatted_body(
 
         embedded = _embedded_body(payload)
         if embedded is not None:
+            if ("sha256" in payload or "body_sha256" in payload) and not _body_hash_matches(
+                payload,
+                embedded,
+            ):
+                continue
             return embedded
+        if "body_b64" in payload:
+            continue
 
         cleaned = (body[: match.start()] + body[match.end() :]).strip()
         if _body_hash_matches(payload, cleaned):
@@ -194,16 +201,18 @@ def _cap_sections(
 
     prefix = metadata_block.strip()
     for heading, text in sections:
-        remaining = budget - estimate_tokens(
-            "\n\n".join(part for part in [prefix, *rendered] if part),
-            model=options.model,
-        )
+        base_context = _join_context([prefix, *rendered])
+        section_prefix = "\n\n" if base_context else ""
+        remaining = budget - estimate_tokens(f"{base_context}{section_prefix}", model=options.model)
         if remaining <= 0:
             truncated = True
             continue
 
         section = f"{heading}\n{_text(text).strip()}".rstrip()
-        if estimate_tokens(section, model=options.model) <= remaining:
+        if (
+            estimate_tokens(f"{base_context}{section_prefix}{section}", model=options.model)
+            <= budget
+        ):
             rendered.append(section)
             continue
 
@@ -224,10 +233,9 @@ def _cap_sections(
         truncated = True
         previous = context
         heading = rendered[-1].split("\n", 1)[0]
-        remaining = budget - estimate_tokens(
-            "\n\n".join(part for part in [metadata_block, *rendered[:-1]] if part),
-            model=options.model,
-        )
+        base_context = _join_context([metadata_block, *rendered[:-1]])
+        section_prefix = "\n\n" if base_context else ""
+        remaining = budget - estimate_tokens(f"{base_context}{section_prefix}", model=options.model)
         rendered[-1] = _truncate_section(
             heading,
             "",
@@ -243,6 +251,10 @@ def _cap_sections(
             context = "\n\n".join(part for part in [metadata_block, *rendered] if part)
 
     return rendered, truncated
+
+
+def _join_context(parts: list[str]) -> str:
+    return "\n\n".join(part for part in parts if part)
 
 
 def _truncate_with_suffix(
@@ -371,7 +383,7 @@ def _embedded_body(payload: Mapping[str, Any]) -> str | None:
         return None
     try:
         return base64.b64decode(body_b64.encode("ascii")).decode("utf-8")
-    except (binascii.Error, ValueError, UnicodeDecodeError):
+    except (binascii.Error, UnicodeEncodeError, UnicodeDecodeError, ValueError):
         return None
 
 

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import math
 import re
@@ -370,7 +371,7 @@ def _embedded_body(payload: Mapping[str, Any]) -> str | None:
         return None
     try:
         return base64.b64decode(body_b64.encode("ascii")).decode("utf-8")
-    except (ValueError, UnicodeDecodeError):
+    except (binascii.Error, ValueError, UnicodeDecodeError):
         return None
 
 

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -5,7 +5,7 @@
 const DURABLE_TRACKER_LABEL = 'tracker:durable';
 const AUTOMATED_LABEL = 'automated';
 const DEFAULT_STUCK_WINDOW_SCHEMA = 'sync-tracker-stuck-window/v1';
-const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+({[\s\S]*?})\s*-->/;
+const STUCK_WINDOW_MARKER_RE = /<!--\s*sync-tracker-stuck-window:v1\s+([\s\S]*?)\s*-->/;
 const DURABLE_HEADER_RE = /^>\s*\*\*Durable tracker\*\*[\s\S]*?(?=\n(?!>)|\n*$)/im;
 
 function cleanString(value) {
@@ -160,21 +160,26 @@ async function ensureLabels({
 }
 
 async function findTracker({ github, owner, repo, label, titlePattern, markerPattern, core, withRetry }) {
-  const labelQuery = unique([DURABLE_TRACKER_LABEL, label]).join(',');
-  const labeledIssues = await paginateIssues({
-    github,
-    owner,
-    repo,
-    labels: labelQuery,
-    core,
-    withRetry,
-  });
-  const openIssues = !labelQuery
+  const labeledIssueGroups = await Promise.all(
+    unique([DURABLE_TRACKER_LABEL, label]).map((labelName) =>
+      paginateIssues({
+        github,
+        owner,
+        repo,
+        labels: labelName,
+        core,
+        withRetry,
+      })
+    )
+  );
+  const openIssues = titlePattern || markerPattern
     ? await paginateIssues({ github, owner, repo, core, withRetry })
     : [];
   const byNumber = new Map();
-  for (const issue of [...labeledIssues, ...openIssues]) {
-    byNumber.set(issue.number, issue);
+  for (const issueGroup of [...labeledIssueGroups, openIssues]) {
+    for (const issue of issueGroup) {
+      byNumber.set(issue.number, issue);
+    }
   }
   for (const issue of byNumber.values()) {
     if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -87,6 +87,15 @@ def test_reuse_formatted_body_returns_none_when_marker_missing_or_mismatched() -
     assert reuse_formatted_body({"body": marker}, "agents-pr-meta-v4") is None
 
 
+def test_reuse_formatted_body_ignores_malformed_embedded_body() -> None:
+    marker = (
+        '<!-- issue-pr-context:formatted-body:v1 '
+        '{"body_b64":"abc","sha256":"bad","workflow":"agents-auto-pilot"} -->'
+    )
+
+    assert reuse_formatted_body({"body": f"Raw body\n\n{marker}"}, "agents-auto-pilot") is None
+
+
 def test_issue_context_shape_for_typical_fixture() -> None:
     issue = {
         "number": 42,

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -89,7 +89,7 @@ def test_reuse_formatted_body_returns_none_when_marker_missing_or_mismatched() -
 
 def test_reuse_formatted_body_ignores_malformed_embedded_body() -> None:
     marker = (
-        '<!-- issue-pr-context:formatted-body:v1 '
+        "<!-- issue-pr-context:formatted-body:v1 "
         '{"body_b64":"abc","sha256":"bad","workflow":"agents-auto-pilot"} -->'
     )
 

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+
 from scripts.langchain.issue_pr_context import (
     ContextOptions,
     build_formatted_body_marker,
@@ -92,8 +95,30 @@ def test_reuse_formatted_body_ignores_malformed_embedded_body() -> None:
         "<!-- issue-pr-context:formatted-body:v1 "
         '{"body_b64":"abc","sha256":"bad","workflow":"agents-auto-pilot"} -->'
     )
+    non_ascii_marker = (
+        "<!-- issue-pr-context:formatted-body:v1 "
+        '{"body_b64":"not-ascii-\u2603","workflow":"agents-auto-pilot"} -->'
+    )
 
     assert reuse_formatted_body({"body": f"Raw body\n\n{marker}"}, "agents-auto-pilot") is None
+    assert (
+        reuse_formatted_body({"body": f"Raw body\n\n{non_ascii_marker}"}, "agents-auto-pilot")
+        is None
+    )
+
+
+def test_reuse_formatted_body_validates_embedded_body_hash() -> None:
+    formatted = "## Tasks\n- [ ] Verify cached body\n"
+    body_b64 = base64.b64encode(formatted.encode("utf-8")).decode("ascii")
+    digest = hashlib.sha256(formatted.encode("utf-8")).hexdigest()
+    marker = (
+        "<!-- issue-pr-context:formatted-body:v1 "
+        f'{{"body_b64":"{body_b64}","sha256":"{digest}","workflow":"agents-auto-pilot"}} -->'
+    )
+    stale_marker = marker.replace(digest, "0" * 64)
+
+    assert reuse_formatted_body({"body": marker}, "agents-auto-pilot") == formatted
+    assert reuse_formatted_body({"body": stale_marker}, "agents-auto-pilot") is None
 
 
 def test_issue_context_shape_for_typical_fixture() -> None:


### PR DESCRIPTION
## Summary
- validate cached formatted-body marker hashes before reuse and continue ignoring malformed base64 payloads
- search durable trackers by durable/campaign labels independently, with marker/title fallback scans
- harden sync stuck-window marker parsing and remove the unused workflow-sync context marker tuple

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- python -m pytest tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m ruff check scripts/langchain/issue_pr_context.py scripts/langchain/followup_issue_generator.py tests/scripts/test_issue_pr_context.py
- python -m black --check scripts/langchain/issue_pr_context.py scripts/langchain/followup_issue_generator.py tests/scripts/test_issue_pr_context.py
- git diff --check

Addresses sync review feedback from current consumer sync PRs.