### PR TITLE
fix: remove unused workflow sync context markers

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1784,23 +1784,6 @@ def _build_why_section(
     return " ".join(parts)
 
 
-WORKFLOW_SYNC_CONTEXT_MARKERS = (
-    "consumer sync",
-    "consumer-sync",
-    "consumer",
-    "consumers",
-    "from the template",
-    "maint-68",
-    "synced",
-    "sync pr",
-    "sync-generated",
-    "template sync",
-    "workflow template sync",
-    "workflow-template",
-    "workflow-owned",
-    "workflows-owned",
-)
-
 WORKFLOW_SYNC_PATH_MARKERS = (
     ".github/actions",
     ".github/scripts",


### PR DESCRIPTION
## Summary
- remove the unused WORKFLOW_SYNC_CONTEXT_MARKERS tuple from followup_issue_generator.py
- keep the existing workflow-sync acceptance/path marker logic unchanged

## Validation
- pytest -q tests/test_followup_issue_generator.py
- python -m ruff check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py

Addresses source-side feedback from consumer sync PR stranske/Counter_Risk#544.