### PR TITLE
fix: detect workflow sync feedback context

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1827,6 +1827,17 @@ EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "workflow-template",
 )
 
+WORKFLOW_SYNC_CONTEXT_MARKERS = (
+    "consumer sync",
+    "consumer-sync",
+    "consumer",
+    "consumers",
+    "from the template",
+    "maint-68",
+    "synced",
+    "sync-generated",
+)
+
 WORKFLOW_SYNC_REPO_LOCAL_MARKERS = (
     "repo-local",
     "repository-local",
@@ -1859,6 +1870,13 @@ def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     return False
 
 
+def _mentions_workflow_sync_context(value: str) -> bool:
+    normalized = str(value or "").strip().lower()
+    return _is_workflow_sync_acceptance_criterion(normalized) or any(
+        marker in normalized for marker in WORKFLOW_SYNC_CONTEXT_MARKERS
+    )
+
+
 def _has_mixed_repo_and_workflow_acceptance_criteria(
     original_issue: OriginalIssueData | list[str],
 ) -> bool:
@@ -1879,7 +1897,7 @@ def _verification_feedback_mentions_workflow_sync(verification_data: Verificatio
         *verification_data.non_pass_findings,
         *verification_data.structural_issues,
     ]
-    return any(_is_workflow_sync_acceptance_criterion(part) for part in parts)
+    return any(_mentions_workflow_sync_context(part) for part in parts)
 
 
 def _select_followup_acceptance_criteria(

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -60,6 +60,27 @@ def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_f
     assert selected == original_issue.acceptance_criteria
 
 
+def test_select_followup_acceptance_criteria_keeps_workflow_items_for_sync_context_feedback() -> (
+    None
+):
+    original_issue = OriginalIssueData(
+        title="Mixed sync follow-up",
+        number=52,
+        tasks=[],
+        acceptance_criteria=[
+            "Workflow template sync PRs are merged across consumers",
+            "Database migrations preserve existing records",
+        ],
+    )
+    verification_data = VerificationData(
+        concerns=["Consumer sync output is not synced in generated repos"]
+    )
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == original_issue.acceptance_criteria
+
+
 def test_select_followup_acceptance_criteria_accepts_plain_list() -> None:
     criteria = [
         "Workflows-owned scripts in Pension-Data stay synced",


### PR DESCRIPTION
## Summary
- Treat workflow-sync context phrases like "consumer sync" and "synced" as workflow-sync feedback when selecting follow-up acceptance criteria
- Add a regression test for mixed workflow/repo-local criteria so sync feedback keeps workflow criteria intact

## Validation
- python -m pytest tests/test_followup_issue_generator.py -q
- python -m black --target-version py312 --check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- python -m ruff check scripts/langchain/followup_issue_generator.py tests/test_followup_issue_generator.py
- node --test .github/scripts/__tests__/sync-tracker-state.test.js

## Post-rebase CI note (2026-05-06)
- After rebase to `origin/main` and force-push of `ed3fb35`, fresh Gate run `25434268607` started successfully but failed in the full Python matrix on both 3.12 and 3.13. Failure mode: `tests/scripts/test_issue_formatter.py::test_format_issue_body_caps_oversized_input` asserts `len(result["formatted_body"]) < len(oversized_body)`, but CI reports `64059 < 60000`. Focused local validation for this PR passed (`py_compile` and `tests/test_followup_issue_generator.py`).
