### PR TITLE
Fix sync tracker review feedback

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -207,6 +207,35 @@ test('findOrCreateTracker discovers an unlabeled tracker by marker', async () =>
   );
 });
 
+test('findOrCreateTracker discovers an unlabeled tracker by title only', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 14,
+        title: 'Sync/Dependabot campaign queue',
+        body: 'existing queue body',
+        labels: [],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'campaign:sync-dependabot',
+    titlePattern: /^Sync\/Dependabot campaign queue$/,
+  });
+
+  assert.equal(tracker.number, 14);
+  assert.equal(tracker.sync_tracker_created, false);
+  assert.equal(github.calls.createdIssues.length, 0);
+  assert.equal(
+    github.calls.issueLists.some((params) => !params.labels),
+    true,
+  );
+});
+
 test('findOrCreateTracker creates a durable tracker when none is found', async () => {
   const github = mockGithub();
   const retryOptions = [];

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -162,6 +162,9 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
   const hasTitle = patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
+  if (titlePattern && hasTitle) {
+    return true;
+  }
   if (markerPattern && hasTitle && !cleanString(issue.body)) {
     return true;
   }

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1828,6 +1828,7 @@ EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
 )
 
 WORKFLOW_SYNC_CONTEXT_MARKERS = (
+    *WORKFLOW_SYNC_ACCEPTANCE_MARKERS,
     "consumer sync",
     "consumer-sync",
     "consumer",
@@ -1836,6 +1837,9 @@ WORKFLOW_SYNC_CONTEXT_MARKERS = (
     "maint-68",
     "synced",
     "sync-generated",
+    "template syncing",
+    "workflow sync",
+    "workflows sync",
 )
 
 WORKFLOW_SYNC_REPO_LOCAL_MARKERS = (

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -162,6 +162,9 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
   const hasTitle = patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
+  if (titlePattern && hasTitle) {
+    return true;
+  }
   if (markerPattern && hasTitle && !cleanString(issue.body)) {
     return true;
   }


### PR DESCRIPTION
## Summary
- allow durable tracker lookup to find unlabeled title-only tracker issues after scanning open issues
- use workflow-sync context markers when deciding whether verifier feedback is sync-related
- sync the managed tracker helper into the consumer template

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- pytest -q tests/test_followup_issue_generator.py
- python scripts/validate_template_sync.py

Source fix for sync-generated consumer PR stranske/Collab-Admin#699 review comments.

## Post-rebase CI note (2026-05-06)
- After rebase to `origin/main` and force-push of `ad58f13`, fresh Gate run `25434353119` started successfully but failed in the full Python matrix on both 3.12 and 3.13. Failure mode matches the other rebased Wave 2 PRs: `tests/scripts/test_issue_formatter.py::test_format_issue_body_caps_oversized_input` asserts `len(result["formatted_body"]) < len(oversized_body)`, but CI reports `64059 < 60000`. Focused local validation for this PR passed (`py_compile`, `node --check`, `node --test .github/scripts/__tests__/sync-tracker-state.test.js`, `tests/test_followup_issue_generator.py`, and `scripts/validate_template_sync.py`).
