### PR TITLE
fix: resolve sync tracker review debt

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -327,6 +327,106 @@ test('isConsumerOpenPr matches open consumer PR branches by pattern', async () =
   );
 });
 
+test('isConsumerOpenPr manually paginates when github.paginate is unavailable', async () => {
+  const pageOne = Array.from({ length: 100 }, (_, index) => ({
+    number: index + 1,
+    head: { ref: `feature/manual-${index + 1}` },
+  }));
+  const calls = [];
+  const github = {
+    rest: {
+      pulls: {
+        list: async (params) => {
+          calls.push(params);
+          return {
+            data: params.page === 1 ? pageOne : [{ number: 101, head: { ref: 'sync/workflows-next' } }],
+          };
+        },
+      },
+    },
+  };
+
+  assert.equal(
+    await isConsumerOpenPr({
+      github,
+      consumerRepo: 'stranske/Ready',
+      branchPattern: /^sync\/workflows-/,
+    }),
+    true,
+  );
+  assert.deepEqual(calls.map((params) => params.page), [1, 2]);
+});
+
+test('isConsumerOpenPr uses token-aware retry injected clients', async () => {
+  const primary = mockGithub({ pulls: [] });
+  delete primary.paginate;
+  const injected = mockGithub({
+    pulls: [{ number: 7, head: { ref: 'sync/workflows-injected-client' } }],
+  });
+  delete injected.paginate;
+  const clients = [];
+
+  assert.equal(
+    await isConsumerOpenPr({
+      github: primary,
+      consumerRepo: 'stranske/Ready',
+      branchPattern: /^sync\/workflows-/,
+      withRetry: async (fn) => {
+        clients.push(injected);
+        return fn(injected);
+      },
+    }),
+    true,
+  );
+  assert.equal(clients.length, 1);
+});
+
+test('findOrCreateTracker manually paginates open issue scans', async () => {
+  const pageOne = Array.from({ length: 100 }, (_, index) => ({
+    number: index + 1,
+    title: `Other issue ${index + 1}`,
+    body: '',
+    labels: [],
+  }));
+  const trackerIssue = {
+    number: 101,
+    title: 'Consumer repo drift detected',
+    body: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+    labels: [],
+  };
+  const allIssues = [...pageOne, trackerIssue];
+  const calls = [];
+  const github = {
+    rest: {
+      issues: {
+        listForRepo: async (params) => {
+          calls.push(params);
+          if (params.labels) {
+            return { data: [] };
+          }
+          return { data: params.page === 1 ? pageOne : [trackerIssue] };
+        },
+        get: async ({ issue_number }) => ({
+          data: allIssues.find((issue) => issue.number === issue_number) || null,
+        }),
+        addLabels: async (params) => ({ data: params.labels.map((name) => ({ name })) }),
+      },
+    },
+  };
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'consumer-sync',
+    titlePattern: /^Consumer repo drift detected$/,
+    markerPattern: /consumer-sync-drift:v1/,
+  });
+
+  assert.equal(tracker.number, 101);
+  assert.equal(calls.some((params) => !params.labels && params.page === 2), true);
+});
+
 test('markStuckWindowBody and clearStuckWindowBody manage the lifecycle marker', () => {
   const marked = markStuckWindowBody('## Sync Status\n\nStill failing.', '2026-05-01T00:00:00Z', {
     updatedAt: '2026-05-02T00:00:00Z',

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -70,13 +70,16 @@ function patternMatches(value, pattern) {
 async function callWithRetry(
   fn,
   label,
-  { withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
+  { github = null, withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
 ) {
   if (typeof withRetry === 'function') {
-    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries });
+    return withRetry(
+      (client) => fn(client || github),
+      { github, maxRetries: 3, allowNonIdempotentRetries },
+    );
   }
   try {
-    return await fn();
+    return await fn(github);
   } catch (error) {
     if (core && typeof core.warning === 'function') {
       core.warning(`${label} failed: ${error.status || error.message}`);
@@ -85,32 +88,58 @@ async function callWithRetry(
   }
 }
 
+async function listAllPages({
+  github,
+  methodForClient,
+  params,
+  label,
+  core = console,
+  withRetry = null,
+  allowNonIdempotentRetries = true,
+}) {
+  const results = [];
+  const perPage = params.per_page || 100;
+  for (let page = 1; ; page += 1) {
+    const response = await callWithRetry(
+      (client = github) => methodForClient(client)({ ...params, page }),
+      `${label} page ${page}`,
+      { github, core, withRetry, allowNonIdempotentRetries },
+    );
+    const data = cleanArray(response?.data);
+    results.push(...data);
+    if (data.length < perPage) {
+      return results;
+    }
+  }
+}
+
 async function paginateIssues({ github, owner, repo, labels = '', core, withRetry }) {
   const params = { owner, repo, state: 'open', per_page: 100 };
   if (labels) {
     params.labels = labels;
   }
-  const method = github.rest.issues.listForRepo;
   if (typeof github.paginate === 'function') {
     return cleanArray(await callWithRetry(
-      () => github.paginate(method, params),
+      (client = github) => client.paginate(client.rest.issues.listForRepo, params),
       `${owner}/${repo} open issues`,
-      { core, withRetry, allowNonIdempotentRetries: true },
+      { github, core, withRetry, allowNonIdempotentRetries: true },
     ));
   }
-  const response = await callWithRetry(
-    () => method(params),
-    `${owner}/${repo} open issues`,
-    { core, withRetry, allowNonIdempotentRetries: true },
-  );
-  return cleanArray(response?.data);
+  return listAllPages({
+    github,
+    methodForClient: (client = github) => client.rest.issues.listForRepo,
+    params,
+    label: `${owner}/${repo} open issues`,
+    core,
+    withRetry,
+  });
 }
 
 async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
   const response = await callWithRetry(
-    () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
+    (client = github) => client.rest.issues.get({ owner, repo, issue_number: issueNumber }),
     `${owner}/${repo}#${issueNumber}`,
-    { core, withRetry, allowNonIdempotentRetries: true },
+    { github, core, withRetry, allowNonIdempotentRetries: true },
   );
   return response?.data || null;
 }
@@ -153,9 +182,10 @@ async function ensureLabels({
     return;
   }
   await callWithRetry(
-    () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
+    (client = github) =>
+      client.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
     `${owner}/${repo}#${issueNumber} add labels`,
-    { core, withRetry, allowNonIdempotentRetries: true },
+    { github, core, withRetry, allowNonIdempotentRetries: true },
   );
 }
 
@@ -241,7 +271,7 @@ async function findOrCreateTracker({
     ? `${cleanString(body)}\n\n${cleanString(markerComment)}`.trim()
     : cleanString(body);
   const response = await callWithRetry(
-    () => github.rest.issues.create({
+    (client = github) => client.rest.issues.create({
       owner,
       repo,
       title: issueTitle,
@@ -249,7 +279,7 @@ async function findOrCreateTracker({
       labels: unique([DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels]),
     }),
     `${owner}/${repo} create durable tracker`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   const created = response?.data || null;
   if (created) {
@@ -305,9 +335,9 @@ async function updateTrackerBody({
     params.title = title;
   }
   const response = await callWithRetry(
-    () => github.rest.issues.update(params),
+    (client = github) => client.rest.issues.update(params),
     `${owner}/${repo}#${tracker.number} update durable tracker`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   return response?.data || null;
 }
@@ -326,14 +356,14 @@ async function appendTrackerComment({
     throw new Error('appendTrackerComment requires github, owner, repo, and tracker.number');
   }
   const response = await callWithRetry(
-    () => github.rest.issues.createComment({
+    (client = github) => client.rest.issues.createComment({
       owner,
       repo,
       issue_number: tracker.number,
       body: cleanString(comment),
     }),
     `${owner}/${repo}#${tracker.number} append tracker comment`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   return response?.data || null;
 }
@@ -351,19 +381,21 @@ async function isConsumerOpenPr({
   if (!github || !parsed) {
     throw new Error('isConsumerOpenPr requires github and consumerRepo');
   }
-  const method = github.rest.pulls.list;
   const params = { owner: parsed.owner, repo: parsed.repo, state, per_page: 100 };
   const pulls = typeof github.paginate === 'function'
     ? cleanArray(await callWithRetry(
-        () => github.paginate(method, params),
+        (client = github) => client.paginate(client.rest.pulls.list, params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry, allowNonIdempotentRetries: true },
+        { github, core, withRetry, allowNonIdempotentRetries: true },
       ))
-    : cleanArray((await callWithRetry(
-        () => method(params),
-        `${parsed.fullName} open pulls`,
-        { core, withRetry, allowNonIdempotentRetries: true },
-      ))?.data);
+    : await listAllPages({
+        github,
+        methodForClient: (client = github) => client.rest.pulls.list,
+        params,
+        label: `${parsed.fullName} open pulls`,
+        core,
+        withRetry,
+      });
   if (!branchPattern) {
     return false;
   }

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1811,6 +1811,22 @@ WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
     "workflow-template",
 )
 
+EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
+    "workflow-owned",
+    "workflows-owned",
+    "maint-68",
+    "synced automation",
+    "synced script",
+    "synced scripts",
+    "synced workflow",
+    "sync pr",
+    "sync-generated",
+    "sync workflow templates",
+    "template sync",
+    "workflow template sync",
+    "workflow-template",
+)
+
 WORKFLOW_SYNC_REPO_LOCAL_MARKERS = (
     "repo-local",
     "repository-local",
@@ -1833,10 +1849,13 @@ def _acceptance_criteria_from_original_issue(
 
 def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     normalized = str(criterion or "").strip().lower()
-    if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
-        return True
+    has_repo_local_marker = any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS)
     if any(marker in normalized for marker in WORKFLOW_SYNC_PATH_MARKERS):
-        return not any(marker in normalized for marker in WORKFLOW_SYNC_REPO_LOCAL_MARKERS)
+        return not has_repo_local_marker
+    if any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS):
+        return not has_repo_local_marker or any(
+            marker in normalized for marker in EXPLICIT_WORKFLOW_SYNC_ACCEPTANCE_MARKERS
+        )
     return False
 
 

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 import json
 import math
 import re
@@ -17,7 +18,7 @@ TOKEN_CHARS = 4
 MARKER_VERSION = "v1"
 MARKER_PREFIX = "issue-pr-context:formatted-body"
 MARKER_RE = re.compile(
-    rf"<!--\s*{re.escape(MARKER_PREFIX)}:{MARKER_VERSION}\s+(\{{.*?\}})\s*-->",
+    rf"<!--\s*{re.escape(MARKER_PREFIX)}:{MARKER_VERSION}\s+(.+?)\s*-->",
     re.DOTALL,
 )
 
@@ -120,8 +121,6 @@ def reuse_formatted_body(
             ):
                 continue
             return embedded
-        if "body_b64" in payload:
-            continue
 
         cleaned = (body[: match.start()] + body[match.end() :]).strip()
         if _body_hash_matches(payload, cleaned):
@@ -145,7 +144,9 @@ def build_formatted_body_marker(
         payload["workflows"] = list(workflows)
     if formatted_body is not None:
         payload["body_b64"] = base64.b64encode(formatted_body.encode("utf-8")).decode("ascii")
-    return f"<!-- {MARKER_PREFIX}:{MARKER_VERSION} {json.dumps(payload, sort_keys=True)} -->"
+        payload["sha256"] = hashlib.sha256(formatted_body.encode("utf-8")).hexdigest()
+    marker_payload = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"<!-- {MARKER_PREFIX}:{MARKER_VERSION} {marker_payload} -->"
 
 
 def _build_payload(
@@ -391,8 +392,6 @@ def _body_hash_matches(payload: Mapping[str, Any], body: str) -> bool:
     expected = payload.get("sha256") or payload.get("body_sha256")
     if not isinstance(expected, str):
         return False
-    import hashlib
-
     return hashlib.sha256(body.encode("utf-8")).hexdigest() == expected
 
 

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -70,13 +70,16 @@ function patternMatches(value, pattern) {
 async function callWithRetry(
   fn,
   label,
-  { withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
+  { github = null, withRetry = null, core = console, allowNonIdempotentRetries = false } = {},
 ) {
   if (typeof withRetry === 'function') {
-    return withRetry(fn, { maxRetries: 3, allowNonIdempotentRetries });
+    return withRetry(
+      (client) => fn(client || github),
+      { github, maxRetries: 3, allowNonIdempotentRetries },
+    );
   }
   try {
-    return await fn();
+    return await fn(github);
   } catch (error) {
     if (core && typeof core.warning === 'function') {
       core.warning(`${label} failed: ${error.status || error.message}`);
@@ -85,32 +88,58 @@ async function callWithRetry(
   }
 }
 
+async function listAllPages({
+  github,
+  methodForClient,
+  params,
+  label,
+  core = console,
+  withRetry = null,
+  allowNonIdempotentRetries = true,
+}) {
+  const results = [];
+  const perPage = params.per_page || 100;
+  for (let page = 1; ; page += 1) {
+    const response = await callWithRetry(
+      (client = github) => methodForClient(client)({ ...params, page }),
+      `${label} page ${page}`,
+      { github, core, withRetry, allowNonIdempotentRetries },
+    );
+    const data = cleanArray(response?.data);
+    results.push(...data);
+    if (data.length < perPage) {
+      return results;
+    }
+  }
+}
+
 async function paginateIssues({ github, owner, repo, labels = '', core, withRetry }) {
   const params = { owner, repo, state: 'open', per_page: 100 };
   if (labels) {
     params.labels = labels;
   }
-  const method = github.rest.issues.listForRepo;
   if (typeof github.paginate === 'function') {
     return cleanArray(await callWithRetry(
-      () => github.paginate(method, params),
+      (client = github) => client.paginate(client.rest.issues.listForRepo, params),
       `${owner}/${repo} open issues`,
-      { core, withRetry, allowNonIdempotentRetries: true },
+      { github, core, withRetry, allowNonIdempotentRetries: true },
     ));
   }
-  const response = await callWithRetry(
-    () => method(params),
-    `${owner}/${repo} open issues`,
-    { core, withRetry, allowNonIdempotentRetries: true },
-  );
-  return cleanArray(response?.data);
+  return listAllPages({
+    github,
+    methodForClient: (client = github) => client.rest.issues.listForRepo,
+    params,
+    label: `${owner}/${repo} open issues`,
+    core,
+    withRetry,
+  });
 }
 
 async function getIssue({ github, owner, repo, issueNumber, core, withRetry }) {
   const response = await callWithRetry(
-    () => github.rest.issues.get({ owner, repo, issue_number: issueNumber }),
+    (client = github) => client.rest.issues.get({ owner, repo, issue_number: issueNumber }),
     `${owner}/${repo}#${issueNumber}`,
-    { core, withRetry, allowNonIdempotentRetries: true },
+    { github, core, withRetry, allowNonIdempotentRetries: true },
   );
   return response?.data || null;
 }
@@ -153,9 +182,10 @@ async function ensureLabels({
     return;
   }
   await callWithRetry(
-    () => github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
+    (client = github) =>
+      client.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: names }),
     `${owner}/${repo}#${issueNumber} add labels`,
-    { core, withRetry, allowNonIdempotentRetries: true },
+    { github, core, withRetry, allowNonIdempotentRetries: true },
   );
 }
 
@@ -241,7 +271,7 @@ async function findOrCreateTracker({
     ? `${cleanString(body)}\n\n${cleanString(markerComment)}`.trim()
     : cleanString(body);
   const response = await callWithRetry(
-    () => github.rest.issues.create({
+    (client = github) => client.rest.issues.create({
       owner,
       repo,
       title: issueTitle,
@@ -249,7 +279,7 @@ async function findOrCreateTracker({
       labels: unique([DURABLE_TRACKER_LABEL, AUTOMATED_LABEL, label, ...labels]),
     }),
     `${owner}/${repo} create durable tracker`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   const created = response?.data || null;
   if (created) {
@@ -305,9 +335,9 @@ async function updateTrackerBody({
     params.title = title;
   }
   const response = await callWithRetry(
-    () => github.rest.issues.update(params),
+    (client = github) => client.rest.issues.update(params),
     `${owner}/${repo}#${tracker.number} update durable tracker`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   return response?.data || null;
 }
@@ -326,14 +356,14 @@ async function appendTrackerComment({
     throw new Error('appendTrackerComment requires github, owner, repo, and tracker.number');
   }
   const response = await callWithRetry(
-    () => github.rest.issues.createComment({
+    (client = github) => client.rest.issues.createComment({
       owner,
       repo,
       issue_number: tracker.number,
       body: cleanString(comment),
     }),
     `${owner}/${repo}#${tracker.number} append tracker comment`,
-    { core, withRetry },
+    { github, core, withRetry },
   );
   return response?.data || null;
 }
@@ -351,19 +381,21 @@ async function isConsumerOpenPr({
   if (!github || !parsed) {
     throw new Error('isConsumerOpenPr requires github and consumerRepo');
   }
-  const method = github.rest.pulls.list;
   const params = { owner: parsed.owner, repo: parsed.repo, state, per_page: 100 };
   const pulls = typeof github.paginate === 'function'
     ? cleanArray(await callWithRetry(
-        () => github.paginate(method, params),
+        (client = github) => client.paginate(client.rest.pulls.list, params),
         `${parsed.fullName} open pulls`,
-        { core, withRetry, allowNonIdempotentRetries: true },
+        { github, core, withRetry, allowNonIdempotentRetries: true },
       ))
-    : cleanArray((await callWithRetry(
-        () => method(params),
-        `${parsed.fullName} open pulls`,
-        { core, withRetry, allowNonIdempotentRetries: true },
-      ))?.data);
+    : await listAllPages({
+        github,
+        methodForClient: (client = github) => client.rest.pulls.list,
+        params,
+        label: `${parsed.fullName} open pulls`,
+        core,
+        withRetry,
+      });
   if (!branchPattern) {
     return false;
   }

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -69,6 +69,21 @@ def test_reuse_formatted_body_returns_embedded_marker_body() -> None:
     reused = reuse_formatted_body(issue, "agents-auto-pilot")
 
     assert reused == formatted
+    assert '"sha256":"' in marker
+    assert '": "' not in marker
+
+
+def test_reuse_formatted_body_parses_marker_payload_with_braces() -> None:
+    formatted = "## Tasks\n- [ ] Keep } in text\n"
+    body_b64 = base64.b64encode(formatted.encode("utf-8")).decode("ascii")
+    digest = hashlib.sha256(formatted.encode("utf-8")).hexdigest()
+    marker = (
+        "<!-- issue-pr-context:formatted-body:v1 "
+        f'{{"body_b64":"{body_b64}","note":"value with }} brace","sha256":"{digest}",'
+        '"workflow":"agents-auto-pilot"} -->'
+    )
+
+    assert reuse_formatted_body({"body": marker}, "agents-auto-pilot") == formatted
 
 
 def test_reuse_formatted_body_returns_cleaned_body_for_matching_marker() -> None:
@@ -103,7 +118,21 @@ def test_reuse_formatted_body_ignores_malformed_embedded_body() -> None:
     assert reuse_formatted_body({"body": f"Raw body\n\n{marker}"}, "agents-auto-pilot") is None
     assert (
         reuse_formatted_body({"body": f"Raw body\n\n{non_ascii_marker}"}, "agents-auto-pilot")
-        is None
+        == "Raw body"
+    )
+
+
+def test_reuse_formatted_body_falls_back_to_cleaned_body_for_malformed_embed() -> None:
+    marker = (
+        "<!-- issue-pr-context:formatted-body:v1 "
+        '{"body_b64":"abc","workflow":"agents-auto-pilot"} -->'
+    )
+
+    assert (
+        reuse_formatted_body(
+            {"body": f"{marker}\n## Tasks\n- [ ] Visible body"}, "agents-auto-pilot"
+        )
+        == "## Tasks\n- [ ] Visible body"
     )
 
 

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -157,6 +157,40 @@ def test_select_followup_acceptance_criteria_keeps_repo_local_actions() -> None:
     assert selected == original_issue.acceptance_criteria
 
 
+def test_select_followup_acceptance_criteria_keeps_repo_local_workflow_file_items() -> None:
+    original_issue = OriginalIssueData(
+        title="Repo-local workflow",
+        number=52,
+        tasks=[],
+        acceptance_criteria=[
+            "The workflow file in this repo handles nightly dashboard exports",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == original_issue.acceptance_criteria
+
+
+def test_select_followup_acceptance_criteria_keeps_explicit_sync_pr_items() -> None:
+    original_issue = OriginalIssueData(
+        title="Workflow sync rollout",
+        number=53,
+        tasks=[],
+        acceptance_criteria=[
+            "The sync PR is opened in this repo for workflow template sync",
+            "The dashboard export renders for the selected account",
+        ],
+    )
+    verification_data = VerificationData(concerns=["The dashboard export failed"])
+
+    selected = _select_followup_acceptance_criteria(original_issue, verification_data)
+
+    assert selected == ["The dashboard export renders for the selected account"]
+
+
 def test_select_followup_acceptance_criteria_treats_workflow_paths_as_sync_by_default() -> None:
     original_issue = OriginalIssueData(
         title="Workflow path rollout",


### PR DESCRIPTION
## Summary
- harden issue/PR formatted-body markers with compact hashed embedded payloads and brace-safe marker parsing
- make workflow-sync acceptance criteria keep repo-local workflow-file items while preserving explicit sync PR detection
- route sync tracker helper calls through token-aware injected clients and manually paginate issues/PRs when github.paginate is unavailable
- sync the consumer template copy of sync_tracker_state

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- python -m pytest tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py -q
- python -m ruff check scripts/langchain/issue_pr_context.py scripts/langchain/followup_issue_generator.py tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py
- python -m black --check --fast scripts/langchain/issue_pr_context.py scripts/langchain/followup_issue_generator.py tests/scripts/test_issue_pr_context.py tests/test_followup_issue_generator.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check