### PR TITLE
fix: sync reference pack helper to consumers

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -210,6 +210,9 @@ scripts:
   - source: scripts/state_fingerprint.py
     description: "Computes workflow state fingerprints for unchanged-state skip gates"
 
+  - source: scripts/reference_packs.py
+    description: "Validates and resolves reference pack configuration for shared runner prompt assembly"
+
   - source: scripts/runner_lib/
     is_directory: true
     description: "Shared runner prompt assembly, output parsing, and dispatch debounce helpers"


### PR DESCRIPTION
## Summary

- Add `scripts/reference_packs.py` to the consumer sync manifest because synced `scripts/runner_lib/core.py` imports it.
- Unblocks trip-planner sync PR #1101, where mypy fails with `Module "scripts" has no attribute "reference_packs"`.

## Validation

- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m pytest tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py -q`
- focused import: `from scripts.runner_lib.core import materialize_reference_packs`
