### PR TITLE
feat: add artifact-cache composite action

### DIFF
--- a/.github/actions/artifact-cache/action.yml
+++ b/.github/actions/artifact-cache/action.yml
@@ -1,0 +1,76 @@
+name: Artifact Cache
+description: Restore, discover, and cache workflow artifacts by run window.
+
+inputs:
+  cache-key-base:
+    description: Cache key prefix, for example weekly-metrics.
+    required: true
+  window-resolution:
+    description: Cache window resolution. Supported values are daily, weekly, and run.
+    required: false
+    default: weekly
+  artifact-name:
+    description: Artifact name to discover and wrap with the cache.
+    required: true
+  fail-fast:
+    description: Error when the artifact is absent instead of falling through to producer steps.
+    required: false
+    default: 'false'
+  artifact-path:
+    description: Local path to restore/download/cache. Defaults to .artifact-cache/<base>/<window>/<artifact>.
+    required: false
+    default: ''
+
+outputs:
+  cache-hit:
+    description: 'true when actions/cache restored the artifact path.'
+    value: ${{ steps.restore.outputs.cache-hit }}
+  artifact-path:
+    description: Local path containing the restored, downloaded, or producer-created artifact data.
+    value: ${{ steps.prepare.outputs.artifact-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare artifact cache key
+      id: prepare
+      shell: bash
+      env:
+        INPUT_CACHE_KEY_BASE: ${{ inputs.cache-key-base }}
+        INPUT_WINDOW_RESOLUTION: ${{ inputs.window-resolution }}
+        INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        INPUT_ARTIFACT_PATH: ${{ inputs.artifact-path }}
+      run: node "$GITHUB_ACTION_PATH/artifact_cache.js" prepare
+
+    - name: Restore artifact cache
+      id: restore
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.prepare.outputs.artifact-path }}
+        key: ${{ steps.prepare.outputs.cache-key }}
+
+    - name: Discover artifact in run window
+      id: discover
+      if: ${{ steps.restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      env:
+        INPUT_CACHE_KEY_BASE: ${{ inputs.cache-key-base }}
+        INPUT_WINDOW_RESOLUTION: ${{ inputs.window-resolution }}
+        INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        INPUT_ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        INPUT_FAIL_FAST: ${{ inputs.fail-fast }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: node "$GITHUB_ACTION_PATH/artifact_cache.js" discover
+
+    - name: Download discovered artifact
+      if: >-
+        ${{
+          steps.restore.outputs.cache-hit != 'true' &&
+          steps.discover.outputs.artifact-found == 'true'
+        }}
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact-name }}
+        run-id: ${{ steps.discover.outputs.run-id }}
+        path: ${{ steps.prepare.outputs.artifact-path }}
+        github-token: ${{ github.token }}

--- a/.github/actions/artifact-cache/action.yml
+++ b/.github/actions/artifact-cache/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: Local path to restore/download/cache. Defaults to .artifact-cache/<base>/<window>/<artifact>.
     required: false
     default: ''
+  producer-run-id:
+    description: Optional workflow run id that must own the discovered artifact.
+    required: false
+    default: ''
+  producer-branch:
+    description: Optional branch that must own the discovered artifact. Defaults to the current ref name.
+    required: false
+    default: ''
 
 outputs:
   cache-hit:
@@ -66,6 +74,8 @@ runs:
         INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
         INPUT_ARTIFACT_PATH: ${{ inputs.artifact-path }}
         INPUT_FAIL_FAST: ${{ inputs.fail-fast }}
+        INPUT_PRODUCER_RUN_ID: ${{ inputs.producer-run-id }}
+        INPUT_PRODUCER_BRANCH: ${{ inputs.producer-branch }}
         GITHUB_TOKEN: ${{ github.token }}
       run: node "$GITHUB_ACTION_PATH/artifact_cache.js" discover
 

--- a/.github/actions/artifact-cache/action.yml
+++ b/.github/actions/artifact-cache/action.yml
@@ -25,6 +25,13 @@ outputs:
   cache-hit:
     description: 'true when actions/cache restored the artifact path.'
     value: ${{ steps.restore.outputs.cache-hit }}
+  artifact-found:
+    description: 'true when the artifact is available from cache or run-window discovery.'
+    value: >-
+      ${{
+        steps.restore.outputs.cache-hit == 'true' ||
+        steps.discover.outputs.artifact-found == 'true'
+      }}
   artifact-path:
     description: Local path containing the restored, downloaded, or producer-created artifact data.
     value: ${{ steps.prepare.outputs.artifact-path }}

--- a/.github/actions/artifact-cache/artifact_cache.js
+++ b/.github/actions/artifact-cache/artifact_cache.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const VALID_WINDOW_RESOLUTIONS = new Set(['daily', 'weekly', 'run']);
+const DEFAULT_GITHUB_API_URL = ['https://api', 'github', 'com'].join('.');
 
 function parseBoolean(value, defaultValue = false) {
   if (value === undefined || value === null || String(value).trim() === '') {
@@ -143,15 +144,47 @@ function artifactInWindow(artifact, window, runId = '') {
   return createdAt >= window.start && createdAt < window.end;
 }
 
-function selectArtifact(artifacts, { artifactName, window, runId = '' }) {
+function artifactRunId(artifact) {
+  return artifact?.workflow_run?.id || artifact?.workflow_run?.run_id || '';
+}
+
+function artifactHeadBranch(artifact) {
+  return artifact?.workflow_run?.head_branch || '';
+}
+
+function artifactMatchesProducer(artifact, { producerRunId = '', producerBranch = '' } = {}) {
+  const expectedRunId = String(producerRunId || '').trim();
+  if (expectedRunId && String(artifactRunId(artifact) || '') !== expectedRunId) {
+    return false;
+  }
+
+  const expectedBranch = String(producerBranch || '').trim();
+  if (expectedBranch && artifactHeadBranch(artifact) !== expectedBranch) {
+    return false;
+  }
+
+  return true;
+}
+
+function selectArtifact(
+  artifacts,
+  { artifactName, window, runId = '', producerRunId = '', producerBranch = '' },
+) {
   return [...(artifacts || [])]
     .filter((artifact) => artifact && artifact.name === artifactName)
     .filter((artifact) => !artifact.expired)
     .filter((artifact) => artifactInWindow(artifact, window, runId))
+    .filter((artifact) => artifactMatchesProducer(artifact, { producerRunId, producerBranch }))
     .sort((a, b) => artifactCreatedAt(b) - artifactCreatedAt(a))[0] || null;
 }
 
-async function listArtifacts({ token, owner, repo, fetchImpl = global.fetch }) {
+async function listArtifacts({
+  token,
+  owner,
+  repo,
+  apiUrl = process.env.GITHUB_API_URL || DEFAULT_GITHUB_API_URL,
+  fetchImpl = global.fetch,
+}) {
   if (!fetchImpl) {
     throw new Error('Global fetch is not available; use Node.js 18 or newer.');
   }
@@ -164,9 +197,10 @@ async function listArtifacts({ token, owner, repo, fetchImpl = global.fetch }) {
 
   const artifacts = [];
   let page = 1;
-  while (page <= 20) {
+  while (true) {
+    const baseUrl = String(apiUrl || DEFAULT_GITHUB_API_URL).replace(/\/+$/, '');
     const response = await fetchImpl(
-      `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?per_page=100&page=${page}`,
+      `${baseUrl}/repos/${owner}/${repo}/actions/artifacts?per_page=100&page=${page}`,
       {
         headers: {
           accept: 'application/vnd.github+json',
@@ -182,7 +216,9 @@ async function listArtifacts({ token, owner, repo, fetchImpl = global.fetch }) {
     const payload = await response.json();
     const pageArtifacts = Array.isArray(payload.artifacts) ? payload.artifacts : [];
     artifacts.push(...pageArtifacts);
-    if (pageArtifacts.length < 100) {
+    const linkHeader = response.headers?.get?.('link') || '';
+    const hasNextPage = linkHeader.includes('rel="next"');
+    if (!hasNextPage && pageArtifacts.length < 100) {
       break;
     }
     page += 1;
@@ -243,6 +279,8 @@ async function discoverCommand() {
     artifactName: plan.artifactName,
     window: plan.window,
     runId: process.env.GITHUB_RUN_ID || '',
+    producerRunId: process.env.INPUT_PRODUCER_RUN_ID || '',
+    producerBranch: process.env.INPUT_PRODUCER_BRANCH || process.env.GITHUB_REF_NAME || '',
   });
 
   if (!artifact) {
@@ -263,7 +301,7 @@ async function discoverCommand() {
     return;
   }
 
-  const runId = artifact.workflow_run?.id || artifact.workflow_run?.run_id || '';
+  const runId = artifactRunId(artifact);
   writeOutputs({
     'artifact-found': 'true',
     'artifact-id': String(artifact.id || ''),

--- a/.github/actions/artifact-cache/artifact_cache.js
+++ b/.github/actions/artifact-cache/artifact_cache.js
@@ -1,0 +1,301 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const VALID_WINDOW_RESOLUTIONS = new Set(['daily', 'weekly', 'run']);
+
+function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return defaultValue;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`Invalid boolean value: ${value}`);
+}
+
+function sanitizeSegment(value) {
+  const sanitized = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return sanitized || 'artifact';
+}
+
+function toUtcDate(input) {
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  return date;
+}
+
+function startOfUtcDay(date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function addDays(date, days) {
+  const copy = new Date(date.getTime());
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function isoWeekParts(dateInput) {
+  const date = startOfUtcDay(toUtcDate(dateInput));
+  const day = date.getUTCDay() || 7;
+  const thursday = addDays(date, 4 - day);
+  const year = thursday.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil((((thursday - yearStart) / 86400000) + 1) / 7);
+  const start = addDays(date, 1 - day);
+  const end = addDays(start, 7);
+  return { year, week, start, end };
+}
+
+function deriveWindow({ resolution = 'weekly', now = new Date(), runId = '' } = {}) {
+  const normalized = String(resolution || 'weekly').trim().toLowerCase();
+  if (!VALID_WINDOW_RESOLUTIONS.has(normalized)) {
+    throw new Error(
+      `Invalid window-resolution "${resolution}". Expected daily, weekly, or run.`,
+    );
+  }
+
+  const date = toUtcDate(now);
+  if (normalized === 'daily') {
+    const start = startOfUtcDay(date);
+    const end = addDays(start, 1);
+    const label = start.toISOString().slice(0, 10);
+    return { resolution: normalized, label, start, end };
+  }
+
+  if (normalized === 'run') {
+    const id = String(runId || '').trim();
+    if (!id) {
+      throw new Error('GITHUB_RUN_ID is required when window-resolution is run.');
+    }
+    return { resolution: normalized, label: `run-${id}`, start: null, end: null };
+  }
+
+  const { year, week, start, end } = isoWeekParts(date);
+  return {
+    resolution: normalized,
+    label: `${year}-W${String(week).padStart(2, '0')}`,
+    start,
+    end,
+  };
+}
+
+function deriveCachePlan({
+  cacheKeyBase,
+  windowResolution = 'weekly',
+  artifactName,
+  artifactPath = '',
+  now = new Date(),
+  runId = '',
+  workspace = process.cwd(),
+} = {}) {
+  const base = String(cacheKeyBase || '').trim();
+  const name = String(artifactName || '').trim();
+  if (!base) {
+    throw new Error('cache-key-base is required.');
+  }
+  if (!name) {
+    throw new Error('artifact-name is required.');
+  }
+
+  const window = deriveWindow({ resolution: windowResolution, now, runId });
+  const safeBase = sanitizeSegment(base);
+  const safeName = sanitizeSegment(name);
+  const resolvedArtifactPath = artifactPath && String(artifactPath).trim()
+    ? String(artifactPath).trim()
+    : path.join('.artifact-cache', safeBase, window.label, safeName);
+
+  return {
+    cacheKey: `${base}-${window.label}`,
+    artifactPath: resolvedArtifactPath,
+    window,
+    artifactName: name,
+    workspace,
+  };
+}
+
+function artifactCreatedAt(artifact) {
+  const raw = artifact?.created_at || artifact?.updated_at;
+  return raw ? toUtcDate(raw) : null;
+}
+
+function artifactInWindow(artifact, window, runId = '') {
+  if (window.resolution === 'run') {
+    const artifactRunId = artifact?.workflow_run?.id || artifact?.workflow_run?.run_id;
+    return String(artifactRunId || '') === String(runId || '');
+  }
+
+  const createdAt = artifactCreatedAt(artifact);
+  if (!createdAt) {
+    return false;
+  }
+  return createdAt >= window.start && createdAt < window.end;
+}
+
+function selectArtifact(artifacts, { artifactName, window, runId = '' }) {
+  return [...(artifacts || [])]
+    .filter((artifact) => artifact && artifact.name === artifactName)
+    .filter((artifact) => !artifact.expired)
+    .filter((artifact) => artifactInWindow(artifact, window, runId))
+    .sort((a, b) => artifactCreatedAt(b) - artifactCreatedAt(a))[0] || null;
+}
+
+async function listArtifacts({ token, owner, repo, fetchImpl = global.fetch }) {
+  if (!fetchImpl) {
+    throw new Error('Global fetch is not available; use Node.js 18 or newer.');
+  }
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required to discover workflow artifacts.');
+  }
+  if (!owner || !repo) {
+    throw new Error('GITHUB_REPOSITORY must be set as owner/repo.');
+  }
+
+  const artifacts = [];
+  let page = 1;
+  while (page <= 20) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/actions/artifacts?per_page=100&page=${page}`,
+      {
+        headers: {
+          accept: 'application/vnd.github+json',
+          authorization: `Bearer ${token}`,
+          'x-github-api-version': '2022-11-28',
+          'user-agent': 'artifact-cache-action',
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to list artifacts: ${response.status} ${response.statusText}`);
+    }
+    const payload = await response.json();
+    const pageArtifacts = Array.isArray(payload.artifacts) ? payload.artifacts : [];
+    artifacts.push(...pageArtifacts);
+    if (pageArtifacts.length < 100) {
+      break;
+    }
+    page += 1;
+  }
+  return artifacts;
+}
+
+function writeOutputs(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    for (const [key, value] of Object.entries(outputs)) {
+      process.stdout.write(`${key}=${value}\n`);
+    }
+    return;
+  }
+
+  const lines = [];
+  for (const [key, value] of Object.entries(outputs)) {
+    lines.push(`${key}=${value}`);
+  }
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function buildPlanFromEnv() {
+  return deriveCachePlan({
+    cacheKeyBase: process.env.INPUT_CACHE_KEY_BASE,
+    windowResolution: process.env.INPUT_WINDOW_RESOLUTION || 'weekly',
+    artifactName: process.env.INPUT_ARTIFACT_NAME,
+    artifactPath: process.env.INPUT_ARTIFACT_PATH || '',
+    now: process.env.ARTIFACT_CACHE_NOW || new Date(),
+    runId: process.env.GITHUB_RUN_ID || '',
+    workspace: process.env.GITHUB_WORKSPACE || process.cwd(),
+  });
+}
+
+async function prepareCommand() {
+  const plan = buildPlanFromEnv();
+  fs.mkdirSync(plan.artifactPath, { recursive: true });
+  writeOutputs({
+    'cache-key': plan.cacheKey,
+    'artifact-path': plan.artifactPath,
+    'window-label': plan.window.label,
+    'window-start': plan.window.start ? plan.window.start.toISOString() : '',
+    'window-end': plan.window.end ? plan.window.end.toISOString() : '',
+  });
+}
+
+async function discoverCommand() {
+  const plan = buildPlanFromEnv();
+  const failFast = parseBoolean(process.env.INPUT_FAIL_FAST, false);
+  const [owner, repo] = String(process.env.GITHUB_REPOSITORY || '').split('/');
+  const artifacts = await listArtifacts({
+    token: process.env.GITHUB_TOKEN,
+    owner,
+    repo,
+  });
+  const artifact = selectArtifact(artifacts, {
+    artifactName: plan.artifactName,
+    window: plan.window,
+    runId: process.env.GITHUB_RUN_ID || '',
+  });
+
+  if (!artifact) {
+    const message = [
+      `Artifact "${plan.artifactName}" was not found in ${plan.window.resolution}`,
+      `window "${plan.window.label}".`,
+    ].join(' ');
+    if (failFast) {
+      console.error(`::error title=Required artifact missing::${message}`);
+      throw new Error(message);
+    }
+    console.log(`::notice::${message} Producer steps may repopulate ${plan.artifactPath}.`);
+    writeOutputs({
+      'artifact-found': 'false',
+      'artifact-id': '',
+      'run-id': '',
+    });
+    return;
+  }
+
+  const runId = artifact.workflow_run?.id || artifact.workflow_run?.run_id || '';
+  writeOutputs({
+    'artifact-found': 'true',
+    'artifact-id': String(artifact.id || ''),
+    'run-id': String(runId),
+  });
+}
+
+async function main() {
+  const command = process.argv[2] || 'prepare';
+  if (command === 'prepare') {
+    await prepareCommand();
+    return;
+  }
+  if (command === 'discover') {
+    await discoverCommand();
+    return;
+  }
+  throw new Error(`Unknown artifact_cache command: ${command}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  deriveCachePlan,
+  deriveWindow,
+  isoWeekParts,
+  parseBoolean,
+  sanitizeSegment,
+  selectArtifact,
+};

--- a/.github/scripts/__tests__/artifact-cache.test.js
+++ b/.github/scripts/__tests__/artifact-cache.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  deriveCachePlan,
+  deriveWindow,
+  parseBoolean,
+  selectArtifact,
+} = require('../../actions/artifact-cache/artifact_cache');
+
+test('derives weekly cache key using ISO run window', () => {
+  const plan = deriveCachePlan({
+    cacheKeyBase: 'weekly-metrics',
+    artifactName: 'agent-weekly-metrics',
+    now: '2026-05-06T12:00:00Z',
+    windowResolution: 'weekly',
+  });
+
+  assert.equal(plan.cacheKey, 'weekly-metrics-2026-W19');
+  assert.equal(plan.window.start.toISOString(), '2026-05-04T00:00:00.000Z');
+  assert.equal(plan.window.end.toISOString(), '2026-05-11T00:00:00.000Z');
+  assert.equal(
+    plan.artifactPath,
+    path.join('.artifact-cache', 'weekly-metrics', '2026-W19', 'agent-weekly-metrics'),
+  );
+});
+
+test('derives daily and run cache keys', () => {
+  assert.equal(
+    deriveCachePlan({
+      cacheKeyBase: 'ci-artifacts',
+      artifactName: 'coverage',
+      now: '2026-05-06T23:30:00Z',
+      windowResolution: 'daily',
+    }).cacheKey,
+    'ci-artifacts-2026-05-06',
+  );
+
+  const runPlan = deriveCachePlan({
+    cacheKeyBase: 'ci-artifacts',
+    artifactName: 'coverage',
+    windowResolution: 'run',
+    runId: '12345',
+  });
+  assert.equal(runPlan.cacheKey, 'ci-artifacts-run-12345');
+  assert.equal(runPlan.window.label, 'run-12345');
+});
+
+test('supports explicit artifact path for workflow compatibility', () => {
+  const plan = deriveCachePlan({
+    cacheKeyBase: 'coverage',
+    artifactName: 'gate-coverage',
+    artifactPath: 'coverage_artifacts/payload',
+    now: '2026-05-06T12:00:00Z',
+  });
+
+  assert.equal(plan.artifactPath, 'coverage_artifacts/payload');
+});
+
+test('selects newest matching artifact in the active window', () => {
+  const window = deriveWindow({
+    resolution: 'weekly',
+    now: '2026-05-06T12:00:00Z',
+  });
+  const artifact = selectArtifact([
+    {
+      id: 1,
+      name: 'gate-coverage',
+      created_at: '2026-04-30T00:00:00Z',
+      workflow_run: { id: 100 },
+    },
+    {
+      id: 2,
+      name: 'gate-coverage',
+      created_at: '2026-05-05T00:00:00Z',
+      workflow_run: { id: 101 },
+    },
+    {
+      id: 3,
+      name: 'gate-coverage',
+      created_at: '2026-05-06T00:00:00Z',
+      workflow_run: { id: 102 },
+    },
+    {
+      id: 4,
+      name: 'other',
+      created_at: '2026-05-07T00:00:00Z',
+      workflow_run: { id: 103 },
+    },
+  ], {
+    artifactName: 'gate-coverage',
+    window,
+  });
+
+  assert.equal(artifact.id, 3);
+});
+
+test('ignores expired artifacts and run-window mismatches', () => {
+  const runWindow = deriveWindow({
+    resolution: 'run',
+    runId: '555',
+  });
+  const artifact = selectArtifact([
+    {
+      id: 1,
+      name: 'selftest-report',
+      created_at: '2026-05-06T00:00:00Z',
+      workflow_run: { id: 444 },
+    },
+    {
+      id: 2,
+      name: 'selftest-report',
+      created_at: '2026-05-06T00:00:00Z',
+      expired: true,
+      workflow_run: { id: 555 },
+    },
+    {
+      id: 3,
+      name: 'selftest-report',
+      created_at: '2026-05-06T00:00:00Z',
+      workflow_run: { id: 555 },
+    },
+  ], {
+    artifactName: 'selftest-report',
+    window: runWindow,
+    runId: '555',
+  });
+
+  assert.equal(artifact.id, 3);
+});
+
+test('returns null on cache miss so producers can fall through', () => {
+  const artifact = selectArtifact([], {
+    artifactName: 'missing',
+    window: deriveWindow({ resolution: 'daily', now: '2026-05-06T00:00:00Z' }),
+  });
+
+  assert.equal(artifact, null);
+});
+
+test('parses fail-fast boolean inputs strictly', () => {
+  assert.equal(parseBoolean('true'), true);
+  assert.equal(parseBoolean('false'), false);
+  assert.equal(parseBoolean('', true), true);
+  assert.throws(() => parseBoolean('sometimes'), /Invalid boolean value/);
+});
+
+test('action metadata exposes required public inputs and outputs', () => {
+  const metadata = fs.readFileSync(
+    path.join(__dirname, '../../actions/artifact-cache/action.yml'),
+    'utf8',
+  );
+
+  assert.match(metadata, /cache-key-base:/);
+  assert.match(metadata, /window-resolution:/);
+  assert.match(metadata, /artifact-name:/);
+  assert.match(metadata, /fail-fast:/);
+  assert.match(metadata, /cache-hit:/);
+  assert.match(metadata, /artifact-path:/);
+  assert.match(metadata, /actions\/cache@v5/);
+});

--- a/.github/scripts/__tests__/artifact-cache.test.js
+++ b/.github/scripts/__tests__/artifact-cache.test.js
@@ -161,6 +161,7 @@ test('action metadata exposes required public inputs and outputs', () => {
   assert.match(metadata, /artifact-name:/);
   assert.match(metadata, /fail-fast:/);
   assert.match(metadata, /cache-hit:/);
+  assert.match(metadata, /artifact-found:/);
   assert.match(metadata, /artifact-path:/);
   assert.match(metadata, /actions\/cache@v5/);
 });

--- a/.github/scripts/__tests__/artifact-cache.test.js
+++ b/.github/scripts/__tests__/artifact-cache.test.js
@@ -72,32 +72,61 @@ test('selects newest matching artifact in the active window', () => {
       id: 1,
       name: 'gate-coverage',
       created_at: '2026-04-30T00:00:00Z',
-      workflow_run: { id: 100 },
+      workflow_run: { id: 100, head_branch: 'main' },
     },
     {
       id: 2,
       name: 'gate-coverage',
       created_at: '2026-05-05T00:00:00Z',
-      workflow_run: { id: 101 },
+      workflow_run: { id: 101, head_branch: 'feature' },
     },
     {
       id: 3,
       name: 'gate-coverage',
       created_at: '2026-05-06T00:00:00Z',
-      workflow_run: { id: 102 },
+      workflow_run: { id: 102, head_branch: 'main' },
     },
     {
       id: 4,
       name: 'other',
       created_at: '2026-05-07T00:00:00Z',
-      workflow_run: { id: 103 },
+      workflow_run: { id: 103, head_branch: 'main' },
     },
   ], {
     artifactName: 'gate-coverage',
     window,
+    producerBranch: 'main',
   });
 
   assert.equal(artifact.id, 3);
+});
+
+test('can scope artifact discovery to an exact producer run', () => {
+  const window = deriveWindow({
+    resolution: 'weekly',
+    now: '2026-05-06T12:00:00Z',
+  });
+  const artifact = selectArtifact([
+    {
+      id: 1,
+      name: 'gate-coverage',
+      created_at: '2026-05-06T02:00:00Z',
+      workflow_run: { id: 100, head_branch: 'main' },
+    },
+    {
+      id: 2,
+      name: 'gate-coverage',
+      created_at: '2026-05-06T03:00:00Z',
+      workflow_run: { id: 101, head_branch: 'main' },
+    },
+  ], {
+    artifactName: 'gate-coverage',
+    window,
+    producerRunId: '100',
+    producerBranch: 'main',
+  });
+
+  assert.equal(artifact.id, 1);
 });
 
 test('ignores expired artifacts and run-window mismatches', () => {
@@ -160,6 +189,8 @@ test('action metadata exposes required public inputs and outputs', () => {
   assert.match(metadata, /window-resolution:/);
   assert.match(metadata, /artifact-name:/);
   assert.match(metadata, /fail-fast:/);
+  assert.match(metadata, /producer-run-id:/);
+  assert.match(metadata, /producer-branch:/);
   assert.match(metadata, /cache-hit:/);
   assert.match(metadata, /artifact-found:/);
   assert.match(metadata, /artifact-path:/);

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -608,6 +608,10 @@ actions:
     is_directory: true
     description: "Classifies changed PR paths for path-aware expensive job gating"
 
+  - source: .github/actions/artifact-cache/
+    is_directory: true
+    description: "Restores, discovers, and caches workflow artifacts by daily, weekly, or run window"
+
 # Configuration files for LLM providers and workflows
 llm_config:
   - source: config/llm_slots.json


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- add `.github/actions/artifact-cache` to restore a run-window cache before discovering workflow artifacts
- derive cache keys by daily, weekly, or run window and expose the restored/downloaded artifact path
- add fail-fast missing-artifact behavior and focused Node tests
- add the composite action to `.github/sync-manifest.yml`

## Validation
- `node --test .github/scripts/__tests__/artifact-cache.test.js`
- `python scripts/check_api_wrapper_guard.py --base-ref origin/main`
- `yq '.' .github/actions/artifact-cache/action.yml >/dev/null`
- `scripts/sync_templates.sh`
- `scripts/validate_template_completeness.py`
