### PR TITLE
fix: address Template sync review feedback

### DIFF
--- a/.github/scripts/__tests__/issue_context_utils.test.js
+++ b/.github/scripts/__tests__/issue_context_utils.test.js
@@ -1,7 +1,14 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
 
-const { buildIssueContext, EXPECTED_SECTIONS, ALL_SECTIONS } = require('../issue_context_utils.js');
+const {
+  buildCappedIssuePayload,
+  buildIssueContext,
+  EXPECTED_SECTIONS,
+  ALL_SECTIONS,
+} = require('../issue_context_utils.js');
 
 const COMPLETE_BODY = `
 ## Scope
@@ -84,4 +91,30 @@ test('ALL_SECTIONS includes all section names', () => {
   assert.ok(ALL_SECTIONS.includes('Scope'));
   assert.ok(ALL_SECTIONS.includes('Tasks'));
   assert.ok(ALL_SECTIONS.includes('Acceptance Criteria'));
+});
+
+test('buildCappedIssuePayload removes temporary input directory', () => {
+  const originalExecFileSync = childProcess.execFileSync;
+  let tempDir = '';
+  childProcess.execFileSync = (_command, args) => {
+    const inputPath = args[args.indexOf('--input-file') + 1];
+    tempDir = inputPath.replace(/\/issue\.md$/, '');
+    assert.ok(fs.existsSync(inputPath));
+    return JSON.stringify({
+      formatted_body: '## Tasks\n- [ ] trimmed',
+      truncated: true,
+      estimated_tokens: 3,
+      token_budget: 4,
+    });
+  };
+
+  try {
+    const result = buildCappedIssuePayload('## Tasks\n- [ ] raw');
+
+    assert.equal(result.formattedBody, '## Tasks\n- [ ] trimmed');
+    assert.equal(result.truncated, true);
+    assert.equal(fs.existsSync(tempDir), false);
+  } finally {
+    childProcess.execFileSync = originalExecFileSync;
+  }
 });

--- a/.github/scripts/issue_context_utils.js
+++ b/.github/scripts/issue_context_utils.js
@@ -17,8 +17,9 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     return { formattedBody: body, truncated: false };
   }
 
+  let tmpDir = '';
   try {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-issue-context-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-issue-context-'));
     const inputPath = path.join(tmpDir, 'issue.md');
     fs.writeFileSync(inputPath, body, 'utf8');
     const args = [
@@ -43,6 +44,10 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     };
   } catch (_error) {
     return { formattedBody: body, truncated: false };
+  } finally {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 }
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -13,6 +13,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -114,56 +116,92 @@ def materialize_reference_packs(
     reference_dir.mkdir(exist_ok=True)
 
     for plan in plans:
-        clone_dir = Path("/tmp") / f"ref-pack-{plan.name}"
-        shutil.rmtree(clone_dir, ignore_errors=True)
-        clone_url = f"https://github.com/{plan.repo}.git"
+        clone_parent = Path(tempfile.mkdtemp(prefix=f"ref-pack-{plan.name}-"))
+        clone_dir = clone_parent / "repo"
+        askpass_path = clone_parent / "git-askpass.sh"
+        git_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
         if token:
-            clone_url = f"https://x-access-token:{token}@github.com/{plan.repo}.git"
+            askpass_path.write_text(
+                "#!/bin/sh\n"
+                'case "$1" in\n'
+                "  *Username*) printf '%s\\n' \"${GIT_ASKPASS_USERNAME:-x-access-token}\" ;;\n"
+                "  *) printf '%s\\n' \"$GIT_ASKPASS_PASSWORD\" ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            askpass_path.chmod(0o700)
+            git_env.update(
+                {
+                    "GIT_ASKPASS": str(askpass_path),
+                    "GIT_ASKPASS_USERNAME": "x-access-token",
+                    "GIT_ASKPASS_PASSWORD": token,
+                }
+            )
 
+        clone_url = f"https://github.com/{plan.repo}.git"
         clone_cmd = ["git", "clone", "--depth=1", "--filter=blob:none", "--sparse"]
         is_sha = bool(re.fullmatch(r"[0-9a-fA-F]{40}", plan.ref))
         if not is_sha:
             clone_cmd.extend(["--branch", plan.ref])
         clone_cmd.extend([clone_url, str(clone_dir)])
-        subprocess.check_call(clone_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-        if is_sha:
+        try:
             subprocess.check_call(
-                ["git", "-C", str(clone_dir), "fetch", "origin", plan.ref, "--depth=1"],
+                clone_cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-            )
-            subprocess.check_call(
-                ["git", "-C", str(clone_dir), "checkout", plan.ref],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                env=git_env,
             )
 
-        subprocess.check_call(
-            ["git", "-C", str(clone_dir), "sparse-checkout", "set", "--no-cone", *plan.paths],
-            stdout=subprocess.DEVNULL,
-        )
-        subprocess.check_call(
-            ["git", "-C", str(clone_dir), "sparse-checkout", "reapply"],
-            stdout=subprocess.DEVNULL,
-        )
-
-        checkout_path = workspace_path / plan.checkout_path
-        checkout_path.mkdir(parents=True, exist_ok=True)
-        for rel_path in plan.paths:
-            src = clone_dir / rel_path
-            dst = checkout_path / rel_path
-            if src.is_dir():
-                shutil.copytree(src, dst, dirs_exist_ok=True)
-            elif src.is_file():
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, dst)
-            else:
-                print(
-                    f"warning: path '{rel_path}' not found in {plan.repo}@{plan.ref}",
-                    file=sys.stderr,
+            if is_sha:
+                subprocess.check_call(
+                    ["git", "-C", str(clone_dir), "fetch", "origin", plan.ref, "--depth=1"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=git_env,
                 )
-        shutil.rmtree(clone_dir, ignore_errors=True)
+                subprocess.check_call(
+                    ["git", "-C", str(clone_dir), "checkout", plan.ref],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=git_env,
+                )
+
+            subprocess.check_call(
+                [
+                    "git",
+                    "-C",
+                    str(clone_dir),
+                    "sparse-checkout",
+                    "set",
+                    "--no-cone",
+                    *plan.paths,
+                ],
+                stdout=subprocess.DEVNULL,
+                env=git_env,
+            )
+            subprocess.check_call(
+                ["git", "-C", str(clone_dir), "sparse-checkout", "reapply"],
+                stdout=subprocess.DEVNULL,
+                env=git_env,
+            )
+
+            checkout_path = workspace_path / plan.checkout_path
+            checkout_path.mkdir(parents=True, exist_ok=True)
+            for rel_path in plan.paths:
+                src = clone_dir / rel_path
+                dst = checkout_path / rel_path
+                if src.is_dir():
+                    shutil.copytree(src, dst, dirs_exist_ok=True)
+                elif src.is_file():
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dst)
+                else:
+                    print(
+                        f"warning: path '{rel_path}' not found in {plan.repo}@{plan.ref}",
+                        file=sys.stderr,
+                    )
+        finally:
+            shutil.rmtree(clone_parent, ignore_errors=True)
 
     summary_path = reference_dir / "REFERENCE_PACKS.md"
     with summary_path.open("w", encoding="utf-8") as handle:
@@ -299,8 +337,19 @@ def parse_runner_output(provider: str, raw_output: str) -> RunnerResult:
     messages, errors = _parse_jsonl_output(clipped) if provider == "codex" else ([], [])
     final_message = messages[-1] if messages else clipped.strip()
 
-    if not errors and re.search(r"(^::error::|\bTraceback\b|\bError:|\bException\b)", clipped):
-        first = next((line.strip() for line in clipped.splitlines() if line.strip()), "")
+    if not errors and re.search(
+        r"(^::error::|\bTraceback\b|\bError:|\bException\b)",
+        clipped,
+        re.MULTILINE,
+    ):
+        first = next(
+            (
+                line.strip()
+                for line in clipped.splitlines()
+                if re.search(r"^::error::|\bTraceback\b|\bError:|\bException\b", line)
+            ),
+            "",
+        )
         errors.append(first or "runner output indicates an error")
 
     if not final_message:
@@ -366,12 +415,25 @@ class PrCommentRunnerStorage:
         repo, token = _github_context()
         return cls(GitHubApi(repo, token))
 
-    def _comments(self, pr_number: int) -> list[dict[str, Any]]:
-        return self.api.paged_get(f"/repos/{self.api.repo}/issues/{pr_number}/comments")
+    def _iter_comments(self, pr_number: int) -> Iterator[dict[str, Any]]:
+        page = 1
+        while True:
+            batch = self.api.request(
+                "GET",
+                f"/repos/{self.api.repo}/issues/{pr_number}/comments?per_page=100&page={page}",
+            )
+            if not isinstance(batch, list):
+                raise RuntimeError(
+                    f"Expected list response from GitHub API comments page for PR {pr_number}"
+                )
+            yield from reversed(batch)
+            if len(batch) < 100:
+                return
+            page += 1
 
     def _find_comment(self, pr_number: int, provider: str) -> dict[str, Any] | None:
         pattern = _marker_re(pr_number, provider)
-        for comment in reversed(self._comments(pr_number)):
+        for comment in self._iter_comments(pr_number):
             body = comment.get("body")
             if isinstance(body, str) and pattern.search(body):
                 return comment

--- a/templates/consumer-repo/.github/scripts/issue_context_utils.js
+++ b/templates/consumer-repo/.github/scripts/issue_context_utils.js
@@ -17,8 +17,9 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     return { formattedBody: body, truncated: false };
   }
 
+  let tmpDir = '';
   try {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-issue-context-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workflows-issue-context-'));
     const inputPath = path.join(tmpDir, 'issue.md');
     fs.writeFileSync(inputPath, body, 'utf8');
     const args = [
@@ -43,6 +44,10 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     };
   } catch (_error) {
     return { formattedBody: body, truncated: false };
+  } finally {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
 }
 

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,7 @@ from scripts.runner_lib import (
     record_completion,
     should_dispatch,
 )
+from scripts.runner_lib.core import PrCommentRunnerStorage, materialize_reference_packs
 
 
 class MemoryRunnerStorage:
@@ -112,6 +114,13 @@ def test_parse_runner_output_detects_error() -> None:
     assert result.summary == "Error: auth failed"
 
 
+def test_parse_runner_output_detects_multiline_error_annotation() -> None:
+    result = parse_runner_output("claude", "Starting work\n::error:: auth failed\n")
+
+    assert result.success is False
+    assert result.error == "::error:: auth failed"
+
+
 def test_parse_runner_output_marks_truncated_output() -> None:
     result = parse_runner_output("claude", "x" * 65000)
 
@@ -146,3 +155,72 @@ def test_record_completion_is_idempotent_for_same_key() -> None:
     assert second["status"] == "completed"
     assert second["completed_at"] == first["completed_at"]
     assert storage.records[(42, "claude")]["result"]["summary"] == "Done"
+
+
+def test_materialize_reference_packs_keeps_token_out_of_git_argv(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "reference_packs.json").write_text(
+        json.dumps(
+            {
+                "baseline": {
+                    "repo": "owner/private",
+                    "ref": "main",
+                    "paths": ["README.md"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_check_call(cmd: list[str], **kwargs: Any) -> int:
+        env = kwargs.get("env") or {}
+        calls.append((cmd, env))
+        assert "secret-token" not in " ".join(cmd)
+        if cmd[:2] == ["git", "clone"]:
+            clone_dir = Path(cmd[-1])
+            clone_dir.mkdir(parents=True)
+            (clone_dir / "README.md").write_text("reference\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(subprocess, "check_call", fake_check_call)
+
+    summary = materialize_reference_packs(tmp_path, token="secret-token")
+
+    assert summary == tmp_path / ".reference" / "REFERENCE_PACKS.md"
+    assert (tmp_path / ".reference" / "baseline" / "README.md").is_file()
+    assert calls
+    assert all(env.get("GIT_ASKPASS_PASSWORD") == "secret-token" for _cmd, env in calls)
+
+
+def test_pr_comment_storage_stops_when_marker_found() -> None:
+    class FakeApi:
+        repo = "owner/repo"
+
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+            self.paths.append(path)
+            assert method == "GET"
+            assert body is None
+            return [
+                {"body": "ordinary comment", "id": 1},
+                {
+                    "body": (
+                        "Runner dispatch state\n\n<!-- runner-dispatch:codex:42:v1 "
+                        '{"provider":"codex","head_sha":"abc"} -->'
+                    ),
+                    "id": 2,
+                },
+            ]
+
+    api = FakeApi()
+    storage = PrCommentRunnerStorage(api)  # type: ignore[arg-type]
+
+    record = storage.read_record(42, "codex")
+
+    assert record == {"provider": "codex", "head_sha": "abc"}
+    assert len(api.paths) == 1


### PR DESCRIPTION
## Summary
- clean issue context temp directories after capped payload generation in source and consumer template copies
- avoid putting GitHub tokens in git clone argv when materializing runner reference packs
- detect multiline GitHub error annotations in runner output
- scan PR comments page-by-page for runner dispatch markers instead of materializing all comments first

## Validation
- pytest tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py -q
- node --test .github/scripts/__tests__/issue_context_utils.test.js
- ruff check scripts/runner_lib/core.py tests/scripts/test_runner_lib.py
- black --target-version py312 --check scripts/runner_lib/core.py tests/scripts/test_runner_lib.py
- PYTHONPYCACHEPREFIX=/tmp/workflows-sync-review-pycache python3 -m py_compile scripts/runner_lib/core.py scripts/reference_packs.py scripts/state_fingerprint.py
- git diff --check

Source follow-up for Template sync PR stranske/Template#688.