### PR TITLE
feat: wire verifier-config module into 4 verifier workflows

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -197,9 +197,49 @@ jobs:
             // Set outputs
             core.setOutput('has_original_issue', linkedIssueNumber ? 'true' : 'false');
 
+      - name: Validate terminal verifier artifact
+        id: terminal-artifact
+        if: steps.check-merged.outputs.merged == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import os
+
+          from scripts.langchain.verifier_config import (
+              artifact_from_verification_text,
+              is_terminal_artifact,
+          )
+
+          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          artifact = artifact_from_verification_text(raw)
+          terminal = is_terminal_artifact(artifact)
+          verdict = str(artifact.get("verdict") or "")
+          reason = (
+              "terminal verifier output"
+              if terminal
+              else "verifier output is partial or missing a terminal verdict"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"terminal={str(terminal).lower()}\n")
+              handle.write(f"verdict={verdict}\n")
+              handle.write(f"reason={reason}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("## Terminal verifier artifact gate\n\n")
+              handle.write(f"- Terminal: `{str(terminal).lower()}`\n")
+              if verdict:
+                  handle.write(f"- Verdict: `{verdict}`\n")
+              handle.write(f"- Reason: {reason}\n")
+          PY
+
       - name: Generate follow-up issue
         id: generate
-        if: steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
@@ -230,7 +270,10 @@ jobs:
 
       - name: Fallback to simple extraction
         id: fallback
-        if: steps.generate.outcome == 'failure' && steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.generate.outcome == 'failure' &&
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         uses: actions/github-script@v9
         with:
           github-token: ${{ steps.select-token.outputs.token }}
@@ -313,7 +356,9 @@ jobs:
 
       - name: Create follow-up issue
         id: create-issue
-        if: steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         uses: actions/github-script@v9
         env:
           ISSUE_TITLE: >-
@@ -380,7 +425,9 @@ jobs:
             core.setOutput('issue_url', issue.data.html_url);
 
       - name: Comment on original PR
-        if: steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         uses: actions/github-script@v9
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -245,9 +245,49 @@ jobs:
             // Set outputs
             core.setOutput('has_original_issue', linkedIssueNumber ? 'true' : 'false');
 
+      - name: Validate terminal verifier artifact
+        id: terminal-artifact
+        if: steps.check-merged.outputs.merged == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import os
+
+          from scripts.langchain.verifier_config import (
+              artifact_from_verification_text,
+              is_terminal_artifact,
+          )
+
+          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          artifact = artifact_from_verification_text(raw)
+          terminal = is_terminal_artifact(artifact)
+          verdict = str(artifact.get("verdict") or "")
+          reason = (
+              "terminal verifier output"
+              if terminal
+              else "verifier output is partial or missing a terminal verdict"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"terminal={str(terminal).lower()}\n")
+              handle.write(f"verdict={verdict}\n")
+              handle.write(f"reason={reason}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("## Terminal verifier artifact gate\n\n")
+              handle.write(f"- Terminal: `{str(terminal).lower()}`\n")
+              if verdict:
+                  handle.write(f"- Verdict: `{verdict}`\n")
+              handle.write(f"- Reason: {reason}\n")
+          PY
+
       - name: Check chain depth limit
         id: chain-check
-        if: steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
@@ -373,6 +413,7 @@ jobs:
         id: extract-verdict
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true'
         continue-on-error: true
         env:
@@ -387,6 +428,7 @@ jobs:
         id: verdict-needs-human
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -457,6 +499,7 @@ jobs:
         id: generate
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         continue-on-error: true
@@ -503,6 +546,7 @@ jobs:
         if: >-
           steps.generate.outcome == 'failure' &&
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -675,6 +719,7 @@ jobs:
         id: create-issue
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -776,6 +821,7 @@ jobs:
         id: dispatch-autopilot
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true' &&
           steps.create-issue.outputs.issue_number != ''
@@ -814,6 +860,7 @@ jobs:
       - name: Comment on original PR
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.langchain import verdict_policy
+from scripts.langchain.verifier_config import EVAL_FOLLOW_UP_BUDGET_TOKENS
 
 try:
     from scripts.langchain.injection_guard import check_prompt_injection
@@ -69,6 +70,8 @@ SECTION_TITLES = {
     "acceptance": "Acceptance Criteria",
     "implementation": "Implementation Notes",
 }
+
+TOKEN_CHARS = 4
 
 LIST_ITEM_REGEX = re.compile(r"^\s*([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
@@ -1387,6 +1390,19 @@ def generate_followup_issue(
         )
 
 
+def _budget_followup_tasks(tasks: list[str]) -> list[str]:
+    budget = max(1, EVAL_FOLLOW_UP_BUDGET_TOKENS)
+    used = 0
+    selected: list[str] = []
+    for task in tasks:
+        estimated = max(1, (len(task) + TOKEN_CHARS - 1) // TOKEN_CHARS)
+        if selected and used + estimated > budget:
+            break
+        selected.append(task)
+        used += estimated
+    return selected
+
+
 def _generate_with_llm(
     verification_data: VerificationData,
     original_issue: OriginalIssueData,
@@ -1445,8 +1461,8 @@ def _generate_with_llm(
     tasks_prompt = GENERATE_TASKS_PROMPT.format(
         analysis_json=json.dumps(analysis, indent=2),
         original_tasks="\n".join(
-            f"- [ ] {t}" for t in original_issue.tasks[:20]
-        ),  # Limit for token budget
+            f"- [ ] {t}" for t in _budget_followup_tasks(original_issue.tasks)
+        ),
     )
 
     tasks_response, trace_id_2, trace_url_2 = _invoke_llm(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -26,8 +26,15 @@ from scripts.langchain.structured_output import (
     build_repair_callback,
     parse_structured_output,
 )
+from scripts.langchain.verifier_config import (
+    EVAL_PAIR_BUDGET_TOKENS,
+    EVAL_SCHEMA_REPAIR_BUDGET_TOKENS,
+    SchemaRepairPolicy,
+)
 
 LOGGER = logging.getLogger(__name__)
+SCHEMA_REPAIR_POLICY = SchemaRepairPolicy()
+TOKEN_CHARS = 4
 
 PR_EVALUATION_PROMPT = """
 You are reviewing a **merged** pull request to evaluate whether the code
@@ -409,6 +416,8 @@ def _get_chain_depth() -> int:
 def _prepare_prompt(context: str, diff: str | None) -> str:
     diff_block = diff.strip() if diff and diff.strip() else "(diff unavailable)"
     context_block = context.strip() if context and context.strip() else "(context unavailable)"
+    diff_block = _cap_prompt_text(diff_block, EVAL_PAIR_BUDGET_TOKENS)
+    context_block = _cap_prompt_text(context_block, EVAL_PAIR_BUDGET_TOKENS)
 
     change_type = _classify_change_type(diff)
 
@@ -435,6 +444,14 @@ def _prepare_prompt(context: str, diff: str | None) -> str:
         prompt = prompt.rstrip() + "\n\n" + CHAIN_DEPTH_ADDENDUM.format(depth=chain_depth) + "\n"
 
     return prompt.format(context=context_block, diff=diff_block)
+
+
+def _cap_prompt_text(text: str, token_budget: int) -> str:
+    max_chars = max(1, token_budget) * TOKEN_CHARS
+    if len(text) <= max_chars:
+        return text
+    marker = "\n[truncated: verifier prompt budget exceeded]"
+    return text[: max(0, max_chars - len(marker))].rstrip() + marker
 
 
 def _extract_pr_metadata(context: str) -> tuple[int | None, str | None]:
@@ -663,17 +680,25 @@ def _fallback_evaluation(
 def _parse_llm_response(
     content: str, provider: str, *, client: object | None = None
 ) -> EvaluationResult:
+    repair = _build_verifier_repair_callback(client) if client is not None else None
     parsed = parse_structured_output(
         content,
         EvaluationPayload,
-        repair=(build_repair_callback(client) if client is not None else None),
-        max_repair_attempts=1,
+        repair=repair,
+        max_repair_attempts=SCHEMA_REPAIR_POLICY.max_attempts,
     )
     if parsed.payload is None:
+        decision = SCHEMA_REPAIR_POLICY.terminal_decision(
+            repair_attempts_used=parsed.repair_attempts_used,
+            error_stage=parsed.error_stage,
+            has_payload=False,
+        )
         if parsed.error_stage == "repair_validation":
             error = f"Failed to parse JSON response after repair: {parsed.error_detail}"
         else:
             error = f"Failed to parse JSON response: {parsed.error_detail}"
+        if decision == "escalate":
+            error = f"Schema repair policy escalated verifier output: {error}"
         return EvaluationResult(
             verdict="CONCERNS",
             scores=None,
@@ -696,6 +721,19 @@ def _parse_llm_response(
         used_llm=True,
         raw_content=parsed.raw_content or content,
     )
+
+
+def _build_verifier_repair_callback(client: object):
+    repair = build_repair_callback(client)
+
+    def _repair(schema_json: str, validation_errors: str, raw_response: str) -> str | None:
+        return repair(
+            schema_json,
+            validation_errors,
+            _cap_prompt_text(raw_response, EVAL_SCHEMA_REPAIR_BUDGET_TOKENS),
+        )
+
+    return _repair
 
 
 def _is_auth_error(exc: Exception) -> bool:

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -104,6 +105,40 @@ def is_terminal_artifact(verifier_run: Any) -> bool:
     return False
 
 
+def artifact_from_verification_text(text: str) -> dict[str, Any]:
+    """Build a verifier artifact candidate from a posted verifier report."""
+
+    raw = (text or "").strip()
+    artifact: dict[str, Any] = {"raw_present": bool(raw)}
+    if not raw:
+        return artifact
+
+    parsed = _coerce_artifact(raw)
+    if isinstance(parsed, dict):
+        return parsed
+
+    verdicts = _extract_verdicts(raw)
+    if verdicts:
+        artifact["verdict"] = (
+            "PASS" if all(verdict == "PASS" for verdict in verdicts) else "CONCERNS"
+        )
+
+    lowered = raw.lower()
+    artifact["repair_pending"] = any(
+        phrase in lowered
+        for phrase in (
+            "repair pending",
+            "schema repair pending",
+            "validation retry",
+            "pending repair",
+            "partial verifier output",
+        )
+    )
+    if "## pr verification" in lowered or "verdict:" in lowered:
+        artifact["artifact_family"] = "verifier-report"
+    return artifact
+
+
 def _coerce_artifact(value: Any) -> Any:
     if value is None:
         return None
@@ -122,6 +157,23 @@ def _coerce_artifact(value: Any) -> Any:
     if hasattr(value, "__dict__"):
         return vars(value)
     return value
+
+
+def _extract_verdicts(text: str) -> list[str]:
+    verdicts: list[str] = []
+    for match in re.finditer(r"verdict:\s*\*?\*?\s*(pass|concerns|fail|error)\b", text, re.I):
+        verdicts.append(match.group(1).upper())
+
+    for match in re.finditer(
+        r"\|\s*[^|\n]+\s*\|\s*[^|\n]*\|\s*(pass|concerns|fail|error)\s*\|", text, re.I
+    ):
+        verdicts.append(match.group(1).upper())
+
+    seen: list[str] = []
+    for verdict in verdicts:
+        if verdict not in seen:
+            seen.append(verdict)
+    return seen
 
 
 def _has_pending_repair(data: dict[str, Any]) -> bool:

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -245,9 +245,49 @@ jobs:
             // Set outputs
             core.setOutput('has_original_issue', linkedIssueNumber ? 'true' : 'false');
 
+      - name: Validate terminal verifier artifact
+        id: terminal-artifact
+        if: steps.check-merged.outputs.merged == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import os
+
+          from scripts.langchain.verifier_config import (
+              artifact_from_verification_text,
+              is_terminal_artifact,
+          )
+
+          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          artifact = artifact_from_verification_text(raw)
+          terminal = is_terminal_artifact(artifact)
+          verdict = str(artifact.get("verdict") or "")
+          reason = (
+              "terminal verifier output"
+              if terminal
+              else "verifier output is partial or missing a terminal verdict"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"terminal={str(terminal).lower()}\n")
+              handle.write(f"verdict={verdict}\n")
+              handle.write(f"reason={reason}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("## Terminal verifier artifact gate\n\n")
+              handle.write(f"- Terminal: `{str(terminal).lower()}`\n")
+              if verdict:
+                  handle.write(f"- Verdict: `{verdict}`\n")
+              handle.write(f"- Reason: {reason}\n")
+          PY
+
       - name: Check chain depth limit
         id: chain-check
-        if: steps.check-merged.outputs.merged == 'true'
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CHAIN_DEPTH: ${{ steps.collect.outputs.chain_depth }}
@@ -373,6 +413,7 @@ jobs:
         id: extract-verdict
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true'
         continue-on-error: true
         env:
@@ -387,6 +428,7 @@ jobs:
         id: verdict-needs-human
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -457,6 +499,7 @@ jobs:
         id: generate
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         continue-on-error: true
@@ -503,6 +546,7 @@ jobs:
         if: >-
           steps.generate.outcome == 'failure' &&
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -675,6 +719,7 @@ jobs:
         id: create-issue
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -776,6 +821,7 @@ jobs:
         id: dispatch-autopilot
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true' &&
           steps.create-issue.outputs.issue_number != ''
@@ -814,6 +860,7 @@ jobs:
       - name: Comment on original PR
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
+          steps.terminal-artifact.outputs.terminal == 'true' &&
           steps.chain-check.outputs.exceeded != 'true' &&
           steps.extract-verdict.outputs.needs_human != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/tests/scripts/test_verifier_config.py
+++ b/tests/scripts/test_verifier_config.py
@@ -7,6 +7,7 @@ from scripts.langchain.verifier_config import (
     EVAL_PAIR_BUDGET_TOKENS,
     EVAL_SCHEMA_REPAIR_BUDGET_TOKENS,
     SchemaRepairPolicy,
+    artifact_from_verification_text,
     is_terminal_artifact,
 )
 
@@ -99,3 +100,38 @@ def test_is_terminal_artifact_rejects_empty_or_partial_values() -> None:
     assert not is_terminal_artifact("")
     assert not is_terminal_artifact({"summary": "still parsing"})
     assert not is_terminal_artifact({"results": [{"verdict": "PASS"}, {"summary": "partial"}]})
+
+
+def test_artifact_from_verification_text_extracts_terminal_verdict() -> None:
+    artifact = artifact_from_verification_text(
+        "## PR Verification Report\n\n**Verdict:** CONCERNS\n\n### Concerns\n- Missing test."
+    )
+
+    assert artifact["verdict"] == "CONCERNS"
+    assert is_terminal_artifact(artifact)
+
+
+def test_artifact_from_verification_text_rejects_pending_repair_report() -> None:
+    artifact = artifact_from_verification_text(
+        "## PR Verification Report\n\nSchema repair pending; validation retry queued."
+    )
+
+    assert artifact["repair_pending"] is True
+    assert not is_terminal_artifact(artifact)
+
+
+def test_artifact_from_verification_text_resolves_provider_table() -> None:
+    artifact = artifact_from_verification_text(
+        "\n".join(
+            [
+                "## PR Verification Comparison",
+                "| Provider | Model | Verdict | Confidence | Summary |",
+                "| --- | --- | --- | --- | --- |",
+                "| openai | gpt | PASS | 90% | ok |",
+                "| anthropic | claude | FAIL | 70% | gap |",
+            ]
+        )
+    )
+
+    assert artifact["verdict"] == "CONCERNS"
+    assert is_terminal_artifact(artifact)


### PR DESCRIPTION
## Summary
- wire `pr_verifier.py` to shared verifier prompt budgets and `SchemaRepairPolicy`
- wire follow-up generation to `EVAL_FOLLOW_UP_BUDGET_TOKENS`
- add `is_terminal_artifact` gates before verify-to-issue and verify-to-new-pr follow-up generation
- update canonical and consumer-template `agents-verify-to-new-pr.yml` in lockstep

## Validation
- `python -m pytest tests/scripts/test_verifier_config.py tests/scripts/test_pr_verifier_structured_output.py tests/scripts/test_pr_verifier_compare.py tests/scripts/test_pr_verifier_comparison_report.py tests/scripts/test_pr_verifier_fallback.py tests/test_followup_issue_generator.py -q`
- `python -m ruff check scripts/langchain/verifier_config.py scripts/langchain/pr_verifier.py scripts/langchain/followup_issue_generator.py tests/scripts/test_verifier_config.py`
- YAML parsed for the touched verifier workflows
- `python scripts/validate_template_completeness.py`

## Notes
`agents-verifier.yml` is a thin caller and does not carry local verifier policy; it picks up the shared module through `reusable-agents-verifier.yml` and `pr_verifier.py`.