### PR TITLE
feat: wire artifact-cache into 4 cache-relevant workflows

### DIFF
--- a/.github/actions/artifact-cache/artifact_cache.js
+++ b/.github/actions/artifact-cache/artifact_cache.js
@@ -211,7 +211,9 @@ async function listArtifacts({
       },
     );
     if (!response.ok) {
-      throw new Error(`Failed to list artifacts: ${response.status} ${response.statusText}`);
+      const error = new Error(`Failed to list artifacts: ${response.status} ${response.statusText}`);
+      error.status = response.status;
+      throw error;
     }
     const payload = await response.json();
     const pageArtifacts = Array.isArray(payload.artifacts) ? payload.artifacts : [];
@@ -224,6 +226,14 @@ async function listArtifacts({
     page += 1;
   }
   return artifacts;
+}
+
+function writeArtifactMissOutputs() {
+  writeOutputs({
+    'artifact-found': 'false',
+    'artifact-id': '',
+    'run-id': '',
+  });
 }
 
 function writeOutputs(outputs) {
@@ -270,11 +280,24 @@ async function discoverCommand() {
   const plan = buildPlanFromEnv();
   const failFast = parseBoolean(process.env.INPUT_FAIL_FAST, false);
   const [owner, repo] = String(process.env.GITHUB_REPOSITORY || '').split('/');
-  const artifacts = await listArtifacts({
-    token: process.env.GITHUB_TOKEN,
-    owner,
-    repo,
-  });
+  let artifacts;
+  try {
+    artifacts = await listArtifacts({
+      token: process.env.GITHUB_TOKEN,
+      owner,
+      repo,
+    });
+  } catch (error) {
+    const message = `Artifact discovery failed: ${error.message || error}`;
+    if (failFast) {
+      console.error(`::error title=Artifact discovery failed::${message}`);
+      throw error;
+    }
+    console.log(`::warning::${message} Producer steps may repopulate ${plan.artifactPath}.`);
+    writeArtifactMissOutputs();
+    return;
+  }
+
   const artifact = selectArtifact(artifacts, {
     artifactName: plan.artifactName,
     window: plan.window,
@@ -293,11 +316,7 @@ async function discoverCommand() {
       throw new Error(message);
     }
     console.log(`::notice::${message} Producer steps may repopulate ${plan.artifactPath}.`);
-    writeOutputs({
-      'artifact-found': 'false',
-      'artifact-id': '',
-      'run-id': '',
-    });
+    writeArtifactMissOutputs();
     return;
   }
 
@@ -332,7 +351,9 @@ if (require.main === module) {
 module.exports = {
   deriveCachePlan,
   deriveWindow,
+  discoverCommand,
   isoWeekParts,
+  listArtifacts,
   parseBoolean,
   sanitizeSegment,
   selectArtifact,

--- a/.github/scripts/__tests__/artifact-cache.test.js
+++ b/.github/scripts/__tests__/artifact-cache.test.js
@@ -4,11 +4,13 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const {
   deriveCachePlan,
   deriveWindow,
+  discoverCommand,
   parseBoolean,
   selectArtifact,
 } = require('../../actions/artifact-cache/artifact_cache');
@@ -170,6 +172,87 @@ test('returns null on cache miss so producers can fall through', () => {
   });
 
   assert.equal(artifact, null);
+});
+
+test('non-fail-fast discovery falls through when artifact listing is forbidden', async () => {
+  const outputPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-cache-test-')),
+    'outputs',
+  );
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+  global.fetch = async () => ({
+    ok: false,
+    status: 403,
+    statusText: 'Forbidden',
+    headers: { get: () => '' },
+  });
+  Object.assign(process.env, {
+    ARTIFACT_CACHE_NOW: '2026-05-06T12:00:00Z',
+    GITHUB_OUTPUT: outputPath,
+    GITHUB_REPOSITORY: 'owner/repo',
+    GITHUB_RUN_ID: '123',
+    GITHUB_TOKEN: 'token',
+    INPUT_ARTIFACT_NAME: 'coverage',
+    INPUT_CACHE_KEY_BASE: 'ci-artifacts',
+    INPUT_FAIL_FAST: 'false',
+    INPUT_WINDOW_RESOLUTION: 'daily',
+  });
+
+  try {
+    await discoverCommand();
+    const outputs = fs.readFileSync(outputPath, 'utf8');
+    assert.match(outputs, /artifact-found=false/);
+    assert.match(outputs, /artifact-id=/);
+    assert.match(outputs, /run-id=/);
+  } finally {
+    global.fetch = originalFetch;
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+  }
+});
+
+test('fail-fast discovery errors when artifact listing is forbidden', async () => {
+  const outputPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-cache-test-')),
+    'outputs',
+  );
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+  global.fetch = async () => ({
+    ok: false,
+    status: 403,
+    statusText: 'Forbidden',
+    headers: { get: () => '' },
+  });
+  Object.assign(process.env, {
+    ARTIFACT_CACHE_NOW: '2026-05-06T12:00:00Z',
+    GITHUB_OUTPUT: outputPath,
+    GITHUB_REPOSITORY: 'owner/repo',
+    GITHUB_RUN_ID: '123',
+    GITHUB_TOKEN: 'token',
+    INPUT_ARTIFACT_NAME: 'coverage',
+    INPUT_CACHE_KEY_BASE: 'ci-artifacts',
+    INPUT_FAIL_FAST: 'true',
+    INPUT_WINDOW_RESOLUTION: 'daily',
+  });
+
+  try {
+    await assert.rejects(discoverCommand(), /Failed to list artifacts: 403 Forbidden/);
+    assert.equal(fs.existsSync(outputPath), false);
+  } finally {
+    global.fetch = originalFetch;
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+  }
 });
 
 test('parses fail-fast boolean inputs strictly', () => {

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github/actions/artifact-cache
             .github/actions/setup-api-client
             .github/scripts/bot_comment_auth_coverage.js
             .github/scripts/coverage_monitor_summary.js
@@ -51,7 +52,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Restore metrics artifact cache
+        id: metrics-cache
+        uses: ./.github/actions/artifact-cache
+        with:
+          cache-key-base: weekly-metrics
+          window-resolution: weekly
+          artifact-name: agent-weekly-metrics
+          artifact-path: artifacts
+          fail-fast: 'false'
+
       - name: Download metrics artifacts
+        if: ${{ steps.metrics-cache.outputs.cache-hit != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/actions/artifact-cache
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -102,6 +103,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github/actions/artifact-cache
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -164,33 +166,39 @@ jobs:
 
       - name: Download coverage trend artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@v8
-        continue-on-error: true
+        id: coverage-trend-cache
+        uses: ./.github/actions/artifact-cache
         with:
-          name: gate-coverage-trend
-          run-id: ${{ steps.discover.outputs.run_id }}
-          path: coverage_artifacts/trend
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-base: gate-coverage-trend-${{ steps.discover.outputs.run_id }}
+          window-resolution: weekly
+          artifact-name: gate-coverage-trend
+          artifact-path: coverage_artifacts/trend
+          producer-run-id: ${{ steps.discover.outputs.run_id }}
+          fail-fast: 'true'
 
       - name: Download coverage trend history artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@v8
-        continue-on-error: true
+        id: coverage-trend-history-cache
+        uses: ./.github/actions/artifact-cache
         with:
-          name: gate-coverage-trend-history
-          run-id: ${{ steps.discover.outputs.run_id }}
-          path: coverage_artifacts/history
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-base: gate-coverage-trend-history-${{ steps.discover.outputs.run_id }}
+          window-resolution: weekly
+          artifact-name: gate-coverage-trend-history
+          artifact-path: coverage_artifacts/history
+          producer-run-id: ${{ steps.discover.outputs.run_id }}
+          fail-fast: 'true'
 
       - name: Download coverage payload artifact
         if: ${{ steps.discover.outputs.run_id }}
-        uses: actions/download-artifact@v8
-        continue-on-error: true
+        id: coverage-payload-cache
+        uses: ./.github/actions/artifact-cache
         with:
-          name: gate-coverage
-          run-id: ${{ steps.discover.outputs.run_id }}
-          path: coverage_artifacts/payload
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-base: gate-coverage-${{ steps.discover.outputs.run_id }}
+          window-resolution: weekly
+          artifact-name: gate-coverage
+          artifact-path: coverage_artifacts/payload
+          producer-run-id: ${{ steps.discover.outputs.run_id }}
+          fail-fast: 'true'
 
       - name: Run coverage guard
         if: ${{ steps.discover.outputs.run_id }}

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1423,6 +1423,17 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Checkout Workflows artifact cache action
+        if: ${{ inputs.cache }}
+        uses: actions/checkout@v6
+        with:
+          repository: stranske/Workflows
+          path: .workflows-lib
+          token: ${{ steps.app_token.outputs.token || github.token }}
+          sparse-checkout: |
+            .github/actions/artifact-cache
+          sparse-checkout-cone-mode: false
+
       - name: Install uv
         shell: bash
         run: |
@@ -1762,6 +1773,19 @@ jobs:
           restore-keys: |
             pytest-${{ runner.os }}-${{ matrix.python-version }}-
             pytest-${{ runner.os }}-
+      - name: Restore CI artifact cache
+        id: ci-artifact-cache
+        if: ${{ inputs.cache }}
+        uses: ./.workflows-lib/.github/actions/artifact-cache
+        with:
+          cache-key-base: ci-artifacts-${{ matrix.python-version }}
+          window-resolution: daily
+          artifact-name: >-
+            ${{ inputs['artifact-prefix'] }}coverage-${{ matrix.python-version }}-${{
+            github.run_attempt }}
+          artifact-path: ${{ env.PROJECT_ROOT }}/artifacts/coverage
+          fail-fast: 'false'
+
       - name: Pytest (unit tests with coverage)
         id: pytest
         continue-on-error: true

--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -543,8 +543,33 @@ full_soft_gate"
               ;;
           esac
 
-      - name: Download self-test report
+      - name: Checkout artifact cache action
         if: ${{ env.ENABLE_HISTORY == 'true' && env.RUN_ID != '' }}
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/actions/artifact-cache
+          sparse-checkout-cone-mode: false
+
+      - name: Restore self-test report cache
+        id: selftest-report-cache
+        if: ${{ env.ENABLE_HISTORY == 'true' && env.RUN_ID != '' }}
+        uses: ./.github/actions/artifact-cache
+        with:
+          cache-key-base: selftest-reusable-ci-report-${{ env.RUN_ID }}
+          window-resolution: daily
+          artifact-name: selftest-report
+          artifact-path: selftest-report
+          producer-run-id: ${{ env.RUN_ID }}
+          fail-fast: 'false'
+
+      - name: Download self-test report
+        if: >-
+          ${{
+            env.ENABLE_HISTORY == 'true' &&
+            env.RUN_ID != '' &&
+            steps.selftest-report-cache.outputs.artifact-found != 'true'
+          }}
         uses: actions/download-artifact@v8
         with:
           run-id: ${{ env.RUN_ID }}

--- a/tests/workflows/test_workflow_selftest_consolidation.py
+++ b/tests/workflows/test_workflow_selftest_consolidation.py
@@ -451,14 +451,36 @@ def test_selftest_runner_publish_job_contract() -> None:
     def _find_step(name: str) -> dict:
         return next((step for step in steps if step.get("name") == name), {})
 
+    cache_step = _find_step("Restore self-test report cache")
+    assert cache_step, "Artifact cache step missing from publish job."
+    assert (
+        cache_step.get("uses") == "./.github/actions/artifact-cache"
+    ), "Self-test report cache should use the shared artifact-cache action."
+    assert (
+        cache_step.get("if") == "${{ env.ENABLE_HISTORY == 'true' && env.RUN_ID != '' }}"
+    ), "Cache step must guard on enable_history input and aggregate run id."
+    cache_with = cache_step.get("with", {})
+    assert (
+        cache_with.get("cache-key-base") == "selftest-reusable-ci-report-${{ env.RUN_ID }}"
+    ), "Cache key base should stay stable for selftest report reuse."
+    assert (
+        cache_with.get("window-resolution") == "daily"
+    ), "Selftest report cache should use a daily run window."
+    assert (
+        cache_with.get("producer-run-id") == "${{ env.RUN_ID }}"
+    ), "Selftest report cache should discover artifacts from the aggregate run."
+
     download_step = _find_step("Download self-test report")
     assert download_step, "Download step missing from publish job."
     assert download_step.get("uses", "").startswith(
         "actions/download-artifact@"
     ), "Download step should use actions/download-artifact."
+    download_condition = download_step.get("if")
     assert (
-        download_step.get("if") == "${{ env.ENABLE_HISTORY == 'true' && env.RUN_ID != '' }}"
-    ), "Download step must guard on enable_history input and aggregate run id."
+        "env.ENABLE_HISTORY == 'true'" in download_condition
+        and "env.RUN_ID != ''" in download_condition
+        and "steps.selftest-report-cache.outputs.artifact-found != 'true'" in download_condition
+    ), "Download step must fall back only when artifact-cache did not find the report."
     download_with = download_step.get("with", {})
     assert (
         download_with.get("run-id") == "${{ env.RUN_ID }}"


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- restore weekly metrics artifacts by weekly window and skip the downloader on cache hit
- wrap coverage guard artifact retrieval with artifact-cache and `fail-fast: true`
- add daily CI artifact cache restore to reusable Python CI outputs
- mirror daily selftest report caching in `selftest-reusable-ci.yml`

## Validation
- `actionlint .github/workflows/agents-weekly-metrics.yml .github/workflows/maint-coverage-guard.yml .github/workflows/reusable-10-ci-python.yml .github/workflows/selftest-reusable-ci.yml`
- `node --test .github/scripts/__tests__/artifact-cache.test.js`
- `scripts/validate_template_completeness.py`
- `python scripts/check_api_wrapper_guard.py --base-ref origin/main`
