### PR TITLE
fix: harden synced runner helpers

### DIFF
--- a/.github/scripts/__tests__/issue_context_utils.test.js
+++ b/.github/scripts/__tests__/issue_context_utils.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 
 const {
   buildCappedIssuePayload,
@@ -116,5 +117,53 @@ test('buildCappedIssuePayload removes temporary input directory', () => {
     assert.equal(fs.existsSync(tempDir), false);
   } finally {
     childProcess.execFileSync = originalExecFileSync;
+  }
+});
+
+test('buildCappedIssuePayload removes temporary directories after success', () => {
+  const originalExec = childProcess.execFileSync;
+  childProcess.execFileSync = () =>
+    JSON.stringify({
+      formatted_body: TASKS_AND_ACCEPTANCE_ONLY,
+      truncated: false,
+      estimated_tokens: 12,
+      token_budget: 4000,
+    });
+
+  try {
+    const before = new Set(
+      fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('workflows-issue-context-'))
+    );
+    const result = buildCappedIssuePayload(COMPLETE_BODY);
+    const after = fs
+      .readdirSync(os.tmpdir())
+      .filter((name) => name.startsWith('workflows-issue-context-') && !before.has(name));
+
+    assert.equal(result.formattedBody, TASKS_AND_ACCEPTANCE_ONLY);
+    assert.deepEqual(after, []);
+  } finally {
+    childProcess.execFileSync = originalExec;
+  }
+});
+
+test('buildCappedIssuePayload removes temporary directories after fallback', () => {
+  const originalExec = childProcess.execFileSync;
+  childProcess.execFileSync = () => {
+    throw new Error('capper failed');
+  };
+
+  try {
+    const before = new Set(
+      fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('workflows-issue-context-'))
+    );
+    const result = buildCappedIssuePayload(COMPLETE_BODY);
+    const after = fs
+      .readdirSync(os.tmpdir())
+      .filter((name) => name.startsWith('workflows-issue-context-') && !before.has(name));
+
+    assert.equal(result.formattedBody, COMPLETE_BODY);
+    assert.deepEqual(after, []);
+  } finally {
+    childProcess.execFileSync = originalExec;
   }
 });

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import dataclasses
 import datetime as dt
 import hashlib
+import importlib
 import json
 import os
 import re
@@ -18,7 +20,6 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Protocol
 
-from scripts import reference_packs
 from scripts.state_fingerprint import GitHubApi, _github_context
 
 MARKER_VERSION = "v1"
@@ -95,12 +96,40 @@ def _prompt_output_name(provider: str, pr_number: str | int | None) -> str:
     return f"{provider}-prompt{suffix}.md"
 
 
+def _load_reference_packs_module() -> Any:
+    try:
+        return importlib.import_module("scripts.reference_packs")
+    except ModuleNotFoundError as exc:
+        if exc.name == "scripts.reference_packs":
+            raise RuntimeError(
+                "reference packs are not supported in this repository because "
+                "scripts/reference_packs.py was not synced"
+            ) from exc
+        raise
+
+
+def _run_git(args: list[str], env: dict[str, str] | None = None) -> None:
+    try:
+        subprocess.check_call(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        redacted = ["<redacted>" if "x-access-token:" in part else part for part in args]
+        raise RuntimeError(
+            f"git command failed with exit code {exc.returncode}: {' '.join(redacted)}"
+        ) from exc
+
+
 def materialize_reference_packs(
     workspace: str | Path = ".",
     reference_pack_name: str | None = None,
     token: str | None = None,
 ) -> Path | None:
     """Validate and materialize configured reference packs into `.reference/`."""
+    reference_packs = _load_reference_packs_module()
     workspace_path = Path(workspace).resolve()
     snapshot = reference_packs.load_reference_packs(workspace_path)
     if not snapshot.exists:
@@ -145,28 +174,16 @@ def materialize_reference_packs(
             clone_cmd.extend(["--branch", plan.ref])
         clone_cmd.extend([clone_url, str(clone_dir)])
         try:
-            subprocess.check_call(
-                clone_cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                env=git_env,
-            )
+            _run_git(clone_cmd, env=git_env)
 
             if is_sha:
-                subprocess.check_call(
+                _run_git(
                     ["git", "-C", str(clone_dir), "fetch", "origin", plan.ref, "--depth=1"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
                     env=git_env,
                 )
-                subprocess.check_call(
-                    ["git", "-C", str(clone_dir), "checkout", plan.ref],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    env=git_env,
-                )
+                _run_git(["git", "-C", str(clone_dir), "checkout", plan.ref], env=git_env)
 
-            subprocess.check_call(
+            _run_git(
                 [
                     "git",
                     "-C",
@@ -176,14 +193,9 @@ def materialize_reference_packs(
                     "--no-cone",
                     *plan.paths,
                 ],
-                stdout=subprocess.DEVNULL,
                 env=git_env,
             )
-            subprocess.check_call(
-                ["git", "-C", str(clone_dir), "sparse-checkout", "reapply"],
-                stdout=subprocess.DEVNULL,
-                env=git_env,
-            )
+            _run_git(["git", "-C", str(clone_dir), "sparse-checkout", "reapply"], env=git_env)
 
             checkout_path = workspace_path / plan.checkout_path
             checkout_path.mkdir(parents=True, exist_ok=True)
@@ -368,17 +380,26 @@ def parse_runner_output(provider: str, raw_output: str) -> RunnerResult:
 
 def _marker_re(pr_number: int, provider: str) -> re.Pattern[str]:
     return re.compile(
-        rf"<!--\s*{MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION}\s+(\{{.*?\}})\s*-->",
+        rf"<!--\s*{MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION}\s+([\s\S]*?)\s*-->",
         re.DOTALL,
     )
 
 
 def _build_marker(pr_number: int, provider: str, record: dict[str, Any]) -> str:
-    payload = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    payload = base64.b64encode(
+        json.dumps(record, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
     return (
         f"Runner dispatch state for {provider} on PR #{pr_number}. Do not edit.\n\n"
-        f"<!-- {MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION} {payload} -->"
+        f"<!-- {MARKER_PREFIX}:{provider}:{pr_number}:{MARKER_VERSION} base64:{payload} -->"
     )
+
+
+def _decode_record_candidate(candidate: str) -> str:
+    value = candidate.strip()
+    if value.startswith("base64:"):
+        return base64.b64decode(value.removeprefix("base64:")).decode("utf-8")
+    return value
 
 
 def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[str, Any] | None:
@@ -393,8 +414,8 @@ def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[st
         candidates.append(stripped)
     for candidate in candidates:
         try:
-            payload = json.loads(candidate)
-        except json.JSONDecodeError:
+            payload = json.loads(_decode_record_candidate(candidate))
+        except (binascii.Error, ValueError, json.JSONDecodeError):
             continue
         if isinstance(payload, dict) and payload.get("provider") == provider:
             return payload

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import subprocess
+import types
 from pathlib import Path
 from typing import Any
 
+import pytest
+import scripts.runner_lib.core as runner_core
 from scripts.runner_lib import (
     assemble_prompt,
     parse_runner_output,
@@ -195,6 +198,26 @@ def test_materialize_reference_packs_keeps_token_out_of_git_argv(
     assert all(env.get("GIT_ASKPASS_PASSWORD") == "secret-token" for _cmd, env in calls)
 
 
+def test_pr_comment_marker_round_trips_nested_result_payload() -> None:
+    result = parse_runner_output("claude", "Done")
+    record = {
+        "provider": "claude",
+        "pr_number": 42,
+        "head_sha": "aaa",
+        "status": "completed",
+        "result": {
+            "summary": result.summary,
+            "nested": {"value": "inner"},
+            "final_message": "contains --> comment closer",
+        },
+    }
+
+    marker = runner_core._build_marker(42, "claude", record)
+    parsed = runner_core._extract_record(marker, 42, "claude")
+
+    assert parsed == record
+
+
 def test_pr_comment_storage_stops_when_marker_found() -> None:
     class FakeApi:
         repo = "owner/repo"
@@ -224,3 +247,58 @@ def test_pr_comment_storage_stops_when_marker_found() -> None:
 
     assert record == {"provider": "codex", "head_sha": "abc"}
     assert len(api.paths) == 1
+
+
+def test_materialize_reference_packs_import_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_import(name: str) -> Any:
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(runner_core.importlib, "import_module", fail_import)
+
+    with pytest.raises(RuntimeError, match="reference packs are not supported"):
+        runner_core.materialize_reference_packs(".")
+
+
+def test_materialize_reference_packs_does_not_put_token_in_git_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = "ghp_secret_token"
+    plan = types.SimpleNamespace(
+        name="baseline",
+        repo="stranske/private-reference",
+        ref="main",
+        paths=["README.md"],
+        checkout_path=".reference/baseline",
+    )
+    fake_reference_packs = types.SimpleNamespace(
+        load_reference_packs=lambda _workspace: types.SimpleNamespace(exists=True, packs=[plan]),
+        build_checkout_plan=lambda _packs: [plan],
+    )
+    calls: list[tuple[list[str], dict[str, str] | None]] = []
+
+    def fake_import(name: str) -> Any:
+        assert name == "scripts.reference_packs"
+        return fake_reference_packs
+
+    def fail_check_call(
+        args: list[str],
+        stdout: Any = None,
+        stderr: Any = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((args, env))
+        raise subprocess.CalledProcessError(128, args)
+
+    monkeypatch.setattr(runner_core.importlib, "import_module", fake_import)
+    monkeypatch.setattr(runner_core.subprocess, "check_call", fail_check_call)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        runner_core.materialize_reference_packs(tmp_path, token=token)
+
+    assert token not in str(exc_info.value)
+    assert calls
+    clone_cmd, clone_env = calls[0]
+    assert all(token not in part for part in clone_cmd)
+    assert clone_env is not None
+    assert clone_env["GIT_ASKPASS_PASSWORD"] == token
+    assert Path(clone_env["GIT_ASKPASS"]).exists() is False


### PR DESCRIPTION
## Summary
- make runner_lib reference pack support lazy so synced consumers without scripts/reference_packs.py can import runner helpers
- avoid putting GitHub tokens in git clone commands and clean reference-pack clone directories on failure
- store PR-comment runner dispatch state as base64 JSON and clean issue-context temp directories in source and consumer template copies

## Validation
- python -m pytest tests/scripts/test_runner_lib.py -q
- node --test .github/scripts/__tests__/issue_context_utils.test.js
- python -m ruff check scripts/runner_lib/core.py tests/scripts/test_runner_lib.py
- python -m black --check scripts/runner_lib/core.py tests/scripts/test_runner_lib.py
- python scripts/validate_template_sync.py
- git diff --check

Addresses review feedback from sync-generated consumer PR stranske/Counter_Risk#548.