### PR TITLE
Follow-up: evidence reference pack sync manifest validation

### DIFF
--- a/tests/scripts/test_reference_packs.py
+++ b/tests/scripts/test_reference_packs.py
@@ -9,6 +9,7 @@ from base64 import b64decode
 from pathlib import Path
 
 import pytest
+import yaml
 from scripts.reference_packs import (
     ReferencePackConfigError,
     build_checkout_plan,
@@ -18,6 +19,20 @@ from scripts.reference_packs import (
     read_reference_pack_config_text,
     reference_pack_config_exists,
 )
+
+
+def test_sync_manifest_ships_reference_packs_before_runner_lib() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest_path = repo_root / ".github" / "sync-manifest.yml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    script_sources = [entry.get("source") for entry in manifest.get("scripts", []) or []]
+
+    assert (repo_root / "scripts" / "reference_packs.py").is_file()
+    assert "scripts/reference_packs.py" in script_sources
+    assert "scripts/runner_lib/" in script_sources
+    assert script_sources.index("scripts/reference_packs.py") < script_sources.index(
+        "scripts/runner_lib/"
+    )
 
 
 def _decode_github_output_value(value: str) -> str:


### PR DESCRIPTION
## Workflow Source

Started from:
- [ ] GitHub issue: #
- [ ] Direct PR / remote GitHub work
- [ ] Local Codex/user request
- [ ] Automation run
- [x] Review follow-up from PR #2036
- [ ] Sync / maintenance campaign
- [ ] Dependabot or dependency update
- [ ] Do not automate

Automation intent:
- [x] Verifier should review this
- [ ] Keepalive may manage this PR
- [ ] Human-only unless checks fail

Notes:
Follow-up for #2036 verifier concerns. Anthropic reported CONCERNS because the manifest-only fix did not provide durable evidence that `scripts/reference_packs.py` exists, is ordered before `scripts/runner_lib/`, and has validation coverage.

## Summary
- Add a regression test that reads the real sync manifest and asserts `scripts/reference_packs.py` is present before `scripts/runner_lib/`.
- Assert the source `scripts/reference_packs.py` file exists so manifest drift is caught by CI.

## Testing
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m pytest tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py -q`
- focused import check: `from scripts.runner_lib.core import materialize_reference_packs`