### PR TITLE
fix: harden sync review context storage

### DIFF
--- a/.github/scripts/__tests__/issue_context_utils.test.js
+++ b/.github/scripts/__tests__/issue_context_utils.test.js
@@ -118,3 +118,25 @@ test('buildCappedIssuePayload removes temporary input directory', () => {
     childProcess.execFileSync = originalExecFileSync;
   }
 });
+
+test('buildCappedIssuePayload preserves intentionally empty formatted body', () => {
+  const originalExecFileSync = childProcess.execFileSync;
+  childProcess.execFileSync = () =>
+    JSON.stringify({
+      formatted_body: '',
+      truncated: true,
+      estimated_tokens: 0,
+      token_budget: 1,
+    });
+
+  try {
+    const result = buildCappedIssuePayload('## Tasks\n- [ ] raw');
+
+    assert.equal(result.formattedBody, '');
+    assert.equal(result.truncated, true);
+    assert.equal(result.estimatedTokens, 0);
+    assert.equal(result.tokenBudget, 1);
+  } finally {
+    childProcess.execFileSync = originalExecFileSync;
+  }
+});

--- a/.github/scripts/issue_context_utils.js
+++ b/.github/scripts/issue_context_utils.js
@@ -37,7 +37,7 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
     const payload = JSON.parse(output);
     return {
-      formattedBody: String(payload.formatted_body || body),
+      formattedBody: String(payload.formatted_body ?? body),
       truncated: Boolean(payload.truncated),
       estimatedTokens: payload.estimated_tokens,
       tokenBudget: payload.token_budget,

--- a/scripts/repo_review_body_writer.py
+++ b/scripts/repo_review_body_writer.py
@@ -39,14 +39,12 @@ import argparse
 import json
 import subprocess
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 try:
+    from scripts.repo_review_evaluator import load_registry
     from scripts.repo_review_round2_runner import invoke_agent
     from scripts.repo_review_round2_schema import validate_converged_set
-    from scripts.repo_review_evaluator import load_registry
     from scripts.repo_review_state import (
         begin_attempt,
         finish_attempt,
@@ -54,9 +52,9 @@ try:
         save_state,
     )
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    from repo_review_evaluator import load_registry  # type: ignore[no-redef]
     from repo_review_round2_runner import invoke_agent  # type: ignore[no-redef]
     from repo_review_round2_schema import validate_converged_set  # type: ignore[no-redef]
-    from repo_review_evaluator import load_registry  # type: ignore[no-redef]
     from repo_review_state import (  # type: ignore[no-redef]
         begin_attempt,
         finish_attempt,
@@ -97,11 +95,16 @@ def canonical_body_writer_prompt() -> Path:
 def verify_clean_sync(repo_path: Path) -> tuple[bool, str]:
     """Confirm `repo_path` is at origin/main or origin/phase-3 HEAD with no
     review-blocking dirty changes."""
+
     def _git(args: list[str]) -> subprocess.CompletedProcess:
         return subprocess.run(
             ["git", "-C", str(repo_path), *args],
-            check=False, capture_output=True, text=True, timeout=30,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
+
     head = _git(["rev-parse", "HEAD"]).stdout.strip()
     for branch in ("main", "phase-3"):
         ref = _git(["rev-parse", f"origin/{branch}"])
@@ -171,7 +174,7 @@ def build_prompt(*, repo: str, output_dir: Path, repo_path: Path) -> str:
         "files and line numbers from the current checkout. If a candidate's "
         "structured `design_refs` / `implementation_refs` cite files that no "
         "longer exist in current main (gap was shipped in an unpulled PR), "
-        "record `body: \"INSUFFICIENT_EVIDENCE: <reason>\"` rather than "
+        'record `body: "INSUFFICIENT_EVIDENCE: <reason>"` rather than '
         "fabricating. INSUFFICIENT_EVIDENCE is a legitimate outcome.\n\n"
         "After writing, validate:\n\n"
         f"  python scripts/repo_review_round2_schema.py --converged {cj} --expected-repo {repo}\n\n"
@@ -195,7 +198,8 @@ def run_body_writer(
     prompt = build_prompt(repo=repo, output_dir=output_dir, repo_path=repo_path)
     additional_dirs = sorted({workflows_steward_root, output_dir, repo_path})
     return invoke_agent(
-        agent, prompt,
+        agent,
+        prompt,
         cwd=workflows_steward_root,
         additional_dirs=additional_dirs,
         log_file=log_path,
@@ -268,7 +272,10 @@ def run(args: argparse.Namespace) -> int:
     except (OSError, json.JSONDecodeError) as exc:
         finish_attempt(state, attempt, succeeded=False, notes=f"cannot parse converged.json: {exc}")
         save_state(output_dir, state)
-        print(f"[body-writer] {args.repo}: cannot parse converged.json after run: {exc}", file=sys.stderr)
+        print(
+            f"[body-writer] {args.repo}: cannot parse converged.json after run: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
     schema_errors = validate_converged_set(data, expected_repo=args.repo)
@@ -288,9 +295,7 @@ def run(args: argparse.Namespace) -> int:
             continue
         errors = body_quality_errors(body)
         if errors:
-            body_failures.append(
-                f"  candidate #{i} '{title}': {'; '.join(errors[:3])}"
-            )
+            body_failures.append(f"  candidate #{i} '{title}': {'; '.join(errors[:3])}")
         else:
             written_count += 1
 
@@ -320,19 +325,24 @@ def main() -> int:
     parser.add_argument("--repo", required=True, help="owner/name from the registry")
     parser.add_argument("--output-dir", required=True, help="output dir")
     parser.add_argument(
-        "--registry", default="config/repo_review_registry.json",
+        "--registry",
+        default="config/repo_review_registry.json",
         help="path to repo_review_registry.json",
     )
     parser.add_argument(
-        "--agent", default="codex",
+        "--agent",
+        default="codex",
         help="agent identifier to spawn (default: codex)",
     )
     parser.add_argument(
-        "--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS,
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
         help="hard timeout in seconds (default: 3600 = 60 min)",
     )
     parser.add_argument(
-        "--skip-sync-check", action="store_true",
+        "--skip-sync-check",
+        action="store_true",
         help="skip the local-repo-at-origin-head check (NOT recommended)",
     )
     args = parser.parse_args()

--- a/scripts/repo_review_coordinator.py
+++ b/scripts/repo_review_coordinator.py
@@ -53,8 +53,6 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - direct script execution
     from repo_review_evaluator import load_registry  # type: ignore[no-redef]
     from repo_review_state import (  # type: ignore[no-redef]
-        VALID_STATUSES,
-        add_pinned_problem,
         load_state,
         save_state,
         transition,
@@ -155,9 +153,7 @@ def archive_prior_cycle(output_dir: Path) -> dict[str, Any]:
     return summary
 
 
-def prior_converged_for_skip_check(
-    output_dir: Path, repo: str
-) -> dict[str, Any] | None:
+def prior_converged_for_skip_check(output_dir: Path, repo: str) -> dict[str, Any] | None:
     """Look for a previously-archived converged.json for this repo to compare against.
 
     Convention: prior cycles' converged sets are archived under
@@ -251,9 +247,7 @@ def should_skip_cycle(
     )
 
 
-def write_skip_converged(
-    output_dir: Path, repo: str, reason: str
-) -> Path:
+def write_skip_converged(output_dir: Path, repo: str, reason: str) -> Path:
     """Synthesize a 'skip-this-cycle' converged.json so downstream evaluator
     surfaces a clear note instead of empty round-2 state."""
     safe = repo.replace("/", "__")
@@ -306,23 +300,33 @@ def run_subprocess(
     with log_path.open("w", encoding="utf-8") as fh:
         try:
             result = subprocess.run(
-                cmd, cwd=cwd, stdout=fh, stderr=subprocess.STDOUT,
-                check=False, timeout=timeout,
+                cmd,
+                cwd=cwd,
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                check=False,
+                timeout=timeout,
             )
         except subprocess.TimeoutExpired:
             duration = (datetime.now(UTC) - started).total_seconds()
             return StepResult(
-                name=name, succeeded=False, duration_seconds=duration,
+                name=name,
+                succeeded=False,
+                duration_seconds=duration,
                 notes=f"timed out after {timeout}s; log: {log_path}",
             )
     duration = (datetime.now(UTC) - started).total_seconds()
     if result.returncode != 0:
         return StepResult(
-            name=name, succeeded=False, duration_seconds=duration,
+            name=name,
+            succeeded=False,
+            duration_seconds=duration,
             notes=f"exit {result.returncode}; log: {log_path}",
         )
     return StepResult(
-        name=name, succeeded=True, duration_seconds=duration,
+        name=name,
+        succeeded=True,
+        duration_seconds=duration,
         notes=f"log: {log_path}",
     )
 
@@ -362,15 +366,23 @@ def coordinate_repo(
     r1_cmd = [
         sys.executable,
         str(workflows_steward_root / "scripts" / "repo_review_round1_runner.py"),
-        "--repo", repo,
-        "--output-dir", str(output_dir),
-        "--registry", str(registry_path),
-        "--agents", *agents,
-        "--turn-timeout", str(round1_timeout),
+        "--repo",
+        repo,
+        "--output-dir",
+        str(output_dir),
+        "--registry",
+        str(registry_path),
+        "--agents",
+        *agents,
+        "--turn-timeout",
+        str(round1_timeout),
     ]
     r1_result = run_subprocess(
-        r1_cmd, cwd=workflows_steward_root, log_path=repo_log_dir / "round1-runner.log",
-        name="round-1", timeout=round1_timeout + 1500,
+        r1_cmd,
+        cwd=workflows_steward_root,
+        log_path=repo_log_dir / "round1-runner.log",
+        name="round-1",
+        timeout=round1_timeout + 1500,
     )
     report["round1"] = {
         "succeeded": r1_result.succeeded,
@@ -389,7 +401,8 @@ def coordinate_repo(
             converged_path = write_skip_converged(output_dir, repo, reason)
             state = load_state(output_dir, repo)
             transition(
-                state, status="round2-converged",
+                state,
+                status="round2-converged",
                 note=f"skip-this-cycle gate fired: {reason}",
             )
             save_state(output_dir, state)
@@ -403,14 +416,21 @@ def coordinate_repo(
     r2_cmd = [
         sys.executable,
         str(workflows_steward_root / "scripts" / "repo_review_round2_runner.py"),
-        "--repo", repo,
-        "--output-dir", str(output_dir),
-        "--agents", *agents,
-        "--turn-timeout", str(round2_timeout),
+        "--repo",
+        repo,
+        "--output-dir",
+        str(output_dir),
+        "--agents",
+        *agents,
+        "--turn-timeout",
+        str(round2_timeout),
     ]
     r2_result = run_subprocess(
-        r2_cmd, cwd=workflows_steward_root, log_path=repo_log_dir / "round2-runner.log",
-        name="round-2", timeout=round2_timeout + 1500,
+        r2_cmd,
+        cwd=workflows_steward_root,
+        log_path=repo_log_dir / "round2-runner.log",
+        name="round-2",
+        timeout=round2_timeout + 1500,
     )
     report["round2"] = {
         "succeeded": r2_result.succeeded,
@@ -426,15 +446,23 @@ def coordinate_repo(
     bw_cmd = [
         sys.executable,
         str(workflows_steward_root / "scripts" / "repo_review_body_writer.py"),
-        "--repo", repo,
-        "--output-dir", str(output_dir),
-        "--registry", str(registry_path),
-        "--agent", "codex",  # Codex has historically produced higher-quality bodies.
-        "--timeout", str(min(round2_timeout, 60 * 60)),
+        "--repo",
+        repo,
+        "--output-dir",
+        str(output_dir),
+        "--registry",
+        str(registry_path),
+        "--agent",
+        "codex",  # Codex has historically produced higher-quality bodies.
+        "--timeout",
+        str(min(round2_timeout, 60 * 60)),
     ]
     bw_result = run_subprocess(
-        bw_cmd, cwd=workflows_steward_root, log_path=repo_log_dir / "body-writer.log",
-        name="body-writer", timeout=min(round2_timeout, 60 * 60) + 600,
+        bw_cmd,
+        cwd=workflows_steward_root,
+        log_path=repo_log_dir / "body-writer.log",
+        name="body-writer",
+        timeout=min(round2_timeout, 60 * 60) + 600,
     )
     report["body_writer"] = {
         "succeeded": bw_result.succeeded,
@@ -501,14 +529,17 @@ def run(args: argparse.Namespace) -> int:
         preflight_cmd = [
             sys.executable,
             str(workflows_steward_root / "scripts" / "repo_review_evaluator.py"),
-            "--output-dir", str(output_dir),
+            "--output-dir",
+            str(output_dir),
         ]
         if args.skip_gitnexus_preflight:
             preflight_cmd.append("--skip-gitnexus-preflight")
         preflight_result = run_subprocess(
-            preflight_cmd, cwd=workflows_steward_root,
+            preflight_cmd,
+            cwd=workflows_steward_root,
             log_path=log_dir / "preflight.log",
-            name="preflight", timeout=1200,
+            name="preflight",
+            timeout=1200,
         )
         if not preflight_result.succeeded:
             print(
@@ -543,7 +574,9 @@ def run(args: argparse.Namespace) -> int:
     queue_out = output_dir / "approved-issue-queue.json"
     if feedback_path.is_file():
         try:
-            from scripts.repo_review_queue_builder import build_queue  # type: ignore[import-not-found]
+            from scripts.repo_review_queue_builder import (
+                build_queue,  # type: ignore[import-not-found]
+            )
         except ModuleNotFoundError:
             sys.path.insert(0, str(workflows_steward_root / "scripts"))
             from repo_review_queue_builder import build_queue  # type: ignore[no-redef]
@@ -565,13 +598,16 @@ def run(args: argparse.Namespace) -> int:
     final_cmd = [
         sys.executable,
         str(workflows_steward_root / "scripts" / "repo_review_evaluator.py"),
-        "--output-dir", str(output_dir),
+        "--output-dir",
+        str(output_dir),
         "--skip-gitnexus-preflight",  # maps already refreshed by round-1
     ]
     final_result = run_subprocess(
-        final_cmd, cwd=workflows_steward_root,
+        final_cmd,
+        cwd=workflows_steward_root,
         log_path=log_dir / "final-evaluator.log",
-        name="final-evaluator", timeout=600,
+        name="final-evaluator",
+        timeout=600,
     )
 
     # 4. Summary report on stderr (cron will capture).
@@ -591,55 +627,73 @@ def run(args: argparse.Namespace) -> int:
             f"r2 {int((r2 or {}).get('duration_seconds') or 0)}s)"
         )
     print(f"[coordinator] final evaluator: {'ok' if final_result.succeeded else 'FAIL'}")
-    return 0 if all(
-        (r.get("round1") or {}).get("succeeded")
-        and (r.get("skip_gate_fired") or (r.get("round2") or {}).get("succeeded"))
-        for r in reports
-    ) else 1
+    return (
+        0
+        if all(
+            (r.get("round1") or {}).get("succeeded")
+            and (r.get("skip_gate_fired") or (r.get("round2") or {}).get("succeeded"))
+            for r in reports
+        )
+        else 1
+    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--output-dir", required=True,
+        "--output-dir",
+        required=True,
         help="output dir, e.g. docs/reports/repo-review",
     )
     parser.add_argument(
-        "--registry", default="config/repo_review_registry.json",
+        "--registry",
+        default="config/repo_review_registry.json",
         help="path to repo_review_registry.json",
     )
     parser.add_argument(
-        "--repos", nargs="*", default=[],
+        "--repos",
+        nargs="*",
+        default=[],
         help="optional explicit repo subset (default: all active in registry)",
     )
     parser.add_argument(
-        "--agents", nargs="+", default=["codex", "claude"],
+        "--agents",
+        nargs="+",
+        default=["codex", "claude"],
         help="agent identifiers to use (default: codex claude)",
     )
     parser.add_argument(
-        "--skip-preflight", action="store_true",
+        "--skip-preflight",
+        action="store_true",
         help="skip the initial evaluator preflight (use existing inputs)",
     )
     parser.add_argument(
-        "--skip-gitnexus-preflight", action="store_true",
+        "--skip-gitnexus-preflight",
+        action="store_true",
         help="skip the GitNexus preflight inside the evaluator (round-1 still refreshes)",
     )
     parser.add_argument(
-        "--round1-timeout", type=int, default=90 * 60,
+        "--round1-timeout",
+        type=int,
+        default=90 * 60,
         help="hard timeout per round-1 agent in seconds (default: 5400)",
     )
     parser.add_argument(
-        "--round2-timeout", type=int, default=45 * 60,
+        "--round2-timeout",
+        type=int,
+        default=45 * 60,
         help="hard timeout per round-2 agent-turn in seconds (default: 2700)",
     )
     parser.add_argument(
-        "--disable-skip-gate", action="store_true",
+        "--disable-skip-gate",
+        action="store_true",
         help="run round-2 even when round-1 fingerprint matches prior cycle",
     )
     parser.add_argument(
-        "--skip-auto-archive", action="store_true",
+        "--skip-auto-archive",
+        action="store_true",
         help="do not move the prior cycle's round1/round2/queue into archive/<date>/ "
-             "before starting (useful for re-running a cycle in place)",
+        "before starting (useful for re-running a cycle in place)",
     )
     args = parser.parse_args()
     return run(args)

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -705,7 +705,9 @@ def build_review_execution(state: dict[str, Any]) -> dict[str, Any]:
         )
     elif findings and findings.get("deeper_review_needed"):
         issue_severity = "material"
-        issue_finding = "Round 1 requested deeper review; do not accept no-new-issues from this state."
+        issue_finding = (
+            "Round 1 requested deeper review; do not accept no-new-issues from this state."
+        )
     elif findings:
         issue_severity = "needs human decision"
         issue_finding = (
@@ -874,9 +876,7 @@ def collect_remote_progress(
     else:
         result["warnings"].append("gh issue list failed or returned non-list")
 
-    cutoff_date = (
-        datetime.now(UTC).date() - timedelta(days=merged_pr_lookback_days)
-    ).isoformat()
+    cutoff_date = (datetime.now(UTC).date() - timedelta(days=merged_pr_lookback_days)).isoformat()
     pr_payload = _gh_json(
         [
             "gh",
@@ -909,9 +909,7 @@ def collect_remote_progress(
     return result
 
 
-def load_round1_findings(
-    output_dir: Path | None, repo: str
-) -> dict[str, Any] | None:
+def load_round1_findings(output_dir: Path | None, repo: str) -> dict[str, Any] | None:
     """Load the most recent round-1 findings.json for `repo` if any exist.
 
     Looks in `<output_dir>/round1/<agent>/<repo_safe>/findings.json` across
@@ -949,9 +947,7 @@ def load_round1_findings(
     return data
 
 
-def load_round2_converged(
-    output_dir: Path | None, repo: str
-) -> dict[str, Any] | None:
+def load_round2_converged(output_dir: Path | None, repo: str) -> dict[str, Any] | None:
     """Load the round-2 converged set for `repo` if it exists.
 
     Looks at `<output_dir>/round2/<repo_safe>/converged.json`. Returns None
@@ -1152,12 +1148,15 @@ def gitnexus_preflight(
         after = before
         refresh_status = "not-needed"
         refresh_error = ""
-        needs_refresh = (
-            before["status"] in GITNEXUS_REFRESH_STATUSES
-            or before.get("needs_embeddings", False)
+        needs_refresh = before["status"] in GITNEXUS_REFRESH_STATUSES or before.get(
+            "needs_embeddings", False
         )
         if needs_refresh:
-            reason = before["status"] if before["status"] in GITNEXUS_REFRESH_STATUSES else "missing-embeddings"
+            reason = (
+                before["status"]
+                if before["status"] in GITNEXUS_REFRESH_STATUSES
+                else "missing-embeddings"
+            )
             if not refresh_stale:
                 refresh_status = "needed-not-requested"
                 warnings.append(
@@ -1854,9 +1853,7 @@ def issue_candidate_records(
         meta = converged.get("meta_candidate")
         if isinstance(meta, dict):
             raw_candidates.append(meta)
-        return _records_from_round2_candidates(
-            raw_candidates, converged, max_items=max_items
-        )
+        return _records_from_round2_candidates(raw_candidates, converged, max_items=max_items)
 
     findings = state.get("round1_findings") or {}
     raw_candidates = findings.get("candidates") if isinstance(findings, dict) else None
@@ -2168,13 +2165,18 @@ def deadlocked_candidates_section(state: dict[str, Any]) -> list[str]:
     deadlocked = converged.get("deadlocked_candidates") or []
     if not deadlocked:
         return []
-    lines: list[str] = ["#### Deadlocked Candidates", "",
+    lines: list[str] = [
+        "#### Deadlocked Candidates",
+        "",
         "These candidates require human resolution — both agents' final-turn "
         "positions are inlined below. Approve, revise, or drop after reading both.",
-        ""]
+        "",
+    ]
     for index, item in enumerate(deadlocked, start=1):
         title = str(item.get("title") or "Untitled")
-        lines.append(f"{index}. **{title}** (source: {item.get('source_agent', '?')}, round1 #{item.get('round1_index', '?')})")
+        lines.append(
+            f"{index}. **{title}** (source: {item.get('source_agent', '?')}, round1 #{item.get('round1_index', '?')})"
+        )
         for mark in item.get("marks_history") or []:
             agent = mark.get("from_agent", "?")
             mark_type = mark.get("mark", "?")
@@ -2226,17 +2228,21 @@ def no_new_work_justifications_section(state: dict[str, Any]) -> list[str]:
     if (converged.get("converged_candidates") or []) or converged.get("meta_candidate"):
         return []
     justifications = [
-        j for j in (converged.get("no_new_work_justifications") or [])
+        j
+        for j in (converged.get("no_new_work_justifications") or [])
         if isinstance(j, dict)
         and j.get("candidate_count") == 0
         and len(str(j.get("justification") or "").strip()) >= 200
     ]
     if len(justifications) < 2:
         return []
-    lines: list[str] = ["#### No-New-Work Justifications", "",
+    lines: list[str] = [
+        "#### No-New-Work Justifications",
+        "",
         "Both agents independently reached the same conclusion. Verify the cited "
         "file/test evidence below before accepting no-new-issues for this cycle.",
-        ""]
+        "",
+    ]
     for j in justifications:
         agent = j.get("agent", "?")
         text = str(j.get("justification") or "").strip()
@@ -3488,14 +3494,14 @@ def write_packet(
                 f"- Round 2 candidates: `{len((state.get('round2_converged') or {}).get('converged_candidates') or [])}`"
                 + (
                     " (+ meta-candidate)"
-                    if isinstance((state.get('round2_converged') or {}).get('meta_candidate'), dict)
+                    if isinstance((state.get("round2_converged") or {}).get("meta_candidate"), dict)
                     else ""
                 ),
                 f"- Round 2 deadlocked: `{len((state.get('round2_converged') or {}).get('deadlocked_candidates') or [])}`",
                 f"- Round 2 meta status: `{(state.get('round2_converged') or {}).get('meta_status', 'n/a')}`"
                 + (
                     " (meta proposal deadlocked — see deadlocked_meta in converged.json)"
-                    if (state.get('round2_converged') or {}).get('deadlocked_meta')
+                    if (state.get("round2_converged") or {}).get("deadlocked_meta")
                     else ""
                 ),
                 f"- Round 2 dual no-new-work justifications: `{sum(1 for j in ((state.get('round2_converged') or {}).get('no_new_work_justifications') or []) if isinstance(j, dict) and j.get('candidate_count') == 0 and str(j.get('justification') or '').strip())}`",

--- a/scripts/repo_review_heartbeat.py
+++ b/scripts/repo_review_heartbeat.py
@@ -137,16 +137,24 @@ def run_with_heartbeat(
     except OSError as exc:
         log_handle.close()
         _write_sentinel(
-            sentinel_path, state="spawn_failed", pid=None,
-            started_at=started_at, last_check=time.time(),
-            last_log_mtime=None, elapsed=time.time() - started_at,
-            stall_for=None, note=f"OSError: {exc}",
+            sentinel_path,
+            state="spawn_failed",
+            pid=None,
+            started_at=started_at,
+            last_check=time.time(),
+            last_log_mtime=None,
+            elapsed=time.time() - started_at,
+            stall_for=None,
+            note=f"OSError: {exc}",
         )
         return HeartbeatResult(
-            succeeded=False, returncode=None,
+            succeeded=False,
+            returncode=None,
             elapsed_seconds=time.time() - started_at,
-            stuck=False, timed_out=False,
-            last_log_mtime=None, note=f"spawn failed: {exc}",
+            stuck=False,
+            timed_out=False,
+            last_log_mtime=None,
+            note=f"spawn failed: {exc}",
             sentinel_path=sentinel_path,
         )
 
@@ -170,7 +178,9 @@ def run_with_heartbeat(
             now = time.time()
             elapsed = now - started_at
             current_mtime = _safe_mtime(log_file)
-            if current_mtime is not None and (last_log_mtime is None or current_mtime > last_log_mtime):
+            if current_mtime is not None and (
+                last_log_mtime is None or current_mtime > last_log_mtime
+            ):
                 last_log_mtime = current_mtime
                 last_growth_time = now
             stall_for = now - last_growth_time
@@ -178,15 +188,22 @@ def run_with_heartbeat(
             if rc is not None:
                 # Process exited.
                 _write_sentinel(
-                    sentinel_path, state="exited",
-                    pid=pid, started_at=started_at, last_check=now,
-                    last_log_mtime=last_log_mtime, elapsed=elapsed,
-                    stall_for=stall_for, note=f"exited rc={rc}",
+                    sentinel_path,
+                    state="exited",
+                    pid=pid,
+                    started_at=started_at,
+                    last_check=now,
+                    last_log_mtime=last_log_mtime,
+                    elapsed=elapsed,
+                    stall_for=stall_for,
+                    note=f"exited rc={rc}",
                 )
                 return HeartbeatResult(
-                    succeeded=(rc == 0), returncode=rc,
+                    succeeded=(rc == 0),
+                    returncode=rc,
                     elapsed_seconds=elapsed,
-                    stuck=False, timed_out=False,
+                    stuck=False,
+                    timed_out=False,
                     last_log_mtime=last_log_mtime,
                     note=f"exited rc={rc}",
                     sentinel_path=sentinel_path,
@@ -213,9 +230,13 @@ def run_with_heartbeat(
                 break
 
             _write_sentinel(
-                sentinel_path, state="running",
-                pid=pid, started_at=started_at, last_check=now,
-                last_log_mtime=last_log_mtime, elapsed=elapsed,
+                sentinel_path,
+                state="running",
+                pid=pid,
+                started_at=started_at,
+                last_check=now,
+                last_log_mtime=last_log_mtime,
+                elapsed=elapsed,
                 stall_for=stall_for,
                 note=f"{label}: alive, log {'growing' if stall_for < heartbeat_interval else f'idle for {stall_for:.0f}s'}",
             )
@@ -235,15 +256,20 @@ def run_with_heartbeat(
         _write_sentinel(
             sentinel_path,
             state="stuck" if stuck else "timed_out",
-            pid=pid, started_at=started_at, last_check=time.time(),
-            last_log_mtime=last_log_mtime, elapsed=elapsed,
+            pid=pid,
+            started_at=started_at,
+            last_check=time.time(),
+            last_log_mtime=last_log_mtime,
+            elapsed=elapsed,
             stall_for=time.time() - last_growth_time,
             note=note,
         )
         return HeartbeatResult(
-            succeeded=False, returncode=proc.returncode,
+            succeeded=False,
+            returncode=proc.returncode,
             elapsed_seconds=elapsed,
-            stuck=stuck, timed_out=timed_out,
+            stuck=stuck,
+            timed_out=timed_out,
             last_log_mtime=last_log_mtime,
             note=note,
             sentinel_path=sentinel_path,

--- a/scripts/repo_review_queue_builder.py
+++ b/scripts/repo_review_queue_builder.py
@@ -28,7 +28,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-
 META_AUDIT_LABEL = "repo-review-meta-audit"
 APPROVE_DECISIONS = {"approve", "revise"}
 SKIP_DECISIONS = {"defer", "no_new_work_accept"}
@@ -74,9 +73,7 @@ def build_queue(round2_dir: Path, feedback_path: Path) -> dict[str, Any]:
     if not round2_dir.is_dir():
         raise FileNotFoundError(f"round2 dir not found: {round2_dir}")
 
-    repo_dirs = {
-        d.name.replace("__", "/"): d for d in round2_dir.iterdir() if d.is_dir()
-    }
+    repo_dirs = {d.name.replace("__", "/"): d for d in round2_dir.iterdir() if d.is_dir()}
 
     queue: list[dict[str, Any]] = []
     skipped: list[dict[str, str]] = []
@@ -114,20 +111,24 @@ def build_queue(round2_dir: Path, feedback_path: Path) -> dict[str, Any]:
         for i, c in enumerate(data.get("converged_candidates", []) or []):
             ok, why = is_uploadable_body(c.get("body"))
             if not ok:
-                skipped.append({
-                    "repo": repo,
-                    "candidate_index": str(i),
-                    "title": str(c.get("title", ""))[:80],
-                    "reason": why,
-                })
+                skipped.append(
+                    {
+                        "repo": repo,
+                        "candidate_index": str(i),
+                        "title": str(c.get("title", ""))[:80],
+                        "reason": why,
+                    }
+                )
                 continue
-            queue.append({
-                "repo": repo,
-                "title": c.get("title", ""),
-                "body": c.get("body", ""),
-                "labels": labels_for(c, is_meta=False),
-                "review_evidence_trace": trace_for(c),
-            })
+            queue.append(
+                {
+                    "repo": repo,
+                    "title": c.get("title", ""),
+                    "body": c.get("body", ""),
+                    "labels": labels_for(c, is_meta=False),
+                    "review_evidence_trace": trace_for(c),
+                }
+            )
 
         # meta candidate (audit-scope) — only if explicitly opted in
         if decision.get("include_meta_candidate", False):
@@ -135,20 +136,24 @@ def build_queue(round2_dir: Path, feedback_path: Path) -> dict[str, Any]:
             if meta:
                 ok, why = is_uploadable_body(meta.get("body"))
                 if ok:
-                    queue.append({
-                        "repo": repo,
-                        "title": meta.get("title", ""),
-                        "body": meta.get("body", ""),
-                        "labels": labels_for(meta, is_meta=True),
-                        "review_evidence_trace": trace_for(meta),
-                    })
+                    queue.append(
+                        {
+                            "repo": repo,
+                            "title": meta.get("title", ""),
+                            "body": meta.get("body", ""),
+                            "labels": labels_for(meta, is_meta=True),
+                            "review_evidence_trace": trace_for(meta),
+                        }
+                    )
                 else:
-                    skipped.append({
-                        "repo": repo,
-                        "candidate_index": "meta",
-                        "title": str(meta.get("title", ""))[:80],
-                        "reason": why,
-                    })
+                    skipped.append(
+                        {
+                            "repo": repo,
+                            "candidate_index": "meta",
+                            "title": str(meta.get("title", ""))[:80],
+                            "reason": why,
+                        }
+                    )
 
     return {
         "generated_on": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
@@ -180,7 +185,9 @@ def parse_args() -> argparse.Namespace:
         help="path to write approved-issue-queue.json",
     )
     parser.add_argument(
-        "--quiet", action="store_true", help="only print summary line",
+        "--quiet",
+        action="store_true",
+        help="only print summary line",
     )
     return parser.parse_args()
 

--- a/scripts/repo_review_round1_runner.py
+++ b/scripts/repo_review_round1_runner.py
@@ -36,14 +36,18 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 # Re-use agent invocation + state primitives from sibling scripts.
 try:
+    from scripts.repo_review_evaluator import (
+        collect_gitnexus_map,
+        load_registry,
+        run_gitnexus_analyze,
+    )
+    from scripts.repo_review_round1_schema import validate_findings
     from scripts.repo_review_round2_runner import (
         invoke_agent,
     )
-    from scripts.repo_review_round1_schema import validate_findings
     from scripts.repo_review_state import (
         begin_attempt,
         finish_attempt,
@@ -52,17 +56,17 @@ try:
         save_state,
         transition,
     )
-    from scripts.repo_review_evaluator import (
+except ModuleNotFoundError:  # pragma: no cover - direct script execution
+    from repo_review_evaluator import (  # type: ignore[no-redef]
+        collect_gitnexus_map,
         load_registry,
         run_gitnexus_analyze,
-        collect_gitnexus_map,
-    )
-except ModuleNotFoundError:  # pragma: no cover - direct script execution
-    from repo_review_round2_runner import (  # type: ignore[no-redef]
-        invoke_agent,
     )
     from repo_review_round1_schema import (  # type: ignore[no-redef]
         validate_findings,
+    )
+    from repo_review_round2_runner import (  # type: ignore[no-redef]
+        invoke_agent,
     )
     from repo_review_state import (  # type: ignore[no-redef]
         begin_attempt,
@@ -71,11 +75,6 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution
         record_round1_finding,
         save_state,
         transition,
-    )
-    from repo_review_evaluator import (  # type: ignore[no-redef]
-        load_registry,
-        run_gitnexus_analyze,
-        collect_gitnexus_map,
     )
 
 
@@ -161,7 +160,10 @@ def sync_repo_to_origin(
     def _git(args: list[str], check: bool = False) -> subprocess.CompletedProcess:
         return subprocess.run(
             ["git", "-C", str(repo_path), *args],
-            check=check, capture_output=True, text=True, timeout=timeout,
+            check=check,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
 
     notes: list[str] = []
@@ -185,11 +187,15 @@ def sync_repo_to_origin(
         # 3. Stash any dirty changes so checkout is safe.
         dirty = _git(["status", "--short"])
         if dirty.stdout.strip():
-            stash = _git([
-                "stash", "push", "-m",
-                "round1-runner sync: stash before sync to origin head",
-                "-u",  # include untracked
-            ])
+            stash = _git(
+                [
+                    "stash",
+                    "push",
+                    "-m",
+                    "round1-runner sync: stash before sync to origin head",
+                    "-u",  # include untracked
+                ]
+            )
             if stash.returncode == 0:
                 notes.append("stashed dirty changes")
 
@@ -208,9 +214,7 @@ def sync_repo_to_origin(
         if current != target:
             checkout = _git(["checkout", target])
             if checkout.returncode != 0:
-                return False, (
-                    f"checkout {target} failed: {checkout.stderr.strip()[:200]}"
-                )
+                return False, (f"checkout {target} failed: {checkout.stderr.strip()[:200]}")
             notes.append(f"checked out {target} (was {current})")
 
         # 6. Fast-forward pull.
@@ -345,10 +349,7 @@ def invoke_round1_agent(
                     spawned=False,
                 )
             # Otherwise fall through to spawn (overwrite invalid file).
-            last_error = (
-                "existing findings.json failed schema validation: "
-                + "; ".join(errors[:3])
-            )
+            last_error = "existing findings.json failed schema validation: " + "; ".join(errors[:3])
 
         ok, message = invoke_agent(
             agent,
@@ -464,7 +465,8 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             transition(
-                state, status="round1-failed",
+                state,
+                status="round1-failed",
                 note=f"local sync failed: {message[:200]}",
             )
             save_state(output_dir, state)
@@ -488,7 +490,8 @@ def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             transition(
-                state, status="round1-failed",
+                state,
+                status="round1-failed",
                 note=f"map refresh failed: {message[:200]}",
             )
             save_state(output_dir, state)

--- a/scripts/repo_review_round1_schema.py
+++ b/scripts/repo_review_round1_schema.py
@@ -157,9 +157,7 @@ def validate_candidate(candidate: Any, index: int) -> list[str]:
 
     acceptance = candidate.get("acceptance_criteria")
     if not _is_str_list(acceptance, min_items=2):
-        errors.append(
-            f"{prefix}.acceptance_criteria: must be a list of ≥2 verifiable conditions"
-        )
+        errors.append(f"{prefix}.acceptance_criteria: must be a list of ≥2 verifiable conditions")
     else:
         joined = " ".join(str(item) for item in acceptance).lower()
         if not any(
@@ -290,9 +288,7 @@ def validate_findings(data: Any, *, expected_repo: str | None = None) -> list[st
 
     if deeper:
         if not _is_nonempty_str(data.get("deeper_review_reason")):
-            errors.append(
-                "deeper_review_reason: required when deeper_review_needed is true"
-            )
+            errors.append("deeper_review_reason: required when deeper_review_needed is true")
 
     if not deeper and not candidates:
         if not _is_nonempty_str(data.get("no_new_work_justification")):

--- a/scripts/repo_review_round2_runner.py
+++ b/scripts/repo_review_round2_runner.py
@@ -42,10 +42,7 @@ import argparse
 import concurrent.futures
 import json
 import os
-import re
-import shlex
 import shutil
-import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
@@ -126,7 +123,9 @@ class CandidateKey:
 @dataclass
 class CandidateResolution:
     key: CandidateKey
-    status: str  # "converged-keep" | "converged-merge" | "converged-drop" | "pending" | "deadlocked"
+    status: (
+        str  # "converged-keep" | "converged-merge" | "converged-drop" | "pending" | "deadlocked"
+    )
     marks_history: list[dict[str, Any]] = field(default_factory=list)
     merge_proposal: dict[str, Any] | None = None
     revision_proposal: dict[str, Any] | None = None
@@ -147,13 +146,7 @@ def round1_findings_path(output_dir: Path, agent: str, repo: str) -> Path:
 
 
 def round2_turn_path(output_dir: Path, repo: str, turn: int, agent: str) -> Path:
-    return (
-        output_dir
-        / "round2"
-        / safe_repo_name(repo)
-        / f"turn-{turn}"
-        / f"{agent}.json"
-    )
+    return output_dir / "round2" / safe_repo_name(repo) / f"turn-{turn}" / f"{agent}.json"
 
 
 def round2_converged_path(output_dir: Path, repo: str) -> Path:
@@ -318,9 +311,7 @@ _HEARTBEAT_INTERVAL = int(os.environ.get("REPO_REVIEW_HEARTBEAT_INTERVAL", "60")
 _STALL_THRESHOLD = int(os.environ.get("REPO_REVIEW_STALL_THRESHOLD", "900"))  # 15 min
 
 
-def invoke_codex(
-    prompt: str, *, cwd: Path, log_file: Path, timeout: int
-) -> tuple[bool, str]:
+def invoke_codex(prompt: str, *, cwd: Path, log_file: Path, timeout: int) -> tuple[bool, str]:
     if shutil.which("codex") is None:
         return False, "codex CLI not on PATH"
     cmd = [
@@ -345,7 +336,10 @@ def invoke_codex(
     if result.succeeded:
         return True, str(log_file)
     if result.stuck:
-        return False, f"codex stuck (no log growth for >{_STALL_THRESHOLD}s; terminated): {log_file}"
+        return (
+            False,
+            f"codex stuck (no log growth for >{_STALL_THRESHOLD}s; terminated): {log_file}",
+        )
     if result.timed_out:
         return False, f"codex timed out after {timeout}s (log: {log_file})"
     return False, f"codex exited {result.returncode} ({result.note}; log: {log_file})"
@@ -381,7 +375,10 @@ def invoke_claude(
     if result.succeeded:
         return True, str(log_file)
     if result.stuck:
-        return False, f"claude stuck (no log growth for >{_STALL_THRESHOLD}s; terminated): {log_file}"
+        return (
+            False,
+            f"claude stuck (no log growth for >{_STALL_THRESHOLD}s; terminated): {log_file}",
+        )
     if result.timed_out:
         return False, f"claude timed out after {timeout}s (log: {log_file})"
     return False, f"claude exited {result.returncode} ({result.note}; log: {log_file})"
@@ -439,8 +436,7 @@ def run_one_turn(
     prior_turn_paths = sorted(
         path
         for path in (output_dir / "round2" / safe_repo_name(repo)).glob("turn-*/*.json")
-        if "turn-" in path.parts[-2]
-        and int(path.parts[-2].rsplit("-", 1)[-1]) < turn
+        if "turn-" in path.parts[-2] and int(path.parts[-2].rsplit("-", 1)[-1]) < turn
     )
 
     def task(agent_label: str) -> AgentTurnResult:
@@ -449,14 +445,16 @@ def run_one_turn(
         out_path.parent.mkdir(parents=True, exist_ok=True)
         if out_path.is_file():
             return AgentTurnResult(
-                agent=agent_label, turn=turn, output_path=out_path,
-                succeeded=True, spawned=False
+                agent=agent_label, turn=turn, output_path=out_path, succeeded=True, spawned=False
             )
         if dry_run:
             return AgentTurnResult(
-                agent=agent_label, turn=turn, output_path=out_path,
-                succeeded=False, spawned=False,
-                error="dry-run: turn output absent and agent spawn skipped"
+                agent=agent_label,
+                turn=turn,
+                output_path=out_path,
+                succeeded=False,
+                spawned=False,
+                error="dry-run: turn output absent and agent spawn skipped",
             )
         prompt = build_prompt(
             repo=repo,
@@ -481,14 +479,21 @@ def run_one_turn(
             )
             if ok and out_path.is_file():
                 return AgentTurnResult(
-                    agent=agent_label, turn=turn, output_path=out_path,
-                    succeeded=True, spawned=True,
+                    agent=agent_label,
+                    turn=turn,
+                    output_path=out_path,
+                    succeeded=True,
+                    spawned=True,
                 )
             last_error = info if not ok else f"agent did not write {out_path}"
             time.sleep(2)
         return AgentTurnResult(
-            agent=agent_label, turn=turn, output_path=out_path,
-            succeeded=False, spawned=True, error=last_error,
+            agent=agent_label,
+            turn=turn,
+            output_path=out_path,
+            succeeded=False,
+            spawned=True,
+            error=last_error,
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(agents)) as executor:
@@ -575,9 +580,7 @@ def compute_convergence(
 
         missing = expected_marker_agents - set(latest_per_agent.keys())
         if missing:
-            resolutions[key] = CandidateResolution(
-                key=key, status="pending", marks_history=history
-            )
+            resolutions[key] = CandidateResolution(key=key, status="pending", marks_history=history)
             continue
 
         marks = {a: entry["mark"] for a, entry in latest_per_agent.items()}
@@ -590,9 +593,7 @@ def compute_convergence(
         elif unique == {"agree-merge"}:
             # Both sides proposed merges; converged-merge with combined framing.
             merge_a = next(
-                e["merge_proposal"]
-                for e in latest_per_agent.values()
-                if e.get("merge_proposal")
+                e["merge_proposal"] for e in latest_per_agent.values() if e.get("merge_proposal")
             )
             resolutions[key] = CandidateResolution(
                 key=key,
@@ -603,11 +604,7 @@ def compute_convergence(
         elif unique <= {"agree-keep", "agree-merge"}:
             # One agent agrees-keep, the other proposes merge — accept the merge framing.
             merge_proposal = next(
-                (
-                    e["merge_proposal"]
-                    for e in latest_per_agent.values()
-                    if e.get("merge_proposal")
-                ),
+                (e["merge_proposal"] for e in latest_per_agent.values() if e.get("merge_proposal")),
                 None,
             )
             resolutions[key] = CandidateResolution(
@@ -629,9 +626,7 @@ def compute_convergence(
                 drop_reason=reason or "Both agents agreed to drop.",
             )
         else:
-            resolutions[key] = CandidateResolution(
-                key=key, status="pending", marks_history=history
-            )
+            resolutions[key] = CandidateResolution(key=key, status="pending", marks_history=history)
     return resolutions
 
 
@@ -684,19 +679,13 @@ def converge_meta(
     smaller set.
     """
     proposing = {
-        agent: meta
-        for agent, meta in meta_by_agent.items()
-        if meta.get("proposed") is True
+        agent: meta for agent, meta in meta_by_agent.items() if meta.get("proposed") is True
     }
     if not proposing:
         return None, "absent"
     if expected_marker_agents - set(meta_by_agent.keys()):
         return None, "single-side"
-    rejecting = [
-        agent
-        for agent, meta in meta_by_agent.items()
-        if meta.get("proposed") is False
-    ]
+    rejecting = [agent for agent, meta in meta_by_agent.items() if meta.get("proposed") is False]
     if proposing and rejecting:
         # Deadlocked: one (or more) agent proposed a meta-candidate; one (or
         # more) explicitly rejected. Per the protocol, surface the rejected
@@ -729,9 +718,7 @@ def converge_meta(
         accept_count = len(meta.get("acceptance_criteria", []) or [])
         return pattern_len + task_count * 30 + accept_count * 30
 
-    primary_agent, primary = max(
-        proposing.items(), key=lambda kv: proposal_score(kv[1])
-    )
+    primary_agent, primary = max(proposing.items(), key=lambda kv: proposal_score(kv[1]))
     alternative_titles = [
         {"agent": a, "title": m.get("title", "")}
         for a, m in proposing.items()
@@ -742,8 +729,7 @@ def converge_meta(
     merged["compatible_alternative_proposals"] = alternative_titles
     merged["primary_source_agent"] = primary_agent
     merged["supporting_candidate_indexes"] = [
-        {"agent": agent, "candidate_index": idx}
-        for agent, idx in sorted(union)
+        {"agent": agent, "candidate_index": idx} for agent, idx in sorted(union)
     ]
     return merged, "converged"
 
@@ -760,9 +746,7 @@ def candidate_for_resolution(
     base = round1_index.get(resolution.key)
     if base is None:
         # Should not happen — every key comes from a round-1 finding.
-        raise SystemExit(
-            f"BUG: round-1 candidate {resolution.key} missing from index"
-        )
+        raise SystemExit(f"BUG: round-1 candidate {resolution.key} missing from index")
     cand = dict(base)
     cand["scope"] = "fix"
     cand["origin"] = {
@@ -773,9 +757,7 @@ def candidate_for_resolution(
     if resolution.status == "converged-merge" and resolution.merge_proposal:
         # Apply the merge proposal on top of the base — preserves design refs
         # etc. while letting the merged framing override title/gap/etc.
-        cand.update(
-            {k: v for k, v in resolution.merge_proposal.items() if v is not None}
-        )
+        cand.update({k: v for k, v in resolution.merge_proposal.items() if v is not None})
         cand["origin"]["merged_from"] = [resolution.merge_proposal.get("source", "")]
     return cand
 
@@ -802,9 +784,7 @@ def meta_to_candidate(
         for ref in meta.get("supporting_candidate_indexes") or []:
             if not isinstance(ref, dict):
                 continue
-            key = CandidateKey(
-                str(ref.get("agent", "")), int(ref.get("candidate_index", 0))
-            )
+            key = CandidateKey(str(ref.get("agent", "")), int(ref.get("candidate_index", 0)))
             base = round1_index.get(key) or {}
             for value in base.get(field) or []:
                 value_str = str(value)
@@ -982,9 +962,7 @@ def synthesize_converged(
             mp = tout.get("meta_candidate_proposal") or {}
             if mp.get("proposed") is False:
                 rejection_reasons[tout["agent"]] = str(
-                    mp.get("rationale", "")
-                    or mp.get("reason", "")
-                    or "no rationale recorded"
+                    mp.get("rationale", "") or mp.get("reason", "") or "no rationale recorded"
                 )
         deadlocked_meta = {
             "proposed_by": proposing_agent,
@@ -1009,8 +987,7 @@ def synthesize_converged(
                 "agent": agent,
                 "path": str(path.resolve()),
                 "candidate_count": len(
-                    json.loads(path.read_text(encoding="utf-8")).get("candidates")
-                    or []
+                    json.loads(path.read_text(encoding="utf-8")).get("candidates") or []
                 ),
             }
             for agent, path in round1_paths.items()
@@ -1026,9 +1003,7 @@ def synthesize_converged(
         # Carry both forward so the human packet can show them side-by-side
         # and the human can verify the justifications match the actual repo
         # state before accepting "no new work" as the cycle outcome.
-        "no_new_work_justifications": _collect_no_new_work_justifications(
-            round1_paths
-        ),
+        "no_new_work_justifications": _collect_no_new_work_justifications(round1_paths),
         "negotiation_log": [
             str(round2_turn_path(output_dir, repo, t["turn"], t["agent"]).resolve())
             for t in turn_outputs
@@ -1047,9 +1022,7 @@ def run(args: argparse.Namespace) -> int:
     repo = args.repo
     requested_agents = tuple(a.strip() for a in args.agents.split(",") if a.strip())
     if len(requested_agents) != 2:
-        raise SystemExit(
-            "--agents must list exactly two labels (e.g. codex,claude)"
-        )
+        raise SystemExit("--agents must list exactly two labels (e.g. codex,claude)")
 
     round1_paths = resolve_negotiation_agents(output_dir, repo, requested_agents)
     expected_marker_agents = set(round1_paths.keys())
@@ -1082,9 +1055,7 @@ def run(args: argparse.Namespace) -> int:
     # converged_candidates=[] and both agents' no_new_work_justifications
     # carried forward to the human packet via deadlocked-meta-style records.
     if not candidate_keys:
-        print(
-            f"[round2] {repo}: both round-1 findings empty — skipping negotiation"
-        )
+        print(f"[round2] {repo}: both round-1 findings empty — skipping negotiation")
         fully_converged = True
         # No marks, no meta — synthesize a convergence record that carries the
         # round-1 justifications through to the human packet.
@@ -1109,11 +1080,7 @@ def run(args: argparse.Namespace) -> int:
             log_dir=log_dir,
         )
         for label, result in turn_results.items():
-            status = (
-                "succeeded"
-                if result.succeeded
-                else f"failed: {result.error}"
-            )
+            status = "succeeded" if result.succeeded else f"failed: {result.error}"
             spawned = "spawned" if result.spawned else "reused"
             print(f"[round2] {repo}: turn {turn} {label} → {status} ({spawned})")
         if not all(r.succeeded for r in turn_results.values()):
@@ -1121,8 +1088,7 @@ def run(args: argparse.Namespace) -> int:
                 f"{label}: {r.error}" for label, r in turn_results.items() if not r.succeeded
             ]
             print(
-                f"[round2] {repo}: turn {turn} aborted — "
-                + "; ".join(failures),
+                f"[round2] {repo}: turn {turn} aborted — " + "; ".join(failures),
                 file=sys.stderr,
             )
             if args.dry_run:
@@ -1144,13 +1110,9 @@ def run(args: argparse.Namespace) -> int:
             candidate_keys, marks_by_candidate, expected_marker_agents
         )
         meta_by_agent = meta_proposals(turn_outputs)
-        meta_proposal, meta_status = converge_meta(
-            meta_by_agent, expected_marker_agents
-        )
+        meta_proposal, meta_status = converge_meta(meta_by_agent, expected_marker_agents)
 
-        pending = [
-            r for r in final_resolutions.values() if r.status == "pending"
-        ]
+        pending = [r for r in final_resolutions.values() if r.status == "pending"]
         meta_pending = meta_status not in ("converged", "absent", "deadlocked", "single-side")
         if not pending and not meta_pending:
             print(
@@ -1186,9 +1148,7 @@ def run(args: argparse.Namespace) -> int:
 
     converged_path = round2_converged_path(output_dir, repo)
     converged_path.parent.mkdir(parents=True, exist_ok=True)
-    converged_path.write_text(
-        json.dumps(converged, indent=2) + "\n", encoding="utf-8"
-    )
+    converged_path.write_text(json.dumps(converged, indent=2) + "\n", encoding="utf-8")
 
     # Repo-scoped state update — never touches global state. If anything goes
     # wrong with this repo, remediation work stays inside its directory.
@@ -1196,7 +1156,9 @@ def run(args: argparse.Namespace) -> int:
         state = load_state(output_dir, repo)
         attempt = begin_attempt(state, phase="round-2", agent="runner")
         finish_attempt(
-            state, attempt, succeeded=True,
+            state,
+            attempt,
+            succeeded=True,
             notes=(
                 f"turns={turns_completed} converged={len(converged['converged_candidates'])} "
                 f"deadlocked={len(converged['deadlocked_candidates'])} "

--- a/scripts/repo_review_round2_schema.py
+++ b/scripts/repo_review_round2_schema.py
@@ -94,30 +94,21 @@ def validate_mark(mark: Any, index: int) -> list[str]:
 
     mark_value = mark.get("mark")
     if mark_value not in ALLOWED_MARKS:
-        errors.append(
-            f"{prefix}.mark: must be one of {sorted(ALLOWED_MARKS)} (got {mark_value!r})"
-        )
+        errors.append(f"{prefix}.mark: must be one of {sorted(ALLOWED_MARKS)} (got {mark_value!r})")
 
     reason = mark.get("reason", "")
     if not _is_nonempty_str(reason):
         errors.append(f"{prefix}.reason: must be a non-empty string")
     elif len(reason.strip()) < REASON_MIN_CHARS:
         errors.append(
-            f"{prefix}.reason: must be ≥{REASON_MIN_CHARS} chars "
-            f"(got {len(reason.strip())})"
+            f"{prefix}.reason: must be ≥{REASON_MIN_CHARS} chars " f"(got {len(reason.strip())})"
         )
 
     if mark_value == "agree-merge" and not isinstance(mark.get("merge_proposal"), dict):
-        errors.append(
-            f"{prefix}.merge_proposal: required when mark is 'agree-merge'"
-        )
+        errors.append(f"{prefix}.merge_proposal: required when mark is 'agree-merge'")
 
-    if mark_value == "disagree-revise" and not isinstance(
-        mark.get("revision_proposal"), dict
-    ):
-        errors.append(
-            f"{prefix}.revision_proposal: required when mark is 'disagree-revise'"
-        )
+    if mark_value == "disagree-revise" and not isinstance(mark.get("revision_proposal"), dict):
+        errors.append(f"{prefix}.revision_proposal: required when mark is 'disagree-revise'")
 
     if mark_value == "disagree-drop":
         # Drop reasons must cite a file ref / test ref / issue / PR.
@@ -146,7 +137,7 @@ def validate_meta_candidate(meta: Any) -> list[str]:
     errors: list[str] = []
     prefix = "meta_candidate_proposal"
     if not isinstance(meta, dict):
-        return [f"{prefix}: must be an object (use {{\"proposed\": false}} when no pattern)"]
+        return [f'{prefix}: must be an object (use {{"proposed": false}} when no pattern)']
 
     proposed = meta.get("proposed")
     if not isinstance(proposed, bool):
@@ -163,9 +154,7 @@ def validate_meta_candidate(meta: Any) -> list[str]:
 
     supporting = meta.get("supporting_candidate_indexes")
     if not isinstance(supporting, list) or len(supporting) < 2:
-        errors.append(
-            f"{prefix}.supporting_candidate_indexes: must list ≥2 anchoring candidates"
-        )
+        errors.append(f"{prefix}.supporting_candidate_indexes: must list ≥2 anchoring candidates")
     else:
         for sub_idx, item in enumerate(supporting):
             sub_prefix = f"{prefix}.supporting_candidate_indexes[{sub_idx}]"
@@ -193,9 +182,7 @@ def validate_meta_candidate(meta: Any) -> list[str]:
 
     acceptance = meta.get("acceptance_criteria")
     if not _is_str_list(acceptance, min_items=META_ACCEPTANCE_MIN):
-        errors.append(
-            f"{prefix}.acceptance_criteria: must list ≥{META_ACCEPTANCE_MIN} criteria"
-        )
+        errors.append(f"{prefix}.acceptance_criteria: must list ≥{META_ACCEPTANCE_MIN} criteria")
     else:
         joined = " ".join(str(c).lower() for c in acceptance)
         if not any(token in joined for token in META_ACCEPTANCE_TOKENS):
@@ -206,15 +193,13 @@ def validate_meta_candidate(meta: Any) -> list[str]:
 
     non_goals = meta.get("non_goals")
     if not _is_str_list(non_goals, min_items=META_NON_GOALS_MIN):
-        errors.append(
-            f"{prefix}.non_goals: must list ≥{META_NON_GOALS_MIN} non-goals"
-        )
+        errors.append(f"{prefix}.non_goals: must list ≥{META_NON_GOALS_MIN} non-goals")
     else:
         joined = " ".join(str(n).lower() for n in non_goals)
         if not any(token in joined for token in META_NON_GOAL_TOKENS):
             errors.append(
                 f"{prefix}.non_goals: must explicitly forbid bundling per-instance fixes "
-                "into a single PR (e.g., \"Do not bundle per-instance fixes into a single PR\")."
+                'into a single PR (e.g., "Do not bundle per-instance fixes into a single PR").'
             )
 
     priority = meta.get("priority")
@@ -226,9 +211,7 @@ def validate_meta_candidate(meta: Any) -> list[str]:
 
     confidence = meta.get("confidence")
     if confidence not in ALLOWED_CONFIDENCE:
-        errors.append(
-            f"{prefix}.confidence: must be one of {sorted(ALLOWED_CONFIDENCE)}"
-        )
+        errors.append(f"{prefix}.confidence: must be one of {sorted(ALLOWED_CONFIDENCE)}")
     elif confidence == "high" and isinstance(supporting, list) and len(supporting) < 4:
         errors.append(
             f"{prefix}.confidence: 'high' requires ≥4 supporting per-instance candidates "

--- a/scripts/repo_review_state.py
+++ b/scripts/repo_review_state.py
@@ -32,17 +32,17 @@ from typing import Any
 STATE_SCHEMA_VERSION = "v1"
 
 VALID_STATUSES = {
-    "fresh",                       # never run
-    "round1-running",              # at least one round-1 agent in flight
-    "round1-complete",             # both round-1 findings on disk, validated
-    "round1-failed",               # one or both round-1 agents failed past retries
-    "round2-running",              # negotiation in progress
-    "round2-converged",            # converged.json written, ready for human review
-    "round2-deadlocked",           # converged.json written WITH deadlocked items
-    "round2-failed",               # negotiation aborted past retries
-    "human-review-queued",         # waiting on feedback config update
-    "approved-pending-upload",     # feedback says approve, queue items waiting
-    "uploaded",                    # remote issues created for this cycle
+    "fresh",  # never run
+    "round1-running",  # at least one round-1 agent in flight
+    "round1-complete",  # both round-1 findings on disk, validated
+    "round1-failed",  # one or both round-1 agents failed past retries
+    "round2-running",  # negotiation in progress
+    "round2-converged",  # converged.json written, ready for human review
+    "round2-deadlocked",  # converged.json written WITH deadlocked items
+    "round2-failed",  # negotiation aborted past retries
+    "human-review-queued",  # waiting on feedback config update
+    "approved-pending-upload",  # feedback says approve, queue items waiting
+    "uploaded",  # remote issues created for this cycle
 }
 
 
@@ -50,8 +50,8 @@ VALID_STATUSES = {
 class AttemptRecord:
     started_at: str
     completed_at: str = ""
-    phase: str = ""               # round-1 | round-2 | upload
-    agent: str = ""               # codex | claude | runner | uploader
+    phase: str = ""  # round-1 | round-2 | upload
+    agent: str = ""  # codex | claude | runner | uploader
     succeeded: bool = False
     notes: str = ""
 
@@ -77,6 +77,7 @@ class PinnedProblem:
 
     The coordinator surfaces these in the human packet so they're visible.
     """
+
     title: str
     first_seen: str
     last_seen: str = ""
@@ -114,9 +115,7 @@ class RepoReviewState:
             "status": self.status,
             "cycle_started_at": self.cycle_started_at,
             "cycle_updated_at": self.cycle_updated_at,
-            "last_attempt": (
-                self.last_attempt.to_dict() if self.last_attempt else None
-            ),
+            "last_attempt": (self.last_attempt.to_dict() if self.last_attempt else None),
             "attempts": [a.to_dict() for a in self.attempts],
             "pinned_problems": [p.to_dict() for p in self.pinned_problems],
             "round1_findings": self.round1_findings,
@@ -173,15 +172,9 @@ def _state_from_dict(data: dict[str, Any]) -> RepoReviewState:
     last_attempt = (
         AttemptRecord(**last_attempt_data) if isinstance(last_attempt_data, dict) else None
     )
-    attempts = [
-        AttemptRecord(**a)
-        for a in (data.get("attempts") or [])
-        if isinstance(a, dict)
-    ]
+    attempts = [AttemptRecord(**a) for a in (data.get("attempts") or []) if isinstance(a, dict)]
     pinned = [
-        PinnedProblem(**p)
-        for p in (data.get("pinned_problems") or [])
-        if isinstance(p, dict)
+        PinnedProblem(**p) for p in (data.get("pinned_problems") or []) if isinstance(p, dict)
     ]
     return RepoReviewState(
         schema_version=str(data.get("schema_version", STATE_SCHEMA_VERSION)),
@@ -231,9 +224,7 @@ def transition(state: RepoReviewState, *, status: str, note: str = "") -> None:
         state.notes = note
 
 
-def record_round1_finding(
-    state: RepoReviewState, agent: str, findings_path: Path
-) -> None:
+def record_round1_finding(state: RepoReviewState, agent: str, findings_path: Path) -> None:
     state.round1_findings[agent] = str(findings_path.resolve())
 
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -381,6 +381,31 @@ def _build_marker(pr_number: int, provider: str, record: dict[str, Any]) -> str:
     )
 
 
+def _marker_safe_text(value: Any, limit: int = 1000) -> str:
+    text = str(value or "")
+    if len(text) > limit:
+        text = f"{text[:limit]}...[truncated {len(text) - limit} chars]"
+    return text.replace("-->", "--\\u003e")
+
+
+def _compact_runner_result_payload(result_payload: dict[str, Any]) -> dict[str, Any]:
+    final_message = str(result_payload.get("final_message") or "")
+    compact: dict[str, Any] = {
+        "schema": "runner-result-summary/v1",
+        "provider": str(result_payload.get("provider") or ""),
+        "success": bool(result_payload.get("success")),
+        "summary": _marker_safe_text(result_payload.get("summary")),
+        "error": _marker_safe_text(result_payload.get("error")),
+        "truncated": bool(result_payload.get("truncated")),
+    }
+    if final_message:
+        compact["final_message_sha256"] = hashlib.sha256(
+            final_message.encode("utf-8")
+        ).hexdigest()
+        compact["final_message_chars"] = len(final_message)
+    return compact
+
+
 def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[str, Any] | None:
     if not value:
         return None
@@ -613,6 +638,7 @@ def record_completion(
         dataclasses.asdict(result) if dataclasses.is_dataclass(result) else dict(result)
     )
     status = "completed" if result_payload.get("success") else "error"
+    compact_result = _compact_runner_result_payload(result_payload)
     prior = storage.read_record(pr_number, provider) or {}
     completed_at = (
         prior.get("completed_at")
@@ -627,7 +653,7 @@ def record_completion(
         "key": key,
         "status": status,
         "completed_at": completed_at,
-        "result": result_payload,
+        "result": compact_result,
     }
     storage.write_record(pr_number, provider, record)
     return record

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -399,9 +399,7 @@ def _compact_runner_result_payload(result_payload: dict[str, Any]) -> dict[str, 
         "truncated": bool(result_payload.get("truncated")),
     }
     if final_message:
-        compact["final_message_sha256"] = hashlib.sha256(
-            final_message.encode("utf-8")
-        ).hexdigest()
+        compact["final_message_sha256"] = hashlib.sha256(final_message.encode("utf-8")).hexdigest()
         compact["final_message_chars"] = len(final_message)
     return compact
 

--- a/scripts/upload_repo_review_issues.py
+++ b/scripts/upload_repo_review_issues.py
@@ -141,8 +141,10 @@ def run_command_with_retry(
             )
     assert last_result is not None
     raise subprocess.CalledProcessError(
-        last_result.returncode, last_result.args,
-        output=last_result.stdout, stderr=last_result.stderr,
+        last_result.returncode,
+        last_result.args,
+        output=last_result.stdout,
+        stderr=last_result.stderr,
     )
 
 
@@ -263,7 +265,6 @@ DEFAULT_LABEL_COLOR = "ededed"
 DEFAULT_LABEL_DESCRIPTION = "Auto-created by repo-review upload helper."
 
 
-
 def ensure_labels(repo: str, labels: list[str], prefix: list[str]) -> None:
     """Create each label on the target repo if missing.
 
@@ -275,10 +276,13 @@ def ensure_labels(repo: str, labels: list[str], prefix: list[str]) -> None:
     already exists, so this is idempotent.
     """
     for label in labels:
-        config = LABELS.get(label, {
-            "color": DEFAULT_LABEL_COLOR,
-            "description": DEFAULT_LABEL_DESCRIPTION,
-        })
+        config = LABELS.get(
+            label,
+            {
+                "color": DEFAULT_LABEL_COLOR,
+                "description": DEFAULT_LABEL_DESCRIPTION,
+            },
+        )
         run_command(
             gh_command(
                 prefix,
@@ -409,7 +413,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path("docs/reports/repo-review/approved-issue-queue.json"),
         help="Path to approved-issue-queue.json (default: the path the "
-             "coordinator's queue-builder writes)",
+        "coordinator's queue-builder writes)",
     )
     parser.add_argument(
         "--gh-prefix",

--- a/templates/consumer-repo/.github/scripts/issue_context_utils.js
+++ b/templates/consumer-repo/.github/scripts/issue_context_utils.js
@@ -37,7 +37,7 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
     const payload = JSON.parse(output);
     return {
-      formattedBody: String(payload.formatted_body || body),
+      formattedBody: String(payload.formatted_body ?? body),
       truncated: Boolean(payload.truncated),
       estimatedTokens: payload.estimated_tokens,
       tokenBudget: payload.token_budget,

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -157,6 +157,29 @@ def test_record_completion_is_idempotent_for_same_key() -> None:
     assert storage.records[(42, "claude")]["result"]["summary"] == "Done"
 
 
+def test_record_completion_stores_compact_marker_safe_result() -> None:
+    storage = MemoryRunnerStorage()
+    result = {
+        "provider": "claude",
+        "success": True,
+        "final_message": "full output --> with marker closer",
+        "summary": "summary --> closer",
+        "error": None,
+        "truncated": False,
+    }
+
+    record = record_completion(42, "aaa", "claude", result, storage=storage)
+
+    stored_result = storage.records[(42, "claude")]["result"]
+    assert record["result"] == stored_result
+    assert stored_result["schema"] == "runner-result-summary/v1"
+    assert stored_result["summary"] == "summary --\\u003e closer"
+    assert "final_message" not in stored_result
+    assert stored_result["final_message_chars"] == len(result["final_message"])
+    assert len(stored_result["final_message_sha256"]) == 64
+    assert "-->" not in json.dumps(stored_result)
+
+
 def test_materialize_reference_packs_keeps_token_out_of_git_argv(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve intentionally empty capped issue bodies in the synced issue context helper
- store compact, marker-safe runner completion summaries instead of full final messages
- keep the consumer template mirror aligned with the source helper

## Validation
- node --test .github/scripts/__tests__/issue_context_utils.test.js
- pytest -q tests/scripts/test_runner_lib.py tests/scripts/test_issue_formatter.py
- python scripts/validate_template_sync.py