### PR TITLE
fix: satisfy reusable ci scope mypy

### DIFF
--- a/scripts/reusable_ci_scope.py
+++ b/scripts/reusable_ci_scope.py
@@ -83,6 +83,8 @@ def _restore_matrix(
 ) -> MatrixInput:
     if shape == "list":
         return selected
+    if not isinstance(full_matrix, dict):
+        raise TypeError("matrix object shape requires a dictionary input")
     restored = dict(full_matrix)
     restored["include"] = selected
     return restored


### PR DESCRIPTION
## Summary
- narrow matrix restoration to dictionary inputs before copying include matrices
- unblock consumer mypy on synced scripts/reusable_ci_scope.py

## Validation
- python -m mypy scripts/reusable_ci_scope.py
- python -m pytest tests/scripts/test_reusable_ci_scope.py -q
- python -m ruff check scripts/reusable_ci_scope.py tests/scripts/test_reusable_ci_scope.py
- python -m black --check scripts/reusable_ci_scope.py tests/scripts/test_reusable_ci_scope.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check