### PR TITLE
fix: require tracker identity markers

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -8,6 +8,7 @@ const {
   clearStuckWindowBody,
   findOrCreateTracker,
   isConsumerOpenPr,
+  issueMatchesTracker,
   markStuckWindowBody,
   patternMatches,
   parseStuckWindow,
@@ -207,7 +208,42 @@ test('findOrCreateTracker discovers an unlabeled tracker by marker', async () =>
   );
 });
 
-test('findOrCreateTracker discovers an unlabeled tracker by title only', async () => {
+test('issueMatchesTracker rejects unlabelled title-only tracker candidates', () => {
+  const issue = {
+    number: 14,
+    title: 'Sync/Dependabot campaign queue',
+    body: 'existing queue body',
+    labels: [],
+  };
+
+  assert.equal(
+    issueMatchesTracker(issue, {
+      label: 'campaign:sync-dependabot',
+      titlePattern: /^Sync\/Dependabot campaign queue$/,
+    }),
+    false,
+  );
+});
+
+test('issueMatchesTracker rejects empty title-only candidates when a marker is required', () => {
+  const issue = {
+    number: 15,
+    title: 'Consumer repo drift detected',
+    body: '',
+    labels: [],
+  };
+
+  assert.equal(
+    issueMatchesTracker(issue, {
+      label: 'consumer-sync',
+      titlePattern: 'Consumer repo drift detected',
+      markerPattern: /consumer-sync-drift:v1/,
+    }),
+    false,
+  );
+});
+
+test('findOrCreateTracker ignores unlabelled title-only issues', async () => {
   const github = mockGithub({
     issues: [
       {
@@ -227,9 +263,9 @@ test('findOrCreateTracker discovers an unlabeled tracker by title only', async (
     titlePattern: /^Sync\/Dependabot campaign queue$/,
   });
 
-  assert.equal(tracker.number, 14);
-  assert.equal(tracker.sync_tracker_created, false);
-  assert.equal(github.calls.createdIssues.length, 0);
+  assert.equal(tracker.number, 99);
+  assert.equal(tracker.sync_tracker_created, true);
+  assert.equal(github.calls.createdIssues.length, 1);
   assert.equal(
     github.calls.issueLists.some((params) => !params.labels),
     true,

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -162,12 +162,6 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
   const hasTitle = patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
-  if (titlePattern && hasTitle) {
-    return true;
-  }
-  if (markerPattern && hasTitle && !cleanString(issue.body)) {
-    return true;
-  }
   return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
 }
 

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -162,12 +162,6 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
   const hasTitle = patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
-  if (titlePattern && hasTitle) {
-    return true;
-  }
-  if (markerPattern && hasTitle && !cleanString(issue.body)) {
-    return true;
-  }
   return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
 }
 


### PR DESCRIPTION
## Summary
- require durable tracker label, configured label, or marker content before matching tracker issues
- keep source and consumer-template sync tracker helpers aligned
- add regression coverage for title-only and empty-body tracker candidates

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js .github/scripts/__tests__/issue_context_utils.test.js
- pytest -q tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py
- python scripts/validate_template_sync.py

Source fix for sync-generated consumer PR stranske/Trend_Model_Project#5232 review comments.