### PR TITLE
feat: extract auto-pilot transition logic into tested helper

### DIFF
--- a/.github/scripts/__tests__/auto-pilot-transitions.test.js
+++ b/.github/scripts/__tests__/auto-pilot-transitions.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  FORCED_STEPS,
+  NEXT_STEPS,
+  STATES,
+  TRANSITION_CONTRACT,
+  determineNextStep,
+  isKeepaliveTasksComplete,
+  normalizeForceStep,
+  redispatchForceStep,
+  resolveCurrentState,
+  transition,
+} = require('../auto_pilot_transitions.js');
+
+const fixtures = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, 'fixtures', 'auto-pilot-transitions.json'),
+    'utf8',
+  ),
+);
+
+test('transition contract documents every state and next step', () => {
+  assert.deepEqual(Object.keys(TRANSITION_CONTRACT.transitions).sort(), Object.values(STATES).sort());
+  assert.deepEqual(
+    Object.values(TRANSITION_CONTRACT.transitions).sort(),
+    [
+      NEXT_STEPS.APPLY,
+      NEXT_STEPS.CAPABILITY_CHECK,
+      NEXT_STEPS.CHECK_COMPLETION,
+      NEXT_STEPS.CREATE_PR,
+      NEXT_STEPS.DONE,
+      NEXT_STEPS.FORMAT,
+      NEXT_STEPS.MONITOR_PR,
+      NEXT_STEPS.OPTIMIZE,
+      NEXT_STEPS.VERIFY,
+    ].sort(),
+  );
+  assert.match(TRANSITION_CONTRACT.guards.join('\n'), /verify:evaluate/);
+  assert.match(TRANSITION_CONTRACT.guards.join('\n'), /optimizer suggestions comment/);
+  assert.match(TRANSITION_CONTRACT.guards.join('\n'), /keepalive state/);
+});
+
+for (const scenario of fixtures.validTransitions) {
+  test(`valid transition: ${scenario.name}`, () => {
+    assert.equal(resolveCurrentState(scenario.event), scenario.state);
+    assert.equal(transition(scenario.state, scenario.event), scenario.nextStep);
+    const result = determineNextStep(scenario.event);
+    assert.equal(result.currentState, scenario.state);
+    assert.equal(result.nextStep, scenario.nextStep);
+    assert.equal(result.forced, false);
+  });
+}
+
+for (const scenario of fixtures.guardCases) {
+  test(`guard condition: ${scenario.name}`, () => {
+    const result = determineNextStep(scenario.event);
+    assert.equal(result.currentState, scenario.state);
+    assert.equal(result.nextStep, scenario.nextStep);
+  });
+}
+
+for (const scenario of fixtures.incidentEdges) {
+  test(`incident edge: ${scenario.name}`, () => {
+    const result = determineNextStep(scenario.event);
+    assert.equal(result.currentState, scenario.state);
+    assert.equal(result.nextStep, scenario.nextStep);
+  });
+}
+
+test('invalid transition state throws', () => {
+  assert.throws(
+    () => transition('needs-teleport', {}),
+    /Invalid auto-pilot state transition: needs-teleport/,
+  );
+});
+
+test('empty transition state throws', () => {
+  assert.throws(
+    () => transition('', {}),
+    /Invalid auto-pilot state transition: <empty>/,
+  );
+});
+
+test('invalid force step throws instead of silently producing an unsupported step', () => {
+  assert.throws(
+    () => determineNextStep({ forceStep: 'unknown-step' }),
+    /Invalid auto-pilot force step: unknown-step/,
+  );
+});
+
+test('valid force steps bypass state detection', () => {
+  for (const forcedStep of FORCED_STEPS) {
+    const result = determineNextStep({
+      forceStep: forcedStep,
+      issueState: 'closed',
+      hasVerify: true,
+    });
+    assert.equal(result.currentState, 'forced');
+    assert.equal(result.nextStep, forcedStep);
+    assert.equal(result.forced, true);
+  }
+});
+
+test('auto and blank force steps are ignored', () => {
+  assert.equal(normalizeForceStep('auto'), '');
+  assert.equal(normalizeForceStep(''), '');
+  assert.equal(normalizeForceStep(null), '');
+});
+
+test('keepalive completion guard matches compact state marker currently emitted by keepalive', () => {
+  assert.equal(
+    isKeepaliveTasksComplete('<!-- keepalive-state:v1 {"last_action":"stop","last_reason":"tasks-complete"} -->'),
+    true,
+  );
+  assert.equal(
+    isKeepaliveTasksComplete('<!-- keepalive-state:v1 {"last_action": "stop", "last_reason": "tasks-complete"} -->'),
+    false,
+  );
+});
+
+test('redispatch map preserves current workflow force_step contract', () => {
+  assert.equal(redispatchForceStep('format'), 'optimize');
+  assert.equal(redispatchForceStep('optimize'), 'apply');
+  assert.equal(redispatchForceStep('apply'), 'capability-check');
+  assert.equal(redispatchForceStep('capability-check'), 'auto');
+  assert.equal(redispatchForceStep('create-pr'), 'auto');
+  assert.equal(redispatchForceStep('monitor-pr'), 'auto');
+  assert.equal(redispatchForceStep('verify'), 'auto');
+});

--- a/.github/scripts/__tests__/fixtures/auto-pilot-transitions.json
+++ b/.github/scripts/__tests__/fixtures/auto-pilot-transitions.json
@@ -1,0 +1,200 @@
+{
+  "validTransitions": [
+    {
+      "name": "closed issue with verify label is done",
+      "state": "closed-verified",
+      "event": {
+        "issueState": "closed",
+        "hasVerify": true
+      },
+      "nextStep": "done"
+    },
+    {
+      "name": "closed issue without verify label triggers verify",
+      "state": "closed-needs-verify",
+      "event": {
+        "issueState": "closed",
+        "hasVerify": false
+      },
+      "nextStep": "verify"
+    },
+    {
+      "name": "open issue without formatted completion marker formats first",
+      "state": "needs-format",
+      "event": {
+        "issueState": "open",
+        "hasFormat": false
+      },
+      "nextStep": "format"
+    },
+    {
+      "name": "formatted issue without optimizer output runs optimizer",
+      "state": "needs-optimize",
+      "event": {
+        "issueState": "open",
+        "hasFormat": true,
+        "hasOptimizerOutput": false
+      },
+      "nextStep": "optimize"
+    },
+    {
+      "name": "optimizer output without apply marker applies suggestions",
+      "state": "needs-apply",
+      "event": {
+        "issueState": "open",
+        "hasFormat": true,
+        "hasOptimizerOutput": true,
+        "hasApply": false
+      },
+      "nextStep": "apply"
+    },
+    {
+      "name": "applied issue without routing agent runs capability check",
+      "state": "needs-capability-check",
+      "event": {
+        "issueState": "open",
+        "hasFormat": true,
+        "hasOptimizerOutput": true,
+        "hasApply": true,
+        "hasAgent": false
+      },
+      "nextStep": "capability-check"
+    },
+    {
+      "name": "prepared issue with routing agent creates PR",
+      "state": "needs-create-pr",
+      "event": {
+        "issueState": "open",
+        "hasFormat": true,
+        "hasOptimizerOutput": true,
+        "hasApply": true,
+        "hasAgent": true
+      },
+      "nextStep": "create-pr"
+    },
+    {
+      "name": "linked PR without complete keepalive state monitors PR",
+      "state": "pr-monitoring",
+      "event": {
+        "issueState": "open",
+        "linkedPr": "42",
+        "keepaliveState": "<!-- keepalive-state:v1 {\"last_action\":\"continue\",\"last_reason\":\"ci-pending\"} -->"
+      },
+      "nextStep": "monitor-pr"
+    },
+    {
+      "name": "linked PR with tasks-complete keepalive state checks completion",
+      "state": "pr-tasks-complete",
+      "event": {
+        "issueState": "open",
+        "linkedPr": "42",
+        "keepaliveState": "<!-- keepalive-state:v1 {\"last_action\":\"stop\",\"last_reason\":\"tasks-complete\"} -->"
+      },
+      "nextStep": "check-completion"
+    }
+  ],
+  "guardCases": [
+    {
+      "name": "old agents:format trigger label does not satisfy formatted guard",
+      "event": {
+        "issueState": "open",
+        "labels": ["agents:format", "agents:auto-pilot"],
+        "hasFormat": false,
+        "hasOptimizerOutput": true,
+        "hasApply": true,
+        "hasAgent": true
+      },
+      "state": "needs-format",
+      "nextStep": "format"
+    },
+    {
+      "name": "optimizer label alone does not satisfy optimizer output guard",
+      "event": {
+        "issueState": "open",
+        "labels": ["agents:formatted", "agents:optimize"],
+        "hasFormat": true,
+        "hasOptimizerOutput": false,
+        "hasApply": false,
+        "hasAgent": false
+      },
+      "state": "needs-optimize",
+      "nextStep": "optimize"
+    },
+    {
+      "name": "apply label before optimizer output still waits for optimizer output",
+      "event": {
+        "issueState": "open",
+        "labels": ["agents:formatted", "agents:apply-suggestions"],
+        "hasFormat": true,
+        "hasOptimizerOutput": false,
+        "hasApply": true,
+        "hasAgent": true
+      },
+      "state": "needs-optimize",
+      "nextStep": "optimize"
+    },
+    {
+      "name": "keepalive stop for non-complete reason monitors PR",
+      "event": {
+        "issueState": "open",
+        "linkedPr": 77,
+        "keepaliveState": "<!-- keepalive-state:v1 {\"last_action\":\"stop\",\"last_reason\":\"max-iterations\"} -->"
+      },
+      "state": "pr-monitoring",
+      "nextStep": "monitor-pr"
+    },
+    {
+      "name": "missing keepalive state monitors PR",
+      "event": {
+        "issueState": "open",
+        "linkedPr": 77,
+        "keepaliveState": ""
+      },
+      "state": "pr-monitoring",
+      "nextStep": "monitor-pr"
+    },
+    {
+      "name": "failed PR state fetch monitors PR",
+      "event": {
+        "issueState": "open",
+        "linkedPr": 77,
+        "keepaliveState": "<!-- keepalive-state:v1 {\"last_action\":\"stop\",\"last_reason\":\"tasks-complete\"} -->",
+        "prStateFetchFailed": true
+      },
+      "state": "pr-monitoring",
+      "nextStep": "monitor-pr"
+    }
+  ],
+  "incidentEdges": [
+    {
+      "name": "issue 1437 shape: closed formatted apply verify is done",
+      "event": {
+        "issueState": "closed",
+        "labels": ["agents:formatted", "agents:apply-suggestions", "verify:evaluate", "agents:auto-pilot"],
+        "hasVerify": true
+      },
+      "state": "closed-verified",
+      "nextStep": "done"
+    },
+    {
+      "name": "issue 1453 shape: closed formatted apply follow-up without verify triggers verify",
+      "event": {
+        "issueState": "closed",
+        "labels": ["agents:formatted", "agents:apply-suggestions", "follow-up"],
+        "hasVerify": false
+      },
+      "state": "closed-needs-verify",
+      "nextStep": "verify"
+    },
+    {
+      "name": "issue 1440 shape: closed unlabeled issue still triggers verify",
+      "event": {
+        "issueState": "closed",
+        "labels": [],
+        "hasVerify": false
+      },
+      "state": "closed-needs-verify",
+      "nextStep": "verify"
+    }
+  ]
+}

--- a/.github/scripts/auto_pilot_transitions.js
+++ b/.github/scripts/auto_pilot_transitions.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const STATES = Object.freeze({
+  CLOSED_VERIFIED: 'closed-verified',
+  CLOSED_NEEDS_VERIFY: 'closed-needs-verify',
+  NEEDS_FORMAT: 'needs-format',
+  NEEDS_OPTIMIZE: 'needs-optimize',
+  NEEDS_APPLY: 'needs-apply',
+  NEEDS_CAPABILITY_CHECK: 'needs-capability-check',
+  NEEDS_CREATE_PR: 'needs-create-pr',
+  PR_MONITORING: 'pr-monitoring',
+  PR_TASKS_COMPLETE: 'pr-tasks-complete',
+});
+
+const NEXT_STEPS = Object.freeze({
+  DONE: 'done',
+  VERIFY: 'verify',
+  FORMAT: 'format',
+  OPTIMIZE: 'optimize',
+  APPLY: 'apply',
+  CAPABILITY_CHECK: 'capability-check',
+  CREATE_PR: 'create-pr',
+  MONITOR_PR: 'monitor-pr',
+  CHECK_COMPLETION: 'check-completion',
+});
+
+const FORCED_STEPS = Object.freeze([
+  NEXT_STEPS.FORMAT,
+  NEXT_STEPS.OPTIMIZE,
+  NEXT_STEPS.APPLY,
+  NEXT_STEPS.CAPABILITY_CHECK,
+  'agent',
+  NEXT_STEPS.VERIFY,
+  NEXT_STEPS.CREATE_PR,
+  NEXT_STEPS.MONITOR_PR,
+  NEXT_STEPS.CHECK_COMPLETION,
+  NEXT_STEPS.DONE,
+]);
+
+const TRANSITION_CONTRACT = Object.freeze({
+  states: STATES,
+  nextSteps: NEXT_STEPS,
+  guards: Object.freeze([
+    'closed issues require verify:evaluate before done',
+    'format requires agents:formatted, not the old agents:format trigger label',
+    'optimize advances only after an optimizer suggestions comment exists',
+    'apply advances only after agents:apply-suggestions is present',
+    'create-pr advances only after a routing agent:* label is present',
+    'linked PRs advance to check-completion only when keepalive state marks tasks complete',
+  ]),
+  transitions: Object.freeze({
+    [STATES.CLOSED_VERIFIED]: NEXT_STEPS.DONE,
+    [STATES.CLOSED_NEEDS_VERIFY]: NEXT_STEPS.VERIFY,
+    [STATES.NEEDS_FORMAT]: NEXT_STEPS.FORMAT,
+    [STATES.NEEDS_OPTIMIZE]: NEXT_STEPS.OPTIMIZE,
+    [STATES.NEEDS_APPLY]: NEXT_STEPS.APPLY,
+    [STATES.NEEDS_CAPABILITY_CHECK]: NEXT_STEPS.CAPABILITY_CHECK,
+    [STATES.NEEDS_CREATE_PR]: NEXT_STEPS.CREATE_PR,
+    [STATES.PR_MONITORING]: NEXT_STEPS.MONITOR_PR,
+    [STATES.PR_TASKS_COMPLETE]: NEXT_STEPS.CHECK_COMPLETION,
+  }),
+});
+
+function normalizeBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return String(value ?? '').trim().toLowerCase() === 'true';
+}
+
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
+function hasLinkedPr(value) {
+  return normalizeText(value) !== '';
+}
+
+function normalizeForceStep(forceStep) {
+  const step = normalizeText(forceStep);
+  if (!step || step === 'auto') {
+    return '';
+  }
+  if (!FORCED_STEPS.includes(step)) {
+    throw new Error(`Invalid auto-pilot force step: ${step}`);
+  }
+  return step;
+}
+
+function isKeepaliveTasksComplete(body) {
+  const text = String(body ?? '');
+  return text.includes('"last_action":"stop"') &&
+    text.includes('"last_reason":"tasks-complete"');
+}
+
+function resolveCurrentState(event = {}) {
+  const issueState = normalizeText(event.issueState).toLowerCase();
+  const linkedPr = hasLinkedPr(event.linkedPr);
+
+  if (issueState === 'closed') {
+    return normalizeBoolean(event.hasVerify)
+      ? STATES.CLOSED_VERIFIED
+      : STATES.CLOSED_NEEDS_VERIFY;
+  }
+
+  if (!linkedPr) {
+    if (!normalizeBoolean(event.hasFormat)) {
+      return STATES.NEEDS_FORMAT;
+    }
+    if (!normalizeBoolean(event.hasOptimizerOutput)) {
+      return STATES.NEEDS_OPTIMIZE;
+    }
+    if (!normalizeBoolean(event.hasApply)) {
+      return STATES.NEEDS_APPLY;
+    }
+    if (!normalizeBoolean(event.hasAgent)) {
+      return STATES.NEEDS_CAPABILITY_CHECK;
+    }
+    return STATES.NEEDS_CREATE_PR;
+  }
+
+  if (event.prStateFetchFailed || !normalizeText(event.keepaliveState)) {
+    return STATES.PR_MONITORING;
+  }
+
+  return isKeepaliveTasksComplete(event.keepaliveState)
+    ? STATES.PR_TASKS_COMPLETE
+    : STATES.PR_MONITORING;
+}
+
+function transition(currentState, event = {}) {
+  const state = normalizeText(currentState);
+  const nextStep = TRANSITION_CONTRACT.transitions[state];
+  if (!nextStep) {
+    throw new Error(`Invalid auto-pilot state transition: ${state || '<empty>'}`);
+  }
+  return nextStep;
+}
+
+function messageFor({ currentState, nextStep, event = {}, forced = false }) {
+  if (forced) {
+    return `Forced step: ${nextStep}`;
+  }
+  if (event.prStateFetchFailed) {
+    return 'Warning: Failed to fetch PR state, defaulting to monitor-pr';
+  }
+  if (hasLinkedPr(event.linkedPr) && !normalizeText(event.keepaliveState)) {
+    return 'No keepalive state found, defaulting to monitor-pr';
+  }
+  switch (currentState) {
+    case STATES.CLOSED_VERIFIED:
+      return 'Issue closed with verification - auto-pilot complete';
+    case STATES.CLOSED_NEEDS_VERIFY:
+      return 'Issue closed - triggering verification';
+    case STATES.NEEDS_FORMAT:
+      return 'Step 1: Format issue';
+    case STATES.NEEDS_OPTIMIZE:
+      return 'Step 2: Run optimizer (inline)';
+    case STATES.NEEDS_APPLY:
+      return 'Step 3: Apply suggestions';
+    case STATES.NEEDS_CAPABILITY_CHECK:
+      return 'Step 4: Run capability check and assign agent';
+    case STATES.NEEDS_CREATE_PR:
+      return 'Step 5: All prep complete, checking for branch to create PR';
+    case STATES.PR_TASKS_COMPLETE:
+      return 'Step 6.5: PR tasks complete - checking for merge';
+    case STATES.PR_MONITORING:
+      return `PR #${normalizeText(event.linkedPr)} exists - monitoring via keepalive`;
+    default:
+      return `Next step: ${nextStep}`;
+  }
+}
+
+function determineNextStep(event = {}) {
+  const forcedStep = normalizeForceStep(event.forceStep);
+  if (forcedStep) {
+    return {
+      currentState: 'forced',
+      forced: true,
+      nextStep: forcedStep,
+      message: messageFor({ nextStep: forcedStep, forced: true }),
+    };
+  }
+
+  const currentState = resolveCurrentState(event);
+  const nextStep = transition(currentState, event);
+  return {
+    currentState,
+    forced: false,
+    nextStep,
+    message: messageFor({ currentState, nextStep, event }),
+  };
+}
+
+function redispatchForceStep(currentStep) {
+  const step = normalizeText(currentStep);
+  const nextStepMap = {
+    [NEXT_STEPS.FORMAT]: NEXT_STEPS.OPTIMIZE,
+    [NEXT_STEPS.OPTIMIZE]: NEXT_STEPS.APPLY,
+    [NEXT_STEPS.APPLY]: NEXT_STEPS.CAPABILITY_CHECK,
+    [NEXT_STEPS.CAPABILITY_CHECK]: 'auto',
+    [NEXT_STEPS.CREATE_PR]: 'auto',
+    [NEXT_STEPS.MONITOR_PR]: 'auto',
+  };
+  return nextStepMap[step] || 'auto';
+}
+
+module.exports = {
+  STATES,
+  NEXT_STEPS,
+  FORCED_STEPS,
+  TRANSITION_CONTRACT,
+  determineNextStep,
+  hasLinkedPr,
+  isKeepaliveTasksComplete,
+  normalizeForceStep,
+  redispatchForceStep,
+  resolveCurrentState,
+  transition,
+};

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -390,6 +390,9 @@ scripts:
   - source: .github/scripts/autopilot_metrics.js
     description: "AutoPilot metrics collection and reporting"
 
+  - source: .github/scripts/auto_pilot_transitions.js
+    description: "Auto-pilot transition contract and next-step helper"
+
   - source: .github/scripts/github_api_retry.js
     description: "Retry logic for GitHub API calls"
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -598,16 +598,7 @@ jobs:
         env:
           FORCE_STEP: ${{ inputs.force_step }}
         run: |
-          # Priority order of steps
-          # 1. If issue closed and has verify label → done
-          # 2. If issue closed without verify → add verify
-          # 3. If no PR → need agent assignment
-          # 4. If has PR → check PR state
-          # 5. If no format → format first
-          # 6. If no optimize label → trigger optimize
-          # 7. If optimize label but no output → wait (optimizer still running)
-          # 8. If has optimizer output but no apply → apply suggestions
-
+          SCRIPTS_PATH="${WORKFLOWS_SCRIPTS_PATH:-$GITHUB_WORKSPACE}"
           ISSUE_STATE="${{ steps.context.outputs.issue_state }}"
           HAS_FORMAT="${{ steps.context.outputs.has_format }}"
           HAS_OPTIMIZER_OUTPUT="${{ steps.context.outputs.has_optimizer_output }}"
@@ -618,48 +609,25 @@ jobs:
 
           # Force step if specified (not 'auto')
           if [[ -n "$FORCE_STEP" && "$FORCE_STEP" != "auto" ]]; then
-            echo "next_step=$FORCE_STEP" >> "$GITHUB_OUTPUT"
-            echo "Forced step: $FORCE_STEP"
+            WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" FORCE_STEP="$FORCE_STEP" node - <<'NODE'
+          const fs = require('fs');
+          const { determineNextStep } = require(
+            `${process.env.WORKFLOWS_SCRIPTS_PATH}/.github/scripts/auto_pilot_transitions.js`
+          );
+
+          const result = determineNextStep({ forceStep: process.env.FORCE_STEP });
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `next_step=${result.nextStep}\n`);
+          console.log(result.message);
+          NODE
             exit 0
           fi
 
-          # Issue closed = done or verify
-          if [[ "$ISSUE_STATE" == "closed" ]]; then
-            if [[ "$HAS_VERIFY" == "true" ]]; then
-              echo "next_step=done" >> "$GITHUB_OUTPUT"
-              echo "Issue closed with verification - auto-pilot complete"
-            else
-              echo "next_step=verify" >> "$GITHUB_OUTPUT"
-              echo "Issue closed - triggering verification"
-            fi
-            exit 0
-          fi
+          PR_STATE_FILE="$(mktemp)"
+          PR_STATE_FETCH_FAILED="false"
 
-          # No PR yet - need to go through issue prep pipeline
-          if [[ -z "$LINKED_PR" ]]; then
-            if [[ "$HAS_FORMAT" != "true" ]]; then
-              echo "next_step=format" >> "$GITHUB_OUTPUT"
-              echo "Step 1: Format issue"
-            elif [[ "$HAS_OPTIMIZER_OUTPUT" != "true" ]]; then
-              # Run optimizer inline (not via label)
-              echo "next_step=optimize" >> "$GITHUB_OUTPUT"
-              echo "Step 2: Run optimizer (inline)"
-            elif [[ "$HAS_APPLY" != "true" ]]; then
-              echo "next_step=apply" >> "$GITHUB_OUTPUT"
-              echo "Step 3: Apply suggestions"
-            elif [[ "$HAS_AGENT" != "true" ]]; then
-              echo "next_step=capability-check" >> "$GITHUB_OUTPUT"
-              echo "Step 4: Run capability check and assign agent"
-            else
-              echo "next_step=create-pr" >> "$GITHUB_OUTPUT"
-              echo "Step 5: All prep complete, checking for branch to create PR"
-            fi
-            exit 0
-          fi
-
-          # Has PR - check if it's complete and ready to merge
-          # Get PR state to see if keepalive has finished
-          if ! PR_STATE=$(LINKED_PR="$LINKED_PR" node - <<'NODE'
+          # Has PR - check if it's complete and ready to merge.
+          # The pure transition helper consumes the fetched keepalive state.
+          if [[ -n "$LINKED_PR" ]] && ! LINKED_PR="$LINKED_PR" node - <<'NODE' > "$PR_STATE_FILE"
           (async () => {
             const { Octokit } = require('@octokit/rest');
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -689,29 +657,43 @@ jobs:
             process.exit(1);
           });
           NODE
-          ); then
-            echo "⚠️ Failed to fetch PR state, defaulting to monitor-pr"
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            exit 0
+          then
+            PR_STATE_FETCH_FAILED="true"
           fi
 
-          # Check if we got any state data
-          if [ -z "$PR_STATE" ]; then
-            echo "No keepalive state found, defaulting to monitor-pr"
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" \
+            ISSUE_STATE="$ISSUE_STATE" \
+            HAS_FORMAT="$HAS_FORMAT" \
+            HAS_OPTIMIZER_OUTPUT="$HAS_OPTIMIZER_OUTPUT" \
+            HAS_APPLY="$HAS_APPLY" \
+            HAS_AGENT="$HAS_AGENT" \
+            LINKED_PR="$LINKED_PR" \
+            HAS_VERIFY="$HAS_VERIFY" \
+            PR_STATE_FILE="$PR_STATE_FILE" \
+            PR_STATE_FETCH_FAILED="$PR_STATE_FETCH_FAILED" \
+            node - <<'NODE'
+          const fs = require('fs');
+          const { determineNextStep } = require(
+            `${process.env.WORKFLOWS_SCRIPTS_PATH}/.github/scripts/auto_pilot_transitions.js`
+          );
 
-          # Check if keepalive marked tasks as complete
-          if echo "$PR_STATE" | grep -q '"last_action":"stop"' && \
-             echo "$PR_STATE" | grep -q '"last_reason":"tasks-complete"'; then
-            echo "next_step=check-completion" >> "$GITHUB_OUTPUT"
-            echo "Step 6.5: PR tasks complete - checking for merge"
-          else
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            echo "PR #$LINKED_PR exists - monitoring via keepalive"
-          fi
-          exit 0
+          const keepaliveState = process.env.PR_STATE_FILE
+            ? fs.readFileSync(process.env.PR_STATE_FILE, 'utf8')
+            : '';
+          const result = determineNextStep({
+            issueState: process.env.ISSUE_STATE,
+            hasFormat: process.env.HAS_FORMAT,
+            hasOptimizerOutput: process.env.HAS_OPTIMIZER_OUTPUT,
+            hasApply: process.env.HAS_APPLY,
+            hasAgent: process.env.HAS_AGENT,
+            linkedPr: process.env.LINKED_PR,
+            hasVerify: process.env.HAS_VERIFY,
+            keepaliveState,
+            prStateFetchFailed: process.env.PR_STATE_FETCH_FAILED === 'true',
+          });
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `next_step=${result.nextStep}\n`);
+          console.log(result.message);
+          NODE
 
       - name: Metrics - Start format timer
         if: steps.next.outputs.next_step == 'format'
@@ -3360,17 +3342,11 @@ jobs:
               return;
             }
 
-            // Determine next step explicitly to avoid label race conditions
-            // Don't rely on 'auto' detection which has API cache timing issues
-            const nextStepMap = {
-              'format': 'optimize',
-              'optimize': 'apply',
-              'apply': 'capability-check',
-              'capability-check': 'auto',  // Let it detect agent/PR state
-              'create-pr': 'auto',  // Re-evaluate after branch/PR creation
-              'monitor-pr': 'auto'  // Let it check PR completion
-            };
-            const nextStep = nextStepMap[currentStep] || 'auto';
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
+            const { redispatchForceStep } = require(
+              `${scriptsPath}/.github/scripts/auto_pilot_transitions.js`
+            );
+            const nextStep = redispatchForceStep(currentStep);
 
             // For monitor-pr or create-pr, add delay to avoid tight polling loops
             // Keepalive updates and branch creation can take time; without delay

--- a/templates/consumer-repo/.github/scripts/auto_pilot_transitions.js
+++ b/templates/consumer-repo/.github/scripts/auto_pilot_transitions.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const STATES = Object.freeze({
+  CLOSED_VERIFIED: 'closed-verified',
+  CLOSED_NEEDS_VERIFY: 'closed-needs-verify',
+  NEEDS_FORMAT: 'needs-format',
+  NEEDS_OPTIMIZE: 'needs-optimize',
+  NEEDS_APPLY: 'needs-apply',
+  NEEDS_CAPABILITY_CHECK: 'needs-capability-check',
+  NEEDS_CREATE_PR: 'needs-create-pr',
+  PR_MONITORING: 'pr-monitoring',
+  PR_TASKS_COMPLETE: 'pr-tasks-complete',
+});
+
+const NEXT_STEPS = Object.freeze({
+  DONE: 'done',
+  VERIFY: 'verify',
+  FORMAT: 'format',
+  OPTIMIZE: 'optimize',
+  APPLY: 'apply',
+  CAPABILITY_CHECK: 'capability-check',
+  CREATE_PR: 'create-pr',
+  MONITOR_PR: 'monitor-pr',
+  CHECK_COMPLETION: 'check-completion',
+});
+
+const FORCED_STEPS = Object.freeze([
+  NEXT_STEPS.FORMAT,
+  NEXT_STEPS.OPTIMIZE,
+  NEXT_STEPS.APPLY,
+  NEXT_STEPS.CAPABILITY_CHECK,
+  'agent',
+  NEXT_STEPS.VERIFY,
+  NEXT_STEPS.CREATE_PR,
+  NEXT_STEPS.MONITOR_PR,
+  NEXT_STEPS.CHECK_COMPLETION,
+  NEXT_STEPS.DONE,
+]);
+
+const TRANSITION_CONTRACT = Object.freeze({
+  states: STATES,
+  nextSteps: NEXT_STEPS,
+  guards: Object.freeze([
+    'closed issues require verify:evaluate before done',
+    'format requires agents:formatted, not the old agents:format trigger label',
+    'optimize advances only after an optimizer suggestions comment exists',
+    'apply advances only after agents:apply-suggestions is present',
+    'create-pr advances only after a routing agent:* label is present',
+    'linked PRs advance to check-completion only when keepalive state marks tasks complete',
+  ]),
+  transitions: Object.freeze({
+    [STATES.CLOSED_VERIFIED]: NEXT_STEPS.DONE,
+    [STATES.CLOSED_NEEDS_VERIFY]: NEXT_STEPS.VERIFY,
+    [STATES.NEEDS_FORMAT]: NEXT_STEPS.FORMAT,
+    [STATES.NEEDS_OPTIMIZE]: NEXT_STEPS.OPTIMIZE,
+    [STATES.NEEDS_APPLY]: NEXT_STEPS.APPLY,
+    [STATES.NEEDS_CAPABILITY_CHECK]: NEXT_STEPS.CAPABILITY_CHECK,
+    [STATES.NEEDS_CREATE_PR]: NEXT_STEPS.CREATE_PR,
+    [STATES.PR_MONITORING]: NEXT_STEPS.MONITOR_PR,
+    [STATES.PR_TASKS_COMPLETE]: NEXT_STEPS.CHECK_COMPLETION,
+  }),
+});
+
+function normalizeBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return String(value ?? '').trim().toLowerCase() === 'true';
+}
+
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
+function hasLinkedPr(value) {
+  return normalizeText(value) !== '';
+}
+
+function normalizeForceStep(forceStep) {
+  const step = normalizeText(forceStep);
+  if (!step || step === 'auto') {
+    return '';
+  }
+  if (!FORCED_STEPS.includes(step)) {
+    throw new Error(`Invalid auto-pilot force step: ${step}`);
+  }
+  return step;
+}
+
+function isKeepaliveTasksComplete(body) {
+  const text = String(body ?? '');
+  return text.includes('"last_action":"stop"') &&
+    text.includes('"last_reason":"tasks-complete"');
+}
+
+function resolveCurrentState(event = {}) {
+  const issueState = normalizeText(event.issueState).toLowerCase();
+  const linkedPr = hasLinkedPr(event.linkedPr);
+
+  if (issueState === 'closed') {
+    return normalizeBoolean(event.hasVerify)
+      ? STATES.CLOSED_VERIFIED
+      : STATES.CLOSED_NEEDS_VERIFY;
+  }
+
+  if (!linkedPr) {
+    if (!normalizeBoolean(event.hasFormat)) {
+      return STATES.NEEDS_FORMAT;
+    }
+    if (!normalizeBoolean(event.hasOptimizerOutput)) {
+      return STATES.NEEDS_OPTIMIZE;
+    }
+    if (!normalizeBoolean(event.hasApply)) {
+      return STATES.NEEDS_APPLY;
+    }
+    if (!normalizeBoolean(event.hasAgent)) {
+      return STATES.NEEDS_CAPABILITY_CHECK;
+    }
+    return STATES.NEEDS_CREATE_PR;
+  }
+
+  if (event.prStateFetchFailed || !normalizeText(event.keepaliveState)) {
+    return STATES.PR_MONITORING;
+  }
+
+  return isKeepaliveTasksComplete(event.keepaliveState)
+    ? STATES.PR_TASKS_COMPLETE
+    : STATES.PR_MONITORING;
+}
+
+function transition(currentState, event = {}) {
+  const state = normalizeText(currentState);
+  const nextStep = TRANSITION_CONTRACT.transitions[state];
+  if (!nextStep) {
+    throw new Error(`Invalid auto-pilot state transition: ${state || '<empty>'}`);
+  }
+  return nextStep;
+}
+
+function messageFor({ currentState, nextStep, event = {}, forced = false }) {
+  if (forced) {
+    return `Forced step: ${nextStep}`;
+  }
+  if (event.prStateFetchFailed) {
+    return 'Warning: Failed to fetch PR state, defaulting to monitor-pr';
+  }
+  if (hasLinkedPr(event.linkedPr) && !normalizeText(event.keepaliveState)) {
+    return 'No keepalive state found, defaulting to monitor-pr';
+  }
+  switch (currentState) {
+    case STATES.CLOSED_VERIFIED:
+      return 'Issue closed with verification - auto-pilot complete';
+    case STATES.CLOSED_NEEDS_VERIFY:
+      return 'Issue closed - triggering verification';
+    case STATES.NEEDS_FORMAT:
+      return 'Step 1: Format issue';
+    case STATES.NEEDS_OPTIMIZE:
+      return 'Step 2: Run optimizer (inline)';
+    case STATES.NEEDS_APPLY:
+      return 'Step 3: Apply suggestions';
+    case STATES.NEEDS_CAPABILITY_CHECK:
+      return 'Step 4: Run capability check and assign agent';
+    case STATES.NEEDS_CREATE_PR:
+      return 'Step 5: All prep complete, checking for branch to create PR';
+    case STATES.PR_TASKS_COMPLETE:
+      return 'Step 6.5: PR tasks complete - checking for merge';
+    case STATES.PR_MONITORING:
+      return `PR #${normalizeText(event.linkedPr)} exists - monitoring via keepalive`;
+    default:
+      return `Next step: ${nextStep}`;
+  }
+}
+
+function determineNextStep(event = {}) {
+  const forcedStep = normalizeForceStep(event.forceStep);
+  if (forcedStep) {
+    return {
+      currentState: 'forced',
+      forced: true,
+      nextStep: forcedStep,
+      message: messageFor({ nextStep: forcedStep, forced: true }),
+    };
+  }
+
+  const currentState = resolveCurrentState(event);
+  const nextStep = transition(currentState, event);
+  return {
+    currentState,
+    forced: false,
+    nextStep,
+    message: messageFor({ currentState, nextStep, event }),
+  };
+}
+
+function redispatchForceStep(currentStep) {
+  const step = normalizeText(currentStep);
+  const nextStepMap = {
+    [NEXT_STEPS.FORMAT]: NEXT_STEPS.OPTIMIZE,
+    [NEXT_STEPS.OPTIMIZE]: NEXT_STEPS.APPLY,
+    [NEXT_STEPS.APPLY]: NEXT_STEPS.CAPABILITY_CHECK,
+    [NEXT_STEPS.CAPABILITY_CHECK]: 'auto',
+    [NEXT_STEPS.CREATE_PR]: 'auto',
+    [NEXT_STEPS.MONITOR_PR]: 'auto',
+  };
+  return nextStepMap[step] || 'auto';
+}
+
+module.exports = {
+  STATES,
+  NEXT_STEPS,
+  FORCED_STEPS,
+  TRANSITION_CONTRACT,
+  determineNextStep,
+  hasLinkedPr,
+  isKeepaliveTasksComplete,
+  normalizeForceStep,
+  redispatchForceStep,
+  resolveCurrentState,
+  transition,
+};

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -527,16 +527,7 @@ jobs:
         env:
           FORCE_STEP: ${{ inputs.force_step }}
         run: |
-          # Priority order of steps
-          # 1. If issue closed and has verify label → done
-          # 2. If issue closed without verify → add verify
-          # 3. If no PR → need agent assignment
-          # 4. If has PR → check PR state
-          # 5. If no format → format first
-          # 6. If no optimize label → trigger optimize
-          # 7. If optimize label but no output → wait (optimizer still running)
-          # 8. If has optimizer output but no apply → apply suggestions
-
+          SCRIPTS_PATH="${WORKFLOWS_SCRIPTS_PATH:-$GITHUB_WORKSPACE}"
           ISSUE_STATE="${{ steps.context.outputs.issue_state }}"
           HAS_FORMAT="${{ steps.context.outputs.has_format }}"
           HAS_OPTIMIZER_OUTPUT="${{ steps.context.outputs.has_optimizer_output }}"
@@ -547,48 +538,25 @@ jobs:
 
           # Force step if specified (not 'auto')
           if [[ -n "$FORCE_STEP" && "$FORCE_STEP" != "auto" ]]; then
-            echo "next_step=$FORCE_STEP" >> "$GITHUB_OUTPUT"
-            echo "Forced step: $FORCE_STEP"
+            WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" FORCE_STEP="$FORCE_STEP" node - <<'NODE'
+          const fs = require('fs');
+          const { determineNextStep } = require(
+            `${process.env.WORKFLOWS_SCRIPTS_PATH}/.github/scripts/auto_pilot_transitions.js`
+          );
+
+          const result = determineNextStep({ forceStep: process.env.FORCE_STEP });
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `next_step=${result.nextStep}\n`);
+          console.log(result.message);
+          NODE
             exit 0
           fi
 
-          # Issue closed = done or verify
-          if [[ "$ISSUE_STATE" == "closed" ]]; then
-            if [[ "$HAS_VERIFY" == "true" ]]; then
-              echo "next_step=done" >> "$GITHUB_OUTPUT"
-              echo "Issue closed with verification - auto-pilot complete"
-            else
-              echo "next_step=verify" >> "$GITHUB_OUTPUT"
-              echo "Issue closed - triggering verification"
-            fi
-            exit 0
-          fi
+          PR_STATE_FILE="$(mktemp)"
+          PR_STATE_FETCH_FAILED="false"
 
-          # No PR yet - need to go through issue prep pipeline
-          if [[ -z "$LINKED_PR" ]]; then
-            if [[ "$HAS_FORMAT" != "true" ]]; then
-              echo "next_step=format" >> "$GITHUB_OUTPUT"
-              echo "Step 1: Format issue"
-            elif [[ "$HAS_OPTIMIZER_OUTPUT" != "true" ]]; then
-              # Run optimizer inline (not via label)
-              echo "next_step=optimize" >> "$GITHUB_OUTPUT"
-              echo "Step 2: Run optimizer (inline)"
-            elif [[ "$HAS_APPLY" != "true" ]]; then
-              echo "next_step=apply" >> "$GITHUB_OUTPUT"
-              echo "Step 3: Apply suggestions"
-            elif [[ "$HAS_AGENT" != "true" ]]; then
-              echo "next_step=capability-check" >> "$GITHUB_OUTPUT"
-              echo "Step 4: Run capability check and assign agent"
-            else
-              echo "next_step=create-pr" >> "$GITHUB_OUTPUT"
-              echo "Step 5: All prep complete, checking for branch to create PR"
-            fi
-            exit 0
-          fi
-
-          # Has PR - check if it's complete and ready to merge
-          # Get PR state to see if keepalive has finished
-          if ! PR_STATE=$(LINKED_PR="$LINKED_PR" node - <<'NODE'
+          # Has PR - check if it's complete and ready to merge.
+          # The pure transition helper consumes the fetched keepalive state.
+          if [[ -n "$LINKED_PR" ]] && ! LINKED_PR="$LINKED_PR" node - <<'NODE' > "$PR_STATE_FILE"
           (async () => {
             const { Octokit } = require('@octokit/rest');
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -618,29 +586,43 @@ jobs:
             process.exit(1);
           });
           NODE
-          ); then
-            echo "⚠️ Failed to fetch PR state, defaulting to monitor-pr"
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            exit 0
+          then
+            PR_STATE_FETCH_FAILED="true"
           fi
 
-          # Check if we got any state data
-          if [ -z "$PR_STATE" ]; then
-            echo "No keepalive state found, defaulting to monitor-pr"
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" \
+            ISSUE_STATE="$ISSUE_STATE" \
+            HAS_FORMAT="$HAS_FORMAT" \
+            HAS_OPTIMIZER_OUTPUT="$HAS_OPTIMIZER_OUTPUT" \
+            HAS_APPLY="$HAS_APPLY" \
+            HAS_AGENT="$HAS_AGENT" \
+            LINKED_PR="$LINKED_PR" \
+            HAS_VERIFY="$HAS_VERIFY" \
+            PR_STATE_FILE="$PR_STATE_FILE" \
+            PR_STATE_FETCH_FAILED="$PR_STATE_FETCH_FAILED" \
+            node - <<'NODE'
+          const fs = require('fs');
+          const { determineNextStep } = require(
+            `${process.env.WORKFLOWS_SCRIPTS_PATH}/.github/scripts/auto_pilot_transitions.js`
+          );
 
-          # Check if keepalive marked tasks as complete
-          if echo "$PR_STATE" | grep -q '"last_action":"stop"' && \
-             echo "$PR_STATE" | grep -q '"last_reason":"tasks-complete"'; then
-            echo "next_step=check-completion" >> "$GITHUB_OUTPUT"
-            echo "Step 6.5: PR tasks complete - checking for merge"
-          else
-            echo "next_step=monitor-pr" >> "$GITHUB_OUTPUT"
-            echo "PR #$LINKED_PR exists - monitoring via keepalive"
-          fi
-          exit 0
+          const keepaliveState = process.env.PR_STATE_FILE
+            ? fs.readFileSync(process.env.PR_STATE_FILE, 'utf8')
+            : '';
+          const result = determineNextStep({
+            issueState: process.env.ISSUE_STATE,
+            hasFormat: process.env.HAS_FORMAT,
+            hasOptimizerOutput: process.env.HAS_OPTIMIZER_OUTPUT,
+            hasApply: process.env.HAS_APPLY,
+            hasAgent: process.env.HAS_AGENT,
+            linkedPr: process.env.LINKED_PR,
+            hasVerify: process.env.HAS_VERIFY,
+            keepaliveState,
+            prStateFetchFailed: process.env.PR_STATE_FETCH_FAILED === 'true',
+          });
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `next_step=${result.nextStep}\n`);
+          console.log(result.message);
+          NODE
 
       - name: Metrics - Start format timer
         if: steps.next.outputs.next_step == 'format'
@@ -3204,17 +3186,11 @@ jobs:
               return;
             }
 
-            // Determine next step explicitly to avoid label race conditions
-            // Don't rely on 'auto' detection which has API cache timing issues
-            const nextStepMap = {
-              'format': 'optimize',
-              'optimize': 'apply',
-              'apply': 'capability-check',
-              'capability-check': 'auto',  // Let it detect agent/PR state
-              'create-pr': 'auto',  // Re-evaluate after branch/PR creation
-              'monitor-pr': 'auto'  // Let it check PR completion
-            };
-            const nextStep = nextStepMap[currentStep] || 'auto';
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH || process.env.GITHUB_WORKSPACE;
+            const { redispatchForceStep } = require(
+              `${scriptsPath}/.github/scripts/auto_pilot_transitions.js`
+            );
+            const nextStep = redispatchForceStep(currentStep);
 
             // For monitor-pr or create-pr, add delay to avoid tight polling loops
             // Keepalive updates and branch creation can take time; without delay


### PR DESCRIPTION
## Summary

- Extracts the auto-pilot next-step transition contract into `.github/scripts/auto_pilot_transitions.js`.
- Replaces inline canonical and consumer-template transition decisions with calls to the helper.
- Adds fixture-backed Node tests for valid transitions, invalid transitions, guard conditions, and incident-shaped edge cases.
- Adds the helper to `.github/sync-manifest.yml` and syncs it into `templates/consumer-repo/.github/scripts/`.

## Validation

- `node --check .github/scripts/auto_pilot_transitions.js`
- `node --test .github/scripts/__tests__/auto-pilot-transitions.test.js` (26 passing)
- `scripts/sync_templates.sh`
- `python scripts/validate_template_completeness.py`
- YAML parse for `.github/workflows/agents-auto-pilot.yml`, `templates/consumer-repo/.github/workflows/agents-auto-pilot.yml`, and `.github/sync-manifest.yml`
- `python -m pytest tests/workflows/test_workflow_naming.py tests/workflows/test_workflow_agents_consolidation.py tests/docs/test_workflow_snippets_yaml.py` (73 passing)

## Note

A broader run including `tests/workflows/test_workflow_llm_installs.py` still has two unrelated reusable Codex prompt harness failures because `GITHUB_WORKSPACE` is unset in that test path.
