### PR TITLE
chore(debug): tighten agents-debug-issue-event trigger to manual or label-only

### DIFF
--- a/.github/workflows/agents-debug-issue-event.yml
+++ b/.github/workflows/agents-debug-issue-event.yml
@@ -1,13 +1,15 @@
 name: Agents Debug Issue Event
 on:
+  workflow_dispatch:
   issues:
-    types: [labeled, unlabeled, opened, reopened]
+    types: [labeled]
 
 permissions:
   contents: read
 
 jobs:
   debug_dump:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'agents:debug'
     runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub Context


### PR DESCRIPTION
## Summary
- add manual dispatch for the debug issue-event workflow
- limit issue-triggered debug runs to labeled events and the `agents:debug` label
- keep the debug dump behavior unchanged once explicitly invoked

## Validation
- `python - <<'PY' ... yaml.safe_load(...)` for `.github/workflows/agents-debug-issue-event.yml`