### PR TITLE
feat(test): add fixture coverage for maint-50 tool-version parsing

### DIFF
--- a/.github/workflows/maint-50-tool-version-check.yml
+++ b/.github/workflows/maint-50-tool-version-check.yml
@@ -58,111 +58,32 @@ jobs:
       - name: Check latest PyPI versions
         id: latest
         run: |
-          python - <<'PY'
-          import json
-          import os
-          import urllib.request
-
-          def get_latest_version(package):
-              try:
-                  url = f"https://pypi.org/pypi/{package}/json"
-                  with urllib.request.urlopen(url, timeout=10) as response:
-                      data = json.loads(response.read())
-                      return data['info']['version']
-              except Exception as e:
-                  print(f"Warning: Could not fetch {package}: {e}")
-                  return None
-
-          packages = {
-              'black': 'black_latest',
-              'ruff': 'ruff_latest',
-              'docformatter': 'docformatter_latest',
-              'isort': 'isort_latest',
-              'mypy': 'mypy_latest',
-              'pytest': 'pytest_latest',
-              'pytest-cov': 'pytest_cov_latest',
-              'coverage': 'coverage_latest',
-          }
-
-          output = os.environ['GITHUB_OUTPUT']
-          with open(output, 'a', encoding='utf-8') as f:
-              for pkg, output_name in packages.items():
-                  version = get_latest_version(pkg)
-                  if version:
-                      f.write(f"{output_name}={version}\n")
-                      print(f"✓ {pkg}: {version}")
-                  else:
-                      f.write(f"{output_name}=unknown\n")
-                      print(f"✗ {pkg}: failed to fetch")
-          PY
+          python scripts/maint_tool_version_check.py latest
 
       - name: Compare versions and generate report
         id: compare
+        env:
+          BLACK_CURRENT: ${{ steps.current.outputs.black_current }}
+          RUFF_CURRENT: ${{ steps.current.outputs.ruff_current }}
+          DOCFORMATTER_CURRENT: ${{ steps.current.outputs.docformatter_current }}
+          ISORT_CURRENT: ${{ steps.current.outputs.isort_current }}
+          MYPY_CURRENT: ${{ steps.current.outputs.mypy_current }}
+          PYTEST_CURRENT: ${{ steps.current.outputs.pytest_current }}
+          PYTEST_COV_CURRENT: ${{ steps.current.outputs.pytest_cov_current }}
+          COVERAGE_CURRENT: ${{ steps.current.outputs.coverage_current }}
+          BLACK_LATEST: ${{ steps.latest.outputs.black_latest }}
+          RUFF_LATEST: ${{ steps.latest.outputs.ruff_latest }}
+          DOCFORMATTER_LATEST: ${{ steps.latest.outputs.docformatter_latest }}
+          ISORT_LATEST: ${{ steps.latest.outputs.isort_latest }}
+          MYPY_LATEST: ${{ steps.latest.outputs.mypy_latest }}
+          PYTEST_LATEST: ${{ steps.latest.outputs.pytest_latest }}
+          PYTEST_COV_LATEST: ${{ steps.latest.outputs.pytest_cov_latest }}
+          COVERAGE_LATEST: ${{ steps.latest.outputs.coverage_latest }}
+          WORKFLOW_URL: >-
+            ${{ github.event.repository.html_url
+            }}/actions/workflows/maint-50-tool-version-check.yml
         run: |
-          python - <<'PY'
-          import os
-
-          current = {
-              'black': '${{ steps.current.outputs.black_current }}',
-              'ruff': '${{ steps.current.outputs.ruff_current }}',
-              'docformatter': '${{ steps.current.outputs.docformatter_current }}',
-              'isort': '${{ steps.current.outputs.isort_current }}',
-              'mypy': '${{ steps.current.outputs.mypy_current }}',
-              'pytest': '${{ steps.current.outputs.pytest_current }}',
-              'pytest-cov': '${{ steps.current.outputs.pytest_cov_current }}',
-              'coverage': '${{ steps.current.outputs.coverage_current }}',
-          }
-
-          latest = {
-              'black': '${{ steps.latest.outputs.black_latest }}',
-              'ruff': '${{ steps.latest.outputs.ruff_latest }}',
-              'docformatter': '${{ steps.latest.outputs.docformatter_latest }}',
-              'isort': '${{ steps.latest.outputs.isort_latest }}',
-              'mypy': '${{ steps.latest.outputs.mypy_latest }}',
-              'pytest': '${{ steps.latest.outputs.pytest_latest }}',
-              'pytest-cov': '${{ steps.latest.outputs.pytest_cov_latest }}',
-              'coverage': '${{ steps.latest.outputs.coverage_latest }}',
-          }
-
-          updates_available = []
-          report_lines = ['## Tool Version Status\n']
-          report_lines.append('| Tool | Current | Latest | Status |')
-          report_lines.append('|------|---------|--------|--------|')
-
-          for tool in sorted(current.keys()):
-              curr_ver = current[tool]
-              latest_ver = latest[tool]
-
-              if latest_ver == 'unknown':
-                  status = '⚠️ Check failed'
-              elif curr_ver != latest_ver:
-                  status = '🆕 Update available'
-                  updates_available.append(f"- **{tool}**: {curr_ver} → {latest_ver}")
-              else:
-                  status = '✅ Current'
-
-              report_lines.append(f'| {tool} | {curr_ver} | {latest_ver} | {status} |')
-
-          report = '\n'.join(report_lines)
-
-          # Write multiline output
-          output = os.environ['GITHUB_OUTPUT']
-          with open(output, 'a', encoding='utf-8') as f:
-              f.write('report<<REPORT_EOF\n')
-              f.write(report)
-              f.write('\nREPORT_EOF\n')
-
-              if updates_available:
-                  f.write('updates<<UPDATES_EOF\n')
-                  f.write('\n'.join(updates_available))
-                  f.write('\nUPDATES_EOF\n')
-                  f.write('has_updates=true\n')
-              else:
-                  f.write('updates=\n')
-                  f.write('has_updates=false\n')
-
-          print(report)
-          PY
+          python scripts/maint_tool_version_check.py compare
 
       - name: Create or update issue
         if: steps.compare.outputs.has_updates == 'true' || github.event.inputs.force_issue == 'true'
@@ -180,44 +101,9 @@ jobs:
                     githubInstance.paginate(method, params),
                 };
             const { withRetry } = retryHelpers;
-            const report = fs.readFileSync(process.env.GITHUB_OUTPUT, 'utf8')
-              .match(/report<<REPORT_EOF\n([\s\S]*?)\nREPORT_EOF/)?.[1] || '';
-            const updates = fs.readFileSync(process.env.GITHUB_OUTPUT, 'utf8')
-              .match(/updates<<UPDATES_EOF\n([\s\S]*?)\nUPDATES_EOF/)?.[1] || '';
-
-            const repoUrl = context.payload.repository.html_url;
-            const workflowUrl = repoUrl + '/actions/workflows/maint-50-tool-version-check.yml';
-            const timestamp = new Date().toISOString();
+            const body = fs.readFileSync('tool-version-issue-body.md', 'utf8');
 
             const title = '🔧 CI/Autofix Tool Updates Available';
-
-            const instructions = [
-              'source .github/workflows/autofix-versions.env',
-              'pip install "black==$BLACK_VERSION" "ruff==$RUFF_VERSION" ' +
-                '"isort==$ISORT_VERSION" "docformatter==$DOCFORMATTER_VERSION" ' +
-                '"mypy==$MYPY_VERSION" "pytest==$PYTEST_VERSION" ' +
-                '"pytest-cov==$PYTEST_COV_VERSION" "coverage==$COVERAGE_VERSION"',
-              'black --check --line-length 100 .',
-              'ruff check .',
-              'mypy src tests'
-            ].join('\n');
-            const instructionsBlock = '```bash\n' + instructions + '\n```';
-
-            const body = report + '\n\n' +
-              '### Updates Available\n\n' +
-              updates + '\n\n' +
-              '### Update Instructions\n\n' +
-              '1. Update `.github/workflows/autofix-versions.env` with the new versions\n' +
-              '2. Test locally:\n' +
-              instructionsBlock + '\n' +
-              '3. Create a PR with the version updates\n' +
-              '4. Ensure all CI checks pass before merging\n\n' +
-              '### Documentation\n\n' +
-              'See `.github/workflows/autofix-versions.env` for the version file.\n\n' +
-              '---\n' +
-              '*This issue was automatically generated by the ' +
-              '[Tool Version Check workflow](' + workflowUrl + ').*\n' +
-              '*Last checked: ' + timestamp + '*';
 
             // Search for existing open issues with this title
             const issues = await withRetry(() =>

--- a/scripts/maint_tool_version_check.py
+++ b/scripts/maint_tool_version_check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Helpers for maint-50 tool version reporting."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    package: str
+    current_output: str
+    latest_output: str
+    current_env: str
+    latest_env: str
+
+
+@dataclass(frozen=True)
+class ToolStatus:
+    tool: str
+    current: str
+    latest: str
+    status: str
+    has_update: bool
+
+
+TOOLS: tuple[ToolSpec, ...] = (
+    ToolSpec(
+        "black",
+        "black",
+        "black_current",
+        "black_latest",
+        "BLACK_CURRENT",
+        "BLACK_LATEST",
+    ),
+    ToolSpec(
+        "coverage",
+        "coverage",
+        "coverage_current",
+        "coverage_latest",
+        "COVERAGE_CURRENT",
+        "COVERAGE_LATEST",
+    ),
+    ToolSpec(
+        "docformatter",
+        "docformatter",
+        "docformatter_current",
+        "docformatter_latest",
+        "DOCFORMATTER_CURRENT",
+        "DOCFORMATTER_LATEST",
+    ),
+    ToolSpec(
+        "isort",
+        "isort",
+        "isort_current",
+        "isort_latest",
+        "ISORT_CURRENT",
+        "ISORT_LATEST",
+    ),
+    ToolSpec(
+        "mypy",
+        "mypy",
+        "mypy_current",
+        "mypy_latest",
+        "MYPY_CURRENT",
+        "MYPY_LATEST",
+    ),
+    ToolSpec(
+        "pytest",
+        "pytest",
+        "pytest_current",
+        "pytest_latest",
+        "PYTEST_CURRENT",
+        "PYTEST_LATEST",
+    ),
+    ToolSpec(
+        "pytest-cov",
+        "pytest-cov",
+        "pytest_cov_current",
+        "pytest_cov_latest",
+        "PYTEST_COV_CURRENT",
+        "PYTEST_COV_LATEST",
+    ),
+    ToolSpec(
+        "ruff",
+        "ruff",
+        "ruff_current",
+        "ruff_latest",
+        "RUFF_CURRENT",
+        "RUFF_LATEST",
+    ),
+)
+
+VERSION_RE = re.compile(
+    r"(?P<version>\d+(?:\.\d+)+(?:[-_.]?(?:a|b|rc|post|dev)\d*)?)",
+    re.IGNORECASE,
+)
+
+
+def parse_tool_version_output(tool: str, output: str) -> str | None:
+    """Extract a version from common CLI or API output without raising."""
+    text = (output or "").strip()
+    if not text or text.lower() == "unknown":
+        return None
+    match = VERSION_RE.search(text)
+    if not match:
+        return None
+    return match.group("version")
+
+
+def latest_pypi_version(package: str) -> str | None:
+    """Fetch the latest PyPI version for *package*, returning None on failure."""
+    url = f"https://pypi.org/pypi/{package}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            data = json.loads(response.read())
+    except Exception as exc:
+        print(f"Warning: Could not fetch {package}: {exc}", file=sys.stderr)
+        return None
+    version = data.get("info", {}).get("version")
+    return str(version) if version else None
+
+
+def compare_versions(current: dict[str, str], latest: dict[str, str]) -> list[ToolStatus]:
+    statuses: list[ToolStatus] = []
+    for spec in sorted(TOOLS, key=lambda item: item.name):
+        current_raw = current.get(spec.name, "")
+        latest_raw = latest.get(spec.name, "")
+        current_version = parse_tool_version_output(spec.name, current_raw)
+        latest_version = parse_tool_version_output(spec.name, latest_raw)
+        if not latest_version:
+            status = "Check failed"
+            has_update = False
+            latest_label = latest_raw or "unknown"
+        elif not current_version:
+            status = "Current version invalid"
+            has_update = False
+            latest_label = latest_version
+        elif current_version != latest_version:
+            status = "Update available"
+            has_update = True
+            latest_label = latest_version
+        else:
+            status = "Current"
+            has_update = False
+            latest_label = latest_version
+        statuses.append(
+            ToolStatus(
+                tool=spec.name,
+                current=current_version or current_raw or "unknown",
+                latest=latest_label,
+                status=status,
+                has_update=has_update,
+            )
+        )
+    return statuses
+
+
+def render_report(statuses: list[ToolStatus]) -> str:
+    lines = [
+        "## Tool Version Status",
+        "",
+        "| Tool | Current | Latest | Status |",
+        "|------|---------|--------|--------|",
+    ]
+    for item in statuses:
+        lines.append(f"| {item.tool} | {item.current} | {item.latest} | {item.status} |")
+    return "\n".join(lines)
+
+
+def render_updates(statuses: list[ToolStatus]) -> str:
+    updates = [
+        f"- **{item.tool}**: {item.current} -> {item.latest}"
+        for item in statuses
+        if item.has_update
+    ]
+    return "\n".join(updates)
+
+
+def render_issue_body(
+    *,
+    report: str,
+    updates: str,
+    workflow_url: str,
+    timestamp: str,
+) -> str:
+    instructions = "\n".join(
+        [
+            "source .github/workflows/autofix-versions.env",
+            'pip install "black==$BLACK_VERSION" "ruff==$RUFF_VERSION" '
+            '"isort==$ISORT_VERSION" "docformatter==$DOCFORMATTER_VERSION" '
+            '"mypy==$MYPY_VERSION" "pytest==$PYTEST_VERSION" '
+            '"pytest-cov==$PYTEST_COV_VERSION" "coverage==$COVERAGE_VERSION"',
+            "black --check --line-length 100 .",
+            "ruff check .",
+            "mypy src tests",
+        ]
+    )
+    updates_block = updates or "No tool updates were detected."
+    return (
+        f"{report}\n\n"
+        "### Updates Available\n\n"
+        f"{updates_block}\n\n"
+        "### Update Instructions\n\n"
+        "1. Update `.github/workflows/autofix-versions.env` with the new versions\n"
+        "2. Test locally:\n"
+        "```bash\n"
+        f"{instructions}\n"
+        "```\n"
+        "3. Create a PR with the version updates\n"
+        "4. Ensure all CI checks pass before merging\n\n"
+        "### Documentation\n\n"
+        "See `.github/workflows/autofix-versions.env` for the version file.\n\n"
+        "---\n"
+        "*This issue was automatically generated by the "
+        f"[Tool Version Check workflow]({workflow_url}).*\n"
+        f"*Last checked: {timestamp}*"
+    )
+
+
+def write_multiline_output(path: Path, name: str, value: str) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{name}<<{name.upper()}_EOF\n")
+        handle.write(value)
+        handle.write(f"\n{name.upper()}_EOF\n")
+
+
+def command_latest() -> int:
+    output = Path(os.environ["GITHUB_OUTPUT"])
+    with output.open("a", encoding="utf-8") as handle:
+        for spec in TOOLS:
+            version = latest_pypi_version(spec.package)
+            value = version or "unknown"
+            handle.write(f"{spec.latest_output}={value}\n")
+            print(f"{spec.package}: {value}")
+    return 0
+
+
+def command_compare() -> int:
+    current = {spec.name: os.getenv(spec.current_env, "") for spec in TOOLS}
+    latest = {spec.name: os.getenv(spec.latest_env, "") for spec in TOOLS}
+    statuses = compare_versions(current, latest)
+    report = render_report(statuses)
+    updates = render_updates(statuses)
+    has_updates = bool(updates)
+
+    workflow_url = os.getenv("WORKFLOW_URL", "")
+    timestamp = os.getenv("CHECK_TIMESTAMP", "")
+    if not timestamp:
+        timestamp = dt.datetime.now(tz=dt.UTC).isoformat()
+    issue_body = render_issue_body(
+        report=report,
+        updates=updates,
+        workflow_url=workflow_url,
+        timestamp=timestamp,
+    )
+
+    Path("tool-version-report.md").write_text(report, encoding="utf-8")
+    Path("tool-version-updates.md").write_text(updates, encoding="utf-8")
+    Path("tool-version-issue-body.md").write_text(issue_body, encoding="utf-8")
+
+    output = Path(os.environ["GITHUB_OUTPUT"])
+    write_multiline_output(output, "report", report)
+    if updates:
+        write_multiline_output(output, "updates", updates)
+    else:
+        with output.open("a", encoding="utf-8") as handle:
+            handle.write("updates=\n")
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(f"has_updates={'true' if has_updates else 'false'}\n")
+    print(report)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("latest")
+    subcommands.add_parser("compare")
+    args = parser.parse_args(argv)
+    if args.command == "latest":
+        return command_latest()
+    if args.command == "compare":
+        return command_compare()
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_maint_tool_version_check.py
+++ b/tests/scripts/test_maint_tool_version_check.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import maint_tool_version_check as check
+
+
+def test_parse_tool_version_outputs_cover_common_tools() -> None:
+    samples = {
+        "black": "black, 25.11.0 (compiled: yes)",
+        "ruff": "ruff 0.14.10",
+        "mypy": "mypy 1.19.0 (compiled: yes)",
+        "pytest": "pytest 8.4.2",
+    }
+
+    assert {
+        tool: check.parse_tool_version_output(tool, output)
+        for tool, output in samples.items()
+    } == {
+        "black": "25.11.0",
+        "ruff": "0.14.10",
+        "mypy": "1.19.0",
+        "pytest": "8.4.2",
+    }
+
+
+def test_compare_versions_renders_updates_and_check_failures() -> None:
+    current = {
+        "black": "black, 25.1.0",
+        "coverage": "coverage 7.10.7",
+        "docformatter": "docformatter 1.7.7",
+        "isort": "isort 6.0.1",
+        "mypy": "mypy 1.19.0",
+        "pytest": "pytest 8.4.2",
+        "pytest-cov": "pytest-cov 7.0.0",
+        "ruff": "ruff 0.14.10",
+    }
+    latest = {
+        "black": "25.11.0",
+        "coverage": "7.10.7",
+        "docformatter": "not a version",
+        "isort": "6.0.1",
+        "mypy": "1.19.0",
+        "pytest": "8.4.2",
+        "pytest-cov": "7.0.0",
+        "ruff": "0.14.10",
+    }
+
+    statuses = check.compare_versions(current, latest)
+    by_tool = {item.tool: item for item in statuses}
+
+    assert by_tool["black"].has_update is True
+    assert by_tool["black"].status == "Update available"
+    assert by_tool["docformatter"].has_update is False
+    assert by_tool["docformatter"].status == "Check failed"
+    assert by_tool["pytest"].status == "Current"
+
+    report = check.render_report(statuses)
+    assert "| black | 25.1.0 | 25.11.0 | Update available |" in report
+    assert "| docformatter | 1.7.7 | not a version | Check failed |" in report
+
+    updates = check.render_updates(statuses)
+    assert updates == "- **black**: 25.1.0 -> 25.11.0"
+
+
+def test_malformed_current_version_is_reported_without_update() -> None:
+    current = {spec.name: "unexpected output" for spec in check.TOOLS}
+    latest = {spec.name: "1.2.3" for spec in check.TOOLS}
+
+    statuses = check.compare_versions(current, latest)
+
+    assert all(item.status == "Current version invalid" for item in statuses)
+    assert not any(item.has_update for item in statuses)
+
+
+def test_render_issue_body_has_expected_update_instructions() -> None:
+    body = check.render_issue_body(
+        report="## Tool Version Status\n\n| Tool | Current | Latest | Status |",
+        updates="- **ruff**: 0.13.2 -> 0.14.10",
+        workflow_url="https://github.com/stranske/Workflows/actions/workflows/maint-50.yml",
+        timestamp="2026-05-06T12:00:00+00:00",
+    )
+
+    assert "### Updates Available" in body
+    assert "- **ruff**: 0.13.2 -> 0.14.10" in body
+    assert "pip install" in body
+    assert "black==$BLACK_VERSION" in body
+    assert "[Tool Version Check workflow]" in body
+    assert body.endswith("*Last checked: 2026-05-06T12:00:00+00:00*")
+
+
+def test_compare_command_writes_github_outputs(monkeypatch, tmp_path: Path) -> None:
+    output_path = tmp_path / "github-output.txt"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("WORKFLOW_URL", "https://example.test/workflow")
+    monkeypatch.setenv("CHECK_TIMESTAMP", "2026-05-06T12:00:00+00:00")
+    for spec in check.TOOLS:
+        monkeypatch.setenv(spec.current_env, "1.0.0")
+        monkeypatch.setenv(spec.latest_env, "1.1.0")
+
+    assert check.command_compare() == 0
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "report<<REPORT_EOF" in output
+    assert "updates<<UPDATES_EOF" in output
+    assert "has_updates=true" in output
+    assert (tmp_path / "tool-version-issue-body.md").exists()

--- a/tests/scripts/test_maint_tool_version_check.py
+++ b/tests/scripts/test_maint_tool_version_check.py
@@ -14,8 +14,7 @@ def test_parse_tool_version_outputs_cover_common_tools() -> None:
     }
 
     assert {
-        tool: check.parse_tool_version_output(tool, output)
-        for tool, output in samples.items()
+        tool: check.parse_tool_version_output(tool, output) for tool, output in samples.items()
     } == {
         "black": "25.11.0",
         "ruff": "0.14.10",


### PR DESCRIPTION
## Summary
- extract maint-50 version comparison and issue body rendering into `scripts/maint_tool_version_check.py`
- add fixture-style coverage for common tool version outputs, malformed output, update reporting, and issue body structure
- update the workflow to call the tested helper while preserving issue create/update behavior

## Validation
- `pytest -q tests/scripts/test_maint_tool_version_check.py`
- `ruff check scripts/maint_tool_version_check.py tests/scripts/test_maint_tool_version_check.py`
- YAML parse for `.github/workflows/maint-50-tool-version-check.yml`