### PR TITLE
Follow-up: clarify workflow outputs docs for issue 10

### DIFF
--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -143,6 +143,8 @@ jobs:
 
 Caller-facing outputs are available only from a subset of reusable workflows. If a workflow is not listed below it exports no `workflow_call` outputs (it still produces artifacts and step summaries).
 
+The exhaustive output reference is [`docs/ci/WORKFLOW_OUTPUTS.md`](ci/WORKFLOW_OUTPUTS.md). It documents each exported `workflow_call` output with its type, description, and usage expression, and it also lists reusable workflows that intentionally publish artifacts or logs without job outputs. Use that page as the source of truth when wiring dependent jobs; the table below is a quick index for the most common chaining surfaces.
+
 | Workflow | Outputs (name → description) |
 |----------|-----------------------------|
 | `reusable-16-agents.yml` | `readiness_report` → JSON payload from the readiness probe; `readiness_table` → Markdown table summarizing assignable agents. |
@@ -155,6 +157,8 @@ Caller-facing outputs are available only from a subset of reusable workflows. If
 | `reusable-agents-issue-bridge.yml` | None (bridge PR creation artifacts/logs). |
 
 ### Using outputs in dependent jobs
+
+The examples below show the two main output-consumption patterns: gating a downstream reusable workflow from orchestrator initialization, and passing a Markdown output into a reporting job.
 
 Orchestrator chaining example:
 

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -141,7 +141,7 @@ jobs:
 
 ## Workflow Outputs
 
-Caller-facing outputs are available only from a subset of reusable workflows. If a workflow is not listed below it exports no `workflow_call` outputs (it still produces artifacts and step summaries).
+Caller-facing outputs are available only from a subset of reusable workflows. The quick index below highlights the most common `workflow_call` outputs and artifact-only reusable workflows; consult the exhaustive catalog before assuming an unlisted workflow has no caller-facing outputs.
 
 The exhaustive output reference is [`docs/ci/WORKFLOW_OUTPUTS.md`](ci/WORKFLOW_OUTPUTS.md). It documents each exported `workflow_call` output with its type, description, and usage expression, and it also lists reusable workflows that intentionally publish artifacts or logs without job outputs. Use that page as the source of truth when wiring dependent jobs; the table below is a quick index for the most common chaining surfaces.
 
@@ -166,20 +166,19 @@ Orchestrator chaining example:
 jobs:
   orchestrator-init:
     uses: stranske/Workflows/.github/workflows/reusable-70-orchestrator-init.yml@main
-    id: init
 
   orchestrator-main:
     needs: orchestrator-init
-    if: needs.init.outputs.has_work == 'true' && needs.init.outputs.rate_limit_safe == 'true'
+    if: needs.orchestrator-init.outputs.has_work == 'true' && needs.orchestrator-init.outputs.rate_limit_safe == 'true'
     uses: stranske/Workflows/.github/workflows/reusable-70-orchestrator-main.yml@main
     with:
-      init_success: ${{ needs.init.result }}
-      enable_keepalive: ${{ needs.init.outputs.enable_keepalive }}
-      keepalive_pause_label: ${{ needs.init.outputs.keepalive_pause_label }}
-      keepalive_round: ${{ needs.init.outputs.keepalive_round }}
-      keepalive_pr: ${{ needs.init.outputs.keepalive_pr }}
-      options_json: ${{ needs.init.outputs.options_json }}
-      token_source: ${{ needs.init.outputs.token_source }}
+      init_success: ${{ needs.orchestrator-init.result }}
+      enable_keepalive: ${{ needs.orchestrator-init.outputs.enable_keepalive }}
+      keepalive_pause_label: ${{ needs.orchestrator-init.outputs.keepalive_pause_label }}
+      keepalive_round: ${{ needs.orchestrator-init.outputs.keepalive_round }}
+      keepalive_pr: ${{ needs.orchestrator-init.outputs.keepalive_pr }}
+      options_json: ${{ needs.orchestrator-init.outputs.options_json }}
+      token_source: ${{ needs.orchestrator-init.outputs.token_source }}
 ```
 
 Agent readiness example (posting the Markdown table):
@@ -188,20 +187,19 @@ Agent readiness example (posting the Markdown table):
 jobs:
   agents-readiness:
     uses: stranske/Workflows/.github/workflows/reusable-16-agents.yml@main
-    id: readiness
     with:
       enable_readiness: 'true'
 
   comment-readiness:
-    needs: readiness
-    if: needs.readiness.outputs.readiness_table != ''
+    needs: agents-readiness
+    if: needs.agents-readiness.outputs.readiness_table != ''
     runs-on: ubuntu-latest
     steps:
       - name: Post readiness table
         uses: actions/github-script@v7
         with:
           script: |
-            const table = `## Agent Readiness\n\n${{ toJSON(needs.readiness.outputs.readiness_table) }}`;
+            const table = `## Agent Readiness\n\n${{ toJSON(needs.agents-readiness.outputs.readiness_table) }}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/docs/ci/WORKFLOW_OUTPUTS.md
+++ b/docs/ci/WORKFLOW_OUTPUTS.md
@@ -1,8 +1,9 @@
 # Workflow Outputs Reference
 
 This page documents every `workflow_call` output exposed by the reusable workflows in this
-repository. Each output includes a type, description, and a short usage example. For workflows
-that only emit artifacts, see the "Workflows without workflow_call outputs" section.
+repository. Each output includes a type, description, and a short usage example. The catalog is
+audited against the reusable workflow declarations under `.github/workflows/reusable-*.yml`; for
+workflows that only emit artifacts, see the "Workflows without workflow_call outputs" section.
 
 ## Reference table of workflow outputs
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:10 -->
> **Source:** Issue #10

Closes #10

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Consumers don't know what outputs are available from reusable workflows, making it difficult to chain workflows or use output data. This gap prevents advanced usage patterns.

#### Tasks
- [ ] Audit all `workflow_call` outputs in reusable-10-ci-python.yml and other reusable workflows.
- [ ] Document each output with name, type, description, and example usage.
- [ ] Add examples showing how to use outputs in dependent jobs.
- [ ] Create a reference table of all workflow outputs.

#### Acceptance criteria
- [ ] docs/INTEGRATION_GUIDE.md has a "Workflow Outputs" section.
- [ ] All outputs from reusable workflows are documented.
- [ ] At least one example shows chaining workflow outputs to a dependent job.

**Head SHA:** e2dcf8a669975eb85ddd550183b743c1278b07f8
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067847) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/25462067814) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067721) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067746) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067738) |
| Health 74 Template Drift | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462064808) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067719) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067777) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/25462067754) |
<!-- auto-status-summary:end -->