### PR TITLE
fix: address sync review blockers

### DIFF
--- a/.github/scripts/__tests__/auto-pilot-transitions.test.js
+++ b/.github/scripts/__tests__/auto-pilot-transitions.test.js
@@ -113,6 +113,14 @@ test('auto and blank force steps are ignored', () => {
   assert.equal(normalizeForceStep(null), '');
 });
 
+test('legacy agent force step maps to implemented capability-check step', () => {
+  assert.equal(normalizeForceStep('agent'), NEXT_STEPS.CAPABILITY_CHECK);
+  assert.equal(
+    determineNextStep({ forceStep: 'agent' }).nextStep,
+    NEXT_STEPS.CAPABILITY_CHECK,
+  );
+});
+
 test('keepalive completion guard matches compact state marker currently emitted by keepalive', () => {
   assert.equal(
     isKeepaliveTasksComplete('<!-- keepalive-state:v1 {"last_action":"stop","last_reason":"tasks-complete"} -->'),

--- a/.github/scripts/__tests__/bot-comment-handler.test.js
+++ b/.github/scripts/__tests__/bot-comment-handler.test.js
@@ -55,6 +55,36 @@ test('comment collection skips bot threads where a human replied by default', ()
   );
 });
 
+test('comment collection detects nested human replies in bot threads', () => {
+  const collected = collectUnresolvedBotComments([
+    {
+      id: 1,
+      user: { login: 'copilot[bot]' },
+      path: 'src/app.js',
+      line: 10,
+      body: 'Please adjust this.',
+    },
+    {
+      id: 2,
+      in_reply_to_id: 1,
+      user: { login: 'github-actions[bot]' },
+      path: 'src/app.js',
+      line: 10,
+      body: 'Bot follow-up.',
+    },
+    {
+      id: 3,
+      in_reply_to_id: 2,
+      user: { login: 'octocat' },
+      path: 'src/app.js',
+      line: 10,
+      body: 'Handled manually.',
+    },
+  ]);
+
+  assert.deepEqual(collected, []);
+});
+
 test('comment collection keeps human-replied bot threads when configured', () => {
   const collected = collectUnresolvedBotComments(commentsFixture, {
     skipIfHumanReplied: false,
@@ -131,6 +161,21 @@ test('prepare prompt fixture preserves collected review comment context', () => 
   assert.match(prompt, /### src\/service\.js:22/);
   assert.match(prompt, /Guard against missing input\./);
   assert.match(prompt, /```diff\n@@ -20,7 \+20,7 @@/);
+});
+
+test('prepare prompt uses longer fences when comment bodies contain fences', () => {
+  const prompt = buildBotCommentsPrompt([
+    {
+      path: 'src/app.js',
+      line: 10,
+      author: 'copilot[bot]',
+      body: 'Use this block:\n```js\nconst x = 1;\n```',
+      diff_hunk: '```diff\n-old\n+new\n```',
+    },
+  ]);
+
+  assert.match(prompt, /````\nUse this block:/);
+  assert.match(prompt, /````diff\n```diff/);
 });
 
 test('dispatch fixture selects the assignee and stable marker comment for Codex', () => {

--- a/.github/scripts/auto_pilot_transitions.js
+++ b/.github/scripts/auto_pilot_transitions.js
@@ -29,7 +29,6 @@ const FORCED_STEPS = Object.freeze([
   NEXT_STEPS.OPTIMIZE,
   NEXT_STEPS.APPLY,
   NEXT_STEPS.CAPABILITY_CHECK,
-  'agent',
   NEXT_STEPS.VERIFY,
   NEXT_STEPS.CREATE_PR,
   NEXT_STEPS.MONITOR_PR,
@@ -80,6 +79,9 @@ function normalizeForceStep(forceStep) {
   const step = normalizeText(forceStep);
   if (!step || step === 'auto') {
     return '';
+  }
+  if (step === 'agent') {
+    return NEXT_STEPS.CAPABILITY_CHECK;
   }
   if (!FORCED_STEPS.includes(step)) {
     throw new Error(`Invalid auto-pilot force step: ${step}`);

--- a/.github/scripts/bot-comment-handler.js
+++ b/.github/scripts/bot-comment-handler.js
@@ -64,6 +64,26 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
   const ignoredPaths = options.ignoredPaths ?? options.ignored_paths ?? '';
   const botComments = [];
   const processedThreads = new Set();
+  const byId = new Map();
+  for (const comment of Array.isArray(comments) ? comments : []) {
+    if (comment?.id !== undefined && comment?.id !== null) {
+      byId.set(comment.id, comment);
+    }
+  }
+
+  function rootThreadId(comment) {
+    let current = comment;
+    const seen = new Set();
+    while (current?.in_reply_to_id && !seen.has(current.id)) {
+      seen.add(current.id);
+      const parent = byId.get(current.in_reply_to_id);
+      if (!parent) {
+        return current.in_reply_to_id;
+      }
+      current = parent;
+    }
+    return current?.id ?? comment?.id;
+  }
 
   for (const comment of Array.isArray(comments) ? comments : []) {
     const login = comment?.user?.login;
@@ -76,17 +96,18 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
       continue;
     }
 
-    const threadId = comment.in_reply_to_id || comment.id;
+    const threadId = rootThreadId(comment);
     if (processedThreads.has(threadId)) {
       continue;
     }
 
     if (skipIfHumanReplied) {
-      const threadReplies = comments.filter((candidate) => {
-        const inThread =
-          candidate?.in_reply_to_id === comment.id || candidate?.in_reply_to_id === threadId;
-        return inThread && !isBotAuthor(candidate?.user?.login, botAuthors);
-      });
+      const threadReplies = comments.filter(
+        (candidate) =>
+          rootThreadId(candidate) === threadId &&
+          candidate?.id !== comment.id &&
+          !isBotAuthor(candidate?.user?.login, botAuthors),
+      );
       if (threadReplies.length > 0) {
         processedThreads.add(threadId);
         continue;
@@ -106,6 +127,15 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
   }
 
   return botComments;
+}
+
+function markdownFenceFor(text, info = '') {
+  const body = String(text ?? '');
+  let fence = '```';
+  while (body.includes(fence)) {
+    fence += '`';
+  }
+  return `${fence}${info}\n${body}\n${fence}`;
 }
 
 function legacyAgentRoute(labels, defaults = {}) {
@@ -188,14 +218,10 @@ function buildBotCommentsPrompt(comments = []) {
       '',
       `**From:** ${comment.author}`,
       '',
-      '```',
-      String(comment.body ?? ''),
-      '```',
+      markdownFenceFor(comment.body),
       '',
       '**Context (diff hunk):**',
-      '```diff',
-      String(comment.diff_hunk ?? ''),
-      '```',
+      markdownFenceFor(comment.diff_hunk, 'diff'),
       '',
       '---',
       '',

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -3,12 +3,6 @@ name: Maint Coverage Guard
 'on':
   schedule:
     - cron: '45 6 * * *'
-  pull_request:
-    paths:
-      - '**/*.py'
-      - '.github/workflows/maint-coverage-guard.yml'
-      - 'config/coverage-baseline.json'
-      - 'scripts/reusable_ci_scope.py'
   workflow_dispatch:
 
 permissions:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.langchain import verdict_policy
+from scripts.langchain.issue_pr_context import estimate_tokens
 from scripts.langchain.verifier_config import EVAL_FOLLOW_UP_BUDGET_TOKENS
 
 try:
@@ -1391,16 +1392,38 @@ def generate_followup_issue(
 
 
 def _budget_followup_tasks(tasks: list[str]) -> list[str]:
-    budget = max(1, EVAL_FOLLOW_UP_BUDGET_TOKENS)
+    budget = max(1, min(1000, EVAL_FOLLOW_UP_BUDGET_TOKENS // 4))
     used = 0
     selected: list[str] = []
-    for task in tasks:
-        estimated = max(1, (len(task) + TOKEN_CHARS - 1) // TOKEN_CHARS)
+    for task in tasks[:20]:
+        estimated = max(1, estimate_tokens(f"- [ ] {task}"))
+        if estimated > budget:
+            if not selected:
+                selected.append(_truncate_task_to_budget(task, budget))
+            break
         if selected and used + estimated > budget:
             break
         selected.append(task)
         used += estimated
     return selected
+
+
+def _truncate_task_to_budget(task: str, budget: int) -> str:
+    suffix = " ..."
+    if estimate_tokens(f"- [ ] {task}") <= budget:
+        return task
+    low = 0
+    high = max(0, len(task))
+    best = ""
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = f"{task[:mid].rstrip()}{suffix}"
+        if estimate_tokens(f"- [ ] {candidate}") <= budget:
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return best or suffix.strip()
 
 
 def _generate_with_llm(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -416,10 +416,11 @@ def _get_chain_depth() -> int:
 def _prepare_prompt(context: str, diff: str | None) -> str:
     diff_block = diff.strip() if diff and diff.strip() else "(diff unavailable)"
     context_block = context.strip() if context and context.strip() else "(context unavailable)"
-    diff_block = _cap_prompt_text(diff_block, EVAL_PAIR_BUDGET_TOKENS)
-    context_block = _cap_prompt_text(context_block, EVAL_PAIR_BUDGET_TOKENS)
+    block_budget = max(1, EVAL_PAIR_BUDGET_TOKENS // 2)
+    diff_block = _cap_prompt_text(diff_block, block_budget)
+    context_block = _cap_prompt_text(context_block, block_budget)
 
-    change_type = _classify_change_type(diff)
+    change_type = _classify_change_type(_bounded_diff_for_classification(diff))
 
     if change_type == "infrastructure":
         if PROMPT_PATH.is_file():
@@ -452,6 +453,20 @@ def _cap_prompt_text(text: str, token_budget: int) -> str:
         return text
     marker = "\n[truncated: verifier prompt budget exceeded]"
     return text[: max(0, max_chars - len(marker))].rstrip() + marker
+
+
+def _bounded_diff_for_classification(diff: str | None) -> str:
+    if not diff:
+        return ""
+    lines = []
+    for line in diff.splitlines():
+        if line.startswith(("diff --git ", "+++ ", "--- ")):
+            lines.append(line)
+        if len(lines) >= 500:
+            break
+    if lines:
+        return "\n".join(lines)
+    return diff[: max(1, EVAL_PAIR_BUDGET_TOKENS // 4) * TOKEN_CHARS]
 
 
 def _extract_pr_metadata(context: str) -> tuple[int | None, str | None]:

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -119,12 +119,11 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
 
     verdicts = _extract_verdicts(raw)
     if verdicts:
-        artifact["verdict"] = (
-            "PASS" if all(verdict == "PASS" for verdict in verdicts) else "CONCERNS"
-        )
+        severity = {"PASS": 0, "CONCERNS": 1, "FAIL": 2, "ERROR": 3}
+        artifact["verdict"] = max(verdicts, key=lambda verdict: severity.get(verdict, -1))
 
     lowered = raw.lower()
-    artifact["repair_pending"] = any(
+    repair_pending = any(
         phrase in lowered
         for phrase in (
             "repair pending",
@@ -136,6 +135,10 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
     )
     if "## pr verification" in lowered or "verdict:" in lowered:
         artifact["artifact_family"] = "verifier-report"
+    if repair_pending and not verdicts:
+        artifact["repair_pending"] = True
+    if artifact.get("artifact_family") == "verifier-report" and not artifact.get("verdict"):
+        artifact["verdict"] = "ERROR"
     return artifact
 
 

--- a/scripts/reference_packs.py
+++ b/scripts/reference_packs.py
@@ -286,7 +286,8 @@ def main(argv: list[str] | None = None) -> int:
         f"reference_packs_config_text={_github_output_value(snapshot.config_text or '')}",
         f"reference_packs_config_text_b64={config_text_b64}",
     ]
-    github_output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with github_output.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
     return 0
 
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -27,6 +27,7 @@ MARKER_PREFIX = "runner-dispatch"
 PROVIDERS = {"autofix", "claude", "codex"}
 PROMPT_PROVIDERS = {"claude", "codex"}
 TERMINAL_STATUSES = {"completed", "error"}
+PENDING_STALE_AFTER_SECONDS = 30 * 60
 
 
 @dataclasses.dataclass(frozen=True)
@@ -398,7 +399,7 @@ def _build_marker(pr_number: int, provider: str, record: dict[str, Any]) -> str:
 def _decode_record_candidate(candidate: str) -> str:
     value = candidate.strip()
     if value.startswith("base64:"):
-        return base64.b64decode(value.removeprefix("base64:")).decode("utf-8")
+        return base64.b64decode(value.removeprefix("base64:"), validate=True).decode("utf-8")
     return value
 
 
@@ -437,6 +438,7 @@ class PrCommentRunnerStorage:
         return cls(GitHubApi(repo, token))
 
     def _iter_comments(self, pr_number: int) -> Iterator[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
         page = 1
         while True:
             batch = self.api.request(
@@ -447,10 +449,11 @@ class PrCommentRunnerStorage:
                 raise RuntimeError(
                     f"Expected list response from GitHub API comments page for PR {pr_number}"
                 )
-            yield from reversed(batch)
+            comments.extend(batch)
             if len(batch) < 100:
-                return
+                break
             page += 1
+        yield from reversed(comments)
 
     def _find_comment(self, pr_number: int, provider: str) -> dict[str, Any] | None:
         pattern = _marker_re(pr_number, provider)
@@ -577,6 +580,29 @@ def _storage_from_name(name: str) -> RunnerDispatchStorage:
     raise ValueError(f"unsupported storage backend: {name}")
 
 
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _pending_record_is_stale(prior: dict[str, Any], *, now: dt.datetime | None = None) -> bool:
+    started_at = _parse_timestamp(prior.get("started_at"))
+    if started_at is None:
+        return True
+    current = now or dt.datetime.now(dt.UTC)
+    return (current - started_at).total_seconds() > PENDING_STALE_AFTER_SECONDS
+
+
 def should_dispatch(
     pr_number: int,
     head_sha: str,
@@ -591,7 +617,7 @@ def should_dispatch(
 
     if prior and prior.get("head_sha") == head_sha:
         status = str(prior.get("status") or "")
-        if status in {"pending", "completed"}:
+        if status == "completed" or (status == "pending" and not _pending_record_is_stale(prior)):
             return DebounceDecision(
                 False,
                 f"duplicate-{status}",
@@ -600,7 +626,11 @@ def should_dispatch(
                 prior_head_sha=head_sha,
             )
 
-    reason = "first-dispatch" if prior is None else "head-sha-changed"
+    reason = (
+        "first-dispatch"
+        if prior is None
+        else "stale-pending" if prior.get("head_sha") == head_sha else "head-sha-changed"
+    )
     record = {
         "provider": provider,
         "pr_number": pr_number,
@@ -763,7 +793,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     assemble = subparsers.add_parser("assemble-prompt", help="assemble provider prompt")
-    assemble.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    assemble.add_argument("--provider", choices=sorted(PROMPT_PROVIDERS), required=True)
     assemble.add_argument("--base-prompt", required=True)
     assemble.add_argument("--workspace", default=".")
     assemble.add_argument("--appendix", default="")
@@ -776,7 +806,7 @@ def build_parser() -> argparse.ArgumentParser:
     assemble.set_defaults(func=_cmd_assemble)
 
     parse = subparsers.add_parser("parse-output", help="parse provider output")
-    parse.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    parse.add_argument("--provider", choices=sorted(PROMPT_PROVIDERS), required=True)
     parse.add_argument("--raw-output-file", default="")
     parse.set_defaults(func=_cmd_parse)
 

--- a/templates/consumer-repo/.github/scripts/auto_pilot_transitions.js
+++ b/templates/consumer-repo/.github/scripts/auto_pilot_transitions.js
@@ -29,7 +29,6 @@ const FORCED_STEPS = Object.freeze([
   NEXT_STEPS.OPTIMIZE,
   NEXT_STEPS.APPLY,
   NEXT_STEPS.CAPABILITY_CHECK,
-  'agent',
   NEXT_STEPS.VERIFY,
   NEXT_STEPS.CREATE_PR,
   NEXT_STEPS.MONITOR_PR,
@@ -80,6 +79,9 @@ function normalizeForceStep(forceStep) {
   const step = normalizeText(forceStep);
   if (!step || step === 'auto') {
     return '';
+  }
+  if (step === 'agent') {
+    return NEXT_STEPS.CAPABILITY_CHECK;
   }
   if (!FORCED_STEPS.includes(step)) {
     throw new Error(`Invalid auto-pilot force step: ${step}`);

--- a/templates/consumer-repo/.github/scripts/bot-comment-handler.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-handler.js
@@ -64,6 +64,26 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
   const ignoredPaths = options.ignoredPaths ?? options.ignored_paths ?? '';
   const botComments = [];
   const processedThreads = new Set();
+  const byId = new Map();
+  for (const comment of Array.isArray(comments) ? comments : []) {
+    if (comment?.id !== undefined && comment?.id !== null) {
+      byId.set(comment.id, comment);
+    }
+  }
+
+  function rootThreadId(comment) {
+    let current = comment;
+    const seen = new Set();
+    while (current?.in_reply_to_id && !seen.has(current.id)) {
+      seen.add(current.id);
+      const parent = byId.get(current.in_reply_to_id);
+      if (!parent) {
+        return current.in_reply_to_id;
+      }
+      current = parent;
+    }
+    return current?.id ?? comment?.id;
+  }
 
   for (const comment of Array.isArray(comments) ? comments : []) {
     const login = comment?.user?.login;
@@ -76,17 +96,18 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
       continue;
     }
 
-    const threadId = comment.in_reply_to_id || comment.id;
+    const threadId = rootThreadId(comment);
     if (processedThreads.has(threadId)) {
       continue;
     }
 
     if (skipIfHumanReplied) {
-      const threadReplies = comments.filter((candidate) => {
-        const inThread =
-          candidate?.in_reply_to_id === comment.id || candidate?.in_reply_to_id === threadId;
-        return inThread && !isBotAuthor(candidate?.user?.login, botAuthors);
-      });
+      const threadReplies = comments.filter(
+        (candidate) =>
+          rootThreadId(candidate) === threadId &&
+          candidate?.id !== comment.id &&
+          !isBotAuthor(candidate?.user?.login, botAuthors),
+      );
       if (threadReplies.length > 0) {
         processedThreads.add(threadId);
         continue;
@@ -106,6 +127,15 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
   }
 
   return botComments;
+}
+
+function markdownFenceFor(text, info = '') {
+  const body = String(text ?? '');
+  let fence = '```';
+  while (body.includes(fence)) {
+    fence += '`';
+  }
+  return `${fence}${info}\n${body}\n${fence}`;
 }
 
 function legacyAgentRoute(labels, defaults = {}) {
@@ -188,14 +218,10 @@ function buildBotCommentsPrompt(comments = []) {
       '',
       `**From:** ${comment.author}`,
       '',
-      '```',
-      String(comment.body ?? ''),
-      '```',
+      markdownFenceFor(comment.body),
       '',
       '**Context (diff hunk):**',
-      '```diff',
-      String(comment.diff_hunk ?? ''),
-      '```',
+      markdownFenceFor(comment.diff_hunk, 'diff'),
       '',
       '---',
       '',

--- a/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
+++ b/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
@@ -24,12 +24,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+DEFAULT_TOKEN_BUDGET = 4000
+EVAL_FOLLOW_UP_BUDGET_TOKENS = DEFAULT_TOKEN_BUDGET
+TOKEN_CHARS = 4
 
 # Prompts for multi-round LLM interaction
 # NOTE: We use a reasoning model (o1/o3-mini) for ANALYZE_VERIFICATION_PROMPT
@@ -225,6 +230,64 @@ Use this exact structure:
 
 Output the complete markdown issue body.
 """.strip()
+
+
+def estimate_tokens(text: str, *, model: str | None = None) -> int:  # noqa: ARG001
+    """Estimate prompt tokens using tiktoken when present, else 4 chars/token."""
+
+    value = text or ""
+    if not value:
+        return 0
+
+    chars_estimate = math.ceil(len(value) / TOKEN_CHARS)
+    try:
+        import tiktoken  # type: ignore[import-not-found]
+    except ImportError:
+        return chars_estimate
+
+    try:
+        encoding = (
+            tiktoken.encoding_for_model(model) if model else tiktoken.get_encoding("cl100k_base")
+        )
+    except Exception:
+        encoding = tiktoken.get_encoding("cl100k_base")
+    return max(len(encoding.encode(value)), chars_estimate)
+
+
+def _budget_followup_tasks(tasks: list[str]) -> list[str]:
+    budget = max(1, min(1000, EVAL_FOLLOW_UP_BUDGET_TOKENS // 4))
+    used = 0
+    selected: list[str] = []
+    for task in tasks[:20]:
+        estimated = max(1, estimate_tokens(f"- [ ] {task}"))
+        if estimated > budget:
+            if not selected:
+                selected.append(_truncate_task_to_budget(task, budget))
+            break
+        if selected and used + estimated > budget:
+            break
+        selected.append(task)
+        used += estimated
+    return selected
+
+
+def _truncate_task_to_budget(task: str, budget: int) -> str:
+    suffix = " ..."
+    if estimate_tokens(f"- [ ] {task}") <= budget:
+        return task
+
+    low = 0
+    high = max(0, len(task))
+    best = ""
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = f"{task[:mid].rstrip()}{suffix}"
+        if estimate_tokens(f"- [ ] {candidate}") <= budget:
+            best = candidate
+            low = mid + 1
+        else:
+            high = mid - 1
+    return best or suffix.strip()
 
 
 @dataclass
@@ -675,8 +738,8 @@ def _generate_with_llm(
     tasks_prompt = GENERATE_TASKS_PROMPT.format(
         analysis_json=json.dumps(analysis, indent=2),
         original_tasks="\n".join(
-            f"- [ ] {t}" for t in original_issue.tasks[:20]
-        ),  # Limit for token budget
+            f"- [ ] {t}" for t in _budget_followup_tasks(original_issue.tasks)
+        ),
     )
 
     tasks_response = _invoke_llm(tasks_prompt, standard_client)

--- a/tests/scripts/test_pr_verifier_infra_detection.py
+++ b/tests/scripts/test_pr_verifier_infra_detection.py
@@ -6,6 +6,7 @@ import textwrap
 
 from scripts.langchain.pr_verifier import (
     INFRA_THRESHOLD,
+    _bounded_diff_for_classification,
     _classify_change_type,
     _prepare_prompt,
 )
@@ -203,3 +204,21 @@ class TestPreparePromptInfraSelection:
     def test_no_diff_uses_standard_prompt(self):
         result = _prepare_prompt("context", None)
         assert "Infrastructure Change Guidance" not in result
+
+    def test_prepare_prompt_bounds_context_and_diff_separately(self):
+        result = _prepare_prompt("context " * 5000, self._app_diff() + ("body\n" * 5000))
+        assert result.count("[truncated: verifier prompt budget exceeded]") >= 1
+
+
+def test_bounded_diff_for_classification_keeps_headers_without_full_body() -> None:
+    diff = (
+        "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+        "--- a/.github/workflows/ci.yml\n"
+        "+++ b/.github/workflows/ci.yml\n"
+        "@@ -1 +1 @@\n" + ("+large body\n" * 10000)
+    )
+
+    bounded = _bounded_diff_for_classification(diff)
+
+    assert ".github/workflows/ci.yml" in bounded
+    assert len(bounded) < len(diff)

--- a/tests/scripts/test_reference_packs.py
+++ b/tests/scripts/test_reference_packs.py
@@ -360,6 +360,7 @@ def test_cli_github_output_includes_presence_and_path(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     github_output = tmp_path / "github_output.txt"
+    github_output.write_text("existing_output=true\n", encoding="utf-8")
 
     result = subprocess.run(
         [
@@ -378,6 +379,7 @@ def test_cli_github_output_includes_presence_and_path(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     output_lines = github_output.read_text(encoding="utf-8")
+    assert output_lines.startswith("existing_output=true\n")
     assert "reference_packs_exists=true" in output_lines
     assert f"reference_packs_path={config_file}" in output_lines
     assert "reference_packs_count=1" in output_lines

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -146,6 +146,22 @@ def test_should_dispatch_first_duplicate_and_sha_changed() -> None:
     assert changed.reason == "head-sha-changed"
 
 
+def test_should_dispatch_allows_stale_pending_record() -> None:
+    storage = MemoryRunnerStorage()
+    storage.records[(42, "codex")] = {
+        "provider": "codex",
+        "pr_number": 42,
+        "head_sha": "aaa",
+        "status": "pending",
+        "started_at": "2026-05-06T00:00:00Z",
+    }
+
+    decision = should_dispatch(42, "aaa", "codex", storage=storage)
+
+    assert decision.should_dispatch is True
+    assert decision.reason == "stale-pending"
+
+
 def test_record_completion_is_idempotent_for_same_key() -> None:
     storage = MemoryRunnerStorage()
     should_dispatch(42, "aaa", "claude", storage=storage)
@@ -218,6 +234,29 @@ def test_pr_comment_marker_round_trips_nested_result_payload() -> None:
     assert parsed == record
 
 
+def test_pr_comment_marker_rejects_invalid_base64_payload() -> None:
+    marker = (
+        "Runner dispatch state\n\n" "<!-- runner-dispatch:codex:42:v1 base64:!!!not-base64!!! -->"
+    )
+
+    assert runner_core._extract_record(marker, 42, "codex") is None
+
+
+def test_prompt_cli_rejects_non_prompt_provider() -> None:
+    parser = runner_core.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "assemble-prompt",
+                "--provider",
+                "autofix",
+                "--base-prompt",
+                ".github/codex/prompts/task.md",
+            ]
+        )
+
+
 def test_pr_comment_storage_stops_when_marker_found() -> None:
     class FakeApi:
         repo = "owner/repo"
@@ -247,6 +286,39 @@ def test_pr_comment_storage_stops_when_marker_found() -> None:
 
     assert record == {"provider": "codex", "head_sha": "abc"}
     assert len(api.paths) == 1
+
+
+def test_pr_comment_storage_selects_newest_marker_across_pages() -> None:
+    class FakeApi:
+        repo = "owner/repo"
+
+        def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+            assert method == "GET"
+            assert body is None
+            if path.endswith("page=1"):
+                return [
+                    {
+                        "body": (
+                            "Runner dispatch state\n\n<!-- runner-dispatch:codex:42:v1 "
+                            '{"provider":"codex","head_sha":"old"} -->'
+                        ),
+                        "id": 1,
+                    }
+                    for _ in range(100)
+                ]
+            return [
+                {
+                    "body": (
+                        "Runner dispatch state\n\n<!-- runner-dispatch:codex:42:v1 "
+                        '{"provider":"codex","head_sha":"new"} -->'
+                    ),
+                    "id": 101,
+                }
+            ]
+
+    storage = PrCommentRunnerStorage(FakeApi())  # type: ignore[arg-type]
+
+    assert storage.read_record(42, "codex") == {"provider": "codex", "head_sha": "new"}
 
 
 def test_materialize_reference_packs_import_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/test_verifier_config.py
+++ b/tests/scripts/test_verifier_config.py
@@ -120,6 +120,25 @@ def test_artifact_from_verification_text_rejects_pending_repair_report() -> None
     assert not is_terminal_artifact(artifact)
 
 
+def test_artifact_from_verification_text_ignores_stale_repair_marker_with_verdict() -> None:
+    artifact = artifact_from_verification_text(
+        "Schema repair pending in an older run.\n\n## PR Verification Report\n\nVerdict: FAIL"
+    )
+
+    assert artifact["verdict"] == "FAIL"
+    assert artifact.get("repair_pending") is not True
+    assert is_terminal_artifact(artifact)
+
+
+def test_artifact_from_verification_text_marks_malformed_report_terminal_error() -> None:
+    artifact = artifact_from_verification_text(
+        "## PR Verification Report\n\nThe verifier output did not include a verdict."
+    )
+
+    assert artifact["verdict"] == "ERROR"
+    assert is_terminal_artifact(artifact)
+
+
 def test_artifact_from_verification_text_resolves_provider_table() -> None:
     artifact = artifact_from_verification_text(
         "\n".join(
@@ -133,5 +152,5 @@ def test_artifact_from_verification_text_resolves_provider_table() -> None:
         )
     )
 
-    assert artifact["verdict"] == "CONCERNS"
+    assert artifact["verdict"] == "FAIL"
     assert is_terminal_artifact(artifact)

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -41,6 +41,36 @@ def test_select_followup_acceptance_criteria_drops_workflow_sync_items() -> None
     ]
 
 
+def test_budget_followup_tasks_reserves_prompt_overhead(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(followup_issue_generator, "EVAL_FOLLOW_UP_BUDGET_TOKENS", 10)
+    monkeypatch.setattr(
+        followup_issue_generator,
+        "estimate_tokens",
+        lambda value: 1 if "first" in value else 10,
+    )
+
+    selected = followup_issue_generator._budget_followup_tasks(["first task", "second task"])
+
+    assert selected == ["first task"]
+
+
+def test_budget_followup_tasks_truncates_single_oversized_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(followup_issue_generator, "EVAL_FOLLOW_UP_BUDGET_TOKENS", 40)
+    monkeypatch.setattr(
+        followup_issue_generator,
+        "estimate_tokens",
+        lambda value: max(1, len(value) // 4),
+    )
+
+    selected = followup_issue_generator._budget_followup_tasks(["x" * 500])
+
+    assert len(selected) == 1
+    assert selected[0].endswith("...")
+    assert len(selected[0]) < 500
+
+
 def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:
     original_issue = OriginalIssueData(
         title="Mixed verifier follow-up",


### PR DESCRIPTION
## Summary
- make coverage guard PR runs read-only/dry-run while keeping scheduled/manual issue updates
- tighten runner/provider parsing, strict base64 marker handling, and reference-pack output appends
- preserve strongest verifier verdicts and reserve prompt overhead for follow-up task budgeting

## Validation
- python -m pytest tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py tests/test_followup_issue_generator.py -q
- python -m ruff check scripts/runner_lib/core.py scripts/reference_packs.py scripts/langchain/followup_issue_generator.py scripts/langchain/verifier_config.py tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py tests/test_followup_issue_generator.py
- python -m black --check --fast scripts/runner_lib/core.py scripts/reference_packs.py scripts/langchain/followup_issue_generator.py scripts/langchain/verifier_config.py tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py tests/test_followup_issue_generator.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check
- PyYAML parse .github/workflows/maint-coverage-guard.yml
- actionlint .github/workflows/maint-coverage-guard.yml