### PR TITLE
fix: address sync review blockers

### DIFF
--- a/.github/scripts/bot-comment-handler.js
+++ b/.github/scripts/bot-comment-handler.js
@@ -47,8 +47,15 @@ function resolveBotAuthors(input, { defaultAuthors = DEFAULT_BOT_AUTHORS } = {})
   return configured.length ? configured : [...defaultAuthors];
 }
 
+function resolveBotAuthorSet(input, options = {}) {
+  if (input instanceof Set) {
+    return input;
+  }
+  return new Set(resolveBotAuthors(input, options).map(normalizeLogin));
+}
+
 function isBotAuthor(login, botAuthorsInput) {
-  const allowed = new Set(resolveBotAuthors(botAuthorsInput).map(normalizeLogin));
+  const allowed = resolveBotAuthorSet(botAuthorsInput);
   return allowed.has(normalizeLogin(login));
 }
 
@@ -59,12 +66,13 @@ function isIgnoredPath(commentPath, ignoredPathsInput) {
 }
 
 function collectUnresolvedBotComments(comments = [], options = {}) {
-  const botAuthors = resolveBotAuthors(options.botAuthors ?? options.bot_authors);
+  const botAuthors = resolveBotAuthorSet(options.botAuthors ?? options.bot_authors);
   const skipIfHumanReplied = options.skipIfHumanReplied ?? options.skip_if_human_replied ?? true;
   const ignoredPaths = options.ignoredPaths ?? options.ignored_paths ?? '';
   const botComments = [];
   const processedThreads = new Set();
   const byId = new Map();
+  const allComments = Array.isArray(comments) ? comments : [];
   for (const comment of Array.isArray(comments) ? comments : []) {
     if (comment?.id !== undefined && comment?.id !== null) {
       byId.set(comment.id, comment);
@@ -85,7 +93,20 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
     return current?.id ?? comment?.id;
   }
 
-  for (const comment of Array.isArray(comments) ? comments : []) {
+  const humanReplyByThread = new Map();
+  if (skipIfHumanReplied) {
+    for (const comment of allComments) {
+      if (isBotAuthor(comment?.user?.login, botAuthors)) {
+        continue;
+      }
+      const threadId = rootThreadId(comment);
+      if (threadId !== comment?.id) {
+        humanReplyByThread.set(threadId, true);
+      }
+    }
+  }
+
+  for (const comment of allComments) {
     const login = comment?.user?.login;
     if (!isBotAuthor(login, botAuthors)) {
       continue;
@@ -101,17 +122,9 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
       continue;
     }
 
-    if (skipIfHumanReplied) {
-      const threadReplies = comments.filter(
-        (candidate) =>
-          rootThreadId(candidate) === threadId &&
-          candidate?.id !== comment.id &&
-          !isBotAuthor(candidate?.user?.login, botAuthors),
-      );
-      if (threadReplies.length > 0) {
-        processedThreads.add(threadId);
-        continue;
-      }
+    if (humanReplyByThread.get(threadId)) {
+      processedThreads.add(threadId);
+      continue;
     }
 
     processedThreads.add(threadId);

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -609,6 +609,7 @@ jobs:
 
           # Force step if specified (not 'auto')
           if [[ -n "$FORCE_STEP" && "$FORCE_STEP" != "auto" ]]; then
+            set -e
             WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" FORCE_STEP="$FORCE_STEP" node - <<'NODE'
           const fs = require('fs');
           const { determineNextStep } = require(

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -72,8 +72,6 @@ SECTION_TITLES = {
     "implementation": "Implementation Notes",
 }
 
-TOKEN_CHARS = 4
-
 LIST_ITEM_REGEX = re.compile(r"^\s*([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
 MISSING_CONCERNS_MESSAGE = (

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -137,8 +137,6 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
         artifact["artifact_family"] = "verifier-report"
     if repair_pending and not verdicts:
         artifact["repair_pending"] = True
-    if artifact.get("artifact_family") == "verifier-report" and not artifact.get("verdict"):
-        artifact["verdict"] = "ERROR"
     return artifact
 
 
@@ -153,7 +151,7 @@ def _coerce_artifact(value: Any) -> Any:
             return json.loads(raw)
         except json.JSONDecodeError:
             return None
-    if isinstance(value, dict | list):
+    if isinstance(value, (dict, list)):
         return value
     if hasattr(value, "model_dump"):
         return value.model_dump()

--- a/scripts/reusable_ci_scope.py
+++ b/scripts/reusable_ci_scope.py
@@ -154,7 +154,11 @@ def _path_matches(path: str, pattern: str) -> bool:
             f"{normalized_pattern}/"
         )
 
-    return fnmatch.fnmatchcase(normalized_path, normalized_pattern)
+    if fnmatch.fnmatchcase(normalized_path, normalized_pattern):
+        return True
+    if normalized_pattern.startswith("**/"):
+        return fnmatch.fnmatchcase(normalized_path, normalized_pattern[3:])
+    return False
 
 
 def _changed_roots(changed_files: list[str]) -> str:

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -448,7 +448,7 @@ class PrCommentRunnerStorage:
                 raise RuntimeError(
                     f"Expected list response from GitHub API comments page for PR {pr_number}"
                 )
-            yield from reversed(batch)
+            yield from batch
             if len(batch) < 100:
                 break
             page += 1
@@ -456,23 +456,10 @@ class PrCommentRunnerStorage:
     def _find_comment(self, pr_number: int, provider: str) -> dict[str, Any] | None:
         pattern = _marker_re(pr_number, provider)
         latest: dict[str, Any] | None = None
-        page = 1
-        while True:
-            batch = self.api.request(
-                "GET",
-                f"/repos/{self.api.repo}/issues/{pr_number}/comments?per_page=100&page={page}",
-            )
-            if not isinstance(batch, list):
-                raise RuntimeError(
-                    f"Expected list response from GitHub API comments page for PR {pr_number}"
-                )
-            for comment in batch:
-                body = comment.get("body")
-                if isinstance(body, str) and pattern.search(body):
-                    latest = comment
-            if len(batch) < 100:
-                break
-            page += 1
+        for comment in self._iter_comments(pr_number):
+            body = comment.get("body")
+            if isinstance(body, str) and pattern.search(body):
+                latest = comment
         return latest
 
     def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None:
@@ -686,9 +673,9 @@ def record_completion(
         else _utc_now()
     )
     compact_result = {
-        key: result_payload.get(key)
-        for key in ("provider", "success", "summary", "error", "truncated")
-        if key in result_payload
+        field: result_payload.get(field)
+        for field in ("provider", "success", "summary", "error", "truncated")
+        if field in result_payload
     }
     record = {
         **prior,

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -416,7 +416,7 @@ def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[st
     for candidate in candidates:
         try:
             payload = json.loads(_decode_record_candidate(candidate))
-        except (binascii.Error, ValueError, json.JSONDecodeError):
+        except (binascii.Error, UnicodeDecodeError, ValueError, json.JSONDecodeError):
             continue
         if isinstance(payload, dict) and payload.get("provider") == provider:
             return payload
@@ -438,7 +438,6 @@ class PrCommentRunnerStorage:
         return cls(GitHubApi(repo, token))
 
     def _iter_comments(self, pr_number: int) -> Iterator[dict[str, Any]]:
-        comments: list[dict[str, Any]] = []
         page = 1
         while True:
             batch = self.api.request(
@@ -449,19 +448,32 @@ class PrCommentRunnerStorage:
                 raise RuntimeError(
                     f"Expected list response from GitHub API comments page for PR {pr_number}"
                 )
-            comments.extend(batch)
+            yield from reversed(batch)
             if len(batch) < 100:
                 break
             page += 1
-        yield from reversed(comments)
 
     def _find_comment(self, pr_number: int, provider: str) -> dict[str, Any] | None:
         pattern = _marker_re(pr_number, provider)
-        for comment in self._iter_comments(pr_number):
-            body = comment.get("body")
-            if isinstance(body, str) and pattern.search(body):
-                return comment
-        return None
+        latest: dict[str, Any] | None = None
+        page = 1
+        while True:
+            batch = self.api.request(
+                "GET",
+                f"/repos/{self.api.repo}/issues/{pr_number}/comments?per_page=100&page={page}",
+            )
+            if not isinstance(batch, list):
+                raise RuntimeError(
+                    f"Expected list response from GitHub API comments page for PR {pr_number}"
+                )
+            for comment in batch:
+                body = comment.get("body")
+                if isinstance(body, str) and pattern.search(body):
+                    latest = comment
+            if len(batch) < 100:
+                break
+            page += 1
+        return latest
 
     def read_record(self, pr_number: int, provider: str) -> dict[str, Any] | None:
         comment = self._find_comment(pr_number, provider)
@@ -626,11 +638,14 @@ def should_dispatch(
                 prior_head_sha=head_sha,
             )
 
-    reason = (
-        "first-dispatch"
-        if prior is None
-        else "stale-pending" if prior.get("head_sha") == head_sha else "head-sha-changed"
-    )
+    if prior is None:
+        reason = "first-dispatch"
+    elif prior.get("head_sha") != head_sha:
+        reason = "head-sha-changed"
+    elif str(prior.get("status") or "") == "pending":
+        reason = "stale-pending"
+    else:
+        reason = f"retry-{str(prior.get('status') or 'unknown')}"
     record = {
         "provider": provider,
         "pr_number": pr_number,
@@ -670,6 +685,11 @@ def record_completion(
         if prior.get("key") == key and prior.get("status") in TERMINAL_STATUSES
         else _utc_now()
     )
+    compact_result = {
+        key: result_payload.get(key)
+        for key in ("provider", "success", "summary", "error", "truncated")
+        if key in result_payload
+    }
     record = {
         **prior,
         "provider": provider,
@@ -678,7 +698,7 @@ def record_completion(
         "key": key,
         "status": status,
         "completed_at": completed_at,
-        "result": result_payload,
+        "result": compact_result,
     }
     storage.write_record(pr_number, provider, record)
     return record

--- a/templates/consumer-repo/.github/scripts/bot-comment-handler.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-handler.js
@@ -47,8 +47,15 @@ function resolveBotAuthors(input, { defaultAuthors = DEFAULT_BOT_AUTHORS } = {})
   return configured.length ? configured : [...defaultAuthors];
 }
 
+function resolveBotAuthorSet(input, options = {}) {
+  if (input instanceof Set) {
+    return input;
+  }
+  return new Set(resolveBotAuthors(input, options).map(normalizeLogin));
+}
+
 function isBotAuthor(login, botAuthorsInput) {
-  const allowed = new Set(resolveBotAuthors(botAuthorsInput).map(normalizeLogin));
+  const allowed = resolveBotAuthorSet(botAuthorsInput);
   return allowed.has(normalizeLogin(login));
 }
 
@@ -59,12 +66,13 @@ function isIgnoredPath(commentPath, ignoredPathsInput) {
 }
 
 function collectUnresolvedBotComments(comments = [], options = {}) {
-  const botAuthors = resolveBotAuthors(options.botAuthors ?? options.bot_authors);
+  const botAuthors = resolveBotAuthorSet(options.botAuthors ?? options.bot_authors);
   const skipIfHumanReplied = options.skipIfHumanReplied ?? options.skip_if_human_replied ?? true;
   const ignoredPaths = options.ignoredPaths ?? options.ignored_paths ?? '';
   const botComments = [];
   const processedThreads = new Set();
   const byId = new Map();
+  const allComments = Array.isArray(comments) ? comments : [];
   for (const comment of Array.isArray(comments) ? comments : []) {
     if (comment?.id !== undefined && comment?.id !== null) {
       byId.set(comment.id, comment);
@@ -85,7 +93,20 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
     return current?.id ?? comment?.id;
   }
 
-  for (const comment of Array.isArray(comments) ? comments : []) {
+  const humanReplyByThread = new Map();
+  if (skipIfHumanReplied) {
+    for (const comment of allComments) {
+      if (isBotAuthor(comment?.user?.login, botAuthors)) {
+        continue;
+      }
+      const threadId = rootThreadId(comment);
+      if (threadId !== comment?.id) {
+        humanReplyByThread.set(threadId, true);
+      }
+    }
+  }
+
+  for (const comment of allComments) {
     const login = comment?.user?.login;
     if (!isBotAuthor(login, botAuthors)) {
       continue;
@@ -101,17 +122,9 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
       continue;
     }
 
-    if (skipIfHumanReplied) {
-      const threadReplies = comments.filter(
-        (candidate) =>
-          rootThreadId(candidate) === threadId &&
-          candidate?.id !== comment.id &&
-          !isBotAuthor(candidate?.user?.login, botAuthors),
-      );
-      if (threadReplies.length > 0) {
-        processedThreads.add(threadId);
-        continue;
-      }
+    if (humanReplyByThread.get(threadId)) {
+      processedThreads.add(threadId);
+      continue;
     }
 
     processedThreads.add(threadId);

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -538,6 +538,7 @@ jobs:
 
           # Force step if specified (not 'auto')
           if [[ -n "$FORCE_STEP" && "$FORCE_STEP" != "auto" ]]; then
+            set -e
             WORKFLOWS_SCRIPTS_PATH="$SCRIPTS_PATH" FORCE_STEP="$FORCE_STEP" node - <<'NODE'
           const fs = require('fs');
           const { determineNextStep } = require(

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -3,12 +3,6 @@ name: Maint Coverage Guard
 'on':
   schedule:
     - cron: '45 6 * * *'
-  pull_request:
-    paths:
-      - '**/*.py'
-      - '.github/workflows/maint-coverage-guard.yml'
-      - 'config/coverage-baseline.json'
-      - 'scripts/reusable_ci_scope.py'
   workflow_dispatch:
 
 permissions:

--- a/tests/bot-comment-handler.test.js
+++ b/tests/bot-comment-handler.test.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  collectUnresolvedBotComments,
   listCommentsWithLimit,
   MAX_COMMENT_PAGES,
 } = require('../.github/scripts/bot-comment-handler');
@@ -26,4 +27,27 @@ test('bot-comment-handler enforces pagination upper bound', async () => {
 
   assert.ok(calls <= MAX_COMMENT_PAGES);
   assert.equal(calls, MAX_COMMENT_PAGES);
+});
+
+test('bot-comment-handler suppresses bot thread when a human replied', () => {
+  const comments = [
+    {
+      id: 1,
+      user: { login: 'copilot[bot]' },
+      path: 'src/app.py',
+      body: 'Please change this.',
+    },
+    {
+      id: 2,
+      in_reply_to_id: 1,
+      user: { login: 'maintainer' },
+      path: 'src/app.py',
+      body: 'Handled separately.',
+    },
+  ];
+
+  assert.deepEqual(
+    collectUnresolvedBotComments(comments, { botAuthors: ['copilot[bot]'] }),
+    [],
+  );
 });

--- a/tests/scripts/test_reusable_ci_scope.py
+++ b/tests/scripts/test_reusable_ci_scope.py
@@ -41,6 +41,20 @@ def test_reduced_matrix_when_scope_detected() -> None:
     assert selected.total_count == 3
 
 
+def test_globstar_scope_matches_root_python_file() -> None:
+    full = {"include": [{"name": "coverage", "scope": {"paths": ["**/*.py"]}}]}
+
+    selected = reusable_ci_scope.select_scenarios(
+        "maint-coverage-guard",
+        ["main.py"],
+        full,
+        reusable_ci_scope.SelectionOptions(),
+    )
+
+    assert selected.matrix == {"include": [{"name": "coverage"}]}
+    assert selected.selected_count == 1
+
+
 def test_force_full_override_returns_full_matrix() -> None:
     full = {
         "include": [

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -162,6 +162,21 @@ def test_should_dispatch_allows_stale_pending_record() -> None:
     assert decision.reason == "stale-pending"
 
 
+def test_should_dispatch_uses_specific_retry_reason_for_error_status() -> None:
+    storage = MemoryRunnerStorage()
+    storage.records[(42, "codex")] = {
+        "provider": "codex",
+        "pr_number": 42,
+        "head_sha": "aaa",
+        "status": "error",
+    }
+
+    decision = should_dispatch(42, "aaa", "codex", storage=storage)
+
+    assert decision.should_dispatch is True
+    assert decision.reason == "retry-error"
+
+
 def test_record_completion_is_idempotent_for_same_key() -> None:
     storage = MemoryRunnerStorage()
     should_dispatch(42, "aaa", "claude", storage=storage)
@@ -174,6 +189,17 @@ def test_record_completion_is_idempotent_for_same_key() -> None:
     assert second["status"] == "completed"
     assert second["completed_at"] == first["completed_at"]
     assert storage.records[(42, "claude")]["result"]["summary"] == "Done"
+
+
+def test_record_completion_stores_compact_result_payload() -> None:
+    storage = MemoryRunnerStorage()
+    should_dispatch(42, "aaa", "codex", storage=storage)
+    result = parse_runner_output("codex", "x" * 10000)
+
+    record = record_completion(42, "aaa", "codex", result, storage=storage)
+
+    assert record["result"]["summary"] == "x" * 500
+    assert "final_message" not in record["result"]
 
 
 def test_materialize_reference_packs_keeps_token_out_of_git_argv(
@@ -238,6 +264,12 @@ def test_pr_comment_marker_rejects_invalid_base64_payload() -> None:
     marker = (
         "Runner dispatch state\n\n" "<!-- runner-dispatch:codex:42:v1 base64:!!!not-base64!!! -->"
     )
+
+    assert runner_core._extract_record(marker, 42, "codex") is None
+
+
+def test_pr_comment_marker_rejects_invalid_utf8_payload() -> None:
+    marker = "Runner dispatch state\n\n<!-- runner-dispatch:codex:42:v1 base64://8= -->"
 
     assert runner_core._extract_record(marker, 42, "codex") is None
 

--- a/tests/scripts/test_verifier_config.py
+++ b/tests/scripts/test_verifier_config.py
@@ -130,13 +130,14 @@ def test_artifact_from_verification_text_ignores_stale_repair_marker_with_verdic
     assert is_terminal_artifact(artifact)
 
 
-def test_artifact_from_verification_text_marks_malformed_report_terminal_error() -> None:
+def test_artifact_from_verification_text_rejects_malformed_report_without_verdict() -> None:
     artifact = artifact_from_verification_text(
         "## PR Verification Report\n\nThe verifier output did not include a verdict."
     )
 
-    assert artifact["verdict"] == "ERROR"
-    assert is_terminal_artifact(artifact)
+    assert artifact["artifact_family"] == "verifier-report"
+    assert "verdict" not in artifact
+    assert not is_terminal_artifact(artifact)
 
 
 def test_artifact_from_verification_text_resolves_provider_table() -> None:


### PR DESCRIPTION
## Summary
- remove PR-triggered coverage guard from consumer template and make scoped globstar matching include root files
- harden runner dispatch markers, compact stored result payloads, and clarify retry reasons
- keep malformed verifier reports non-terminal, fail auto-pilot forced-step helper errors, and precompute bot-comment thread state

## Validation
- python -m pytest tests/scripts/test_reusable_ci_scope.py tests/scripts/test_runner_lib.py tests/scripts/test_verifier_config.py tests/test_followup_issue_generator.py -q
- node --test tests/bot-comment-handler.test.js .github/scripts/__tests__/auto-pilot-transitions.test.js
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m ruff check scripts/reusable_ci_scope.py scripts/runner_lib/core.py scripts/langchain/verifier_config.py scripts/langchain/followup_issue_generator.py tests/scripts/test_reusable_ci_scope.py tests/scripts/test_runner_lib.py tests/scripts/test_verifier_config.py
- python -m black --check scripts/reusable_ci_scope.py scripts/runner_lib/core.py scripts/langchain/verifier_config.py scripts/langchain/followup_issue_generator.py tests/scripts/test_reusable_ci_scope.py tests/scripts/test_runner_lib.py tests/scripts/test_verifier_config.py
- git diff --check
- python -m py_compile scripts/reusable_ci_scope.py scripts/runner_lib/core.py scripts/langchain/verifier_config.py scripts/langchain/followup_issue_generator.py
- targeted PyYAML parse for touched workflows
- actionlint .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml

Note: a broader focused mypy command was attempted but the local process wrapper hung without output after the above checks passed.