### PR TITLE
fix: bump workflow llm anthropic pin

### DIFF
--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -10,6 +10,6 @@
 langchain==1.2.17
 langchain-community==0.4.1
 langchain-openai==1.2.1
-langchain-anthropic==1.4.2
+langchain-anthropic==1.4.3
 pydantic==2.13.3
 requests==2.33.1


### PR DESCRIPTION
## Summary
- bump the centrally synced workflow LLM `langchain-anthropic` pin to 1.4.3
- routes overlapping consumer Dependabot updates through Workflows source instead of per-repo edits

## Validation
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `git diff --check`