### PR TITLE
fix: address sync review followups

### DIFF
--- a/.github/scripts/__tests__/bot-comment-handler.test.js
+++ b/.github/scripts/__tests__/bot-comment-handler.test.js
@@ -85,6 +85,21 @@ test('comment collection detects nested human replies in bot threads', () => {
   assert.deepEqual(collected, []);
 });
 
+test('comment collection preserves zero line numbers', () => {
+  const collected = collectUnresolvedBotComments([
+    {
+      id: 1,
+      user: { login: 'copilot[bot]' },
+      path: 'src/generated.js',
+      line: 0,
+      original_line: 12,
+      body: 'Check the generated header.',
+    },
+  ]);
+
+  assert.equal(collected[0].line, 0);
+});
+
 test('comment collection keeps human-replied bot threads when configured', () => {
   const collected = collectUnresolvedBotComments(commentsFixture, {
     skipIfHumanReplied: false,

--- a/.github/scripts/bot-comment-handler.js
+++ b/.github/scripts/bot-comment-handler.js
@@ -151,7 +151,7 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
     botComments.push({
       id: comment.id,
       path: comment.path,
-      line: comment.line || comment.original_line,
+      line: comment.line ?? comment.original_line,
       body: comment.body,
       author: login,
       url: comment.html_url,

--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -212,7 +212,12 @@ jobs:
               is_terminal_artifact,
           )
 
-          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          verification_path = Path("verification_data.txt")
+          raw = (
+              verification_path.read_text(encoding="utf-8")
+              if verification_path.exists()
+              else ""
+          )
           artifact = artifact_from_verification_text(raw)
           terminal = is_terminal_artifact(artifact)
           verdict = str(artifact.get("verdict") or "")
@@ -385,7 +390,8 @@ jobs:
             let _defaultAgent = 'codex';
             try {
               const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
-              _defaultAgent = loadAgentRegistry('./.github/agents/registry.yml').default_agent || 'codex';
+              const registry = loadAgentRegistry('./.github/agents/registry.yml');
+              _defaultAgent = registry.default_agent || 'codex';
             } catch (_) {}
             let agentKey = _defaultAgent;
             try {
@@ -396,11 +402,13 @@ jobs:
               });
             } catch (err) {
               core.warning(
-                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ${err.message}`
+                `Failed to resolve agent from PR labels; defaulting to ${_defaultAgent}: ` +
+                  err.message
               );
               agentKey = _defaultAgent;
             }
-            const normalized = String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
+            const normalized =
+              String(agentKey || _defaultAgent).trim().toLowerCase() || _defaultAgent;
             const agentLabel = `agent:${normalized}`;
             const fromLabel = `from:${normalized}`;
 

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -260,7 +260,12 @@ jobs:
               is_terminal_artifact,
           )
 
-          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          verification_path = Path("verification_data.txt")
+          raw = (
+              verification_path.read_text(encoding="utf-8")
+              if verification_path.exists()
+              else ""
+          )
           artifact = artifact_from_verification_text(raw)
           terminal = is_terminal_artifact(artifact)
           verdict = str(artifact.get("verdict") or "")

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -90,75 +90,11 @@ jobs:
               core.setOutput('proceed', 'true');
             }
 
-  select-scope:
-    name: Select coverage guard scope
-    needs: rate-limit-check
-    if: ${{ needs.rate-limit-check.outputs.proceed == 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      selected_count: ${{ steps.scope.outputs.selected_count }}
-      rationale: ${{ steps.scope.outputs.rationale }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Select guard scenario
-        id: scope
-        run: |
-          python - <<'PY'
-          import os
-
-          from scripts.reusable_ci_scope import (
-              SelectionOptions,
-              describe_selection,
-              select_scenarios,
-          )
-
-          matrix = {
-              "include": [
-                  {
-                      "name": "coverage_guard",
-                      "scope": {
-                          "paths": [
-                              "**/*.py",
-                              ".github/workflows/maint-coverage-guard.yml",
-                              "config/coverage-baseline.json",
-                              "scripts/reusable_ci_scope.py",
-                          ],
-                          "reason": "coverage guard inputs changed",
-                      },
-                  }
-              ]
-          }
-          selected = select_scenarios(
-              "maint-coverage-guard",
-              [],
-              matrix,
-              SelectionOptions(force_full=True),
-          )
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-              handle.write(f"selected_count={selected.selected_count}\n")
-              handle.write(f"rationale={describe_selection(selected, matrix)}\n")
-          print(describe_selection(selected, matrix))
-          PY
-
   guard:
     name: coverage baseline monitor
-    needs:
-      - rate-limit-check
-      - select-scope
+    needs: rate-limit-check
     if: >-
-      ${{
-        needs.rate-limit-check.outputs.proceed == 'true' &&
-        needs.select-scope.outputs.selected_count != '0'
-      }}
+      ${{ needs.rate-limit-check.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-bot-comment-handler.yml
+++ b/.github/workflows/reusable-bot-comment-handler.yml
@@ -157,7 +157,8 @@ jobs:
           elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
             use_legacy=true
             app_auth_mode=legacy-app-id
-            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
+            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID"
+            echo "and pass gh_app_client_id to avoid the deprecated app-id path."
           fi
           {
             echo "client_id_configured=${client_id_configured}"
@@ -386,7 +387,11 @@ jobs:
               botComments = [];
               const processedThreads = new Set();
               for (const comment of comments) {
-                if (!botAuthorList.some(bot => comment.user.login.toLowerCase() === bot.toLowerCase())) {
+                if (
+                  !botAuthorList.some(
+                    bot => comment.user.login.toLowerCase() === bot.toLowerCase()
+                  )
+                ) {
                   continue;
                 }
                 const commentPath = comment.path || '';
@@ -411,7 +416,7 @@ jobs:
                 botComments.push({
                   id: comment.id,
                   path: comment.path,
-                  line: comment.line || comment.original_line,
+                  line: comment.line ?? comment.original_line,
                   body: comment.body,
                   author: comment.user.login,
                   url: comment.html_url,
@@ -700,7 +705,8 @@ jobs:
           elif [ -n "${GH_APP_ID}" ] && [ -n "${GH_APP_PRIVATE_KEY}" ]; then
             use_legacy=true
             app_auth_mode=legacy-app-id
-            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID and pass gh_app_client_id to avoid the deprecated app-id path."
+            echo "::warning title=Legacy GitHub App ID fallback::Configure GH_APP_CLIENT_ID"
+            echo "and pass gh_app_client_id to avoid the deprecated app-id path."
           fi
           {
             echo "client_id_configured=${client_id_configured}"

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -454,7 +454,9 @@ def _cap_prompt_text(text: str, token_budget: int) -> str:
     if len(text) <= max_chars:
         return text
     marker = "\n[truncated: verifier prompt budget exceeded]"
-    return text[: max(0, max_chars - len(marker))].rstrip() + marker
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    return (text[: max_chars - len(marker)].rstrip() + marker)[:max_chars]
 
 
 def _bounded_diff_for_classification(diff: str | None) -> str:

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -461,7 +461,7 @@ class PrCommentRunnerStorage:
 
     def _iter_comments(self, pr_number: int, *, direction: str = "asc") -> Iterator[dict[str, Any]]:
         page = 1
-        direction = "desc" if direction == "desc" else "asc"
+        direction = "desc" if direction.strip().lower() == "desc" else "asc"
         while True:
             batch = self.api.request(
                 "GET",
@@ -842,7 +842,7 @@ def build_parser() -> argparse.ArgumentParser:
     assemble.set_defaults(func=_cmd_assemble)
 
     parse = subparsers.add_parser("parse-output", help="parse provider output")
-    parse.add_argument("--provider", choices=sorted(PROMPT_PROVIDERS), required=True)
+    parse.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
     parse.add_argument("--raw-output-file", default="")
     parse.set_defaults(func=_cmd_parse)
 

--- a/templates/consumer-repo/.github/scripts/bot-comment-handler.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-handler.js
@@ -151,7 +151,7 @@ function collectUnresolvedBotComments(comments = [], options = {}) {
     botComments.push({
       id: comment.id,
       path: comment.path,
-      line: comment.line || comment.original_line,
+      line: comment.line ?? comment.original_line,
       body: comment.body,
       author: login,
       url: comment.html_url,

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -99,75 +99,11 @@ jobs:
               core.setOutput('proceed', 'true');
             }
 
-  select-scope:
-    name: Select coverage guard scope
-    needs: rate-limit-check
-    if: ${{ needs.rate-limit-check.outputs.proceed == 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      selected_count: ${{ steps.scope.outputs.selected_count }}
-      rationale: ${{ steps.scope.outputs.rationale }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.12'
-
-      - name: Select guard scenario
-        id: scope
-        run: |
-          python - <<'PY'
-          import os
-
-          from scripts.reusable_ci_scope import (
-              SelectionOptions,
-              describe_selection,
-              select_scenarios,
-          )
-
-          matrix = {
-              "include": [
-                  {
-                      "name": "coverage_guard",
-                      "scope": {
-                          "paths": [
-                              "**/*.py",
-                              ".github/workflows/maint-coverage-guard.yml",
-                              "config/coverage-baseline.json",
-                              "scripts/reusable_ci_scope.py",
-                          ],
-                          "reason": "coverage guard inputs changed",
-                      },
-                  }
-              ]
-          }
-          selected = select_scenarios(
-              "maint-coverage-guard",
-              [],
-              matrix,
-              SelectionOptions(force_full=True),
-          )
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
-              handle.write(f"selected_count={selected.selected_count}\n")
-              handle.write(f"rationale={describe_selection(selected, matrix)}\n")
-          print(describe_selection(selected, matrix))
-          PY
-
   guard:
     name: coverage baseline monitor
-    needs:
-      - rate-limit-check
-      - select-scope
+    needs: rate-limit-check
     if: >-
-      ${{
-        needs.rate-limit-check.outputs.proceed == 'true' &&
-        needs.select-scope.outputs.selected_count != '0'
-      }}
+      ${{ needs.rate-limit-check.outputs.proceed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       # Mint GitHub App token early to use for API calls (avoids rate limits)

--- a/tests/scripts/test_pr_verifier_infra_detection.py
+++ b/tests/scripts/test_pr_verifier_infra_detection.py
@@ -7,6 +7,7 @@ import textwrap
 from scripts.langchain.pr_verifier import (
     INFRA_THRESHOLD,
     _bounded_diff_for_classification,
+    _cap_prompt_text,
     _classify_change_type,
     _prepare_prompt,
 )
@@ -222,6 +223,12 @@ def test_bounded_diff_for_classification_keeps_headers_without_full_body() -> No
 
     assert ".github/workflows/ci.yml" in bounded
     assert len(bounded) < len(diff)
+
+
+def test_cap_prompt_text_respects_tiny_budget() -> None:
+    capped = _cap_prompt_text("large prompt body", 2)
+
+    assert len(capped) <= 8
 
 
 def test_bounded_diff_for_classification_does_not_split_entire_diff() -> None:

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -289,6 +289,14 @@ def test_prompt_cli_rejects_non_prompt_provider() -> None:
         )
 
 
+def test_parse_output_cli_accepts_autofix_provider() -> None:
+    parser = runner_core.build_parser()
+
+    args = parser.parse_args(["parse-output", "--provider", "autofix"])
+
+    assert args.provider == "autofix"
+
+
 def test_pr_comment_storage_stops_when_marker_found() -> None:
     class FakeApi:
         repo = "owner/repo"
@@ -318,6 +326,26 @@ def test_pr_comment_storage_stops_when_marker_found() -> None:
 
     assert record == {"provider": "codex", "head_sha": "abc"}
     assert len(api.paths) == 1
+
+
+def test_pr_comment_storage_normalizes_direction_case() -> None:
+    class FakeApi:
+        repo = "owner/repo"
+
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+            self.paths.append(path)
+            assert method == "GET"
+            assert body is None
+            return []
+
+    api = FakeApi()
+    storage = PrCommentRunnerStorage(api)  # type: ignore[arg-type]
+
+    assert list(storage._iter_comments(42, direction="DESC")) == []
+    assert "direction=desc" in api.paths[0]
 
 
 def test_pr_comment_storage_selects_newest_marker_from_newest_page() -> None:


### PR DESCRIPTION
## Summary
- address active review debt from the latest sync wave in Workflows source
- remove the no-op coverage selector job and gate coverage only on the rate-limit check
- preserve zero review line numbers, restore autofix parse-output support, normalize comment direction input, and cap verifier prompt text strictly
- handle missing verifier artifacts as non-terminal instead of hard failing

## Validation
- python -m pytest tests/scripts/test_runner_lib.py tests/scripts/test_pr_verifier_infra_detection.py -q
- node --test .github/scripts/__tests__/bot-comment-handler.test.js
- python scripts/validate_workflow_yaml.py .github/workflows/maint-coverage-guard.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml .github/workflows/agents-verify-to-new-pr.yml .github/workflows/agents-verify-to-issue-v2.yml .github/workflows/reusable-bot-comment-handler.yml
- actionlint .github/workflows/maint-coverage-guard.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml .github/workflows/agents-verify-to-new-pr.yml .github/workflows/agents-verify-to-issue-v2.yml .github/workflows/reusable-bot-comment-handler.yml
- python scripts/validate_template_sync.py
- python -m ruff check scripts/runner_lib/core.py scripts/langchain/pr_verifier.py tests/scripts/test_runner_lib.py tests/scripts/test_pr_verifier_infra_detection.py
- git diff --check