### PR TITLE
fix: close remaining sync review debt

### DIFF
--- a/.github/scripts/__tests__/bot-comment-handler.test.js
+++ b/.github/scripts/__tests__/bot-comment-handler.test.js
@@ -23,7 +23,6 @@ const REGISTRY_PATH = path.resolve(__dirname, '..', '..', 'agents', 'registry.ym
 
 test('default bot author allowlist recognizes canonical review bots', () => {
   for (const login of [
-    'Copilot',
     'copilot[bot]',
     'github-actions[bot]',
     'coderabbitai[bot]',
@@ -35,6 +34,7 @@ test('default bot author allowlist recognizes canonical review bots', () => {
 
 test('default bot author allowlist rejects human users', () => {
   assert.equal(isBotAuthor('octocat', DEFAULT_BOT_AUTHORS), false);
+  assert.equal(isBotAuthor('Copilot', DEFAULT_BOT_AUTHORS), false);
 });
 
 test('custom bot author input replaces the default workflow allowlist', () => {

--- a/.github/scripts/__tests__/fixtures/bot-comment-handler-comments.json
+++ b/.github/scripts/__tests__/fixtures/bot-comment-handler-comments.json
@@ -4,7 +4,7 @@
     "path": "src/app.js",
     "line": 12,
     "body": "Use a stable comparison here.",
-    "user": { "login": "Copilot" },
+    "user": { "login": "copilot[bot]" },
     "html_url": "https://example.invalid/pull/42#discussion_r1001",
     "diff_hunk": "@@ -10,7 +10,7 @@"
   },

--- a/.github/scripts/bot-comment-handler.js
+++ b/.github/scripts/bot-comment-handler.js
@@ -3,7 +3,6 @@
 const DEFAULT_PER_PAGE = 100;
 const MAX_COMMENT_PAGES = 10;
 const DEFAULT_BOT_AUTHORS = Object.freeze([
-  'Copilot',
   'copilot[bot]',
   'github-actions[bot]',
   'coderabbitai[bot]',
@@ -367,17 +366,20 @@ function buildWrapperTerminalDisposition(options = {}) {
 }
 
 /**
- * List PR/issue comments with a hard pagination upper bound.
+ * List issue conversation comments with a hard pagination upper bound.
  *
  * Callers should pass a `listFn` obtained via createTokenAwareRetry
  * (from github-api-with-retry.js) so that every page request gets
  * automatic token rotation and rate-limit back-off.
+ * This helper is for `issues.listComments`, which is also used for PR
+ * conversation comments. Pull-request review comment APIs use different
+ * parameter names and should not be passed here.
  *
  * @param {object} options
  * @param {string} options.owner - Repository owner.
  * @param {string} options.repo  - Repository name.
- * @param {number} options.issueNumber - PR or issue number.
- * @param {function} options.listFn - Paginated list function (required).
+ * @param {number} options.issueNumber - Issue or PR conversation number.
+ * @param {function} options.listFn - issues.listComments-compatible function.
  * @param {number} [options.perPage=100]  - Items per page.
  * @param {number} [options.maxPages=10]  - Hard upper bound on pages fetched.
  * @returns {Promise<object[]>} Collected comments.

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1397,7 +1397,9 @@ def _budget_followup_tasks(tasks: list[str]) -> list[str]:
         estimated = max(1, estimate_tokens(f"- [ ] {task}"))
         if estimated > budget:
             if not selected:
-                selected.append(_truncate_task_to_budget(task, budget))
+                truncated = _truncate_task_to_budget(task, budget)
+                if truncated:
+                    selected.append(truncated)
             break
         if selected and used + estimated > budget:
             break
@@ -1421,7 +1423,9 @@ def _truncate_task_to_budget(task: str, budget: int) -> str:
             low = mid + 1
         else:
             high = mid - 1
-    return best or suffix.strip()
+    if best:
+        return best
+    return suffix if estimate_tokens(f"- [ ] {suffix}") <= budget else ""
 
 
 def _generate_with_llm(

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -115,16 +115,17 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
 
     parsed = _coerce_artifact(raw)
     if isinstance(parsed, dict):
-        return parsed
+        return {**artifact, **parsed}
     if isinstance(parsed, list):
-        return {"artifact_family": "verifier-report", "results": parsed}
+        return {**artifact, "artifact_family": "verifier-report", "results": parsed}
 
     verdicts = _extract_verdicts(raw)
     if verdicts:
         severity = {"PASS": 0, "CONCERNS": 1, "FAIL": 2, "ERROR": 3}
         artifact["verdict"] = max(verdicts, key=lambda verdict: severity.get(verdict, -1))
 
-    lowered = raw.lower()
+    latest_raw = _latest_verifier_report(raw)
+    lowered = latest_raw.lower()
     repair_pending = (
         any(
             phrase in lowered
@@ -143,6 +144,15 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
     if repair_pending:
         artifact["repair_pending"] = True
     return artifact
+
+
+def _latest_verifier_report(raw: str) -> str:
+    lowered = raw.lower()
+    marker = "## pr verification"
+    index = lowered.rfind(marker)
+    if index == -1:
+        return raw
+    return raw[index:]
 
 
 def _coerce_artifact(value: Any) -> Any:

--- a/scripts/reusable_ci_scope.py
+++ b/scripts/reusable_ci_scope.py
@@ -337,7 +337,12 @@ def _parse_matrix(args: argparse.Namespace) -> MatrixInput:
 def _write_github_outputs(path: str, outputs: dict[str, str]) -> None:
     with open(path, "a", encoding="utf-8") as handle:
         for key, value in outputs.items():
-            handle.write(f"{key}={value}\n")
+            delimiter = f"__REUSABLE_CI_SCOPE_{key.upper()}__"
+            while delimiter in value:
+                delimiter = f"_{delimiter}_"
+            handle.write(f"{key}<<{delimiter}\n")
+            handle.write(f"{value}\n")
+            handle.write(f"{delimiter}\n")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/templates/consumer-repo/.github/scripts/bot-comment-handler.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-handler.js
@@ -3,7 +3,6 @@
 const DEFAULT_PER_PAGE = 100;
 const MAX_COMMENT_PAGES = 10;
 const DEFAULT_BOT_AUTHORS = Object.freeze([
-  'Copilot',
   'copilot[bot]',
   'github-actions[bot]',
   'coderabbitai[bot]',
@@ -367,17 +366,20 @@ function buildWrapperTerminalDisposition(options = {}) {
 }
 
 /**
- * List PR/issue comments with a hard pagination upper bound.
+ * List issue conversation comments with a hard pagination upper bound.
  *
  * Callers should pass a `listFn` obtained via createTokenAwareRetry
  * (from github-api-with-retry.js) so that every page request gets
  * automatic token rotation and rate-limit back-off.
+ * This helper is for `issues.listComments`, which is also used for PR
+ * conversation comments. Pull-request review comment APIs use different
+ * parameter names and should not be passed here.
  *
  * @param {object} options
  * @param {string} options.owner - Repository owner.
  * @param {string} options.repo  - Repository name.
- * @param {number} options.issueNumber - PR or issue number.
- * @param {function} options.listFn - Paginated list function (required).
+ * @param {number} options.issueNumber - Issue or PR conversation number.
+ * @param {function} options.listFn - issues.listComments-compatible function.
  * @param {number} [options.perPage=100]  - Items per page.
  * @param {number} [options.maxPages=10]  - Hard upper bound on pages fetched.
  * @returns {Promise<object[]>} Collected comments.

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -260,7 +260,12 @@ jobs:
               is_terminal_artifact,
           )
 
-          raw = Path("verification_data.txt").read_text(encoding="utf-8")
+          verification_path = Path("verification_data.txt")
+          raw = (
+              verification_path.read_text(encoding="utf-8")
+              if verification_path.exists()
+              else ""
+          )
           artifact = artifact_from_verification_text(raw)
           terminal = is_terminal_artifact(artifact)
           verdict = str(artifact.get("verdict") or "")

--- a/tests/scripts/test_reusable_ci_scope.py
+++ b/tests/scripts/test_reusable_ci_scope.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from scripts import reusable_ci_scope
 
@@ -119,3 +120,18 @@ def test_cli_outputs_matrix_and_rationale(capsys) -> None:
     assert exit_code == 0
     assert payload["matrix"] == {"include": [{"name": "tests"}]}
     assert payload["rationale"] == "running 1/2 scenarios because only `tests/` changed"
+
+
+def test_github_outputs_use_multiline_format(tmp_path: Path) -> None:
+    output_path = tmp_path / "outputs.txt"
+
+    reusable_ci_scope._write_github_outputs(
+        str(output_path),
+        {"rationale": "first line\nsecond=line%"},
+    )
+
+    assert output_path.read_text(encoding="utf-8") == (
+        "rationale<<__REUSABLE_CI_SCOPE_RATIONALE__\n"
+        "first line\nsecond=line%\n"
+        "__REUSABLE_CI_SCOPE_RATIONALE__\n"
+    )

--- a/tests/scripts/test_verifier_config.py
+++ b/tests/scripts/test_verifier_config.py
@@ -142,6 +142,20 @@ def test_artifact_from_verification_text_preserves_newer_pending_repair_after_ol
     assert not is_terminal_artifact(artifact)
 
 
+def test_artifact_from_verification_text_ignores_older_pending_repair_before_latest_verdict() -> (
+    None
+):
+    artifact = artifact_from_verification_text(
+        "## PR Verification Report\n\nSchema repair pending; validation retry queued."
+        "\n\n---\n\n"
+        "## PR Verification Report\n\nVerdict: PASS"
+    )
+
+    assert artifact["verdict"] == "PASS"
+    assert artifact.get("repair_pending") is not True
+    assert is_terminal_artifact(artifact)
+
+
 def test_artifact_from_verification_text_ignores_stale_repair_marker_with_verdict() -> None:
     artifact = artifact_from_verification_text(
         "Schema repair pending in an older run.\n\n## PR Verification Report\n\nVerdict: FAIL"
@@ -176,6 +190,7 @@ def test_artifact_from_verification_text_resolves_provider_table() -> None:
     )
 
     assert artifact["verdict"] == "FAIL"
+    assert artifact["raw_present"] is True
     assert is_terminal_artifact(artifact)
 
 
@@ -185,5 +200,6 @@ def test_artifact_from_verification_text_preserves_json_array_results() -> None:
     )
 
     assert artifact["artifact_family"] == "verifier-report"
+    assert artifact["raw_present"] is True
     assert artifact["results"][1]["verdict"] == "CONCERNS"
     assert is_terminal_artifact(artifact)

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -86,6 +86,17 @@ def test_budget_followup_tasks_never_returns_leading_space_suffix(
     assert selected == ["..."]
 
 
+def test_budget_followup_tasks_omits_task_when_suffix_exceeds_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(followup_issue_generator, "EVAL_FOLLOW_UP_BUDGET_TOKENS", 4)
+    monkeypatch.setattr(followup_issue_generator, "estimate_tokens", lambda value: 100)
+
+    selected = followup_issue_generator._budget_followup_tasks(["x" * 500])
+
+    assert selected == []
+
+
 def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:
     original_issue = OriginalIssueData(
         title="Mixed verifier follow-up",


### PR DESCRIPTION
## Summary
- scope verifier repair-pending parsing to the latest report while preserving parsed artifact metadata
- harden GitHub output writing and tiny follow-up task budgets
- tighten bot-comment author/comment handling and sync consumer template copies

## Validation
- python -m pytest tests/scripts/test_verifier_config.py tests/scripts/test_pr_verifier_infra_detection.py tests/scripts/test_runner_lib.py tests/scripts/test_reusable_ci_scope.py tests/test_followup_issue_generator.py -q
- node --test .github/scripts/__tests__/bot-comment-handler.test.js
- python -m ruff check scripts/langchain/verifier_config.py scripts/langchain/followup_issue_generator.py scripts/reusable_ci_scope.py tests/scripts/test_verifier_config.py tests/scripts/test_reusable_ci_scope.py tests/test_followup_issue_generator.py
- python -m black --check scripts/langchain/verifier_config.py scripts/langchain/followup_issue_generator.py scripts/reusable_ci_scope.py tests/scripts/test_verifier_config.py tests/scripts/test_reusable_ci_scope.py tests/test_followup_issue_generator.py
- python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py
- python scripts/validate_workflow_yaml.py .github/workflows/agents-verify-to-new-pr.yml templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml .github/workflows/maint-coverage-guard.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
- actionlint on touched workflows
- git diff --check