### PR TITLE
Fix Claude keepalive prompt fallback

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -802,6 +802,15 @@ jobs:
             exit 1
           fi
 
+          if [ -z "${PROMPT_FILE:-}" ]; then
+            if [ -n "${PR_NUMBER:-}" ]; then
+              PROMPT_FILE="claude-prompt-${PR_NUMBER}.md"
+            else
+              PROMPT_FILE="claude-prompt.md"
+            fi
+            echo "::notice::Prompt output was empty; using assembled prompt fallback: ${PROMPT_FILE}"
+          fi
+
           if [ -z "$PROMPT_FILE" ] || [ ! -f "$PROMPT_FILE" ]; then
             summary="Prompt preparation failed (missing prompt file)."
             echo "exit-code=1" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- fall back to the deterministic assembled Claude prompt path when the assemble step output is empty
- prevents Claude keepalive runs from failing with `Prompt preparation failed (missing prompt file)` after evaluator dispatch

## Validation
- `python -m pytest tests/scripts/test_runner_lib.py -q`

## Recovery context
- Counter_Risk opener PRs were unblocked from skipped Gate Followups by enabling `USE_CONSOLIDATED_WORKFLOWS=true`
- Claude-routed PRs then reached the runner and exposed this reusable workflow prompt-output failure