### PR TITLE
fix: pin reusable ci workflows checkout ref

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -393,6 +393,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
+          ref: main
           path: .workflows-lib
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -705,6 +706,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
+          ref: main
           path: .workflows-lib
           sparse-checkout: |
             scripts/reusable_ci_scope.py
@@ -1499,6 +1501,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
+          ref: main
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
@@ -2450,6 +2453,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
+          ref: main
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |


### PR DESCRIPTION
## Summary
- Pin internal stranske/Workflows checkout steps in reusable Python CI to ref: main
- Avoid default-branch API resolution during sparse checkout, which is currently hitting GitHub installation rate limits in consumer CI

## Validation
- actionlint .github/workflows/reusable-10-ci-python.yml
- python scripts/validate_workflow_yaml.py .github/workflows/reusable-10-ci-python.yml (fails on pre-existing line-length warnings at lines 567, 963, 1281, 1624)