### PR TITLE
fix: address final sync review debt

### DIFF
--- a/.github/scripts/__tests__/agent-registry.test.js
+++ b/.github/scripts/__tests__/agent-registry.test.js
@@ -46,6 +46,17 @@ test('loadAgentRegistry loads the repo registry file', () => {
   assert.ok(registry.agents.codex);
 });
 
+test('loadAgentRegistry accepts a registry path string', () => {
+  const registry = loadAgentRegistry(REGISTRY_PATH);
+  assert.equal(registry.default_agent, 'codex');
+  assert.ok(registry.agents.codex);
+});
+
+test('runner helpers accept a registry path string', () => {
+  assert.equal(resolveAgentFromLabels(['agent:codex'], REGISTRY_PATH), 'codex');
+  assert.equal(getRunnerWorkflow('codex', REGISTRY_PATH), '.github/workflows/reusable-codex-run.yml');
+});
+
 test('resolveAgentFromLabels returns default agent when no labels present', () => {
   const agentKey = resolveAgentFromLabels([], { registryPath: REGISTRY_PATH });
   assert.equal(agentKey, 'codex');

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -135,7 +135,15 @@ function parseRegistryYaml(text) {
   return root;
 }
 
-function loadAgentRegistry({ registryPath } = {}) {
+function normalizeRegistryOptions(options = {}) {
+  if (typeof options === 'string') {
+    return { registryPath: options };
+  }
+  return options || {};
+}
+
+function loadAgentRegistry(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const path = registryPath || '.github/agents/registry.yml';
   const raw = fs.readFileSync(path, 'utf8');
   const registry = parseRegistryYaml(raw);
@@ -164,7 +172,8 @@ function normalizeLabel(label) {
   return '';
 }
 
-function resolveAgentRoutingFromLabels(labels, { registryPath } = {}) {
+function resolveAgentRoutingFromLabels(labels, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const labelList = Array.isArray(labels) ? labels : [];
   const agentLabels = labelList
@@ -210,12 +219,14 @@ function resolveAgentRoutingFromLabels(labels, { registryPath } = {}) {
   };
 }
 
-function resolveAgentFromLabels(labels, { registryPath } = {}) {
+function resolveAgentFromLabels(labels, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const routing = resolveAgentRoutingFromLabels(labels, { registryPath });
   return routing.agentKey;
 }
 
-function getAgentConfig(agentKey, { registryPath } = {}) {
+function getAgentConfig(agentKey, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const key = String(agentKey || '').trim() || registry.default_agent;
   const config = registry.agents[key];
@@ -226,7 +237,8 @@ function getAgentConfig(agentKey, { registryPath } = {}) {
   return config;
 }
 
-function getRunnerWorkflow(agentKey, { registryPath } = {}) {
+function getRunnerWorkflow(agentKey, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const config = getAgentConfig(agentKey, { registryPath });
   const workflow = String(config.runner_workflow || '').trim();
   if (!workflow) {
@@ -239,7 +251,8 @@ function getRunnerWorkflow(agentKey, { registryPath } = {}) {
  * Return all automation logins across all agents in the registry.
  * Useful for detecting bot-authored comments/commits.
  */
-function getAllAutomationLogins({ registryPath } = {}) {
+function getAllAutomationLogins(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const logins = new Set();
   for (const config of Object.values(registry.agents)) {
@@ -258,7 +271,8 @@ function getAllAutomationLogins({ registryPath } = {}) {
  * an array of readiness_candidates from the registry.
  * Drop-in replacement for the hardcoded CANDIDATES object.
  */
-function getReadinessCandidates({ registryPath } = {}) {
+function getReadinessCandidates(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const result = {};
   for (const [key, config] of Object.entries(registry.agents)) {
@@ -273,14 +287,16 @@ function getReadinessCandidates({ registryPath } = {}) {
  * Return the keepalive marker prefix from registry,
  * falling back to 'agent-keepalive' if not set.
  */
-function getKeepaliveMarkerPrefix({ registryPath } = {}) {
+function getKeepaliveMarkerPrefix(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   return String(
     registry.keepalive_marker_prefix || 'agent-keepalive'
   );
 }
 
-function getAgentEntries({ registryPath } = {}) {
+function getAgentEntries(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   return Object.entries(registry.agents || {}).map(([key, config]) => ({
     key,

--- a/.github/scripts/bot-comment-handler.js
+++ b/.github/scripts/bot-comment-handler.js
@@ -200,8 +200,8 @@ function resolveBotCommentAgent(labels = [], options = {}) {
 
   try {
     const { loadAgentRegistry, getRunnerWorkflow } = require('./agent_registry.js');
-    defaultAgent = options.defaultAgent || loadAgentRegistry({ registryPath }).default_agent || DEFAULT_AGENT;
-    defaultWorkflow = basename(getRunnerWorkflow(defaultAgent, { registryPath })) || defaultWorkflow;
+    defaultAgent = options.defaultAgent || loadAgentRegistry(registryPath).default_agent || DEFAULT_AGENT;
+    defaultWorkflow = basename(getRunnerWorkflow(defaultAgent, registryPath)) || defaultWorkflow;
   } catch (_) {
     // Preserve the workflow's legacy default when the registry is unavailable.
   }

--- a/scripts/langchain/verifier_config.py
+++ b/scripts/langchain/verifier_config.py
@@ -115,7 +115,7 @@ def artifact_from_verification_text(text: str) -> dict[str, Any]:
 
     parsed = _coerce_artifact(raw)
     if isinstance(parsed, dict):
-        return {**artifact, **parsed}
+        return {**parsed, **artifact}
     if isinstance(parsed, list):
         return {**artifact, "artifact_family": "verifier-report", "results": parsed}
 

--- a/scripts/reference_packs.py
+++ b/scripts/reference_packs.py
@@ -212,9 +212,11 @@ def _snapshot_to_dict(snapshot: ReferencePackSnapshot) -> dict[str, Any]:
     }
 
 
-def _github_output_value(value: str) -> str:
-    """Escape output values to avoid multi-line output parsing issues."""
-    return value.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+def _github_output_block(key: str, value: str) -> list[str]:
+    delimiter = f"__{key.upper()}_EOF__"
+    while delimiter in value:
+        delimiter = f"_{delimiter}"
+    return [f"{key}<<{delimiter}", value, delimiter]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -280,13 +282,17 @@ def main(argv: list[str] | None = None) -> int:
         f"reference_packs_exists={'true' if snapshot.exists else 'false'}",
         f"reference_packs_path={snapshot.config_path}",
         f"reference_packs_count={len(snapshot.packs)}",
-        "reference_packs_json="
-        f"{_github_output_value(json.dumps([asdict(pack) for pack in snapshot.packs], separators=(',', ':')))}",
-        f"reference_packs_payload_json={_github_output_value(canonical_payload_json)}",
-        f"reference_packs_checkout_plan_json={_github_output_value(checkout_plan_json)}",
-        f"reference_packs_config_text={_github_output_value(snapshot.config_text or '')}",
         f"reference_packs_config_text_b64={config_text_b64}",
     ]
+    lines.extend(
+        _github_output_block(
+            "reference_packs_json",
+            json.dumps([asdict(pack) for pack in snapshot.packs], separators=(",", ":")),
+        )
+    )
+    lines.extend(_github_output_block("reference_packs_payload_json", canonical_payload_json))
+    lines.extend(_github_output_block("reference_packs_checkout_plan_json", checkout_plan_json))
+    lines.extend(_github_output_block("reference_packs_config_text", snapshot.config_text or ""))
     with github_output.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
     return 0

--- a/templates/consumer-repo/.github/scripts/agent_registry.js
+++ b/templates/consumer-repo/.github/scripts/agent_registry.js
@@ -135,7 +135,15 @@ function parseRegistryYaml(text) {
   return root;
 }
 
-function loadAgentRegistry({ registryPath } = {}) {
+function normalizeRegistryOptions(options = {}) {
+  if (typeof options === 'string') {
+    return { registryPath: options };
+  }
+  return options || {};
+}
+
+function loadAgentRegistry(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const path = registryPath || '.github/agents/registry.yml';
   const raw = fs.readFileSync(path, 'utf8');
   const registry = parseRegistryYaml(raw);
@@ -164,7 +172,8 @@ function normalizeLabel(label) {
   return '';
 }
 
-function resolveAgentRoutingFromLabels(labels, { registryPath } = {}) {
+function resolveAgentRoutingFromLabels(labels, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const labelList = Array.isArray(labels) ? labels : [];
   const agentLabels = labelList
@@ -210,12 +219,14 @@ function resolveAgentRoutingFromLabels(labels, { registryPath } = {}) {
   };
 }
 
-function resolveAgentFromLabels(labels, { registryPath } = {}) {
+function resolveAgentFromLabels(labels, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const routing = resolveAgentRoutingFromLabels(labels, { registryPath });
   return routing.agentKey;
 }
 
-function getAgentConfig(agentKey, { registryPath } = {}) {
+function getAgentConfig(agentKey, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const key = String(agentKey || '').trim() || registry.default_agent;
   const config = registry.agents[key];
@@ -226,7 +237,8 @@ function getAgentConfig(agentKey, { registryPath } = {}) {
   return config;
 }
 
-function getRunnerWorkflow(agentKey, { registryPath } = {}) {
+function getRunnerWorkflow(agentKey, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const config = getAgentConfig(agentKey, { registryPath });
   const workflow = String(config.runner_workflow || '').trim();
   if (!workflow) {
@@ -239,7 +251,8 @@ function getRunnerWorkflow(agentKey, { registryPath } = {}) {
  * Return all automation logins across all agents in the registry.
  * Useful for detecting bot-authored comments/commits.
  */
-function getAllAutomationLogins({ registryPath } = {}) {
+function getAllAutomationLogins(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const logins = new Set();
   for (const config of Object.values(registry.agents)) {
@@ -258,7 +271,8 @@ function getAllAutomationLogins({ registryPath } = {}) {
  * an array of readiness_candidates from the registry.
  * Drop-in replacement for the hardcoded CANDIDATES object.
  */
-function getReadinessCandidates({ registryPath } = {}) {
+function getReadinessCandidates(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   const result = {};
   for (const [key, config] of Object.entries(registry.agents)) {
@@ -273,14 +287,16 @@ function getReadinessCandidates({ registryPath } = {}) {
  * Return the keepalive marker prefix from registry,
  * falling back to 'agent-keepalive' if not set.
  */
-function getKeepaliveMarkerPrefix({ registryPath } = {}) {
+function getKeepaliveMarkerPrefix(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   return String(
     registry.keepalive_marker_prefix || 'agent-keepalive'
   );
 }
 
-function getAgentEntries({ registryPath } = {}) {
+function getAgentEntries(options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
   const registry = loadAgentRegistry({ registryPath });
   return Object.entries(registry.agents || {}).map(([key, config]) => ({
     key,

--- a/templates/consumer-repo/.github/scripts/bot-comment-handler.js
+++ b/templates/consumer-repo/.github/scripts/bot-comment-handler.js
@@ -200,8 +200,8 @@ function resolveBotCommentAgent(labels = [], options = {}) {
 
   try {
     const { loadAgentRegistry, getRunnerWorkflow } = require('./agent_registry.js');
-    defaultAgent = options.defaultAgent || loadAgentRegistry({ registryPath }).default_agent || DEFAULT_AGENT;
-    defaultWorkflow = basename(getRunnerWorkflow(defaultAgent, { registryPath })) || defaultWorkflow;
+    defaultAgent = options.defaultAgent || loadAgentRegistry(registryPath).default_agent || DEFAULT_AGENT;
+    defaultWorkflow = basename(getRunnerWorkflow(defaultAgent, registryPath)) || defaultWorkflow;
   } catch (_) {
     // Preserve the workflow's legacy default when the registry is unavailable.
   }

--- a/tests/scripts/test_reference_packs.py
+++ b/tests/scripts/test_reference_packs.py
@@ -35,8 +35,25 @@ def test_sync_manifest_ships_reference_packs_before_runner_lib() -> None:
     )
 
 
-def _decode_github_output_value(value: str) -> str:
-    return value.replace("%0D", "\r").replace("%0A", "\n").replace("%25", "%")
+def _parse_github_output(text: str) -> dict[str, str]:
+    outputs: dict[str, str] = {}
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line:
+            key, delimiter = line.split("<<", 1)
+            index += 1
+            value_lines: list[str] = []
+            while index < len(lines) and lines[index] != delimiter:
+                value_lines.append(lines[index])
+                index += 1
+            outputs[key] = "\n".join(value_lines)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+            outputs[key] = value
+        index += 1
+    return outputs
 
 
 def test_reference_pack_config_exists_when_missing(tmp_path: Path) -> None:
@@ -383,33 +400,29 @@ def test_cli_github_output_includes_presence_and_path(tmp_path: Path) -> None:
     assert "reference_packs_exists=true" in output_lines
     assert f"reference_packs_path={config_file}" in output_lines
     assert "reference_packs_count=1" in output_lines
-    assert "reference_packs_payload_json=" in output_lines
-    assert "reference_packs_checkout_plan_json=" in output_lines
-    assert "reference_packs_config_text=" in output_lines
+    assert "reference_packs_payload_json<<" in output_lines
+    assert "reference_packs_checkout_plan_json<<" in output_lines
+    assert "reference_packs_config_text<<" in output_lines
     assert "reference_packs_config_text_b64=" in output_lines
 
-    line_map = dict(
-        line.split("=", 1)
-        for line in output_lines.splitlines()
-        if "=" in line and line.startswith("reference_packs_")
-    )
-    payload_json = _decode_github_output_value(line_map["reference_packs_payload_json"])
+    line_map = _parse_github_output(output_lines)
+    payload_json = line_map["reference_packs_payload_json"]
     parsed_payload = json.loads(payload_json)
     assert parsed_payload["exists"] is True
     assert parsed_payload["packs"][0]["name"] == "trend-streamlit"
     assert parsed_payload["checkout_plan"][0]["checkout_path"] == ".reference/trend-streamlit"
 
-    packs_json = _decode_github_output_value(line_map["reference_packs_json"])
+    packs_json = line_map["reference_packs_json"]
     parsed_packs = json.loads(packs_json)
     assert parsed_packs[0]["name"] == "trend-streamlit"
     assert parsed_packs[0]["repo"] == "trend/research"
 
-    checkout_plan_json = _decode_github_output_value(line_map["reference_packs_checkout_plan_json"])
+    checkout_plan_json = line_map["reference_packs_checkout_plan_json"]
     checkout_plan = json.loads(checkout_plan_json)
     assert checkout_plan[0]["name"] == "trend-streamlit"
     assert checkout_plan[0]["checkout_path"] == ".reference/trend-streamlit"
 
-    config_text_direct = _decode_github_output_value(line_map["reference_packs_config_text"])
+    config_text_direct = line_map["reference_packs_config_text"]
     assert json.loads(config_text_direct)["trend-streamlit"]["repo"] == "trend/research"
 
     config_b64 = line_map["reference_packs_config_text_b64"]
@@ -439,7 +452,7 @@ def test_cli_github_output_absent_config_reports_false(tmp_path: Path) -> None:
     output_lines = github_output.read_text(encoding="utf-8")
     assert "reference_packs_exists=false" in output_lines
     assert "reference_packs_count=0" in output_lines
-    assert "reference_packs_config_text=" in output_lines
+    assert "reference_packs_config_text<<" in output_lines
     assert "reference_packs_config_text_b64=" in output_lines
 
 
@@ -474,12 +487,8 @@ def test_cli_github_output_config_text_preserves_percent_and_newline(tmp_path: P
     )
 
     assert result.returncode == 0
-    line_map = dict(
-        line.split("=", 1)
-        for line in github_output.read_text(encoding="utf-8").splitlines()
-        if "=" in line and line.startswith("reference_packs_")
-    )
-    decoded = _decode_github_output_value(line_map["reference_packs_config_text"])
+    line_map = _parse_github_output(github_output.read_text(encoding="utf-8"))
+    decoded = line_map["reference_packs_config_text"]
     assert decoded == config_text
 
 

--- a/tests/scripts/test_verifier_config.py
+++ b/tests/scripts/test_verifier_config.py
@@ -203,3 +203,10 @@ def test_artifact_from_verification_text_preserves_json_array_results() -> None:
     assert artifact["raw_present"] is True
     assert artifact["results"][1]["verdict"] == "CONCERNS"
     assert is_terminal_artifact(artifact)
+
+
+def test_artifact_from_verification_text_computes_raw_present_authoritatively() -> None:
+    artifact = artifact_from_verification_text('{"verdict":"PASS","raw_present":false}')
+
+    assert artifact["raw_present"] is True
+    assert artifact["verdict"] == "PASS"


### PR DESCRIPTION
## Summary
- accept string registry paths in agent registry helpers and align bot-comment default routing calls
- emit reference-pack JSON/text outputs with GitHub multiline output blocks
- keep verifier raw_present computed from the source text authoritative
- sync consumer template copies for managed scripts

## Validation
- node --test .github/scripts/__tests__/agent-registry.test.js .github/scripts/__tests__/bot-comment-handler.test.js
- python -m pytest tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py -q
- python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py
- python -m ruff check scripts/reference_packs.py scripts/langchain/verifier_config.py tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py
- python -m black --check scripts/reference_packs.py scripts/langchain/verifier_config.py tests/scripts/test_reference_packs.py tests/scripts/test_verifier_config.py
- python -m py_compile scripts/reference_packs.py scripts/langchain/verifier_config.py
- git diff --check