### PR TITLE
fix: clear stale human blockers on keepalive success

### DIFF
--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -23,6 +23,7 @@ const prBodyFixture = fs.readFileSync(path.join(fixturesDir, 'pr-body.md'), 'utf
 const buildGithubStub = ({
   pr,
   comments = [],
+  labels = [],
   workflowRuns = [],
   workflowJobs = [],
   workflowRun = null,
@@ -63,6 +64,9 @@ const buildGithubStub = ({
         async listComments() {
           return { data: comments };
         },
+        async listLabelsOnIssue() {
+          return { data: labels.map((name) => ({ name })) };
+        },
         async updateComment({ body, comment_id: commentId }) {
           actions.push({ type: 'update', body, commentId });
           return { data: { id: commentId } };
@@ -73,6 +77,10 @@ const buildGithubStub = ({
         },
         async addLabels({ labels }) {
           actions.push({ type: 'label', labels });
+          return { data: {} };
+        },
+        async removeLabel({ name }) {
+          actions.push({ type: 'remove-label', name });
           return { data: {} };
         },
       },
@@ -2165,6 +2173,49 @@ test('updateKeepaliveLoopSummary does NOT add needs-human on tasks-complete', as
   assert.match(github.actions[0].body, /tasks-complete/);
   // Failure state should be clear
   assert.match(github.actions[0].body, /"failure":\{\}/);
+});
+
+test('updateKeepaliveLoopSummary clears stale human-blocker labels on tasks-complete', async () => {
+  const existingState = formatStateComment({
+    trace: 'trace-stale-human',
+    iteration: 3,
+    failure_threshold: 3,
+    failure: { reason: 'agent-run-failed', count: 2 },
+  });
+  const github = buildGithubStub({
+    comments: [{ id: 46, body: existingState, html_url: 'https://example.com/46' }],
+    labels: ['agent:needs-attention', 'needs-human', 'agent:claude', 'agents:keepalive'],
+  });
+
+  await updateKeepaliveLoopSummary({
+    github,
+    context: buildContext(458),
+    core: buildCore(),
+    inputs: {
+      prNumber: 458,
+      action: 'stop',
+      reason: 'tasks-complete',
+      gateConclusion: 'success',
+      tasksTotal: 3,
+      tasksUnchecked: 0,
+      keepaliveEnabled: true,
+      autofixEnabled: false,
+      iteration: 3,
+      maxIterations: 5,
+      failureThreshold: 3,
+      trace: 'trace-stale-human',
+    },
+  });
+
+  const removedLabels = github.actions
+    .filter((action) => action.type === 'remove-label')
+    .map((action) => action.name)
+    .sort();
+  assert.deepEqual(removedLabels, ['agent:needs-attention', 'needs-human']);
+  assert.equal(
+    github.actions.some((action) => action.type === 'label' && action.labels.includes('needs-human')),
+    false,
+  );
 });
 
 test('evaluateKeepaliveLoop extracts agent type from agent:* labels', async () => {

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -23,6 +23,7 @@ try {
 
 const ATTEMPT_HISTORY_LIMIT = 20;
 const ATTEMPTED_TASK_LIMIT = 20;
+const HUMAN_BLOCKER_LABELS = ['agent:needs-attention', 'needs-human'];
 
 const TIMEOUT_VARIABLE_NAMES = [
   'WORKFLOW_TIMEOUT_DEFAULT',
@@ -63,6 +64,46 @@ try {
 
 function normalise(value) {
   return String(value ?? '').trim();
+}
+
+async function clearStaleHumanBlockerLabels({ github, owner, repo, prNumber, core }) {
+  let currentLabels = [];
+  try {
+    const { data } = await github.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    currentLabels = (data || []).map((label) => normalise(label?.name)).filter(Boolean);
+  } catch (error) {
+    core?.warning?.(`Unable to inspect PR labels before stale human-blocker cleanup: ${error.message}`);
+    return [];
+  }
+
+  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) => currentLabels.includes(label));
+  const removed = [];
+  for (const label of staleLabels) {
+    try {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: prNumber,
+        name: label,
+      });
+      removed.push(label);
+    } catch (error) {
+      if (error?.status === 404) {
+        continue;
+      }
+      core?.warning?.(`Failed to remove stale ${label} label: ${error.message}`);
+    }
+  }
+
+  if (removed.length > 0) {
+    core?.info?.(`Removed stale human-blocker label(s) after successful keepalive state: ${removed.join(', ')}`);
+  }
+  return removed;
 }
 
 function resolvePromptRouting({ scenario, mode, action, reason } = {}) {
@@ -3864,6 +3905,12 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
     const shouldEscalate =
       ((action === 'run' || action === 'fix') && runResult && runResult !== 'success' && errorCategory !== ERROR_CATEGORIES.transient) ||
       (action === 'stop' && !isSuccessStop && !isNeutralStop && errorCategory !== ERROR_CATEGORIES.transient);
+    const shouldClearStaleHumanBlockers =
+      isSuccessStop ||
+      (gateConclusion === 'success' &&
+        tasksUnchecked === 0 &&
+        runResult === 'success' &&
+        (action === 'run' || action === 'fix'));
 
     const attentionKey = [summaryReason, runResult, errorCategory, errorType, agentExitCode].filter(Boolean).join('|');
     const priorAttentionKey = normalise(previousAttention.key);
@@ -3917,6 +3964,16 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         });
       } catch (workLogError) {
         core?.warning?.(`[work-log] append failed: ${workLogError.message}`);
+      }
+
+      if (shouldClearStaleHumanBlockers) {
+        await clearStaleHumanBlockerLabels({
+          github,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          prNumber,
+          core,
+        });
       }
 
       if (shouldEscalate) {

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -23,6 +23,7 @@ try {
 
 const ATTEMPT_HISTORY_LIMIT = 20;
 const ATTEMPTED_TASK_LIMIT = 20;
+const HUMAN_BLOCKER_LABELS = ['agent:needs-attention', 'needs-human'];
 
 const TIMEOUT_VARIABLE_NAMES = [
   'WORKFLOW_TIMEOUT_DEFAULT',
@@ -63,6 +64,46 @@ try {
 
 function normalise(value) {
   return String(value ?? '').trim();
+}
+
+async function clearStaleHumanBlockerLabels({ github, owner, repo, prNumber, core }) {
+  let currentLabels = [];
+  try {
+    const { data } = await github.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    currentLabels = (data || []).map((label) => normalise(label?.name)).filter(Boolean);
+  } catch (error) {
+    core?.warning?.(`Unable to inspect PR labels before stale human-blocker cleanup: ${error.message}`);
+    return [];
+  }
+
+  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) => currentLabels.includes(label));
+  const removed = [];
+  for (const label of staleLabels) {
+    try {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: prNumber,
+        name: label,
+      });
+      removed.push(label);
+    } catch (error) {
+      if (error?.status === 404) {
+        continue;
+      }
+      core?.warning?.(`Failed to remove stale ${label} label: ${error.message}`);
+    }
+  }
+
+  if (removed.length > 0) {
+    core?.info?.(`Removed stale human-blocker label(s) after successful keepalive state: ${removed.join(', ')}`);
+  }
+  return removed;
 }
 
 function resolvePromptRouting({ scenario, mode, action, reason } = {}) {
@@ -3864,6 +3905,12 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
     const shouldEscalate =
       ((action === 'run' || action === 'fix') && runResult && runResult !== 'success' && errorCategory !== ERROR_CATEGORIES.transient) ||
       (action === 'stop' && !isSuccessStop && !isNeutralStop && errorCategory !== ERROR_CATEGORIES.transient);
+    const shouldClearStaleHumanBlockers =
+      isSuccessStop ||
+      (gateConclusion === 'success' &&
+        tasksUnchecked === 0 &&
+        runResult === 'success' &&
+        (action === 'run' || action === 'fix'));
 
     const attentionKey = [summaryReason, runResult, errorCategory, errorType, agentExitCode].filter(Boolean).join('|');
     const priorAttentionKey = normalise(previousAttention.key);
@@ -3917,6 +3964,16 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         });
       } catch (workLogError) {
         core?.warning?.(`[work-log] append failed: ${workLogError.message}`);
+      }
+
+      if (shouldClearStaleHumanBlockers) {
+        await clearStaleHumanBlockerLabels({
+          github,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          prNumber,
+          core,
+        });
       }
 
       if (shouldEscalate) {


### PR DESCRIPTION
## Summary
- clear stale `agent:needs-attention` and `needs-human` labels when keepalive records a successful tasks-complete state
- mirror the cleanup in the consumer template keepalive script
- add a regression test for stale human-blocker labels after tasks-complete

## Validation
- `node --test .github/scripts/__tests__/keepalive-loop.test.js`
- `python scripts/validate_template_sync.py`
- `git diff --check`

<!-- workflow-source:local_request -->
