### PR TITLE
fix: address consumer sync review feedback

### DIFF
--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -2184,7 +2184,7 @@ test('updateKeepaliveLoopSummary clears stale human-blocker labels on tasks-comp
   });
   const github = buildGithubStub({
     comments: [{ id: 46, body: existingState, html_url: 'https://example.com/46' }],
-    labels: ['agent:needs-attention', 'needs-human', 'agent:claude', 'agents:keepalive'],
+    labels: ['Agent:Needs-Attention', 'NEEDS-HUMAN', 'agent:claude', 'agents:keepalive'],
   });
 
   await updateKeepaliveLoopSummary({

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -75,13 +75,17 @@ async function clearStaleHumanBlockerLabels({ github, owner, repo, prNumber, cor
       issue_number: prNumber,
       per_page: 100,
     });
-    currentLabels = (data || []).map((label) => normalise(label?.name)).filter(Boolean);
+    currentLabels = (data || [])
+      .map((label) => normalise(label?.name).toLowerCase())
+      .filter(Boolean);
   } catch (error) {
     core?.warning?.(`Unable to inspect PR labels before stale human-blocker cleanup: ${error.message}`);
     return [];
   }
 
-  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) => currentLabels.includes(label));
+  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) =>
+    currentLabels.includes(label.toLowerCase())
+  );
   const removed = [];
   for (const label of staleLabels) {
     try {

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -125,7 +125,8 @@ workflows:
 
   # Version pins
   - source: .github/workflows/autofix-versions.env
-    description: "Autofix tool version pins - shared dev tool versions (synced)"
+    description: "Autofix tool version pins - create-only starting point; existing repos manage pins locally"
+    sync_mode: create_only
 
   # Dependabot configuration and automation
   - source: .github/dependabot.yml

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -1319,7 +1319,10 @@ def build_summary(
             f"- Pinned versions: {_format_counter(codex_cli_freshness['pinned_versions'])}",
             f"- Latest versions: {_format_counter(codex_cli_freshness['latest_versions'])}",
             f"- Outdated records: {codex_cli_freshness['outdated_records']}",
-            (f"- Latest unavailable records: {codex_cli_freshness['latest_unavailable_records']}"),
+            (
+                "- Latest unavailable records: "
+                f"{codex_cli_freshness['latest_unavailable_records']}"
+            ),
             (
                 "- Max version delta: "
                 f"major {codex_cli_freshness['max_version_delta']['major']}, "

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -75,13 +75,17 @@ async function clearStaleHumanBlockerLabels({ github, owner, repo, prNumber, cor
       issue_number: prNumber,
       per_page: 100,
     });
-    currentLabels = (data || []).map((label) => normalise(label?.name)).filter(Boolean);
+    currentLabels = (data || [])
+      .map((label) => normalise(label?.name).toLowerCase())
+      .filter(Boolean);
   } catch (error) {
     core?.warning?.(`Unable to inspect PR labels before stale human-blocker cleanup: ${error.message}`);
     return [];
   }
 
-  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) => currentLabels.includes(label));
+  const staleLabels = HUMAN_BLOCKER_LABELS.filter((label) =>
+    currentLabels.includes(label.toLowerCase())
+  );
   const removed = [];
   for (const label of staleLabels) {
     try {

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -1319,7 +1319,10 @@ def build_summary(
             f"- Pinned versions: {_format_counter(codex_cli_freshness['pinned_versions'])}",
             f"- Latest versions: {_format_counter(codex_cli_freshness['latest_versions'])}",
             f"- Outdated records: {codex_cli_freshness['outdated_records']}",
-            (f"- Latest unavailable records: {codex_cli_freshness['latest_unavailable_records']}"),
+            (
+                "- Latest unavailable records: "
+                f"{codex_cli_freshness['latest_unavailable_records']}"
+            ),
             (
                 "- Max version delta: "
                 f"major {codex_cli_freshness['max_version_delta']['major']}, "


### PR DESCRIPTION
## Summary\n- Normalize stale human-blocker label comparisons in keepalive cleanup so mixed-case labels are removed.\n- Keep the aggregate metrics summary formatter-stable in source and consumer template copies.\n- Mark autofix-versions.env as create-only in the consumer sync manifest so existing consumer repos keep repo-specific tool pins.\n\n## Validation\n- node --check .github/scripts/keepalive_loop.js\n- node --check templates/consumer-repo/.github/scripts/keepalive_loop.js\n- node --test .github/scripts/__tests__/keepalive-loop.test.js\n- node --test .github/scripts/__tests__/agents-pr-meta-keepalive.test.js\n- python -m black --check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py\n- python scripts/sync_tool_versions.py --check\n- python scripts/validate_template_sync.py\n- pytest -q tests/scripts/test_aggregate_agent_metrics.py tests/scripts/test_sync_tool_versions.py tests/scripts/test_validate_template_sync.py\n- pytest -q tests/workflows/test_consumer_sync_create_only_evidence.py\n- git diff --check\n\nSource fix for consumer sync PR stranske/Travel-Plan-Permission#1074.