### PR TITLE
[codex] Keep autofix pins out of template sync

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -123,11 +123,6 @@ workflows:
   - source: .github/workflows/maint-76-claude-code-review.yml
     description: "Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch"
 
-  # Version pins
-  - source: .github/workflows/autofix-versions.env
-    description: "Autofix tool version pins - create-only starting point; existing repos manage pins locally"
-    sync_mode: create_only
-
   # Dependabot configuration and automation
   - source: .github/dependabot.yml
     description: "Dependabot config - ignores dev tools synced via maint-52"

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -197,6 +197,12 @@ for `ruff`, `black`, `mypy`, `pytest`, `coverage`, `isort`, and `docformatter`.
 The matching `pyproject.toml`, consumer template, integration template, and
 direct `requirements.lock` pins must move in the same Workflows PR.
 
+Consumer repos receive those pins through `maint-52-sync-dev-versions.yml`, not
+the general `maint-68-sync-consumer-repos.yml` template sync. Keep
+`.github/workflows/autofix-versions.env` out of `.github/sync-manifest.yml` so a
+workflow-template sync PR cannot update the env file without the matching
+`pyproject.toml` and `requirements.lock` changes.
+
 Dependabot should not be merged when it only bumps one of those shared tool pins
 in `pyproject.toml`; route that change through the Workflows source pin update
 path instead. Runtime dependency bumps remain normal Dependabot work.

--- a/templates/README.md
+++ b/templates/README.md
@@ -124,7 +124,7 @@ Consumer Repos (Travel-Plan-Permission, Template)
 |----------|-------|---------------|
 | **Thin callers** | `agents-*.yml`, `autofix.yml`, `pr-00-gate.yml` | Full sync from templates |
 | **CI config** | `ci.yml` | Repo-specific (not synced) |
-| **Version pins** | `autofix-versions.env` | Version updates synced, overrides preserved |
+| **Version pins** | `autofix-versions.env` | Synced by maint-52 with matching `pyproject.toml`/`requirements.lock` changes |
 | **Repo-specific** | `maint-*.yml`, custom workflows | Not synced |
 
 ### Required: artifact-prefix for Multi-Job Workflows

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -293,6 +293,21 @@ def test_consumer_sync_diff_keeps_functional_lines_in_comparison():
     ), "Maint 68 must not ignore fixed line ranges that can contain version pins"
 
 
+def test_autofix_versions_env_is_not_general_template_synced():
+    manifest = yaml.safe_load(Path(".github/sync-manifest.yml").read_text(encoding="utf-8"))
+    workflow_sources = {
+        entry.get("source") for entry in manifest.get("workflows", []) if isinstance(entry, dict)
+    }
+    assert ".github/workflows/autofix-versions.env" not in workflow_sources
+
+    version_sync_text = (WORKFLOWS_DIR / "maint-52-sync-dev-versions.yml").read_text(
+        encoding="utf-8"
+    )
+    assert ".github/workflows/autofix-versions.env" in version_sync_text
+    assert "pyproject.toml .github/workflows/autofix-versions.env" in version_sync_text
+    assert "requirements.lock" in version_sync_text
+
+
 def test_consumer_sync_repo_exclusions_live_in_manifest():
     workflow_text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
     manifest_text = Path(".github/sync-manifest.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove .github/workflows/autofix-versions.env from the general consumer sync manifest
- document that maint-52 owns consumer dev-tool pin alignment with pyproject.toml and requirements.lock
- add a regression test that keeps the env file out of maint-68 template sync while confirming maint-52 still stages the matching dependency files

## Why
The sync-generated trip-planner PR #1134 updated autofix-versions.env by itself, while trip-planner's pyproject.toml and requirements.lock still pinned mypy 1.20.2. The matching dev-version PR #1133 already carries the env, pyproject, and lockfile together; maint-68 should not create a second partial version-pin PR.

## Validation
- pytest tests/workflows/test_workflow_agents_consolidation.py -q
- python -c "import yaml; yaml.safe_load(open('.github/sync-manifest.yml', encoding='utf-8'))"
- git diff --check