### PR TITLE
fix: group workflow llm dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dev = [
     "hypothesis>=6.152.2",
     "pandas",
     "numpy<3.0",
-    "pydantic>=2.13.3",
-    "requests>=2.33.1",
+    "pydantic>=2.13.4",
+    "requests>=2.34.0",
     "jsonschema>=4.26.0",
     "PyYAML>=6.0.0",
 
@@ -59,11 +59,11 @@ dev = [
 # Install with: pip install -e ".[langchain]"
 # Versions auto-updated by scripts/update_langchain_versions.py
 langchain = [
-    "langchain>=1.2.17,<1.3",
-    "langchain-core>=1.3.2,<1.4",
+    "langchain>=1.2.18,<1.3",
+    "langchain-core>=1.3.3,<1.4",
     "langchain-community>=0.4,<0.5",
     "langchain-openai>=1.2.1,<1.3",
-    "langchain-anthropic>=1.4.2,<1.5",
+    "langchain-anthropic>=1.4.3,<1.5",
     "faiss-cpu>=1.13.2,<2.0",  # Vector store for dedup workflow
 ]
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -8,13 +8,15 @@ aiosignal==1.4.0
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.100.0
+anthropic==0.101.0
     # via langchain-anthropic
 anyio==4.13.0
     # via
     #   anthropic
     #   httpx
     #   openai
+ast-serialize==0.3.0
+    # via mypy
 attrs==26.1.0
     # via
     #   aiohttp
@@ -86,11 +88,11 @@ httpx==0.28.1
     #   openai
 httpx-sse==0.4.3
     # via langchain-community
-hypothesis==6.152.4
+hypothesis==6.152.6
     # via workflows (pyproject.toml)
 identify==2.6.19
     # via pre-commit
-idna==3.13
+idna==3.14
     # via
     #   anyio
     #   httpx
@@ -112,21 +114,21 @@ jsonschema==4.26.0
     # via workflows (pyproject.toml)
 jsonschema-specifications==2025.9.1
     # via jsonschema
-langchain==1.2.17
+langchain==1.2.18
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-anthropic==1.4.2
+langchain-anthropic==1.4.3
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-classic==1.0.5
+langchain-classic==1.0.7
     # via langchain-community
 langchain-community==0.4.1
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-core==1.3.2
+langchain-core==1.3.3
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -149,7 +151,7 @@ langchain-text-splitters==1.1.2
     # via langchain-classic
 langgraph==1.1.10
     # via langchain
-langgraph-checkpoint==4.0.3
+langgraph-checkpoint==4.1.0
     # via
     #   langgraph
     #   langgraph-prebuilt
@@ -157,12 +159,12 @@ langgraph-prebuilt==1.0.13
     # via langgraph
 langgraph-sdk==0.3.14
     # via langgraph
-langsmith==0.8.2
+langsmith==0.8.3
     # via
     #   langchain-classic
     #   langchain-community
     #   langchain-core
-librt==0.10.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 marshmallow==3.26.2
     # via dataclasses-json
@@ -188,7 +190,7 @@ numpy==2.4.4
     #   faiss-cpu
     #   langchain-community
     #   pandas
-openai==2.35.1
+openai==2.36.0
     # via langchain-openai
 orjson==3.11.9
     # via
@@ -224,13 +226,13 @@ pluggy==1.6.0
     #   pytest-cov
 pre-commit==4.6.0
     # via workflows (pyproject.toml)
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
 pycodestyle==2.14.0
     # via flake8
-pydantic==2.13.3
+pydantic==2.13.4
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -243,9 +245,9 @@ pydantic==2.13.3
     #   langsmith
     #   openai
     #   pydantic-settings
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.14.0
+pydantic-settings==2.14.1
     # via langchain-community
 pyflakes==3.4.0
     # via flake8
@@ -281,9 +283,9 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2026.4.4
+regex==2026.5.9
     # via tiktoken
-requests==2.33.1
+requests==2.34.0
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -347,11 +349,9 @@ typing-inspection==0.4.2
     #   pydantic-settings
 tzdata==2026.2 ; sys_platform == 'emscripten' or sys_platform == 'win32'
     # via pandas
-untokenize==0.1.1
-    # via docformatter
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
-uuid-utils==0.14.1
+uuid-utils==0.15.0
     # via
     #   langchain-core
     #   langsmith

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 # Core runtime dependencies
-requests==2.33.1
+requests==2.34.0
 pytest==9.0.3
 pyyaml==6.0.3
-pydantic==2.13.3
+pydantic==2.13.4
 numpy==2.4.4
 pandas==3.0.2
 tomlkit==0.14.0
 
 # LangChain integration
-langchain==1.2.17
-langchain-core==1.3.2
+langchain==1.2.18
+langchain-core==1.3.3
 langchain-community==0.4.1
 langchain-openai==1.2.1
-langchain-anthropic==1.4.2
+langchain-anthropic==1.4.3
 faiss-cpu==1.13.2

--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -1,13 +1,15 @@
 # LLM workflow dependency pins (used by agents-auto-pilot.yml)
 # Rationale:
 # - These are standalone runtime pins for workflow LLM steps, not app deps.
-# - Use strict X.Y.Z pins to keep workflow installs reproducible.
-# - `langchain-core` is pinned to the resolver-confirmed compatible version
-#   for the selected `langchain` pin.
-langchain==1.2.15
-langchain-core==1.3.0
+# - These pins intentionally drift from pyproject.toml/requirements.lock so
+#   workflow automation can upgrade independently; no consumer dependency
+#   change is required when bumping this file.
+# - Use strict X.Y.Z pins for direct workflow dependencies.
+# - Do not pin `langchain-core` directly here; let the selected `langchain`
+#   release resolve a mutually compatible core version.
+langchain==1.2.18
 langchain-community==0.4.1
-langchain-openai==1.1.14
-langchain-anthropic==1.4.0
-pydantic==2.13.2
-requests==2.33.1
+langchain-openai==1.2.1
+langchain-anthropic==1.4.3
+pydantic==2.13.4
+requests==2.34.0

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -124,6 +124,7 @@ def _render_prompt_with_assemble_step(
             "PR_NUMBER": pr_number,
             "MODE": mode,
             "GITHUB_OUTPUT": str(github_output),
+            "GITHUB_WORKSPACE": str(Path.cwd()),
         }
     )
 

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -7,9 +7,9 @@
 # - Use strict X.Y.Z pins for direct workflow dependencies.
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
-langchain==1.2.17
+langchain==1.2.18
 langchain-community==0.4.1
 langchain-openai==1.2.1
 langchain-anthropic==1.4.3
-pydantic==2.13.3
-requests==2.33.1
+pydantic==2.13.4
+requests==2.34.0


### PR DESCRIPTION
## Summary
- group the Workflows-owned LLM/runtime pin bumps that were split across Dependabot PRs
- align `tools/requirements-llm.txt` and the consumer template copy
- regenerate `requirements.lock` and fix the workflow prompt test harness for `GITHUB_WORKSPACE`

## Validation
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m pytest tests/test_dependency_version_alignment.py tests/workflows/test_workflow_llm_installs.py -q`
- `git diff --check`

## Campaign context
Supersedes the partial Dependabot bumps for `langchain`, `langchain-core`, `langchain-anthropic`, `pydantic`, and `requests` across Workflows-owned LLM workflow pin files.
