### PR TITLE
fix: bump claude code review action

### DIFF
--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
+        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Summary
- update the synced Claude Code review workflow template to the v1.0.120 action commit
- keep the existing pinned-commit style and v1 comment

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
- git diff --check

Related to the sync/dependabot cleanup campaign.