### PR TITLE
Issue #2086: schedule metrics retention policy nightly

### DIFF
--- a/.github/workflows/maint-metrics-retention.yml
+++ b/.github/workflows/maint-metrics-retention.yml
@@ -8,7 +8,8 @@ on:
       dry_run:
         description: "Run scripts/metrics_retention.py with --dry-run"
         required: false
-        default: "false"
+        type: boolean
+        default: false
   pull_request:
     paths:
       - "scripts/metrics_retention.py"

--- a/.github/workflows/maint-metrics-retention.yml
+++ b/.github/workflows/maint-metrics-retention.yml
@@ -1,0 +1,130 @@
+name: Maint Metrics Retention
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run scripts/metrics_retention.py with --dry-run"
+        required: false
+        default: "false"
+  pull_request:
+    paths:
+      - "scripts/metrics_retention.py"
+      - "config/retention-policy.json"
+      - ".github/workflows/maint-metrics-retention.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  apply-retention:
+    name: Apply metrics retention policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Determine dry-run mode
+        id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "flag=--dry-run" >> "$GITHUB_OUTPUT"
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${DISPATCH_DRY_RUN}" = "true" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "flag=--dry-run" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run metrics retention policy
+        env:
+          DRY_RUN_FLAG: ${{ steps.mode.outputs.flag }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          python scripts/metrics_retention.py --config config/retention-policy.json ${DRY_RUN_FLAG}
+
+      - name: Summarize storage reduction
+        if: always()
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          log_path = Path("metrics-retention.ndjson")
+          dry_run = os.environ.get("DRY_RUN", "false") == "true"
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+          lines: list[str] = []
+          lines.append("## Metrics retention summary")
+          lines.append("")
+          lines.append(f"- Dry-run: `{dry_run}`")
+
+          if not log_path.exists():
+              lines.append("- No retention log produced (script did not run or no metrics targets).")
+              summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+              raise SystemExit(0)
+
+          latest_summary: dict | None = None
+          for raw in log_path.read_text(encoding="utf-8").splitlines():
+              raw = raw.strip()
+              if not raw:
+                  continue
+              try:
+                  record = json.loads(raw)
+              except json.JSONDecodeError:
+                  continue
+              if record.get("record_type") == "retention_summary":
+                  latest_summary = record
+
+          if latest_summary is None:
+              lines.append("- No `retention_summary` record found in `metrics-retention.ndjson`.")
+          else:
+              reduction = latest_summary.get("reduction_percent")
+              files_processed = latest_summary.get("files_processed")
+              bytes_before = latest_summary.get("bytes_before")
+              bytes_after = latest_summary.get("bytes_after")
+              records_archived = (
+                  (latest_summary.get("records_archived_weekly") or 0)
+                  + (latest_summary.get("records_archived_monthly") or 0)
+              )
+              records_purged = latest_summary.get("records_purged")
+              lines.append(f"- Storage reduction: **{reduction}%**")
+              lines.append(f"- Files processed: {files_processed}")
+              lines.append(f"- Bytes before -> after: {bytes_before} -> {bytes_after}")
+              lines.append(f"- Records archived (weekly + monthly): {records_archived}")
+              lines.append(f"- Records purged: {records_purged}")
+
+          summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload retention log artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: metrics-retention-log
+          path: metrics-retention.ndjson
+          if-no-files-found: ignore
+          retention-days: 90

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -302,7 +302,8 @@ The nightly schedule is implemented by `.github/workflows/maint-metrics-retentio
 `scripts/metrics_retention.py` at 02:00 UTC, supports `workflow_dispatch` (with an optional `dry_run` input) for manual
 runs, and runs in `--dry-run` mode on `pull_request` triggers that touch the script, the policy config, or the workflow
 file itself. The retention log is uploaded as the `metrics-retention-log` artifact and the storage reduction percentage
-is surfaced in the workflow step summary.
+is surfaced in the workflow step summary. Fresh checkouts with no metrics logs are treated as successful no-op runs:
+the script writes a zero-file `retention_summary` record so pull-request validation still produces durable evidence.
 
 ## Security Considerations
 

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -298,8 +298,11 @@ Archived data can be restored when needed:
 Retention operations are tracked in `metrics-retention.ndjson`, including record counts, archive destinations, and storage
 reduction percentages.
 
-Needs-human: add a scheduled workflow (e.g. nightly) to run `scripts/metrics_retention.py` so the policy executes
-automatically.
+The nightly schedule is implemented by `.github/workflows/maint-metrics-retention.yml`. The workflow runs
+`scripts/metrics_retention.py` at 02:00 UTC, supports `workflow_dispatch` (with an optional `dry_run` input) for manual
+runs, and runs in `--dry-run` mode on `pull_request` triggers that touch the script, the policy config, or the workflow
+file itself. The retention log is uploaded as the `metrics-retention-log` artifact and the storage reduction percentage
+is surfaced in the workflow step summary.
 
 ## Security Considerations
 

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -87,7 +87,7 @@ The gate uses the shared `.github/scripts/detect-changes.js` helper to decide wh
 * Gate's `summary` job now emits the consolidated PR comment, uploads `gate-summary.md`, and publishes `gate-coverage.json` / `gate-coverage-delta.json` for downstream consumers.
 * [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) keeps `pyproject.toml`, templates, and `requirements.lock` aligned to the canonical `autofix-versions.env` file.
 * [`maint-coverage-guard.yml`](../../.github/workflows/maint-coverage-guard.yml) periodically verifies that the latest Gate run meets baseline coverage expectations.
-* [`maint-metrics-retention.yml`](../../.github/workflows/maint-metrics-retention.yml) runs `scripts/metrics_retention.py` nightly (02:00 UTC) to enforce the retention policy in `config/retention-policy.json`, uploads `metrics-retention.ndjson` as an artifact, and surfaces the storage reduction percentage in the step summary.
+* [`maint-metrics-retention.yml`](../../.github/workflows/maint-metrics-retention.yml) runs `scripts/metrics_retention.py` nightly (02:00 UTC) to enforce the retention policy in `config/retention-policy.json`, uploads `metrics-retention.ndjson` as an artifact, and surfaces the storage reduction percentage in the step summary. When no metrics logs are present, the run succeeds with a zero-file no-op summary.
 * [`maint-46-post-ci.yml`](../../.github/workflows/maint-46-post-ci.yml) wakes up after Gate completes, validates the workflow syntax with `actionlint`, downloads the Gate artifacts, renders the consolidated CI summary (including coverage deltas), and republishes the Gate commit status while saving a markdown preview for evidence capture.
 
 ## Autofix & Maintenance

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -87,6 +87,7 @@ The gate uses the shared `.github/scripts/detect-changes.js` helper to decide wh
 * Gate's `summary` job now emits the consolidated PR comment, uploads `gate-summary.md`, and publishes `gate-coverage.json` / `gate-coverage-delta.json` for downstream consumers.
 * [`maint-sync-env-from-pyproject.yml`](../../.github/workflows/maint-sync-env-from-pyproject.yml) keeps `pyproject.toml`, templates, and `requirements.lock` aligned to the canonical `autofix-versions.env` file.
 * [`maint-coverage-guard.yml`](../../.github/workflows/maint-coverage-guard.yml) periodically verifies that the latest Gate run meets baseline coverage expectations.
+* [`maint-metrics-retention.yml`](../../.github/workflows/maint-metrics-retention.yml) runs `scripts/metrics_retention.py` nightly (02:00 UTC) to enforce the retention policy in `config/retention-policy.json`, uploads `metrics-retention.ndjson` as an artifact, and surfaces the storage reduction percentage in the step summary.
 * [`maint-46-post-ci.yml`](../../.github/workflows/maint-46-post-ci.yml) wakes up after Gate completes, validates the workflow syntax with `actionlint`, downloads the Gate artifacts, renders the consolidated CI summary (including coverage deltas), and republishes the Gate commit status while saving a markdown preview for evidence capture.
 
 ## Autofix & Maintenance

--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -498,6 +498,11 @@ Keep this table handy when you are triaging automation: it confirms which workfl
   downloads the latest Gate coverage payload plus the trend artifact and
   compares them against `config/coverage-baseline.json`, surfacing notices when
   coverage dips outside the allowed guard band.
+- **Maint Metrics Retention** – `.github/workflows/maint-metrics-retention.yml`
+  runs `scripts/metrics_retention.py` nightly (02:00 UTC) with
+  `config/retention-policy.json`, uploads `metrics-retention.ndjson` as an
+  artifact, and writes the storage reduction percentage to the step summary.
+  Pull-request triggers activate `--dry-run` mode automatically.
   - Coverage reports intentionally exclude CLI-only entry points (for example,
     `if __name__ == "__main__"` blocks marked with `# pragma: no cover`).
 - **Maint 46 Post CI** – `.github/workflows/maint-46-post-ci.yml` is a recovery

--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -502,7 +502,8 @@ Keep this table handy when you are triaging automation: it confirms which workfl
   runs `scripts/metrics_retention.py` nightly (02:00 UTC) with
   `config/retention-policy.json`, uploads `metrics-retention.ndjson` as an
   artifact, and writes the storage reduction percentage to the step summary.
-  Pull-request triggers activate `--dry-run` mode automatically.
+  Pull-request triggers activate `--dry-run` mode automatically. Fresh checkouts
+  with no metrics logs produce a successful zero-file no-op summary.
   - Coverage reports intentionally exclude CLI-only entry points (for example,
     `if __name__ == "__main__"` blocks marked with `# pragma: no cover`).
 - **Maint 46 Post CI** – `.github/workflows/maint-46-post-ci.yml` is a recovery

--- a/scripts/metrics_retention.py
+++ b/scripts/metrics_retention.py
@@ -323,8 +323,6 @@ def _build_log_record(
 
 
 def _append_log(log_path: Path, payload: dict[str, Any], *, dry_run: bool) -> None:
-    if dry_run:
-        return
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, sort_keys=True) + "\n")
@@ -466,9 +464,6 @@ def main(argv: list[str]) -> int:
         log_path,
         include_defaults=include_defaults,
     )
-    if not targets:
-        print("metrics_retention: no metrics files found.", file=sys.stderr)
-        return 1
 
     summary = {
         "files_processed": 0,
@@ -483,6 +478,22 @@ def main(argv: list[str]) -> int:
         "bytes_after": 0,
         "bytes_archived": 0,
     }
+
+    if not targets:
+        summary_payload = {
+            "timestamp": now.isoformat().replace("+00:00", "Z"),
+            "schema_version": 1,
+            "component": "metrics_retention",
+            "record_type": "retention_summary",
+            "dry_run": args.dry_run,
+            "reduction_percent": 0.0,
+            "min_reduction_percent": args.min_reduction_percent,
+            "met_reduction_target": None,
+            **summary,
+        }
+        _append_log(log_path, summary_payload, dry_run=args.dry_run)
+        print("metrics_retention: no metrics files found; wrote no-op summary.")
+        return 0
 
     for path in targets:
         stats = apply_retention_to_file(path, policy, now=now, dry_run=args.dry_run)

--- a/tests/scripts/test_metrics_retention.py
+++ b/tests/scripts/test_metrics_retention.py
@@ -190,3 +190,63 @@ def test_main_defaults_include_agents_dir(tmp_path: Path, monkeypatch) -> None:
     )
 
     assert exit_code == 0
+    log_records = [json.loads(line) for line in _load_lines(log_path)]
+    assert log_records[-1]["record_type"] == "retention_summary"
+    assert log_records[-1]["dry_run"] is True
+    assert log_records[-1]["files_processed"] == 1
+
+
+def test_main_no_metrics_files_writes_noop_summary(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "retention-policy.json"
+    log_path = tmp_path / "metrics-retention.ndjson"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "retention": {
+                    "daily": {"keep_days": 1},
+                    "weekly": {"keep_weeks": 1},
+                    "monthly": {"keep_months": 1},
+                },
+                "archive": {"enabled": False, "storage_dir": str(tmp_path / "archives")},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = metrics_retention.main(
+        [
+            "--config",
+            str(config_path),
+            "--log-path",
+            str(log_path),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    log_records = [json.loads(line) for line in _load_lines(log_path)]
+    assert log_records == [
+        {
+            "bytes_after": 0,
+            "bytes_archived": 0,
+            "bytes_before": 0,
+            "component": "metrics_retention",
+            "dry_run": True,
+            "files_processed": 0,
+            "met_reduction_target": None,
+            "min_reduction_percent": None,
+            "parse_errors": 0,
+            "record_type": "retention_summary",
+            "records_archived_monthly": 0,
+            "records_archived_weekly": 0,
+            "records_kept": 0,
+            "records_purged": 0,
+            "records_skipped": 0,
+            "records_total": 0,
+            "reduction_percent": 0.0,
+            "schema_version": 1,
+            "timestamp": log_records[0]["timestamp"],
+        }
+    ]

--- a/tests/workflows/test_maint_metrics_retention.py
+++ b/tests/workflows/test_maint_metrics_retention.py
@@ -33,6 +33,11 @@ def test_workflow_has_required_triggers() -> None:
 
 def test_workflow_invokes_retention_script_with_dry_run_branch() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data = _load_workflow()
+    triggers = data.get(True) or data.get("on")
+    dry_run_input = triggers["workflow_dispatch"]["inputs"]["dry_run"]
+    assert dry_run_input["type"] == "boolean"
+    assert dry_run_input["default"] is False
     assert "scripts/metrics_retention.py" in text, "workflow must invoke the retention script"
     assert (
         "--config config/retention-policy.json" in text

--- a/tests/workflows/test_maint_metrics_retention.py
+++ b/tests/workflows/test_maint_metrics_retention.py
@@ -1,0 +1,60 @@
+"""Shape tests for the metrics-retention scheduled workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(".github/workflows/maint-metrics-retention.yml")
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.is_file(), f"missing workflow file: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_workflow_has_required_triggers() -> None:
+    data = _load_workflow()
+    # PyYAML parses the `on:` key as the Python literal `True` because of the YAML 1.1
+    # boolean rules used by `yaml.safe_load`.
+    triggers = data.get(True) or data.get("on")
+    assert triggers is not None, "workflow must declare triggers"
+    assert "schedule" in triggers, "must run on a cron schedule"
+    assert (
+        isinstance(triggers["schedule"], list) and triggers["schedule"]
+    ), "schedule must list cron entries"
+    assert all(
+        "cron" in entry for entry in triggers["schedule"]
+    ), "each schedule entry needs a cron expression"
+    assert "workflow_dispatch" in triggers, "must support manual workflow_dispatch"
+    assert "pull_request" in triggers, "must trigger on pull_request for dry-run validation"
+
+
+def test_workflow_invokes_retention_script_with_dry_run_branch() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "scripts/metrics_retention.py" in text, "workflow must invoke the retention script"
+    assert (
+        "--config config/retention-policy.json" in text
+    ), "workflow must pass the canonical retention policy config"
+    assert "--dry-run" in text, "workflow must support a dry-run code path"
+    assert (
+        "github.event_name" in text and "pull_request" in text
+    ), "workflow must branch on pull_request to activate --dry-run mode"
+
+
+def test_workflow_uploads_retention_log_artifact() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "actions/upload-artifact" in text, "must upload the retention log as an artifact"
+    assert (
+        "metrics-retention-log" in text
+    ), "artifact name must be metrics-retention-log per design doc"
+    assert "metrics-retention.ndjson" in text, "must upload the DEFAULT_RETENTION_LOG path"
+
+
+def test_workflow_emits_reduction_percent_to_step_summary() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "GITHUB_STEP_SUMMARY" in text, "workflow must write to $GITHUB_STEP_SUMMARY"
+    assert (
+        "reduction_percent" in text or "Storage reduction" in text
+    ), "step summary must surface the storage reduction percentage from the retention run"

--- a/tests/workflows/test_workflow_naming.py
+++ b/tests/workflows/test_workflow_naming.py
@@ -257,6 +257,7 @@ EXPECTED_NAMES = {
     "maint-72-fix-pr-body-conflicts.yml": "Maint 72 Fix PR Body Conflicts",
     "maint-61-create-floating-v1-tag.yml": "Maint 61 Create Floating v1 Tag",
     "maint-coverage-guard.yml": "Maint Coverage Guard",
+    "maint-metrics-retention.yml": "Maint Metrics Retention",
     "pr-00-gate.yml": "Gate",
     "pr-11-ci-smoke.yml": "PR 11 - Minimal invariant CI",
     "reusable-10-ci-python.yml": "Reusable CI",


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2086 -->
> **Source:** Issue #2086

Closes #2086

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/agent-automation.md:301` contains an explicit unfulfilled design commitment: "Needs-human: add a scheduled workflow (e.g. nightly) to run `scripts/metrics_retention.py` so the policy executes automatically." The script is fully implemented — `scripts/metrics_retention.py` exposes a CLI with `--dry-run`, `--restore`, `--metrics-paths`, and `--archive-dir` flags (see `build_parser()` at line 393) and defaults to `DEFAULT_RETENTION_LOG = Path("metrics-retention.ndjson")` at line 17. The retention policy is fully encoded in `config/retention-policy.json` (14-day daily / 8-week weekly / 24-month monthly windows, archiving to `archives/metrics/`). `tests/scripts/test_metrics_retention.py` covers the core logic.

Despite this, `rg "metrics_retention" .github/workflows/` returns zero matches: there is no scheduled trigger anywhere in `.github/workflows/`. The policy runs only if a human manually invokes the script — defeating the design intent. Stale metrics files accumulate indefinitely, and there is no audit trail of what was archived or when.

#### Tasks
- [ ] Create `.github/workflows/maint-metrics-retention.yml` with triggers: `schedule` (e.g., `cron: '0 2 * * *'` nightly at 02:00 UTC), `workflow_dispatch`, and `pull_request` (runs `--dry-run`).
- [ ] Add a `checkout` step and a Python setup step using the same pinned Python version as the CI matrix (check `autofix-versions.env` for the canonical pin).
- [ ] Add a run step: use `python scripts/metrics_retention.py` for `schedule` and `workflow_dispatch` events; `python scripts/metrics_retention.py --dry-run` when triggered by `pull_request`.
- [ ] Add an `actions/upload-artifact` step to upload `metrics-retention.ndjson` (the `DEFAULT_RETENTION_LOG` path) as artifact `metrics-retention-log`.
- [ ] Parse the storage reduction percentage from the NDJSON log or script stdout and write it to `$GITHUB_STEP_SUMMARY` so the reduction is visible in the Actions UI without downloading the artifact.
- [ ] Verify `python -m pytest tests/scripts/test_metrics_retention.py -q` still passes — no script changes should be needed.

#### Acceptance criteria
- [ ] `rg "metrics_retention" .github/workflows/` returns at least one match naming the new workflow file.
- [ ] The new workflow has a `schedule` trigger with a cron expression and a `workflow_dispatch`; `pull_request` triggers invoke `--dry-run`.
- [ ] The workflow step summary includes the storage reduction percentage from the retention run.
- [ ] `python -m pytest tests/scripts/test_metrics_retention.py -q` passes with no regressions.
- [ ] The workflow uploads `metrics-retention.ndjson` as a named artifact so retention history is inspectable from the GitHub Actions UI.

<!-- auto-status-summary:end -->