### PR TITLE
Issue #2087: add repo-review orchestration tests

### DIFF
--- a/tests/scripts/test_repo_review_coordinator.py
+++ b/tests/scripts/test_repo_review_coordinator.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+
+from scripts import repo_review_coordinator as coordinator
+from scripts import repo_review_state
+
+
+def _candidate(title: str = "Keep approved repo-local work") -> dict[str, object]:
+    return {
+        "title": title,
+        "gap": "A reviewed design commitment still lacks executable coverage.",
+        "design_refs": ["docs/design.md"],
+    }
+
+
+def _write_round1_findings(
+    output_dir: Path,
+    repo: str,
+    agent: str,
+    candidates: list[dict[str, object]],
+) -> None:
+    safe = repo.replace("/", "__")
+    path = output_dir / "round1" / agent / safe / "findings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "agent": agent,
+                "repo": repo,
+                "candidates": candidates,
+                "no_new_work_justification": "",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_prior_converged(
+    output_dir: Path,
+    repo: str,
+    candidates: list[dict[str, object]],
+) -> None:
+    safe = repo.replace("/", "__")
+    path = output_dir / "archive" / "2026-05-01" / "round2" / safe / "converged.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "v1",
+                "repo": repo,
+                "turns_completed": 1,
+                "round1_sources": [],
+                "converged_candidates": candidates,
+                "deadlocked_candidates": [],
+                "dropped_candidates": [],
+                "meta_candidate": None,
+                "meta_status": "absent",
+                "deadlocked_meta": None,
+                "no_new_work_justifications": [],
+                "negotiation_log": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_should_skip_cycle_when_round1_fingerprint_matches_prior_cycle(tmp_path: Path) -> None:
+    repo = "stranske/Example"
+    output_dir = tmp_path / "repo-review"
+    candidates = [_candidate("Codex candidate"), _candidate("Claude candidate")]
+    _write_prior_converged(output_dir, repo, candidates)
+    _write_round1_findings(output_dir, repo, "codex", [candidates[0]])
+    _write_round1_findings(output_dir, repo, "claude", [candidates[1]])
+
+    should_skip, reason = coordinator.should_skip_cycle(
+        output_dir,
+        repo,
+        ["codex", "claude"],
+    )
+
+    assert should_skip is True
+    assert "fingerprint matches prior cycle" in reason
+
+
+def test_coordinate_repo_writes_skip_converged_and_round2_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = "stranske/Example"
+    output_dir = tmp_path / "repo-review"
+    candidates = [_candidate("Codex candidate"), _candidate("Claude candidate")]
+    _write_prior_converged(output_dir, repo, candidates)
+
+    def fake_run_subprocess(cmd, *, cwd, log_path, name, timeout):
+        _write_round1_findings(output_dir, repo, "codex", [candidates[0]])
+        _write_round1_findings(output_dir, repo, "claude", [candidates[1]])
+        return coordinator.StepResult(name=name, succeeded=True, duration_seconds=0.01)
+
+    monkeypatch.setattr(coordinator, "run_subprocess", fake_run_subprocess)
+
+    report = coordinator.coordinate_repo(
+        repo=repo,
+        output_dir=output_dir,
+        workflows_steward_root=tmp_path,
+        registry_path=tmp_path / "config" / "repo_review_registry.json",
+        agents=["codex", "claude"],
+        log_dir=output_dir / "logs" / "coordinator",
+        round1_timeout=30,
+        round2_timeout=30,
+        skip_gate_enabled=True,
+    )
+
+    state = repo_review_state.load_state(output_dir, repo)
+    converged = json.loads(
+        (output_dir / "round2" / "stranske__Example" / "converged.json").read_text(encoding="utf-8")
+    )
+    assert report["skip_gate_fired"] is True
+    assert state.status == "round2-converged"
+    assert converged["synthesized_via_skip_gate"] is True
+
+
+def test_coordinate_repo_allows_mocked_round1_to_round2_state_progression(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = "stranske/Example"
+    output_dir = tmp_path / "repo-review"
+    seen_steps: list[str] = []
+
+    def fake_run_subprocess(cmd, *, cwd, log_path, name, timeout):
+        state = repo_review_state.load_state(output_dir, repo)
+        if name == "round-1":
+            repo_review_state.transition(state, status="round1-running")
+            repo_review_state.save_state(output_dir, state)
+            state = repo_review_state.load_state(output_dir, repo)
+            repo_review_state.transition(state, status="round1-complete")
+            repo_review_state.save_state(output_dir, state)
+        elif name == "round-2":
+            repo_review_state.transition(state, status="round2-running")
+            repo_review_state.save_state(output_dir, state)
+            state = repo_review_state.load_state(output_dir, repo)
+            repo_review_state.transition(state, status="round2-converged")
+            repo_review_state.save_state(output_dir, state)
+        seen_steps.append(name)
+        return coordinator.StepResult(name=name, succeeded=True, duration_seconds=0.01)
+
+    monkeypatch.setattr(coordinator, "run_subprocess", fake_run_subprocess)
+
+    report = coordinator.coordinate_repo(
+        repo=repo,
+        output_dir=output_dir,
+        workflows_steward_root=tmp_path,
+        registry_path=tmp_path / "config" / "repo_review_registry.json",
+        agents=["codex", "claude"],
+        log_dir=output_dir / "logs" / "coordinator",
+        round1_timeout=30,
+        round2_timeout=30,
+        skip_gate_enabled=False,
+    )
+
+    state = repo_review_state.load_state(output_dir, repo)
+    assert seen_steps == ["round-1", "round-2", "body-writer"]
+    assert report["round1"]["succeeded"] is True
+    assert report["round2"]["succeeded"] is True
+    assert report["body_writer"]["succeeded"] is True
+    assert state.status == "round2-converged"

--- a/tests/scripts/test_repo_review_round2_runner.py
+++ b/tests/scripts/test_repo_review_round2_runner.py
@@ -1,0 +1,156 @@
+import json
+from pathlib import Path
+
+import pytest
+from scripts import repo_review_round2_runner as runner
+
+
+def _candidate(title: str = "Keep approved repo-local work") -> dict[str, object]:
+    return {
+        "title": title,
+        "gap": "A reviewed design commitment is not covered by implementation evidence.",
+        "current_state": "The repo has source files, but the reviewed path is untested.",
+        "required_change": "Add the focused test or workflow guard named by the candidate.",
+        "design_refs": ["docs/design.md"],
+        "implementation_refs": ["scripts/example.py"],
+        "test_refs": ["tests/scripts/test_example.py"],
+        "acceptance_criteria": ["The targeted pytest command passes."],
+        "non_goals": ["Do not bundle unrelated cleanup."],
+        "tasks": ["Add focused coverage.", "Run the targeted check."],
+        "priority": "normal",
+        "confidence": "high",
+    }
+
+
+def _write_round1_findings(
+    path: Path,
+    *,
+    agent: str,
+    repo: str = "stranske/Example",
+    candidates: list[dict[str, object]] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "agent": agent,
+                "repo": repo,
+                "design_summary": "Example repo design summary.",
+                "implementation_classification": [],
+                "readiness_summary": "Example readiness summary.",
+                "remote_progress_check": "No overlap.",
+                "archive_dedup_check": "No overlap.",
+                "candidates": candidates if candidates is not None else [_candidate()],
+                "no_new_work_justification": "",
+                "deeper_review_needed": False,
+                "deeper_review_reason": "",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("contents", "exists", "expected"),
+    [
+        ("  oauth-token-value\n", True, "oauth-token-value"),
+        ("   \n", True, None),
+        ("", False, None),
+    ],
+)
+def test_read_claude_oauth_token_uses_configured_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    contents: str,
+    exists: bool,
+    expected: str | None,
+) -> None:
+    token_path = tmp_path / "claude-oauth-token.txt"
+    if exists:
+        token_path.write_text(contents, encoding="utf-8")
+    monkeypatch.setattr(runner, "CLAUDE_OAUTH_TOKEN_FILE", token_path)
+
+    assert runner._read_claude_oauth_token() == expected
+
+
+def test_compute_convergence_uses_implicit_source_agent_agree_keep() -> None:
+    key = runner.CandidateKey("codex", 1)
+    marks_by_candidate = {
+        key: [
+            {
+                "from_agent": "claude",
+                "turn": 1,
+                "mark": "agree-keep",
+                "reason": "Counterpart verified the candidate has concrete implementation evidence.",
+                "merge_proposal": None,
+                "revision_proposal": None,
+            }
+        ]
+    }
+
+    result = runner.compute_convergence(
+        [key],
+        marks_by_candidate,
+        expected_marker_agents={"codex", "claude"},
+    )
+
+    assert result[key].status == "converged-keep"
+
+
+def test_synthesize_converged_surfaces_pending_candidate_as_deadlocked(tmp_path: Path) -> None:
+    repo = "stranske/Example"
+    output_dir = tmp_path / "review"
+    codex_path = output_dir / "round1" / "codex" / "stranske__Example" / "findings.json"
+    claude_path = output_dir / "round1" / "claude" / "stranske__Example" / "findings.json"
+    _write_round1_findings(codex_path, agent="codex", repo=repo)
+    _write_round1_findings(claude_path, agent="claude", repo=repo, candidates=[])
+
+    key = runner.CandidateKey("codex", 1)
+    marks_by_candidate = {
+        key: [
+            {
+                "from_agent": "claude",
+                "turn": 1,
+                "mark": "disagree-drop",
+                "reason": "Claude found a merged PR that appears to cover the same behavior.",
+                "merge_proposal": None,
+                "revision_proposal": None,
+            }
+        ]
+    }
+    resolutions = runner.compute_convergence(
+        [key],
+        marks_by_candidate,
+        expected_marker_agents={"codex", "claude"},
+    )
+
+    payload = runner.synthesize_converged(
+        repo=repo,
+        output_dir=output_dir,
+        round1_paths={"codex": codex_path, "claude": claude_path},
+        turn_outputs=[
+            {
+                "agent": "claude",
+                "turn": 1,
+                "marks": [
+                    {
+                        "source_agent": "codex",
+                        "candidate_index": 1,
+                        "mark": "disagree-drop",
+                        "reason": "Claude found a merged PR that appears to cover the same behavior.",
+                    }
+                ],
+                "meta_candidate_proposal": {"proposed": False, "rationale": "No pattern."},
+            }
+        ],
+        turns_completed=3,
+        final_resolutions=resolutions,
+        meta_proposal=None,
+        meta_status="absent",
+        deadlocked_reason_max_turns_exhausted=True,
+    )
+
+    assert payload["converged_candidates"] == []
+    assert payload["deadlocked_candidates"][0]["title"] == "Keep approved repo-local work"
+    assert payload["deadlocked_candidates"][0]["source_agent"] == "codex"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2087 -->
> **Source:** Issue #2087

Closes #2087

<!-- pr-preamble:end -->

## Summary
- Add focused unit coverage for repo_review_round2_runner token reads, implicit convergence, and deadlock synthesis.
- Add coordinator tests for skip-gate fingerprinting, skip-state output, and mocked round1 -> round2 state progression.
- Keep tests isolated from live Claude credentials, GitHub, and agent subprocesses.

## Validation
- python -m pytest tests/scripts/test_repo_review_round2_runner.py -q
- python -m pytest tests/scripts/test_repo_review_coordinator.py -q
- python -m ruff check tests/scripts/test_repo_review_round2_runner.py tests/scripts/test_repo_review_coordinator.py
- python -m black --check --line-length 100 --target-version py312 tests/scripts/test_repo_review_round2_runner.py tests/scripts/test_repo_review_coordinator.py
- git diff --check
- rg -n "claude-oauth-token" tests/ (only tmp_path fixture assignment)

Note: the issue-requested `python scripts/dev_check.sh` treats a shell script as Python and fails with `SyntaxError`; `bash scripts/dev_check.sh` starts but this macOS /bin/bash lacks `mapfile`, so it exits at the existing script line 488.

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The Phase-4 repo-review pipeline added five orchestration scripts — `repo_review_round1_runner.py`, `repo_review_round2_runner.py` (1,345 lines, 33 functions), `repo_review_coordinator.py`, `repo_review_heartbeat.py`, and `repo_review_body_writer.py` — with zero test coverage across all 3,411 lines. The adjacent layer has complete coverage: `tests/scripts/test_repo_review_evaluator.py` covers `scripts/repo_review_evaluator.py` and `tests/scripts/test_upload_repo_review_issues.py` covers `scripts/upload_repo_review_issues.py`, establishing a clear project norm these runner scripts violate.

The most critical untested path is `_read_claude_oauth_token()` in `scripts/repo_review_round2_runner.py:404-415`. This function reads a `chmod-600` credential file at `~/.codex/automations/reviewed-repo-weekly-design-review/claude-oauth-token.txt` (the `CLAUDE_OAUTH_TOKEN_FILE` constant at line 396). A bug in the "file absent" or "empty file" branch silently returns `None` and produces a non-obvious auth failure during the round-2 negotiation rather than a clear error — a class of regression that manual review misses but a parametrized test catches immediately. Commit 555de2ae added this path without any accompanying test.

#### Tasks
- [ ] Create `tests/scripts/test_repo_review_round2_runner.py` with parametrized cases for `_read_claude_oauth_token`: (a) file present with content → returns stripped token string; (b) `CLAUDE_OAUTH_TOKEN_FILE` does not exist → returns `None`; (c) file present but empty after strip → returns `None`. Monkeypatch `CLAUDE_OAUTH_TOKEN_FILE` to a `tmp_path`-based path in all cases.
- [ ] In the same test file, add at least one `_compute_convergence` scenario: both agents mark `agree-keep` → candidate status is `converged_keep`; and a deadlock scenario (both agents `disagree-drop`) → candidate surfaces as `deadlocked`.
- [ ] Create `tests/scripts/test_repo_review_coordinator.py` that mocks `round1_runner` and `round2_runner` subprocess calls, then verifies: (a) skip-gate fires and returns `no_op` when candidate fingerprints match the prior cycle's converged set; (b) per-repo state progresses from `round1-running` → `round1-complete` → `round2-converged` in the sequential coordinator flow described in `scripts/repo_review_coordinator.py:1-30`.
- [ ] Ensure no test file imports or reads a live credential path; confirm `rg "claude-oauth-token" tests/` returns zero matches outside a `tmp_path` fixture assignment.
- [ ] Run `python scripts/dev_check.sh` and confirm the new test files are discovered and pass; fix any import errors before opening the PR.

#### Acceptance criteria
- [ ] `python -m pytest tests/scripts/test_repo_review_round2_runner.py -q` passes, covering the three `_read_claude_oauth_token` cases and at least one convergence and one deadlock scenario.
- [ ] `python -m pytest tests/scripts/test_repo_review_coordinator.py -q` passes, covering the skip-gate fingerprint check and the per-repo `round1-running` → `round2-converged` state progression.
- [ ] `rg "claude-oauth-token" tests/` returns zero matches outside of a `tmp_path`-based fixture assignment (no live credential path imported).
- [ ] `python scripts/dev_check.sh` exits 0 with the new test files included and discovered by pytest without additional conftest changes.
- [ ] Both new test files live under `tests/scripts/` matching the existing evaluator and uploader test pattern.

<!-- auto-status-summary:end -->