### PR TITLE
Issue #2088: update REPO_REVIEW_PROCESS Weekly Run to Phase-4 coordinator

### DIFF
--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -57,7 +57,7 @@ python scripts/repo_review_coordinator.py \
 The coordinator is the Phase-4 entry point. It runs the evaluator preflight,
 then for each `active` repo drives the skip-this-cycle gate, round-1 fan-out
 (Codex + Claude in parallel), round-2 negotiation, and per-repo state update,
-before a final evaluator pass renders the human-decision-packet. Pass
+before a final evaluator pass renders `human-decision-packet.md`. Pass
 `--repos <repo> [<repo> ...]` to run the full Phase-4 flow against only the
 named subset of `active` repos:
 
@@ -90,8 +90,8 @@ The coordinator orchestrates five Phase-4 scripts under `scripts/`:
   evaluator preflight → skip-this-cycle gate → round-1 → round-2 → body-writer
   → final evaluator pass.
 - `repo_review_round1_runner.py` — round-1 fan-out runner that refreshes the
-  GitNexus map and spawns Codex + Claude in parallel for the initial design-vs-
-  implementation pass.
+  GitNexus map and spawns Codex + Claude in parallel for the initial
+  design-vs-implementation pass.
 - `repo_review_round2_runner.py` — round-2 negotiation runner that coordinates
   per-turn agent calls, validates schema, and synthesizes `converged.json`.
   Protocol details: [`REPO_REVIEW_ROUND2_PROTOCOL.md`](REPO_REVIEW_ROUND2_PROTOCOL.md).

--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -49,8 +49,31 @@ Every active repo review uses the same dimensions:
 Run from the Workflows repo:
 
 ```bash
-python scripts/repo_review_evaluator.py
+python scripts/repo_review_coordinator.py \
+    --output-dir docs/reports/repo-review \
+    --registry config/repo_review_registry.json
 ```
+
+The coordinator is the Phase-4 entry point. It runs the evaluator preflight,
+then for each `active` repo drives the skip-this-cycle gate, round-1 fan-out
+(Codex + Claude in parallel), round-2 negotiation, and per-repo state update,
+before a final evaluator pass renders the human-decision-packet. Pass
+`--repos <repo> [<repo> ...]` to run the full Phase-4 flow against only the
+named subset of `active` repos:
+
+```bash
+python scripts/repo_review_coordinator.py \
+    --output-dir docs/reports/repo-review \
+    --registry config/repo_review_registry.json \
+    --repos stranske/Manager-Database stranske/trip-planner
+```
+
+`python scripts/repo_review_evaluator.py` remains valid as a standalone
+preflight step: it produces the per-repo `review-inputs.md` artifacts without
+running the multi-agent round-1/round-2 negotiation. Use it when you only need
+fresh evaluator inputs (for example, regenerating evidence before a human
+review pass); use the coordinator when you need the complete weekly packet
+with converged candidates and human-decision sections.
 
 The default weekly run performs a GitNexus preflight for active repos before
 the packet is generated. It checks map freshness and refreshes stale or missing
@@ -58,6 +81,30 @@ active maps with `gitnexus analyze <repo> --skip-agents-md` when the CLI is
 available. Use `--no-refresh-stale-gitnexus` to report stale maps without
 refreshing, or `--skip-gitnexus-preflight` only when GitNexus is deliberately
 out of scope for that run.
+
+### Phase-4 Components
+
+The coordinator orchestrates five Phase-4 scripts under `scripts/`:
+
+- `repo_review_coordinator.py` — sequential per-repo orchestrator that drives
+  evaluator preflight → skip-this-cycle gate → round-1 → round-2 → body-writer
+  → final evaluator pass.
+- `repo_review_round1_runner.py` — round-1 fan-out runner that refreshes the
+  GitNexus map and spawns Codex + Claude in parallel for the initial design-vs-
+  implementation pass.
+- `repo_review_round2_runner.py` — round-2 negotiation runner that coordinates
+  per-turn agent calls, validates schema, and synthesizes `converged.json`.
+  Protocol details: [`REPO_REVIEW_ROUND2_PROTOCOL.md`](REPO_REVIEW_ROUND2_PROTOCOL.md).
+- `repo_review_heartbeat.py` — heartbeat-aware subprocess runner that polls
+  agent log mtime and terminates stuck agents before the wall timeout so the
+  retry budget can fire on a fresh process.
+- `repo_review_body_writer.py` — body-writer pass that converts round-2
+  converged candidates into `AGENT_ISSUE_FORMAT.md`-compliant issue bodies
+  with concrete file:line refs, tasks, and acceptance criteria.
+
+Round-1 schema and round-2 protocol references:
+[`REPO_REVIEW_ROUND1_SCHEMA.md`](REPO_REVIEW_ROUND1_SCHEMA.md) and
+[`REPO_REVIEW_ROUND2_PROTOCOL.md`](REPO_REVIEW_ROUND2_PROTOCOL.md).
 
 Outputs are written to `docs/reports/repo-review/`:
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2088 -->
> **Source:** Issue #2088

Closes #2088

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/ops/REPO_REVIEW_PROCESS.md` is listed in CLAUDE.md as a trustworthy entry point for reasoning about the repo-review pipeline. Its Weekly Run section currently instructs: "Run from the Workflows repo: `python scripts/repo_review_evaluator.py`" — the pre-Phase-4 single-agent entry point. The actual production command, documented in `scripts/repo_review_coordinator.py:1-30`, is:

```
python scripts/repo_review_coordinator.py \
    --output-dir docs/reports/repo-review \
    --registry config/repo_review_registry.json
```

The coordinator drives evaluator preflight → round-1 fan-out (Codex + Claude in parallel) → skip-this-cycle gate → round-2 negotiation → body-writer pass → human decision packet. Running `scripts/repo_review_evaluator.py` directly invokes only the evaluator preflight; it produces `review-inputs.md` artifacts per repo but skips the entire multi-agent negotiation layer. The resulting `docs/reports/repo-review/` output is missing `converged.json`, round-2 turn files, and the human-decision-packet.md sections that downstream automation (the opener lane) depends on. The doc also has zero mentions of coordinator, round-1 runner, round-2 runner, heartbeat, body-writer, or Phase-4, so a new operator or automated agent following only this doc as entry context will silently produce incomplete output.

#### Tasks
- [ ] In `docs/ops/REPO_REVIEW_PROCESS.md`, replace the Weekly Run command block (`python scripts/repo_review_evaluator.py`) with the coordinator command: `python scripts/repo_review_coordinator.py --output-dir docs/reports/repo-review --registry config/repo_review_registry.json`. Add a `--repos` flag example for single-repo targeted runs.
- [ ] Add a note immediately below the coordinator command that `python scripts/repo_review_evaluator.py` remains valid as a standalone preflight step (produces review-inputs artifacts without running the multi-agent negotiation).
- [ ] Add a "Phase-4 Components" subsection listing: `repo_review_coordinator.py` (sequential per-repo orchestrator), `repo_review_round1_runner.py` (parallel Codex + Claude fan-out), `repo_review_round2_runner.py` (negotiation and convergence), `repo_review_heartbeat.py` (progress monitor), and `repo_review_body_writer.py` (issue body generation). Add cross-references to `docs/ops/REPO_REVIEW_ROUND2_PROTOCOL.md` and `docs/ops/REPO_REVIEW_ROUND1_SCHEMA.md`.
- [ ] Confirm `python scripts/dev_check.sh` exits 0 — this is a docs-only change and should pass immediately without any script or workflow edits.

#### Acceptance criteria
- [ ] `grep -n "repo_review_evaluator" docs/ops/REPO_REVIEW_PROCESS.md` returns only references to the evaluator as a preflight sub-step, not as the primary weekly run command.
- [ ] `grep -n "repo_review_coordinator" docs/ops/REPO_REVIEW_PROCESS.md` returns at least one match in the Weekly Run section showing it as the primary entry point.
- [ ] The updated Weekly Run section names all five Phase-4 components and links to `docs/ops/REPO_REVIEW_ROUND2_PROTOCOL.md`.
- [ ] `python scripts/dev_check.sh` exits 0 after the doc change.

<!-- auto-status-summary:end -->