### PR TITLE
Issue #2090: add weekly doc-drift scanner step to repo-review cron

### DIFF
--- a/config/repo_review_automation.toml
+++ b/config/repo_review_automation.toml
@@ -1,0 +1,157 @@
+# Weekly repo-review automation configuration.
+#
+# This file documents the cron automation that drives the weekly
+# design-vs-implementation review cycle. The automation is named
+# "reviewed-repo-weekly-design-review" and is invoked by the macOS
+# launchd job / cron via the claude CLI with the coordinator script below.
+#
+# To run manually (skip archiving and evaluator preflight):
+#   python scripts/repo_review_coordinator.py \
+#       --output-dir docs/reports/repo-review \
+#       --registry config/repo_review_registry.json \
+#       --skip-preflight --skip-auto-archive
+#
+# Token path (populated by the token-refresh automation):
+#   ~/.codex/automations/reviewed-repo-weekly-design-review/claude-oauth-token.txt
+
+[automation]
+name = "reviewed-repo-weekly-design-review"
+schedule = "0 9 * * 1"  # Mondays 09:00 local time
+entry_point = "scripts/repo_review_coordinator.py"
+output_dir = "docs/reports/repo-review"
+registry = "config/repo_review_registry.json"
+
+[automation.timeouts]
+round1_per_agent_seconds = 5400   # 90 min
+round2_per_turn_seconds = 2700    # 45 min
+backlog_scan_seconds = 300
+docs_drift_scan_seconds = 1800    # ~5-10 min across 9 repos
+notify_seconds = 60
+
+# ---------------------------------------------------------------------------
+# Operational notes
+#
+# Each note documents one coordinator step: what it does, why it exists,
+# where its output lives, and what to do if it fails.
+# ---------------------------------------------------------------------------
+
+[operational_notes.preflight]
+step = "1. Evaluator preflight"
+description = """
+Runs repo_review_evaluator.py to produce per-repo review-inputs.md,
+remote-progress.md, and archive-progress.md. These are the inputs round-1
+reviewer agents read. The preflight also refreshes stale GitNexus maps for
+active repos (unless --skip-gitnexus-preflight is passed).
+"""
+output = "docs/reports/repo-review/repos/<owner>__<repo>/{review-inputs,remote-progress,archive-progress}.md"
+if_skipped = "--skip-preflight uses whatever inputs are already on disk; safe for re-runs."
+
+[operational_notes.per_repo_rounds]
+step = "2. Per-repo round-1 + round-2 + body-writer"
+description = """
+For each active repo, sequentially:
+  a. Round-1: two independent reviewer agents (codex + claude) each produce
+     findings.json with a ranked candidate set.
+  b. Skip-this-cycle gate: if round-1 fingerprint matches the prior cycle's
+     converged set, skip round-2 and write a stub converged.json.
+  c. Round-2: negotiation + synthesis → converged.json.
+  d. Body-writer: converts structured candidates into AGENT_ISSUE_FORMAT.md-
+     compliant issue bodies. Uses claude (not codex) to avoid macOS sandbox
+     nesting on apply_patch (empirically verified 2026-05-07).
+Sequential execution is intentional: "1 repo per hour" rate-limit-conservative
+cadence. No global state file — each repo's state lives in state.json.
+"""
+output = "docs/reports/repo-review/round2/<owner>__<repo>/converged.json"
+if_failed = "round1=FAIL aborts that repo; round2=FAIL is surfaced in the summary but does not block other repos."
+
+[operational_notes.queue_builder]
+step = "3. Queue builder"
+description = """
+Reads converged.json files and config/repo_review_feedback.json to produce
+the approved-issue-queue.json. Pure data assembly — no subprocess. Repos
+that deadlocked or were skipped are handled by the builder's per-repo
+decision routing. The cron does NOT auto-upload; the human reviews the
+packet and runs upload_repo_review_issues.py --apply.
+"""
+output = "docs/reports/repo-review/approved-issue-queue.json"
+if_failed = "Non-fatal. Logged to stderr; cycle continues without a queue file."
+
+[operational_notes.final_evaluator]
+step = "4. Final evaluator pass"
+description = """
+Second run of repo_review_evaluator.py to refresh the human-decision-packet.md
+and the per-repo decision briefs using the converged.json outputs. Skips the
+GitNexus preflight (maps already refreshed by round-1 runner).
+"""
+output = "docs/reports/repo-review/human-decision-packet.md"
+if_failed = "Logged to coordinator/final-evaluator.log. The packet from the prior step is still on disk."
+
+[operational_notes.backlog_scan]
+step = "5. Backlog scan"
+description = """
+Scans all active repos for enhancement/feature issues that lack a priority:*
+label. The scan auto-labels eligible issues with priority:normal (or
+priority:low if the issue was created >90 days ago with no milestone).
+Umbrella/epic/blocked items are surfaced for human decision rather than
+auto-labeled. Without this safety net, manually-created enhancement issues
+with no priority label sit invisible indefinitely — the Inv-Man-Intake
+#25/#26/#27 case from 2026-05-07 confirmed the failure mode.
+
+Runs with --apply so labels are actually written during the cron. The
+notify step renders the auto-labeled and needs-human lists in the desktop
+reminder.
+"""
+output = "docs/reports/repo-review/backlog-scan.json"
+log = "docs/reports/repo-review/logs/coordinator/backlog-scan.log"
+expected_runtime = "~30 s across 9 repos (GitHub API rate-limited)"
+if_failed = "Non-fatal. Logged to backlog-scan.log. The desktop reminder omits the backlog section."
+
+[operational_notes.docs_drift_scan]
+step = "5b. Docs-drift scan"
+description = """
+Scans source-of-truth operational docs (README.md, AGENTS.md, CLAUDE.md,
+docs/ops/*, docs/ci/*, docs/keepalive/*, etc.) for drift against the current
+implementation. The doc list per repo is defined in
+config/source_of_truth_docs.yml.
+
+For each (repo, doc) pair the scanner spawns a focused claude invocation that
+reads the doc plus the relevant implementation files (verified via rg queries)
+and classifies each load-bearing claim as:
+  stale          — was true once; no longer reflects current implementation.
+  contradictory  — disagrees with another source-of-truth doc or implementation.
+  accurate-no-drift — verified against current implementation.
+
+GitNexus integration is graceful: when .gitnexus/meta.json is missing or
+marked stale the scanner instructs claude to skip behavioral call-graph checks
+(logged at INFO: "skipping behavioral check") and rely on rg for existence
+checks only. This is not a failure — it is recorded per-doc.
+
+The 2026-05-13 cycle confirmed the need: three drift instances were found
+ad-hoc (README.md model versions stale, docs/ci/WORKFLOWS.md autofix
+self-contradiction, docs/ops/REPO_REVIEW_PROCESS.md pre-Phase-4 entry
+point). Without a recurring scan these accumulate undetected.
+
+The notify step renders a "Doc drift detected" section in the desktop
+reminder, grouped by repo, with one bundled gh issue create snippet per
+affected repo (NOT one per doc).
+"""
+output = "docs/reports/repo-review/docs-drift-scan.json"
+log = "docs/reports/repo-review/logs/coordinator/docs-drift-scan.log"
+expected_runtime = "~5-10 min across 9 repos (LLM calls per doc; ~14 docs for Workflows, fewer for others)"
+if_failed = "Non-fatal. Logged to docs-drift-scan.log. The desktop reminder omits the doc-drift section."
+config = "config/source_of_truth_docs.yml"
+
+[operational_notes.notify]
+step = "6. Notify"
+description = """
+Surfaces the cycle outcome to the human reviewer via:
+  a. macOS osascript notification: one-line summary, lands in Notification
+     Center.
+  b. Desktop file at ~/Desktop/REPO-REVIEW-ACTION-NEEDED.md: persistent
+     until the human deletes it. Includes upload queue, backlog-scan results,
+     and doc-drift results. The human reviews this file and runs
+     upload_repo_review_issues.py --apply for approved issues.
+"""
+output = "~/Desktop/REPO-REVIEW-ACTION-NEEDED.md"
+log = "docs/reports/repo-review/logs/coordinator/notify.log"
+if_failed = "Non-fatal. Logged to notify.log. The desktop file may be absent or stale."

--- a/config/source_of_truth_docs.yml
+++ b/config/source_of_truth_docs.yml
@@ -1,0 +1,53 @@
+# Source-of-truth docs that the weekly doc-drift scanner classifies for drift
+# against current implementation. Issue #2090.
+#
+# Scope: docs cited from CLAUDE.md / AGENTS.md / README.md as authoritative
+# operational entry points. Design proposals, archives, and historical
+# analysis docs are intentionally NOT listed -- those are append-only
+# narrative, not load-bearing operational documentation.
+#
+# Schema:
+#   repos:
+#     <owner>/<repo>:
+#       local_path: <path under workspace_root, matches repo_review_registry.json>
+#       docs:
+#         - path: <relative path within the repo>
+#           focus: short label for the kind of drift to watch for
+#         ...
+#
+# The scanner reads each doc, asks claude to compare load-bearing claims
+# against the current implementation, and emits one drift record per
+# (doc, claim) pair. See scripts/repo_review_docs_drift_scan.py.
+
+repos:
+  stranske/Workflows:
+    local_path: Workflows-steward
+    docs:
+      - path: README.md
+        focus: pipeline overview, model versions, entry-point commands
+      - path: AGENTS.md
+        focus: agent identifiers and routing labels
+      - path: CLAUDE.md
+        focus: workspace orientation and reading list
+      - path: docs/INTEGRATION_GUIDE.md
+        focus: consumer integration commands, version policy
+      - path: docs/ops/REPO_REVIEW_PROCESS.md
+        focus: weekly run command, Phase-4 entry point, queue lifecycle
+      - path: docs/ops/REPO_REVIEW_ROUND1_SCHEMA.md
+        focus: round-1 output schema and required fields
+      - path: docs/ops/REPO_REVIEW_ROUND2_PROTOCOL.md
+        focus: round-2 negotiation protocol and converged.json shape
+      - path: docs/keepalive/GoalsAndPlumbing.md
+        focus: keepalive contract, label gates, activation guardrails
+      - path: docs/keepalive/Agents.md
+        focus: multi-agent routing labels and runner mapping
+      - path: docs/AGENTS_POLICY.md
+        focus: protection layers and protected workflow inventory
+      - path: docs/LABELS.md
+        focus: canonical label inventory and trigger semantics
+      - path: docs/ci/WORKFLOWS.md
+        focus: CI workflow inventory, autofix contract
+      - path: docs/MODEL_MANAGEMENT.md
+        focus: model identifiers in current use, refresh cadence
+      - path: docs/WORKFLOW_GUIDE.md
+        focus: workflow authoring guidance and reusable-workflow references

--- a/scripts/repo_review_coordinator.py
+++ b/scripts/repo_review_coordinator.py
@@ -645,7 +645,7 @@ def run(args: argparse.Namespace) -> int:
         cwd=workflows_steward_root,
         log_path=log_dir / "backlog-scan.log",
         name="backlog-scan",
-        timeout=300,  # 9 repos × ~30s of gh API time
+        timeout=300,  # 9 repos x roughly 30s of GitHub API time
     )
     if not backlog_result.succeeded:
         print(
@@ -669,6 +669,8 @@ def run(args: argparse.Namespace) -> int:
             str(docs_drift_config),
             "--out",
             str(docs_drift_path),
+            "--workspace-root",
+            str(workspace_root),
         ]
         docs_drift_result = run_subprocess(
             docs_drift_cmd,

--- a/scripts/repo_review_coordinator.py
+++ b/scripts/repo_review_coordinator.py
@@ -653,6 +653,41 @@ def run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    # 5b. Docs-drift scan: classify load-bearing claims in source-of-truth
+    #     operational docs (README/AGENTS/CLAUDE/docs/ops/...) for drift vs
+    #     current implementation. Issue #2090. Same non-fatal pattern as
+    #     backlog-scan -- failures are logged but don't abort the cycle.
+    docs_drift_path = output_dir / "docs-drift-scan.json"
+    docs_drift_config = workflows_steward_root / "config" / "source_of_truth_docs.yml"
+    if docs_drift_config.is_file():
+        docs_drift_cmd = [
+            sys.executable,
+            str(workflows_steward_root / "scripts" / "repo_review_docs_drift_scan.py"),
+            "--registry",
+            str(registry_path),
+            "--docs-config",
+            str(docs_drift_config),
+            "--out",
+            str(docs_drift_path),
+        ]
+        docs_drift_result = run_subprocess(
+            docs_drift_cmd,
+            cwd=workflows_steward_root,
+            log_path=log_dir / "docs-drift-scan.log",
+            name="docs-drift-scan",
+            timeout=1800,  # ~5-10 min across 9 repos with claude LLM calls per doc
+        )
+        if not docs_drift_result.succeeded:
+            print(
+                f"[coordinator] docs-drift-scan FAILED (non-fatal): {docs_drift_result.notes}",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"[coordinator] docs-drift-scan: skipping -- config not found at {docs_drift_config}",
+            file=sys.stderr,
+        )
+
     # 6. Surface the cycle outcome to the human reviewer (macOS notification +
     #    persistent desktop file). The cron does NOT auto-upload; humans must
     #    review the packet and run upload_repo_review_issues.py --apply. The
@@ -667,6 +702,8 @@ def run(args: argparse.Namespace) -> int:
         str(output_dir / "approved-issue-queue.json"),
         "--backlog-scan",
         str(backlog_scan_path),
+        "--docs-drift-scan",
+        str(docs_drift_path),
         "--workflows-steward-root",
         str(workflows_steward_root),
     ]

--- a/scripts/repo_review_docs_drift_scan.py
+++ b/scripts/repo_review_docs_drift_scan.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Weekly scan of source-of-truth operational docs for drift vs current implementation.
+
+The 2026-05-13 weekly cycle confirmed three drift instances in Workflows
+source-of-truth docs (README model versions, docs/ci/WORKFLOWS.md autofix
+self-contradiction, docs/ops/REPO_REVIEW_PROCESS.md pre-Phase-4 entry point).
+Each was discovered ad-hoc by a round-1 reviewer agent looking at a different
+design slice. There is no recurring mechanism that catches drift between
+weekly cycles -- drift just accumulates until somebody happens to read an
+affected doc and notice. CLAUDE.md flags this failure mode explicitly
+(agents read docs as authoritative input to their reasoning; stale docs
+compound the damage).
+
+This scanner runs once per cycle, after backlog-scan and before notify. For
+each (repo, doc) pair in ``config/source_of_truth_docs.yml`` it invokes
+claude with a focused prompt that reads the doc plus the relevant
+implementation files, and emits a JSON list of drift instances each
+classified as ``stale``, ``contradictory``, or ``accurate-no-drift``. The
+output JSON lands at ``<output_dir>/docs-drift-scan.json``; the notify
+helper renders one bundled remediation block per repo with non-empty
+non-accurate drift, with a ready-to-paste ``gh issue create`` snippet.
+
+The scanner is structurally non-fatal: any failure (claude unavailable,
+prompt rejection, JSON parse error, doc missing) is recorded against that
+(repo, doc) pair and the scan continues. The coordinator wraps the whole
+script in the same non-fatal pattern as ``repo_review_backlog_scan.py``.
+
+GitNexus integration is graceful: when the repo's ``.gitnexus/meta.json``
+is missing or marked stale, the scanner instructs claude to skip behavioral
+call-graph checks and rely on ``rg`` for pattern-based existence checks
+only. This is not failure -- it is documented in the per-doc result.
+
+CLI:
+
+    python scripts/repo_review_docs_drift_scan.py \\
+        --registry config/repo_review_registry.json \\
+        --docs-config config/source_of_truth_docs.yml \\
+        --out docs/reports/repo-review/docs-drift-scan.json
+
+Flags:
+
+    --workspace-root <path>   parent dir containing each repo's local_path
+                              (default: '..' relative to --registry parent)
+    --repos <repo> [<repo>]   restrict to a subset (default: all active)
+    --timeout <seconds>       per-doc claude timeout (default: 600)
+    --dry-run                 skip claude calls; emit empty drift result per
+                              doc. Used by tests and by local cron rehearsal
+                              when claude auth is unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_CLASSIFICATIONS = ("stale", "contradictory", "accurate-no-drift")
+DRIFT_CLASSIFICATIONS = ("stale", "contradictory")
+
+DEFAULT_PER_DOC_TIMEOUT = 600
+_HEARTBEAT_INTERVAL = 60
+_STALL_THRESHOLD = 900
+
+CLAUDE_OAUTH_TOKEN_FILE = Path(
+    os.path.expanduser(
+        "~/.codex/automations/reviewed-repo-weekly-design-review/claude-oauth-token.txt"
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DriftInstance:
+    doc_path: str
+    claim: str
+    authoritative_source: str
+    classification: str  # stale | contradictory | accurate-no-drift
+
+
+@dataclass
+class DocResult:
+    repo: str
+    doc_path: str
+    instances: list[DriftInstance] = field(default_factory=list)
+    gitnexus_status: str = "unknown"
+    error: str | None = None  # populated when claude/JSON parsing failed
+
+
+# ---------------------------------------------------------------------------
+# Config + registry
+# ---------------------------------------------------------------------------
+
+
+def load_docs_config(path: Path) -> dict[str, dict[str, Any]]:
+    """Return ``{ "<owner>/<repo>": {"local_path": ..., "docs": [...]} }``."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    repos = data.get("repos") or {}
+    if not isinstance(repos, dict):
+        raise ValueError(f"docs config root.repos must be a mapping, got {type(repos).__name__}")
+    return repos
+
+
+def load_active_repos(registry_path: Path) -> set[str]:
+    """Return the active-repo full-names from the registry (filter set)."""
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    return {
+        str(r.get("repo"))
+        for r in (data.get("repos") or [])
+        if isinstance(r, dict) and r.get("status") == "active" and r.get("repo")
+    }
+
+
+# ---------------------------------------------------------------------------
+# GitNexus staleness
+# ---------------------------------------------------------------------------
+
+
+def is_gitnexus_stale(repo_root: Path) -> str:
+    """Return ``fresh``, ``stale``, or ``missing`` for the repo's GitNexus map.
+
+    ``.gitnexus/meta.json`` is the source of truth. ``stale: true`` (or any
+    truthy value at that key) means the map is older than the configured TTL
+    and behavioral call-graph queries should be skipped. Anything that fails
+    to parse is treated as ``missing`` so the scanner degrades gracefully.
+    """
+    meta = repo_root / ".gitnexus" / "meta.json"
+    if not meta.is_file():
+        return "missing"
+    try:
+        data = json.loads(meta.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "missing"
+    if data.get("stale"):
+        return "stale"
+    return "fresh"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing (pure -- this is what the tests pin down)
+# ---------------------------------------------------------------------------
+
+
+_JSON_OBJECT_RE = re.compile(r"\{[\s\S]*\}")
+
+
+def parse_drift_response(raw_text: str, *, doc_path: str) -> tuple[list[DriftInstance], str | None]:
+    """Extract the drift-instance list from a claude response.
+
+    Claude may wrap the JSON in prose, fenced code blocks, or commentary.
+    We extract the outermost JSON object, validate its shape, and coerce
+    each instance to ``DriftInstance``. Returns ``(instances, error)``;
+    ``error`` is non-None when nothing parseable was found.
+    """
+    if not raw_text or not raw_text.strip():
+        return [], "empty response"
+    match = _JSON_OBJECT_RE.search(raw_text)
+    if not match:
+        return [], "no JSON object found in response"
+    try:
+        payload = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        return [], f"JSON decode failed: {exc.msg}"
+    if not isinstance(payload, dict):
+        return [], "JSON root is not an object"
+
+    raw_instances = payload.get("instances") or []
+    if not isinstance(raw_instances, list):
+        return [], "'instances' is not a list"
+
+    result: list[DriftInstance] = []
+    for item in raw_instances:
+        if not isinstance(item, dict):
+            continue
+        classification = str(item.get("classification") or "").strip()
+        if classification not in VALID_CLASSIFICATIONS:
+            # Treat unknown classifications as not-actionable; skip rather
+            # than fail the whole doc.
+            continue
+        result.append(
+            DriftInstance(
+                doc_path=doc_path,
+                claim=str(item.get("claim") or "").strip()[:500],
+                authoritative_source=str(item.get("authoritative_source") or "").strip()[:500],
+                classification=classification,
+            )
+        )
+    return result, None
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+def build_doc_prompt(
+    *,
+    repo: str,
+    doc_path: str,
+    doc_focus: str,
+    gitnexus_status: str,
+) -> str:
+    """Compose the per-doc claude prompt.
+
+    Kept short and explicit. Claude has the repo at cwd and may invoke ``rg``,
+    ``gitnexus``, ``git``, etc. directly. Only the JSON output is consumed.
+    """
+    behavioral_clause = {
+        "fresh": (
+            "GitNexus map is FRESH for this repo. You MAY call "
+            "`gitnexus context <symbol>` or `gitnexus impact <path>` for "
+            "behavioral claims about call paths."
+        ),
+        "stale": (
+            "GitNexus map is STALE. SKIP behavioral call-graph checks "
+            "gracefully -- rely on `rg` for pattern/identifier existence "
+            "checks only. Note skipped checks in your reasoning but do not "
+            "fail the doc."
+        ),
+        "missing": (
+            "No GitNexus map present. SKIP behavioral call-graph checks. "
+            "Use `rg` for pattern/identifier existence checks only."
+        ),
+    }[gitnexus_status]
+    return f"""You are auditing a source-of-truth operational doc for drift against current implementation.
+
+REPO: {repo}
+DOC: {doc_path}
+FOCUS: {doc_focus}
+
+{behavioral_clause}
+
+Process:
+1. Read the doc at `{doc_path}`.
+2. For each load-bearing operational claim (commands, file paths, identifiers, labels, workflow filenames, model identifiers, expected outputs), verify it against the CURRENT implementation in this repo. Use `rg` to confirm strings/identifiers/filenames still exist as cited; cross-reference against the file(s) the claim cites or implies.
+3. Classify each verified claim as one of:
+   - `stale`: the claim was true once but no longer reflects current implementation (e.g. command renamed, file moved, identifier deprecated).
+   - `contradictory`: the claim disagrees with another source-of-truth doc or with current implementation in a way that is actively misleading.
+   - `accurate-no-drift`: the claim is verified against current implementation.
+
+Output ONLY a single JSON object on its own line(s), no prose, no markdown fence, with this shape:
+
+{{
+  "doc_path": "{doc_path}",
+  "instances": [
+    {{
+      "claim": "<short quote or paraphrase, <=500 chars>",
+      "authoritative_source": "<file:line or scripts/foo.py:42 form, <=500 chars>",
+      "classification": "stale|contradictory|accurate-no-drift"
+    }}
+  ]
+}}
+
+Include at least one `accurate-no-drift` entry per doc when no drift is found, so the audit trail records the doc was actually scanned. If the doc cannot be located, return an empty `instances` list.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Claude invocation (mirrors round2_runner._build_claude_env / invoke_claude)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_claude_binary() -> str | None:
+    env_path = os.environ.get("CLAUDE_CODE_EXECPATH")
+    if env_path and Path(env_path).is_file():
+        return env_path
+    bundled_root = Path(os.path.expanduser("~/Library/Application Support/Claude/claude-code"))
+    if bundled_root.is_dir():
+
+        def _version_key(p: Path) -> tuple[int, ...]:
+            try:
+                return tuple(int(x) for x in p.name.split("."))
+            except ValueError:
+                return (0,)
+
+        candidates = sorted(
+            (p for p in bundled_root.iterdir() if p.is_dir()),
+            key=_version_key,
+            reverse=True,
+        )
+        for ver_dir in candidates:
+            binary = ver_dir / "claude.app" / "Contents" / "MacOS" / "claude"
+            if binary.is_file():
+                return str(binary)
+    return shutil.which("claude")
+
+
+def _read_claude_oauth_token() -> str | None:
+    try:
+        if not CLAUDE_OAUTH_TOKEN_FILE.is_file():
+            return None
+        token = CLAUDE_OAUTH_TOKEN_FILE.read_text(encoding="utf-8").strip()
+        return token or None
+    except OSError:
+        return None
+
+
+def _build_claude_env() -> dict[str, str]:
+    keep = ("HOME", "PATH", "LOGNAME", "LANG", "LC_ALL", "TMPDIR", "TERM", "SHELL", "TZ")
+    env = {k: v for k, v in os.environ.items() if k in keep}
+    token = _read_claude_oauth_token()
+    if token:
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    return env
+
+
+def invoke_claude_for_doc(
+    *,
+    prompt: str,
+    cwd: Path,
+    timeout: int,
+    log_file: Path,
+) -> tuple[bool, str]:
+    """Run claude against the repo at ``cwd`` with the given prompt.
+
+    Returns ``(ok, output_or_error)``. ``output_or_error`` is the stdout text
+    on success (which the parser then extracts JSON from), or a short error
+    description on failure.
+    """
+    binary = _resolve_claude_binary()
+    if binary is None:
+        return False, "claude CLI not found"
+    cmd = [
+        binary,
+        "-p",
+        "--permission-mode",
+        "bypassPermissions",
+        "--no-session-persistence",
+    ]
+    env = _build_claude_env()
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        log_file.write_text(f"TIMEOUT after {timeout}s\n", encoding="utf-8")
+        return False, f"claude timed out after {timeout}s"
+    log_file.write_text(
+        f"=== stdout ===\n{result.stdout}\n=== stderr ===\n{result.stderr}\n",
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        return False, f"claude exited rc={result.returncode}: {result.stderr.strip()[:200]}"
+    return True, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Scanner core (the dependency-injected invoker is what tests pin)
+# ---------------------------------------------------------------------------
+
+
+ClaudeInvoker = Callable[..., tuple[bool, str]]
+
+
+def scan_doc(
+    *,
+    repo: str,
+    doc_path: str,
+    doc_focus: str,
+    repo_root: Path,
+    log_dir: Path,
+    timeout: int,
+    invoker: ClaudeInvoker,
+) -> DocResult:
+    """Scan one (repo, doc) pair and return a DocResult.
+
+    Bounded: any failure is captured on the result; the caller continues.
+    """
+    gitnexus = is_gitnexus_stale(repo_root)
+    result = DocResult(repo=repo, doc_path=doc_path, gitnexus_status=gitnexus)
+    if not (repo_root / doc_path).is_file():
+        result.error = f"doc not found at {doc_path}"
+        return result
+    prompt = build_doc_prompt(
+        repo=repo,
+        doc_path=doc_path,
+        doc_focus=doc_focus,
+        gitnexus_status=gitnexus,
+    )
+    safe_doc = doc_path.replace("/", "__")
+    log_file = log_dir / f"docs-drift-scan.{repo.replace('/', '__')}.{safe_doc}.log"
+    ok, output = invoker(prompt=prompt, cwd=repo_root, timeout=timeout, log_file=log_file)
+    if not ok:
+        result.error = output
+        return result
+    instances, parse_err = parse_drift_response(output, doc_path=doc_path)
+    if parse_err and not instances:
+        result.error = parse_err
+        return result
+    result.instances = instances
+    return result
+
+
+def dry_run_invoker(*, prompt: str, cwd: Path, timeout: int, log_file: Path) -> tuple[bool, str]:
+    """Stand-in invoker used for ``--dry-run`` / local rehearsal / tests.
+
+    Returns an empty-but-valid JSON payload so the rest of the pipeline runs
+    end-to-end without touching the live LLM. Real drift detection requires
+    the production invoker; this exists so coordinator integration and
+    notify rendering can be exercised offline.
+    """
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.write_text("dry-run -- skipped claude invocation\n", encoding="utf-8")
+    return True, '{"doc_path": "<dry-run>", "instances": []}'
+
+
+# ---------------------------------------------------------------------------
+# Aggregation -- one drift-block per repo, NOT per doc
+# ---------------------------------------------------------------------------
+
+
+def aggregate(doc_results: list[DocResult]) -> dict[str, Any]:
+    """Group results by repo, sort, compute summary counts."""
+    by_repo: dict[str, dict[str, Any]] = {}
+    for res in doc_results:
+        bucket = by_repo.setdefault(
+            res.repo,
+            {
+                "repo": res.repo,
+                "docs_scanned": 0,
+                "drift_instances": [],
+                "accurate_instances": [],
+                "errors": [],
+                "gitnexus_summary": {},
+            },
+        )
+        bucket["docs_scanned"] += 1
+        bucket["gitnexus_summary"][res.gitnexus_status] = (
+            bucket["gitnexus_summary"].get(res.gitnexus_status, 0) + 1
+        )
+        if res.error:
+            bucket["errors"].append({"doc_path": res.doc_path, "error": res.error})
+            continue
+        for inst in res.instances:
+            record = asdict(inst)
+            if inst.classification in DRIFT_CLASSIFICATIONS:
+                bucket["drift_instances"].append(record)
+            else:
+                bucket["accurate_instances"].append(record)
+
+    # Stable ordering: repos alphabetically; within a repo, drift items by doc_path.
+    repos_sorted = sorted(by_repo.values(), key=lambda b: b["repo"])
+    for bucket in repos_sorted:
+        bucket["drift_instances"].sort(key=lambda i: (i["doc_path"], i["classification"]))
+        bucket["accurate_instances"].sort(key=lambda i: i["doc_path"])
+
+    total_drift = sum(len(b["drift_instances"]) for b in repos_sorted)
+    total_accurate = sum(len(b["accurate_instances"]) for b in repos_sorted)
+    total_errors = sum(len(b["errors"]) for b in repos_sorted)
+    return {
+        "generated_on": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "total_docs_scanned": sum(b["docs_scanned"] for b in repos_sorted),
+        "total_drift_instances": total_drift,
+        "total_accurate_instances": total_accurate,
+        "total_errors": total_errors,
+        "by_repo": repos_sorted,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Top-level scan
+# ---------------------------------------------------------------------------
+
+
+def scan(
+    *,
+    docs_config: dict[str, dict[str, Any]],
+    active_repos: set[str],
+    workspace_root: Path,
+    repo_subset: set[str] | None,
+    log_dir: Path,
+    timeout: int,
+    invoker: ClaudeInvoker,
+) -> dict[str, Any]:
+    doc_results: list[DocResult] = []
+    for repo, repo_config in docs_config.items():
+        if repo not in active_repos:
+            continue
+        if repo_subset and repo not in repo_subset:
+            continue
+        local_path = str(repo_config.get("local_path") or "")
+        if not local_path:
+            doc_results.append(
+                DocResult(
+                    repo=repo,
+                    doc_path="<config>",
+                    error=f"docs config for {repo} missing 'local_path'",
+                )
+            )
+            continue
+        repo_root = (workspace_root / local_path).resolve()
+        if not repo_root.is_dir():
+            doc_results.append(
+                DocResult(
+                    repo=repo,
+                    doc_path="<workspace>",
+                    error=f"repo root not found at {repo_root}",
+                )
+            )
+            continue
+        for doc_entry in repo_config.get("docs") or []:
+            doc_path = str(doc_entry.get("path") or "")
+            doc_focus = str(doc_entry.get("focus") or "")
+            if not doc_path:
+                continue
+            doc_results.append(
+                scan_doc(
+                    repo=repo,
+                    doc_path=doc_path,
+                    doc_focus=doc_focus,
+                    repo_root=repo_root,
+                    log_dir=log_dir,
+                    timeout=timeout,
+                    invoker=invoker,
+                )
+            )
+    return aggregate(doc_results)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, required=True)
+    parser.add_argument("--docs-config", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=None,
+        help="parent dir containing each repo's local_path (default: registry parent's parent)",
+    )
+    parser.add_argument("--repos", nargs="*", default=[])
+    parser.add_argument("--timeout", type=int, default=DEFAULT_PER_DOC_TIMEOUT)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="skip claude calls; emit empty drift result per doc (used for "
+        "offline rehearsal and unit tests)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        docs_config = load_docs_config(args.docs_config)
+    except (FileNotFoundError, yaml.YAMLError, ValueError) as exc:
+        print(f"[docs-drift-scan] cannot load docs config: {exc}", file=sys.stderr)
+        return 2
+    try:
+        active = load_active_repos(args.registry)
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"[docs-drift-scan] cannot load registry: {exc}", file=sys.stderr)
+        return 2
+
+    workspace_root = (
+        args.workspace_root.resolve()
+        if args.workspace_root
+        else args.registry.resolve().parent.parent
+    )
+    log_dir = args.out.parent / "logs" / "coordinator"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    invoker: ClaudeInvoker = dry_run_invoker if args.dry_run else invoke_claude_for_doc
+    repo_subset = set(args.repos) if args.repos else None
+
+    result = scan(
+        docs_config=docs_config,
+        active_repos=active,
+        workspace_root=workspace_root,
+        repo_subset=repo_subset,
+        log_dir=log_dir,
+        timeout=args.timeout,
+        invoker=invoker,
+    )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"[docs-drift-scan] scanned {result['total_docs_scanned']} doc(s) across "
+        f"{len(result['by_repo'])} repo(s); "
+        f"drift={result['total_drift_instances']} "
+        f"accurate={result['total_accurate_instances']} "
+        f"errors={result['total_errors']} -> {args.out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repo_review_docs_drift_scan.py
+++ b/scripts/repo_review_docs_drift_scan.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -69,8 +68,6 @@ VALID_CLASSIFICATIONS = ("stale", "contradictory", "accurate-no-drift")
 DRIFT_CLASSIFICATIONS = ("stale", "contradictory")
 
 DEFAULT_PER_DOC_TIMEOUT = 600
-_HEARTBEAT_INTERVAL = 60
-_STALL_THRESHOLD = 900
 
 CLAUDE_OAUTH_TOKEN_FILE = Path(
     os.path.expanduser(
@@ -125,6 +122,15 @@ def load_active_repos(registry_path: Path) -> set[str]:
     }
 
 
+def resolve_workspace_root(registry_path: Path) -> Path:
+    """Resolve the registry's workspace_root using the evaluator contract."""
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    workspace_root = Path(data.get("workspace_root", "."))
+    if not workspace_root.is_absolute():
+        workspace_root = (registry_path.resolve().parent.parent / workspace_root).resolve()
+    return workspace_root
+
+
 # ---------------------------------------------------------------------------
 # GitNexus staleness
 # ---------------------------------------------------------------------------
@@ -155,9 +161,6 @@ def is_gitnexus_stale(repo_root: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-_JSON_OBJECT_RE = re.compile(r"\{[\s\S]*\}")
-
-
 def parse_drift_response(raw_text: str, *, doc_path: str) -> tuple[list[DriftInstance], str | None]:
     """Extract the drift-instance list from a claude response.
 
@@ -168,13 +171,24 @@ def parse_drift_response(raw_text: str, *, doc_path: str) -> tuple[list[DriftIns
     """
     if not raw_text or not raw_text.strip():
         return [], "empty response"
-    match = _JSON_OBJECT_RE.search(raw_text)
-    if not match:
+    decoder = json.JSONDecoder()
+    payload: Any | None = None
+    last_error: json.JSONDecodeError | None = None
+    for start, char in enumerate(raw_text):
+        if char != "{":
+            continue
+        try:
+            candidate, _end = decoder.raw_decode(raw_text[start:])
+        except json.JSONDecodeError as exc:
+            last_error = exc
+            continue
+        if isinstance(candidate, dict) and "instances" in candidate:
+            payload = candidate
+            break
+    if payload is None:
+        if last_error:
+            return [], f"JSON decode failed: {last_error.msg}"
         return [], "no JSON object found in response"
-    try:
-        payload = json.loads(match.group(0))
-    except json.JSONDecodeError as exc:
-        return [], f"JSON decode failed: {exc.msg}"
     if not isinstance(payload, dict):
         return [], "JSON root is not an object"
 
@@ -520,7 +534,19 @@ def scan(
                 )
             )
             continue
-        for doc_entry in repo_config.get("docs") or []:
+        for index, doc_entry in enumerate(repo_config.get("docs") or []):
+            if not isinstance(doc_entry, dict):
+                doc_results.append(
+                    DocResult(
+                        repo=repo,
+                        doc_path=f"<config.docs[{index}]>",
+                        error=(
+                            "docs config entry must be a mapping, "
+                            f"got {type(doc_entry).__name__}"
+                        ),
+                    )
+                )
+                continue
             doc_path = str(doc_entry.get("path") or "")
             doc_focus = str(doc_entry.get("focus") or "")
             if not doc_path:
@@ -579,11 +605,14 @@ def main() -> int:
         print(f"[docs-drift-scan] cannot load registry: {exc}", file=sys.stderr)
         return 2
 
-    workspace_root = (
-        args.workspace_root.resolve()
-        if args.workspace_root
-        else args.registry.resolve().parent.parent
-    )
+    if args.workspace_root:
+        workspace_root = args.workspace_root.resolve()
+    else:
+        try:
+            workspace_root = resolve_workspace_root(args.registry)
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            print(f"[docs-drift-scan] cannot resolve workspace root: {exc}", file=sys.stderr)
+            return 2
     log_dir = args.out.parent / "logs" / "coordinator"
     log_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/repo_review_notify.py
+++ b/scripts/repo_review_notify.py
@@ -312,15 +312,26 @@ def write_desktop_reminder(
     auto_labeled_count = len(backlog.get("auto_labeled", []) or [])
     needs_human_count = len(backlog.get("needs_human", []) or [])
     backlog_count = auto_labeled_count + needs_human_count
+    docs_drift_count = int((docs_drift or {}).get("total_drift_instances", 0) or 0)
+    docs_drift_error_count = int((docs_drift or {}).get("total_errors", 0) or 0)
+    docs_drift_signal_count = docs_drift_count + docs_drift_error_count
 
-    if total == 0 and backlog_count == 0:
+    if total == 0 and backlog_count == 0 and docs_drift_signal_count == 0:
         headline = (
             "## ✓ Clean week — no action required\n\n"
             "No fresh design-vs-implementation gaps, no unaddressed "
             "enhancement issues across the fleet. The system will run "
             "again next Wednesday."
         )
-    elif total == 0 and needs_human_count == 0:
+    elif total == 0 and backlog_count == 0:
+        headline = (
+            f"## {docs_drift_signal_count} doc-drift item"
+            f"{'s' if docs_drift_signal_count != 1 else ''} need review\n\n"
+            "No fresh design-vs-implementation gaps or backlog decisions, "
+            "but the docs-drift scan found remediation work or scan errors. "
+            "See the doc-drift section below."
+        )
+    elif total == 0 and needs_human_count == 0 and docs_drift_signal_count == 0:
         headline = (
             f"## ✓ Clean week ({auto_labeled_count} backlog item"
             f"{'s' if auto_labeled_count != 1 else ''} auto-labeled)\n\n"
@@ -330,13 +341,22 @@ def write_desktop_reminder(
             "priority — no action required from you, see the FYI section below."
         )
     elif total == 0:
+        detail_parts = []
+        if needs_human_count:
+            detail_parts.append(
+                f"{needs_human_count} backlog item" f"{'s' if needs_human_count != 1 else ''}"
+            )
+        if docs_drift_signal_count:
+            detail_parts.append(
+                f"{docs_drift_signal_count} doc-drift item"
+                f"{'s' if docs_drift_signal_count != 1 else ''}"
+            )
+        detail = " and ".join(detail_parts)
         headline = (
-            f"## {needs_human_count} backlog item"
-            f"{'s' if needs_human_count != 1 else ''} need your decision\n\n"
+            f"## {detail} need your decision\n\n"
             "No fresh design-vs-implementation gaps this week, but the cron "
-            f"found {needs_human_count} stale issue"
-            f"{'s' if needs_human_count != 1 else ''} (umbrella/epic-shaped or "
-            "blocked) that it couldn't safely auto-label. See the section below."
+            "found items that need review before the queue is clean. See the "
+            "backlog and doc-drift sections below."
         )
     else:
         repo_lines = "\n".join(f"- **{r}**: {n}" for r, n in sorted(by_repo.items()))

--- a/scripts/repo_review_notify.py
+++ b/scripts/repo_review_notify.py
@@ -200,10 +200,95 @@ def format_backlog_section(backlog: dict[str, Any]) -> str:
     return format_auto_labeled_section(backlog) + format_needs_human_section(backlog)
 
 
+def load_docs_drift_scan(path: Path | None) -> dict[str, Any]:
+    """Load the docs-drift-scan.json output, or return empty if absent/malformed."""
+    if path is None or not path.is_file():
+        return {"by_repo": []}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"by_repo": []}
+
+
+def format_docs_drift_section(drift: dict[str, Any]) -> str:
+    """Render the docs-drift section: ONE bundled remediation block per repo
+    with non-empty drift, with a ready-to-paste ``gh issue create`` snippet.
+
+    Repos with only accurate-no-drift instances are not shown (the audit
+    trail lives in the JSON output for those). Repos with errors but no
+    drift are surfaced briefly so the human knows the scan ran.
+    """
+    by_repo = drift.get("by_repo") or []
+    drifting = [b for b in by_repo if b.get("drift_instances")]
+    error_only = [b for b in by_repo if b.get("errors") and not b.get("drift_instances")]
+
+    if not drifting and not error_only:
+        return ""
+
+    parts: list[str] = []
+    if drifting:
+        plural = "s" if len(drifting) != 1 else ""
+        parts.append(
+            f"\n\n## Doc drift detected ({len(drifting)} repo{plural})\n\n"
+            "The weekly doc-drift scanner flagged source-of-truth docs that "
+            "no longer reflect current implementation. Each repo gets ONE "
+            "bundled remediation issue (drifting docs as task checkboxes); "
+            "do not file per-doc issues.\n"
+        )
+        for bucket in drifting:
+            repo = bucket["repo"]
+            instances = bucket["drift_instances"]
+            doc_list = sorted({inst["doc_path"] for inst in instances})
+            instance_count = len(instances)
+            inst_plural = "s" if instance_count != 1 else ""
+            doc_plural = "s" if len(doc_list) != 1 else ""
+            parts.append(
+                f"\n### {repo} -- {instance_count} drift instance{inst_plural} "
+                f"across {len(doc_list)} doc{doc_plural}\n"
+            )
+            for inst in instances:
+                cls = inst["classification"]
+                claim = inst["claim"][:160]
+                src = inst["authoritative_source"][:160]
+                parts.append(f"  - **{cls}** _{inst['doc_path']}_: {claim}\n")
+                if src:
+                    parts.append(f"    Authoritative source: `{src}`\n")
+            body_lines = "\n".join(f"- [ ] {p}" for p in doc_list)
+            title = f"Remediate doc drift across {len(doc_list)} source-of-truth doc{doc_plural}"
+            body_arg = (
+                f"## Drift detected by weekly doc-drift scanner\n\n"
+                f"Affected docs:\n\n{body_lines}\n\n"
+                f"See `<output_dir>/docs-drift-scan.json` for per-claim detail."
+            )
+            parts.append(
+                f"\n  Bundled remediation snippet:\n\n"
+                f"  ```\n"
+                f"  gh issue create --repo {repo} \\\n"
+                f'      --title "{title}" \\\n'
+                f"      --label priority:normal \\\n"
+                f"      --body {json.dumps(body_arg)}\n"
+                f"  ```\n"
+            )
+
+    if error_only:
+        plural = "s" if len(error_only) != 1 else ""
+        parts.append(
+            f"\n\n## Doc-drift scan errors ({len(error_only)} repo{plural})\n\n"
+            "The scanner ran but couldn't classify the listed docs. No "
+            "drift was detected in the docs it COULD scan -- the errors "
+            "may be transient (claude unavailable, doc moved, etc.).\n"
+        )
+        for bucket in error_only:
+            parts.append(f"- **{bucket['repo']}**: {len(bucket['errors'])} doc(s) errored\n")
+
+    return "".join(parts)
+
+
 def write_desktop_reminder(
     *,
     queue_summary: dict[str, Any],
     backlog: dict[str, Any],
+    docs_drift: dict[str, Any],
     packet_path: Path,
     queue_path: Path,
     output_dir: Path,
@@ -270,6 +355,7 @@ def write_desktop_reminder(
     )
 
     backlog_section = format_backlog_section(backlog)
+    docs_drift_section = format_docs_drift_section(docs_drift)
 
     next_action = (
         ""
@@ -300,7 +386,7 @@ def write_desktop_reminder(
     body = f"""# Weekly repo-review packet ready — {today}
 
 {headline}
-{skipped_note}{next_action}{backlog_section}
+{skipped_note}{next_action}{backlog_section}{docs_drift_section}
 ## When you're done
 
 Delete this file once you've acted on the queued issues AND the backlog:
@@ -353,6 +439,14 @@ def main() -> int:
         "adds a 'Backlog needing your attention' section to the desktop file",
     )
     parser.add_argument(
+        "--docs-drift-scan",
+        type=Path,
+        default=None,
+        help="path to docs-drift-scan.json from scripts/repo_review_docs_drift_scan.py "
+        "(default: <output_dir>/docs-drift-scan.json if present); when present, "
+        "adds a 'Doc drift detected' section to the desktop file",
+    )
+    parser.add_argument(
         "--skip-notification",
         action="store_true",
         help="suppress the macOS notification (still writes the desktop file)",
@@ -383,6 +477,13 @@ def main() -> int:
         args.backlog_scan if args.backlog_scan is not None else output_dir / "backlog-scan.json"
     )
     backlog = load_backlog_scan(backlog_path)
+
+    docs_drift_path = (
+        args.docs_drift_scan
+        if args.docs_drift_scan is not None
+        else output_dir / "docs-drift-scan.json"
+    )
+    docs_drift = load_docs_drift_scan(docs_drift_path)
     auto_labeled_count = len(backlog.get("auto_labeled", []) or [])
     needs_human_count = len(backlog.get("needs_human", []) or [])
     backlog_count = auto_labeled_count + needs_human_count
@@ -431,6 +532,7 @@ def main() -> int:
         target = write_desktop_reminder(
             queue_summary=summary,
             backlog=backlog,
+            docs_drift=docs_drift,
             packet_path=packet_path,
             queue_path=queue_path,
             output_dir=output_dir,
@@ -438,9 +540,14 @@ def main() -> int:
         )
         print(f"[notify] wrote {target}")
 
+    docs_drift_total = (docs_drift or {}).get("total_drift_instances", 0) or 0
+    docs_drift_repos = sum(
+        1 for b in (docs_drift or {}).get("by_repo") or [] if b.get("drift_instances")
+    )
     print(
         f"[notify] {total} issue(s) ready, {summary['skipped_count']} repo decision(s) skipped, "
-        f"{auto_labeled_count} backlog auto-labeled, {needs_human_count} backlog need decision"
+        f"{auto_labeled_count} backlog auto-labeled, {needs_human_count} backlog need decision, "
+        f"{docs_drift_total} doc-drift instance(s) across {docs_drift_repos} repo(s)"
     )
     return 0
 

--- a/tests/scripts/test_repo_review_docs_drift_scan.py
+++ b/tests/scripts/test_repo_review_docs_drift_scan.py
@@ -21,6 +21,7 @@ from scripts.repo_review_docs_drift_scan import (
     load_active_repos,
     load_docs_config,
     parse_drift_response,
+    resolve_workspace_root,
     scan,
     scan_doc,
 )
@@ -156,6 +157,19 @@ def test_parse_drift_response_malformed_json():
     assert err.startswith("JSON decode failed")
 
 
+def test_parse_drift_response_uses_first_valid_instances_object():
+    raw = (
+        'Ignore this diagnostic object: {"note": "not payload"}\n'
+        'Actual payload: {"instances": [{"claim": "c", '
+        '"authoritative_source": "s", "classification": "stale"}]}\n'
+        "Trailing brace text {not-json}"
+    )
+    instances, err = parse_drift_response(raw, doc_path="x.md")
+    assert err is None
+    assert len(instances) == 1
+    assert instances[0].classification == "stale"
+
+
 # ---------------------------------------------------------------------------
 # Seeded-fixture classifier verification (acceptance-criteria check)
 # ---------------------------------------------------------------------------
@@ -273,6 +287,16 @@ def test_load_active_repos_filters_inactive(tmp_path: Path):
         encoding="utf-8",
     )
     assert load_active_repos(reg) == {"stranske/A", "stranske/C"}
+
+
+def test_resolve_workspace_root_honors_registry_contract(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    steward = workspace / "Workflows-steward"
+    config = steward / "config"
+    config.mkdir(parents=True)
+    registry = config / "repo_review_registry.json"
+    registry.write_text(json.dumps({"workspace_root": "..", "repos": []}), encoding="utf-8")
+    assert resolve_workspace_root(registry) == workspace.resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +474,36 @@ repos:
     assert summary["by_repo"][0]["repo"] == "stranske/Workflows"
 
 
+def test_scan_records_malformed_doc_entry_without_aborting(tmp_path: Path):
+    workspace, registry = _make_fixture_workspace(tmp_path)
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        """
+repos:
+  stranske/Workflows:
+    local_path: Workflows-steward
+    docs:
+      - README.md
+      - path: README.md
+        focus: x
+""",
+        encoding="utf-8",
+    )
+    summary = scan(
+        docs_config=load_docs_config(cfg_path),
+        active_repos=load_active_repos(registry),
+        workspace_root=workspace,
+        repo_subset=None,
+        log_dir=tmp_path / "logs",
+        timeout=10,
+        invoker=lambda **kw: (True, '{"instances": []}'),
+    )
+    bucket = summary["by_repo"][0]
+    assert summary["total_docs_scanned"] == 2
+    assert summary["total_errors"] == 1
+    assert bucket["errors"][0]["doc_path"] == "<config.docs[0]>"
+
+
 def test_scan_doc_records_missing_file(tmp_path: Path):
     (tmp_path / "Workflows-steward").mkdir()
     res = scan_doc(
@@ -550,3 +604,44 @@ def test_notify_emits_empty_string_when_no_drift_no_errors():
         ]
     }
     assert format_docs_drift_section(drift) == ""
+
+
+def test_notify_headline_reflects_docs_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from scripts.repo_review_notify import write_desktop_reminder
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = write_desktop_reminder(
+        queue_summary={
+            "total": 0,
+            "by_repo": {},
+            "skipped_count": 0,
+            "issue_titles": [],
+        },
+        backlog={"auto_labeled": [], "needs_human": []},
+        docs_drift={
+            "total_drift_instances": 1,
+            "total_errors": 0,
+            "by_repo": [
+                {
+                    "repo": "stranske/X",
+                    "drift_instances": [
+                        {
+                            "doc_path": "README.md",
+                            "claim": "c",
+                            "authoritative_source": "s",
+                            "classification": "stale",
+                        }
+                    ],
+                    "accurate_instances": [],
+                    "errors": [],
+                }
+            ],
+        },
+        packet_path=tmp_path / "packet.md",
+        queue_path=tmp_path / "queue.json",
+        output_dir=tmp_path / "out",
+        workflows_steward_root=tmp_path / "Workflows-steward",
+    )
+    rendered = path.read_text(encoding="utf-8")
+    assert "doc-drift item" in rendered
+    assert "Clean week" not in rendered

--- a/tests/scripts/test_repo_review_docs_drift_scan.py
+++ b/tests/scripts/test_repo_review_docs_drift_scan.py
@@ -1,0 +1,552 @@
+"""Tests for scripts/repo_review_docs_drift_scan.py.
+
+The classifier and aggregator are pure functions and are exercised directly.
+The end-to-end scan() call uses a fake invoker so no live LLM call is made;
+the fake returns the seeded fixture drift responses (3 known drifts from the
+2026-05-13 weekly cycle plus accurate-no-drift baselines) so the classifier
+is verified against real-world cases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from scripts.repo_review_docs_drift_scan import (
+    DriftInstance,
+    aggregate,
+    build_doc_prompt,
+    is_gitnexus_stale,
+    load_active_repos,
+    load_docs_config,
+    parse_drift_response,
+    scan,
+    scan_doc,
+)
+
+# ---------------------------------------------------------------------------
+# Seeded fixtures -- the three drift instances confirmed during 2026-05-13.
+# ---------------------------------------------------------------------------
+
+SEEDED_FIXTURE_RESPONSES: dict[str, str] = {
+    "README.md": json.dumps(
+        {
+            "doc_path": "README.md",
+            "instances": [
+                {
+                    "claim": "README cites claude-3-5-sonnet-20241022 as the default model",
+                    "authoritative_source": "tools/langchain_client.py:96-98 _default_slots()",
+                    "classification": "stale",
+                },
+                {
+                    "claim": "Pipeline orchestration overview accurately summarizes phase ordering",
+                    "authoritative_source": "scripts/repo_review_coordinator.py:1-30 module docstring",
+                    "classification": "accurate-no-drift",
+                },
+            ],
+        }
+    ),
+    "docs/ci/WORKFLOWS.md": json.dumps(
+        {
+            "doc_path": "docs/ci/WORKFLOWS.md",
+            "instances": [
+                {
+                    "claim": "Autofix is documented as both ON for all PRs and as gated by autofix label",
+                    "authoritative_source": "templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml",
+                    "classification": "contradictory",
+                }
+            ],
+        }
+    ),
+    "docs/ops/REPO_REVIEW_PROCESS.md": json.dumps(
+        {
+            "doc_path": "docs/ops/REPO_REVIEW_PROCESS.md",
+            "instances": [
+                {
+                    "claim": "Weekly Run section cites repo_review_evaluator.py as the entry point",
+                    "authoritative_source": "scripts/repo_review_coordinator.py is the Phase-4 entry point",
+                    "classification": "stale",
+                }
+            ],
+        }
+    ),
+    "docs/AGENTS_POLICY.md": json.dumps(
+        {
+            "doc_path": "docs/AGENTS_POLICY.md",
+            "instances": [
+                {
+                    "claim": "Protected workflow inventory matches .github/workflows/",
+                    "authoritative_source": ".github/workflows/ listing",
+                    "classification": "accurate-no-drift",
+                }
+            ],
+        }
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# parse_drift_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_drift_response_extracts_seeded_stale():
+    raw = SEEDED_FIXTURE_RESPONSES["README.md"]
+    instances, err = parse_drift_response(raw, doc_path="README.md")
+    assert err is None
+    assert len(instances) == 2
+    classifications = sorted(i.classification for i in instances)
+    assert classifications == ["accurate-no-drift", "stale"]
+
+
+def test_parse_drift_response_classifies_contradictory():
+    raw = SEEDED_FIXTURE_RESPONSES["docs/ci/WORKFLOWS.md"]
+    instances, err = parse_drift_response(raw, doc_path="docs/ci/WORKFLOWS.md")
+    assert err is None
+    assert len(instances) == 1
+    assert instances[0].classification == "contradictory"
+
+
+def test_parse_drift_response_handles_prose_wrapper():
+    raw = (
+        "Sure, here's the audit result:\n\n"
+        '```json\n{"doc_path": "x.md", "instances": [{"claim": "c", '
+        '"authoritative_source": "s", "classification": "stale"}]}\n```\n'
+        "Let me know if you want detail."
+    )
+    instances, err = parse_drift_response(raw, doc_path="x.md")
+    assert err is None
+    assert len(instances) == 1
+    assert instances[0].classification == "stale"
+
+
+def test_parse_drift_response_drops_invalid_classification():
+    raw = json.dumps(
+        {
+            "doc_path": "x.md",
+            "instances": [
+                {"claim": "c1", "authoritative_source": "s1", "classification": "stale"},
+                {"claim": "c2", "authoritative_source": "s2", "classification": "ambiguous"},
+            ],
+        }
+    )
+    instances, err = parse_drift_response(raw, doc_path="x.md")
+    assert err is None
+    # Invalid classification dropped silently rather than failing the doc.
+    assert len(instances) == 1
+    assert instances[0].classification == "stale"
+
+
+def test_parse_drift_response_empty():
+    instances, err = parse_drift_response("", doc_path="x.md")
+    assert instances == []
+    assert err == "empty response"
+
+
+def test_parse_drift_response_no_json():
+    instances, err = parse_drift_response("just prose, no object", doc_path="x.md")
+    assert instances == []
+    assert "no JSON object" in err
+
+
+def test_parse_drift_response_malformed_json():
+    instances, err = parse_drift_response("{not valid json}", doc_path="x.md")
+    assert instances == []
+    assert err.startswith("JSON decode failed")
+
+
+# ---------------------------------------------------------------------------
+# Seeded-fixture classifier verification (acceptance-criteria check)
+# ---------------------------------------------------------------------------
+
+
+def test_seeded_three_known_drifts_classify_as_stale_or_contradictory():
+    """The 2026-05-13 cycle confirmed 3 drift instances. Verify each is
+    classified as stale or contradictory (NOT accurate-no-drift)."""
+    expected = {
+        "README.md": "stale",
+        "docs/ci/WORKFLOWS.md": "contradictory",
+        "docs/ops/REPO_REVIEW_PROCESS.md": "stale",
+    }
+    for doc_path, expected_class in expected.items():
+        instances, err = parse_drift_response(SEEDED_FIXTURE_RESPONSES[doc_path], doc_path=doc_path)
+        assert err is None, f"{doc_path} parse failed: {err}"
+        drift_only = [i for i in instances if i.classification != "accurate-no-drift"]
+        assert drift_only, f"{doc_path} should have at least one drift instance"
+        assert drift_only[0].classification == expected_class
+
+
+# ---------------------------------------------------------------------------
+# GitNexus staleness
+# ---------------------------------------------------------------------------
+
+
+def test_gitnexus_status_missing(tmp_path: Path):
+    assert is_gitnexus_stale(tmp_path) == "missing"
+
+
+def test_gitnexus_status_fresh(tmp_path: Path):
+    nexus = tmp_path / ".gitnexus"
+    nexus.mkdir()
+    (nexus / "meta.json").write_text(json.dumps({"stale": False}), encoding="utf-8")
+    assert is_gitnexus_stale(tmp_path) == "fresh"
+
+
+def test_gitnexus_status_stale(tmp_path: Path):
+    nexus = tmp_path / ".gitnexus"
+    nexus.mkdir()
+    (nexus / "meta.json").write_text(json.dumps({"stale": True}), encoding="utf-8")
+    assert is_gitnexus_stale(tmp_path) == "stale"
+
+
+def test_gitnexus_status_malformed_falls_back_to_missing(tmp_path: Path):
+    nexus = tmp_path / ".gitnexus"
+    nexus.mkdir()
+    (nexus / "meta.json").write_text("not json", encoding="utf-8")
+    assert is_gitnexus_stale(tmp_path) == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status, expected_substring",
+    [
+        ("fresh", "GitNexus map is FRESH"),
+        ("stale", "SKIP behavioral call-graph checks"),
+        ("missing", "No GitNexus map present"),
+    ],
+)
+def test_build_doc_prompt_branches_on_gitnexus_status(status, expected_substring):
+    prompt = build_doc_prompt(
+        repo="stranske/Workflows",
+        doc_path="README.md",
+        doc_focus="model versions",
+        gitnexus_status=status,
+    )
+    assert expected_substring in prompt
+    assert "stranske/Workflows" in prompt
+    assert "README.md" in prompt
+    assert "model versions" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Config loaders
+# ---------------------------------------------------------------------------
+
+
+def test_load_docs_config_round_trip(tmp_path: Path):
+    cfg = tmp_path / "source_of_truth_docs.yml"
+    cfg.write_text(
+        """
+repos:
+  stranske/Foo:
+    local_path: Foo
+    docs:
+      - path: README.md
+        focus: f1
+      - path: docs/x.md
+        focus: f2
+""",
+        encoding="utf-8",
+    )
+    parsed = load_docs_config(cfg)
+    assert "stranske/Foo" in parsed
+    assert len(parsed["stranske/Foo"]["docs"]) == 2
+
+
+def test_load_active_repos_filters_inactive(tmp_path: Path):
+    reg = tmp_path / "registry.json"
+    reg.write_text(
+        json.dumps(
+            {
+                "repos": [
+                    {"repo": "stranske/A", "status": "active"},
+                    {"repo": "stranske/B", "status": "paused"},
+                    {"repo": "stranske/C", "status": "active"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert load_active_repos(reg) == {"stranske/A", "stranske/C"}
+
+
+# ---------------------------------------------------------------------------
+# Aggregate: one bundled remediation block per repo, NOT per doc
+# ---------------------------------------------------------------------------
+
+
+def _doc_result(repo: str, doc: str, classifications: list[str]):
+    from scripts.repo_review_docs_drift_scan import DocResult
+
+    instances = [
+        DriftInstance(
+            doc_path=doc,
+            claim=f"claim-{c}",
+            authoritative_source=f"src-{c}",
+            classification=c,
+        )
+        for c in classifications
+    ]
+    return DocResult(repo=repo, doc_path=doc, instances=instances, gitnexus_status="fresh")
+
+
+def test_aggregate_groups_by_repo_and_separates_drift_from_accurate():
+    results = [
+        _doc_result("stranske/X", "README.md", ["stale", "accurate-no-drift"]),
+        _doc_result("stranske/X", "docs/AGENTS.md", ["contradictory"]),
+        _doc_result("stranske/Y", "README.md", ["accurate-no-drift"]),
+    ]
+    summary = aggregate(results)
+    by_repo = {b["repo"]: b for b in summary["by_repo"]}
+    assert sorted(by_repo) == ["stranske/X", "stranske/Y"]
+    assert len(by_repo["stranske/X"]["drift_instances"]) == 2
+    assert len(by_repo["stranske/X"]["accurate_instances"]) == 1
+    assert by_repo["stranske/Y"]["drift_instances"] == []
+    assert summary["total_drift_instances"] == 2
+    assert summary["total_accurate_instances"] == 2
+
+
+def test_aggregate_propagates_errors_without_drift_double_count():
+    from scripts.repo_review_docs_drift_scan import DocResult
+
+    results = [
+        DocResult(repo="stranske/X", doc_path="README.md", error="claude rc=1"),
+        _doc_result("stranske/X", "docs/AGENTS.md", ["stale"]),
+    ]
+    summary = aggregate(results)
+    bucket = summary["by_repo"][0]
+    assert bucket["repo"] == "stranske/X"
+    assert len(bucket["errors"]) == 1
+    assert len(bucket["drift_instances"]) == 1
+    assert summary["total_errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scan() with mocked invoker (no live claude calls)
+# ---------------------------------------------------------------------------
+
+
+def _make_fixture_workspace(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a minimal workspace with a Workflows-steward checkout containing
+    the three seeded-drift docs plus a clean baseline doc. Returns
+    (workspace_root, registry_path)."""
+    workspace = tmp_path / "workspace"
+    steward = workspace / "Workflows-steward"
+    docs_dir = steward / "docs"
+    ci_dir = steward / "docs" / "ci"
+    ops_dir = steward / "docs" / "ops"
+    for d in (docs_dir, ci_dir, ops_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    (steward / "README.md").write_text("dummy README\n", encoding="utf-8")
+    (ci_dir / "WORKFLOWS.md").write_text("dummy WORKFLOWS\n", encoding="utf-8")
+    (ops_dir / "REPO_REVIEW_PROCESS.md").write_text("dummy process\n", encoding="utf-8")
+    (docs_dir / "AGENTS_POLICY.md").write_text("dummy policy\n", encoding="utf-8")
+    registry = steward / "config" / "repo_review_registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps({"repos": [{"repo": "stranske/Workflows", "status": "active"}]}),
+        encoding="utf-8",
+    )
+    return workspace, registry
+
+
+def _make_fixture_docs_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "source_of_truth_docs.yml"
+    cfg.write_text(
+        """
+repos:
+  stranske/Workflows:
+    local_path: Workflows-steward
+    docs:
+      - path: README.md
+        focus: model versions
+      - path: docs/ci/WORKFLOWS.md
+        focus: autofix contract
+      - path: docs/ops/REPO_REVIEW_PROCESS.md
+        focus: Phase-4 entry point
+      - path: docs/AGENTS_POLICY.md
+        focus: protected workflows
+""",
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_scan_end_to_end_with_seeded_fixtures(tmp_path: Path):
+    workspace, registry = _make_fixture_workspace(tmp_path)
+    cfg_path = _make_fixture_docs_config(tmp_path)
+    docs_config = load_docs_config(cfg_path)
+    active = load_active_repos(registry)
+
+    log_dir = tmp_path / "logs"
+
+    def fake_invoker(*, prompt: str, cwd: Path, timeout: int, log_file: Path):
+        # Pick the doc from the prompt's DOC: line.
+        for line in prompt.splitlines():
+            if line.startswith("DOC:"):
+                doc_path = line.split(":", 1)[1].strip()
+                break
+        else:
+            doc_path = ""
+        return True, SEEDED_FIXTURE_RESPONSES.get(doc_path, '{"instances": []}')
+
+    summary = scan(
+        docs_config=docs_config,
+        active_repos=active,
+        workspace_root=workspace,
+        repo_subset=None,
+        log_dir=log_dir,
+        timeout=10,
+        invoker=fake_invoker,
+    )
+
+    # Acceptance criteria: at least the 3 known drifts plus clean baselines.
+    assert summary["total_docs_scanned"] == 4
+    assert summary["total_drift_instances"] == 3, summary
+    assert summary["total_accurate_instances"] >= 2, summary
+    bucket = summary["by_repo"][0]
+    drift_docs = sorted({i["doc_path"] for i in bucket["drift_instances"]})
+    assert drift_docs == [
+        "README.md",
+        "docs/ci/WORKFLOWS.md",
+        "docs/ops/REPO_REVIEW_PROCESS.md",
+    ]
+
+
+def test_scan_skips_non_active_repos(tmp_path: Path):
+    workspace, registry = _make_fixture_workspace(tmp_path)
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        """
+repos:
+  stranske/Workflows:
+    local_path: Workflows-steward
+    docs:
+      - path: README.md
+        focus: x
+  stranske/Inactive:
+    local_path: NotPresent
+    docs:
+      - path: README.md
+        focus: y
+""",
+        encoding="utf-8",
+    )
+    summary = scan(
+        docs_config=load_docs_config(cfg_path),
+        active_repos=load_active_repos(registry),
+        workspace_root=workspace,
+        repo_subset=None,
+        log_dir=tmp_path / "logs",
+        timeout=10,
+        invoker=lambda **kw: (True, '{"instances": []}'),
+    )
+    assert len(summary["by_repo"]) == 1
+    assert summary["by_repo"][0]["repo"] == "stranske/Workflows"
+
+
+def test_scan_doc_records_missing_file(tmp_path: Path):
+    (tmp_path / "Workflows-steward").mkdir()
+    res = scan_doc(
+        repo="stranske/Workflows",
+        doc_path="docs/never-existed.md",
+        doc_focus="x",
+        repo_root=tmp_path / "Workflows-steward",
+        log_dir=tmp_path / "logs",
+        timeout=10,
+        invoker=lambda **kw: (True, '{"instances": []}'),
+    )
+    assert res.error is not None
+    assert "not found" in res.error
+
+
+def test_scan_doc_propagates_invoker_failure(tmp_path: Path):
+    steward = tmp_path / "Workflows-steward"
+    steward.mkdir()
+    (steward / "README.md").write_text("dummy\n", encoding="utf-8")
+    res = scan_doc(
+        repo="stranske/Workflows",
+        doc_path="README.md",
+        doc_focus="x",
+        repo_root=steward,
+        log_dir=tmp_path / "logs",
+        timeout=10,
+        invoker=lambda **kw: (False, "claude rc=1: boom"),
+    )
+    assert res.error == "claude rc=1: boom"
+    assert res.instances == []
+
+
+# ---------------------------------------------------------------------------
+# Notify renderer (one snippet per repo, NOT per doc -- acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_renders_one_snippet_per_repo_not_per_doc(tmp_path: Path):
+    from scripts.repo_review_notify import format_docs_drift_section
+
+    drift = {
+        "by_repo": [
+            {
+                "repo": "stranske/X",
+                "drift_instances": [
+                    {
+                        "doc_path": "README.md",
+                        "claim": "c1",
+                        "authoritative_source": "s1",
+                        "classification": "stale",
+                    },
+                    {
+                        "doc_path": "docs/ops/REPO_REVIEW_PROCESS.md",
+                        "claim": "c2",
+                        "authoritative_source": "s2",
+                        "classification": "stale",
+                    },
+                    {
+                        "doc_path": "docs/ci/WORKFLOWS.md",
+                        "claim": "c3",
+                        "authoritative_source": "s3",
+                        "classification": "contradictory",
+                    },
+                ],
+                "accurate_instances": [],
+                "errors": [],
+            }
+        ]
+    }
+    rendered = format_docs_drift_section(drift)
+    # Acceptance criterion: ONE gh issue create command per affected repo,
+    # NOT one per doc. Despite 3 drift instances spanning 3 docs, the
+    # rendered section must contain exactly one `gh issue create` invocation.
+    assert rendered.count("gh issue create --repo stranske/X") == 1
+    assert "README.md" in rendered
+    assert "docs/ops/REPO_REVIEW_PROCESS.md" in rendered
+    assert "docs/ci/WORKFLOWS.md" in rendered
+
+
+def test_notify_emits_empty_string_when_no_drift_no_errors():
+    from scripts.repo_review_notify import format_docs_drift_section
+
+    drift = {
+        "by_repo": [
+            {
+                "repo": "stranske/X",
+                "drift_instances": [],
+                "accurate_instances": [
+                    {
+                        "doc_path": "README.md",
+                        "claim": "c",
+                        "authoritative_source": "s",
+                        "classification": "accurate-no-drift",
+                    }
+                ],
+                "errors": [],
+            }
+        ]
+    }
+    assert format_docs_drift_section(drift) == ""


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2090 -->
> **Source:** Issue #2090

Closes #2090

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Operational documentation drifts faster than humans remember to update it. The 2026-05-13 weekly cycle confirmed three drift instances in source-of-truth docs (`README.md` model versions, `docs/ci/WORKFLOWS.md` autofix self-contradiction, `docs/ops/REPO_REVIEW_PROCESS.md` pointing at the pre-Phase-4 entry point). Each was found ad-hoc by a round-1 reviewer agent looking at a different design slice. There is no recurring mechanism that catches drift between weekly review cycles — drift just accumulates until someone happens to read the affected doc and notice.

CLAUDE.md flags the failure mode explicitly ("agents read one doc, treat its signal as system ground truth, take the wrong action"). The damage compounds because agents read these docs as authoritative input to their own reasoning.

A per-PR CI gate is overkill — slight staleness is tolerable. A per-doc-instance issue tree is wrong — docs have mutual references and need coordinated fixes. The right tool is a **weekly scan that surfaces drift in the existing desktop reminder**, with one bundled remediation issue per repo per cycle when drift is found.

#### Tasks
- [x] Add `config/source_of_truth_docs.yml` with one entry per repo listing the source-of-truth doc paths. For `stranske/Workflows`, seed it with the ~13 docs CLAUDE.md cites (README.md, docs/INTEGRATION_GUIDE.md, docs/ops/REPO_REVIEW_PROCESS.md, docs/keepalive/GoalsAndPlumbing.md, docs/AGENTS_POLICY.md, docs/LABELS.md, docs/keepalive/Agents.md, docs/ci/WORKFLOWS.md, docs/MODEL_MANAGEMENT.md, docs/WORKFLOW_GUIDE.md, docs/ops/REPO_REVIEW_ROUND2_PROTOCOL.md, docs/ops/REPO_REVIEW_ROUND1_SCHEMA.md, AGENTS.md).
- [x] Write `scripts/repo_review_docs_drift_scan.py`. For each (repo, doc) in the config: invoke claude with a focused prompt that reads the doc + relevant implementation files (selected by `rg` queries against terms the doc mentions) and emits a JSON list of drift instances. Each instance has `{doc_path, claim, authoritative_source, classification}` where classification ∈ `{stale, contradictory, accurate-no-drift}`.
- [ ] In the per-doc prompt, instruct claude: (a) use `rg` for command/identifier/filename existence checks; (b) call `gitnexus context|impact` for behavioral claims about call paths when the local GitNexus map is current; (c) skip behavioral checks gracefully when `.gitnexus/meta.json` reports stale.
- [ ] Add coordinator wiring: new step `5b. docs-drift scan` after `5. backlog-scan` and before `6. notify`. Same retry/timeout pattern as backlog-scan; failures are non-fatal.
- [x] Update `scripts/repo_review_notify.py`: load `<output_dir>/docs-drift-scan.json` if present; render a "Doc drift detected" section in the desktop reminder, grouped by repo, with one `gh issue create` snippet per affected repo to file a holistic remediation issue.
- [x] Document the new step in the cron's automation TOML prompt under "Operational notes" with the same depth as the existing backlog-scan note.
- [ ] Seed the scanner with the 3 drifts confirmed this cycle (`README.md` model versions, `WORKFLOWS.md` autofix contradiction, `REPO_REVIEW_PROCESS.md` Phase-4 entry point) as integration-test fixtures so the scanner's logic is exercised against real cases.

#### Acceptance criteria
- [ ] `python scripts/repo_review_docs_drift_scan.py --registry config/repo_review_registry.json --out /tmp/test-drift.json` runs on Workflows-steward and returns at least the 3 known drifts plus a clean (`accurate-no-drift`) classification for at least 5 other source-of-truth docs.
- [ ] `pytest tests/scripts/test_repo_review_docs_drift_scan.py` exercises the classifier logic against the seeded fixture drifts and verifies they classify as `stale` / `contradictory` not `accurate-no-drift`.
- [ ] A full cron dry-run (with `--skip-preflight --skip-auto-archive`) produces a `<output_dir>/docs-drift-scan.json` AND a desktop reminder file whose "Doc drift detected" section lists the seeded drifts.
- [ ] The desktop reminder's "Doc drift" section gives one `gh issue create` snippet per repo with non-empty drift, NOT one per doc.
- [ ] When `.gitnexus/meta.json` is stale or missing, the scanner completes with the call-graph checks gracefully skipped (logged but not fatal). Verify with `rg 'skipping behavioral check' <output_dir>/logs/coordinator/docs-drift-scan.log`.
- [ ] The cron's `automation.toml` "Operational notes" section documents the new step, where its output lives, and the expected runtime (~5–10 min across 9 repos).

<!-- auto-status-summary:end -->