### PR TITLE
Issue #2098: align agents policy covered files

### DIFF
--- a/docs/AGENTS_POLICY.md
+++ b/docs/AGENTS_POLICY.md
@@ -61,6 +61,8 @@ replaced them entirely.
    includes the files above. The `Health 45 Agents Guard` status check is marked as
    required.
 - The repository ruleset shows the three workflows in its “Protected file
-  patterns” section with **Block deletion** and **Block rename** enabled.
+  patterns section (`agents-63-issue-intake.yml`,
+  `agents-70-orchestrator.yml`, and `agents-guard.yml`) with
+  **Block deletion** and **Block rename** enabled.
 - A maintainer can describe the override procedure without referencing this
   document (spot check during ops reviews).

--- a/docs/AGENTS_POLICY.md
+++ b/docs/AGENTS_POLICY.md
@@ -10,10 +10,14 @@ Agents 70 (orchestrator).
 
 - `.github/workflows/agents-63-issue-intake.yml`
 - `.github/workflows/agents-70-orchestrator.yml`
+- `.github/workflows/agents-guard.yml`
 
-These are the only active Agents entry points. Former consumer wrappers
-(`agents-61-consumer-compat.yml`, `agents-62-consumer.yml`) must not be
-reintroduced; the orchestrator surface replaced them entirely.
+The first two workflows are the only active Agents entry points. The guard
+workflow is co-protected because it enforces the protected-workflow policy in
+CI; losing or renaming it would remove the automated safety net. Former
+consumer wrappers (`agents-61-consumer-compat.yml`,
+`agents-62-consumer.yml`) must not be reintroduced; the orchestrator surface
+replaced them entirely.
 
 ## Protection layers
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2098 -->
> **Source:** Issue #2098

Closes #2098

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Identified by the doc-drift audit for #2089. The Agents Workflow Protection Policy doc contradicts itself about how many workflow files are protected.

- `docs/AGENTS_POLICY.md` "Covered files" section names exactly two workflows: `agents-63-issue-intake.yml` and `agents-70-orchestrator.yml`.
- `docs/AGENTS_POLICY.md` "Verification checklist" later asserts: *"The repository ruleset shows the three workflows in its 'Protected file patterns' section with Block deletion and Block rename enabled."*

The third workflow is most likely `agents-guard.yml` (the protection guard itself, which also has CODEOWNERS implications and is loaded by `.github/scripts/agents-guard.js`), but the doc never says so. Either the doc undercounts in the "Covered files" section or overcounts in the verification checklist; an operator following the verification checklist literally will look for a third protected pattern that the rest of the doc does not name.

This is the same misdirection class flagged by the CLAUDE.md failure-mode warning: an agent reads the verification checklist, sees "three workflows", configures a ruleset accordingly (or confirms one), and either omits a protected file or fails to confirm because no third file is named to verify.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2089](https://github.com/stranske/Workflows/issues/2089)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Decide whether `.github/workflows/agents-guard.yml` is intentionally co-protected; if yes, add it to the "Covered files" list with a one-line rationale.
- [x] Reconcile the "Verification checklist" line about "the three workflows" with whatever count the "Covered files" list ends up at.
- [x] Verify that the post-fix doc passes `rg -c 'agents-(63|70|guard)' docs/AGENTS_POLICY.md` against the named-files count described in the checklist (e.g., 3 distinct workflow names matched).

#### Acceptance criteria
- [x] The number of workflow files explicitly named in "Covered files" matches the count claimed in the "Verification checklist" section.
- [x] If `agents-guard.yml` is added, the doc explains why a protection workflow is itself protected.
- [x] No new workflow names introduced that do not exist on `main` (`.github/workflows/agents-guard.yml` etc. must be live).

<!-- auto-status-summary:end -->