### PR TITLE
Follow-up #2099: restore agent:codex-invite docs as supported issue-bridge invite override

### DIFF
--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -13,7 +13,7 @@ This document describes all labels that trigger automated workflows or affect CI
 | `agent:auto` | Issue or PR labeled | Delegates routing to the auto-delegation policy; do not combine with concrete `agent:<name>` labels
 | `agent:retry` | PR labeled | Requests one re-dispatch of the matching keepalive runner
 | `agent:rate-limited` | Auto-applied | Marks a PR as backing off from a rate-limit failure
-| `agent:codex-invite` | Issue labeled (with `agent:codex`) | Overrides PR mode to `invite` for `agent:codex` via the issue-bridge `-invite` suffix parser; requires the base `agent:codex` label
+| `agent:codex-invite` | Issue labeled (with `agent:codex`) | Overrides PR mode to `invite` for `agent:codex` only when the issue bridge allows issue-label mode selection (`force_mode: false`); requires the base `agent:codex` label
 | `agent:needs-attention` | Auto-applied | Indicates agent needs human intervention
 | `status:ready` | Issue labeled | Marks issue as ready for agent processing
 | `agents:format` | Issue labeled | Direct issue formatting
@@ -192,7 +192,7 @@ This document describes all labels that trigger automated workflows or affect CI
 
 **Effect:**
 1. The issue-bridge label parser in `.github/workflows/reusable-agents-issue-bridge.yml` strips the `-invite` suffix and records `invite=true` for the base `agent:codex` entry (see the `inviteSuffix` handling around the `parses agent:<name>-invite` block).
-2. The mode-resolution step then forces the bridge into `invite` mode for codex even if the calling workflow requested `create`, so the bridge posts human invite instructions instead of creating a branch and draft PR.
+2. The mode-resolution step then selects `invite` mode for codex when the calling workflow does not force its input mode (`force_mode: false`). If the caller leaves `force_mode` at its default `true`, the bridge respects the requested input mode instead.
 3. Applying `agent:codex-invite` alone (without `agent:codex`) is rejected: the bridge fails with `Invite labels (agent:codex-invite) require a matching base agent:<name>.`
 
 **Workflow:** `.github/workflows/reusable-agents-issue-bridge.yml` (label parser + mode resolution). The generic `agent:<name>-invite` mechanism is implemented in the same file, so the same pattern applies to other concrete agents.
@@ -532,7 +532,7 @@ These labels are used for categorization but do not trigger workflows.
 | `agent:<name>` + `agents:keepalive` | `agent:retry` | Forces one re-dispatch; keepalive removes the label at the top of its run
 | `agent:retry` | (removed by `agents-keepalive-loop.yml`) | Co-removes any stale `agent:rate-limited`
 | `agent:rate-limited` | `agent:retry` | Retry-label handler removes stale `agent:rate-limited` before keepalive evaluation
-| `agent:codex` | `agent:codex-invite` | Forces the issue-bridge into `invite` mode for `agent:codex` (posts human invite instructions instead of creating a branch/PR)
+| `agent:codex` | `agent:codex-invite` | Selects issue-bridge `invite` mode for `agent:codex` when `force_mode: false`; with the default forced input mode, the requested mode still wins
 | `agent:codex` | `status:ready` | Agent begins processing
 | `agent:needs-attention` | (removed) | Agent resumes processing
 | (none) | `agents:format` | Direct formatting

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -13,7 +13,7 @@ This document describes all labels that trigger automated workflows or affect CI
 | `agent:auto` | Issue or PR labeled | Delegates routing to the auto-delegation policy; do not combine with concrete `agent:<name>` labels
 | `agent:retry` | PR labeled | Requests one re-dispatch of the matching keepalive runner
 | `agent:rate-limited` | Auto-applied | Marks a PR as backing off from a rate-limit failure
-| `agent:codex-invite` | Issue labeled | (**Deprecated** — no workflow references this label; see detail section) |
+| `agent:codex-invite` | Issue labeled (with `agent:codex`) | Overrides PR mode to `invite` for `agent:codex` via the issue-bridge `-invite` suffix parser; requires the base `agent:codex` label
 | `agent:needs-attention` | Auto-applied | Indicates agent needs human intervention
 | `status:ready` | Issue labeled | Marks issue as ready for agent processing
 | `agents:format` | Issue labeled | Direct issue formatting
@@ -186,11 +186,16 @@ This document describes all labels that trigger automated workflows or affect CI
 
 ### `agent:codex-invite`
 
-**Applies to:** Issues
+**Applies to:** Issues (must be paired with `agent:codex`)
 
-**Status:** **Deprecated.** `grep -rn codex-invite .github/ scripts/ tools/` returns no matches on `main`. No workflow, script, or tool currently references this label. It was an invite-mode override for `agent:codex` that kept the issue-triggered bridge in invite mode, but the feature is no longer wired in any active workflow. Do not apply this label; it has no effect.
+**Trigger:** When applied to an issue together with `agent:codex`
 
-**If invite-mode behaviour is needed:** Use the base `agent:codex` or `agent:claude` label and configure the intake workflow directly.
+**Effect:**
+1. The issue-bridge label parser in `.github/workflows/reusable-agents-issue-bridge.yml` strips the `-invite` suffix and records `invite=true` for the base `agent:codex` entry (see the `inviteSuffix` handling around the `parses agent:<name>-invite` block).
+2. The mode-resolution step then forces the bridge into `invite` mode for codex even if the calling workflow requested `create`, so the bridge posts human invite instructions instead of creating a branch and draft PR.
+3. Applying `agent:codex-invite` alone (without `agent:codex`) is rejected: the bridge fails with `Invite labels (agent:codex-invite) require a matching base agent:<name>.`
+
+**Workflow:** `.github/workflows/reusable-agents-issue-bridge.yml` (label parser + mode resolution). The generic `agent:<name>-invite` mechanism is implemented in the same file, so the same pattern applies to other concrete agents.
 
 ---
 
@@ -527,7 +532,7 @@ These labels are used for categorization but do not trigger workflows.
 | `agent:<name>` + `agents:keepalive` | `agent:retry` | Forces one re-dispatch; keepalive removes the label at the top of its run
 | `agent:retry` | (removed by `agents-keepalive-loop.yml`) | Co-removes any stale `agent:rate-limited`
 | `agent:rate-limited` | `agent:retry` | Retry-label handler removes stale `agent:rate-limited` before keepalive evaluation
-| `agent:codex` | `agent:codex-invite` | (**Deprecated**) No longer active; label has no effect |
+| `agent:codex` | `agent:codex-invite` | Forces the issue-bridge into `invite` mode for `agent:codex` (posts human invite instructions instead of creating a branch/PR)
 | `agent:codex` | `status:ready` | Agent begins processing
 | `agent:needs-attention` | (removed) | Agent resumes processing
 | (none) | `agents:format` | Direct formatting

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -13,7 +13,7 @@ This document describes all labels that trigger automated workflows or affect CI
 | `agent:auto` | Issue or PR labeled | Delegates routing to the auto-delegation policy; do not combine with concrete `agent:<name>` labels
 | `agent:retry` | PR labeled | Requests one re-dispatch of the matching keepalive runner
 | `agent:rate-limited` | Auto-applied | Marks a PR as backing off from a rate-limit failure
-| `agent:codex-invite` | Issue labeled (with `agent:codex`) | Overrides PR mode to `invite` for `agent:codex` only when the issue bridge allows issue-label mode selection (`force_mode: false`); requires the base `agent:codex` label
+| ~~`agent:codex-invite`~~ | *(deprecated)* | No workflow, script, or tool references this label by name; the generic `agent:<name>-invite` mechanism in `reusable-agents-issue-bridge.yml` still works but this specific label is unmaintained — see detail section below
 | `agent:needs-attention` | Auto-applied | Indicates agent needs human intervention
 | `status:ready` | Issue labeled | Marks issue as ready for agent processing
 | `agents:format` | Issue labeled | Direct issue formatting
@@ -184,7 +184,9 @@ This document describes all labels that trigger automated workflows or affect CI
 
 ---
 
-### `agent:codex-invite`
+### ~~`agent:codex-invite`~~ *(deprecated)*
+
+> **Deprecated.** `grep -rn codex-invite .github/ scripts/ tools/` returns no matches. The label is not referenced by name in any active workflow, script, or tool. The underlying `-invite` suffix mechanism in `reusable-agents-issue-bridge.yml` remains functional for any `agent:<name>-invite` label, but `agent:codex-invite` specifically is unmaintained. Do not apply this label; use `force_mode: false` at the workflow call site instead if you need invite-mode control.
 
 **Applies to:** Issues (must be paired with `agent:codex`)
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2099 -->
> **Source:** Issue #2099

Closes #2099

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Identified by the doc-drift audit for #2089. `docs/LABELS.md` is named in `CLAUDE.md` as the *canonical label inventory* and is *load-bearing for trigger semantics*. It is also synced to consumer repos via `.github/sync-manifest.yml:636-637`, so its drift propagates to every supported repo's label documentation.

The doc currently omits several agent labels that are actively used by workflows on `main`, and documents one label that no workflow, script, or tool references.

### Labels actively used but undocumented in LABELS.md

| Label | Evidence (live use) |
|---|---|
| `agent:claude` | `.github/workflows/agents-bot-comment-handler.yml:12`, `.github/workflows/agents-auto-label.yml:37`, `.github/workflows/reusable-pr-context.yml:222`, `.github/workflows/agents-keepalive-loop.yml`, `.github/workflows/agents-guard.yml`; registered in `.github/agents/registry.yml` as a first-class agent with `branch_prefix: claude/issue-` and runner `reusable-claude-run.yml`. |
| `agent:auto` | `.github/workflows/agents-auto-label.yml:38`, `.github/workflows/reusable-pr-context.yml:222`. Used to delegate routing to `agent_delegation_policy.js` on capacity stalls. |
| `agent:retry` | `.github/workflows/agents-keepalive-loop.yml:171,191,200,319` (explicit retry handling and label removal); `.github/workflows/agents-auto-pilot.yml:382`. |
| `agent:rate-limited` | `.github/workflows/agents-auto-pilot.yml:380`, `.github/workflows/agents-keepalive-loop.yml:215,222,229,234`. |

### Labels documented but stale (no active trigger)

- `agent:codex-invite` — documented at `docs/LABELS.md:12,98-112` but `grep -rn codex-invite .github/ scripts/ tools/` returns no matches. Either the feature was removed and the doc was not updated, or the label is purely informational and that should be stated.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2089](https://github.com/stranske/Workflows/issues/2089)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add Quick Reference + detail section for `agent:claude` (issue-applied; routes to `reusable-claude-run.yml` per `.github/agents/registry.yml`; analogous to `agent:codex`).
- [x] Add Quick Reference + detail section for `agent:auto` (delegation-policy fallback; pairs with concrete `agent:*` label for capacity-stuck recovery).
- [x] Add Quick Reference + detail section for `agent:retry` (auto-applied by `agents-auto-pilot.yml` and consumed/cleaned by `agents-keepalive-loop.yml`).
- [x] Add Quick Reference + detail section for `agent:rate-limited` (auto-applied during rate-limit backoff; consumed/cleaned by keepalive).
- [x] Verify `agent:codex-invite` is truly inactive (rerun `grep -rn codex-invite .github/ scripts/ tools/` at fix time); mark as deprecated or remove with a one-line note.
- [x] If `docs/LABELS.md` is the synced source of truth for consumer repos (per `.github/sync-manifest.yml`), include a note that consumer copies will reflect these additions on next sync.

#### Acceptance criteria
- [x] `rg -c '^\| `agent:claude`' docs/LABELS.md` ≥ 1 (quick-reference row exists).
- [x] `rg -c '^### `agent:claude`' docs/LABELS.md` ≥ 1 (detail section exists). Same for `agent:auto`, `agent:retry`, `agent:rate-limited`.
- [x] `grep -rn codex-invite .github/ scripts/ tools/` is empty AND `docs/LABELS.md` either no longer documents it or marks it deprecated.
- [x] PR description names `docs/LABELS.md` as the synced source of truth and confirms no logic in workflow YAML changed.

<!-- auto-status-summary:end -->