### PR TITLE
fix(autofix): remove invalid workflow_job trigger from consumer template

### DIFF
--- a/.github/actionlint-allowlist.txt
+++ b/.github/actionlint-allowlist.txt
@@ -8,9 +8,6 @@ property "(token_rotation_json|service_bot_pat|actions_bot_pat|owner_pr_pat|agen
 # actionlint 1.7.3 doesn't recognize this newer permission scope
 unknown permission scope "models"
 
-# actionlint 1.7.3 doesn't recognize the workflow_job trigger yet.
-unknown Webhook event "workflow_job"
-
 # These are style warnings for consecutive echo redirects. Grouping them would
 # reduce readability in our workflow context.
 SC2129:style:.+: Consider using { cmd1; cmd2; } >> file instead of individual redirects

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -3,11 +3,16 @@
 #
 # Triggers:
 # - Gate/CI/Python CI workflow completes with failure (lint/format issues detected)
-# - Lint job fails early (workflow_job completed)
 # - PR labeled with 'autofix' or 'autofix:clean' (manual trigger)
 #
 # Note: push trigger removed — it caused "This isn't working right now" errors
-# because GitHub Actions can't resolve the reusable workflow reference on push events
+# because GitHub Actions can't resolve the reusable workflow reference on push events.
+#
+# Note: workflow_job removed 2026-05-14 — `workflow_job` is a webhook event
+# (delivered to webhook subscribers), NOT a valid `on:` trigger for workflows.
+# Adding it via PR #1528 caused every push to every consumer repo to record a
+# failed Autofix run with "This run likely failed because of a workflow file
+# issue" — for ~3 months until detected during 2026-05-14 verification.
 #
 # Copy this file to: .github/workflows/autofix.yml
 #
@@ -18,8 +23,6 @@ name: Autofix
 on:
   workflow_run:
     workflows: ["Gate", "CI", "Python CI"]
-    types: [completed]
-  workflow_job:
     types: [completed]
   pull_request_target:
     types:
@@ -40,11 +43,6 @@ concurrency:
         github.event.workflow_run.pull_requests &&
         github.event.workflow_run.pull_requests[0] &&
         github.event.workflow_run.pull_requests[0].number
-      )
-      || (
-        github.event.workflow_job.pull_requests &&
-        github.event.workflow_job.pull_requests[0] &&
-        github.event.workflow_job.pull_requests[0].number
       )
       || github.run_id
     }}
@@ -78,9 +76,7 @@ jobs:
             (event_name == 'pull_request_target' && action == 'labeled' &&
              (label.name == 'autofix' || label.name == 'autofix:clean')) ||
             (event_name == 'workflow_run' && workflow_run.conclusion == 'failure' &&
-             length(workflow_run.pull_requests) > 0) ||
-            (event_name == 'workflow_job' && workflow_job.conclusion == 'failure' &&
-             length(workflow_job.pull_requests) > 0)
+             length(workflow_run.pull_requests) > 0)
 
       - name: Checkout for API helpers
         if: steps.eligibility.outputs.should-run == 'true'
@@ -361,121 +357,6 @@ jobs:
                 pr,
                 sameRepo,
                 callerActor: run.actor?.login || context.actor,
-              });
-              return;
-            }
-
-            // --- workflow_job trigger (early lint failure) ---
-            if (context.eventName === 'workflow_job') {
-              const workflowJob = context.payload.workflow_job;
-              if (!workflowJob) {
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const workflowName = String(workflowJob.workflow_name || '').trim();
-              const jobName = String(workflowJob.name || '').toLowerCase();
-              const conclusion = String(workflowJob.conclusion || '').toLowerCase();
-
-              // Only respond to failing lint jobs in the workflows we care about.
-              const relevantJob =
-                jobName.includes('lint-format') || jobName.includes('lint-ruff');
-              if (!relevantJob) {
-                core.info(
-                  `workflow_job '${workflowJob.name}' is not a lint-format/lint-ruff job.`
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const allowedWorkflows = new Set(['Gate', 'CI', 'Python CI']);
-              if (workflowName && !allowedWorkflows.has(workflowName)) {
-                core.info(
-                  `workflow_job is from workflow '${workflowName}', not Gate/CI/Python CI; ` +
-                  'skipping.'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (conclusion !== 'failure') {
-                core.info(
-                  `workflow_job '${workflowJob.name}' concluded '${workflowJob.conclusion}' ` +
-                  '— no autofix needed'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const prs = workflowJob.pull_requests || [];
-              if (!prs.length) {
-                core.info('workflow_job event has no associated PR; skipping.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const prNumber = prs[0].number;
-              const triggerHeadSha = String(workflowJob.head_sha || '');
-              const { owner, repo } = context.repo;
-              const { data: pr } = await withRetry((client) =>
-                client.rest.pulls.get({ owner, repo, pull_number: prNumber })
-              );
-
-              if (pr.state !== 'open') {
-                core.info(`PR #${prNumber} is ${pr.state}`);
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (pr.draft) {
-                core.info('PR is draft.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const sameRepo =
-                pr.head.repo !== null &&
-                pr.head.repo.full_name === pr.base.repo?.full_name;
-              if (!sameRepo) {
-                core.info('Fork PR — not supported.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const headSha = pr.head?.sha;
-              if (!headSha) {
-                core.info('PR head SHA missing; skipping autofix.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              if (triggerHeadSha && triggerHeadSha !== headSha) {
-                core.info(
-                  `workflow_job head_sha ${triggerHeadSha} does not match PR head ${headSha}; ` +
-                  'skipping stale event.'
-                );
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              const files = await listFilesOrNullOnRateLimit({ owner, repo, prNumber });
-              const hasPython =
-                files === null
-                  ? true
-                  : files.some(
-                      (file) =>
-                        file.filename.endsWith('.py') || file.filename.endsWith('.pyi')
-                    );
-              if (!hasPython) {
-                core.info('No Python files changed.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-
-              setOutputs({
-                pr,
-                sameRepo,
-                callerActor: context.payload.sender?.login || context.actor,
               });
               return;
             }

--- a/tests/workflows/test_workflow_on_triggers_valid.py
+++ b/tests/workflows/test_workflow_on_triggers_valid.py
@@ -38,8 +38,8 @@ make it through review by hiding behind an allowlist tweak.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import pytest
 import yaml
@@ -145,7 +145,9 @@ def test_at_least_one_workflow_file_is_discovered() -> None:
     )
 
 
-@pytest.mark.parametrize("workflow_path", list(_iter_workflow_files()), ids=lambda p: str(p.relative_to(ROOT)))
+@pytest.mark.parametrize(
+    "workflow_path", list(_iter_workflow_files()), ids=lambda p: str(p.relative_to(ROOT))
+)
 def test_workflow_only_uses_valid_on_triggers(workflow_path: Path) -> None:
     """Every event listed under ``on:`` must be a real workflow trigger.
 

--- a/tests/workflows/test_workflow_on_triggers_valid.py
+++ b/tests/workflows/test_workflow_on_triggers_valid.py
@@ -1,0 +1,182 @@
+"""Static guard: every workflow YAML file uses only real GitHub Actions
+triggers in its top-level ``on:`` block.
+
+Background — why this test exists
+=================================
+PR #1528 (merged 2026-02-16) added::
+
+    on:
+      workflow_job:
+        types: [completed]
+
+…to the consumer-repo autofix.yml template. ``workflow_job`` is a *webhook
+event* (delivered to org-level webhook subscribers); it is **not** a valid
+``on:`` trigger for a GitHub Actions workflow. Every push to every consumer
+repo since the 2026-02-17 sync has recorded a failed Autofix run with the
+opaque message "This run likely failed because of a workflow file issue."
+The failure mode wasn't load-bearing — the working `workflow_run` path on
+the same workflow continued to fire — so it took ~3 months to detect.
+
+Two reasons CI didn't catch the regression at PR time:
+
+1. The workflow only runs via the triggers listed in its ``on:`` block. The
+   PR itself didn't fire any of those triggers, so the workflow was never
+   instantiated during PR CI, and the "This run likely failed" recording
+   was visible only after merge + sync.
+2. The same PR added an ``actionlint-allowlist.txt`` entry for
+   ``unknown Webhook event "workflow_job"`` — the static check that would
+   have flagged the unknown event was explicitly silenced.
+
+This test is a belt-and-suspenders companion to actionlint. It enumerates
+every ``.github/workflows/*.yml`` and every ``templates/**/.github/
+workflows/*.yml`` in the repo, parses the YAML, and asserts every
+top-level ``on:`` key is in the documented set of workflow trigger events.
+Unknown trigger names fail the test loudly, naming the file and the bad
+event, so a future "feat: trigger early on $not_a_real_event" PR cannot
+make it through review by hiding behind an allowlist tweak.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Source: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+# Keep alphabetized. ``workflow_job`` deliberately omitted — it's a webhook
+# event for webhook subscribers, NOT a workflow trigger.
+VALID_WORKFLOW_TRIGGERS: frozenset[str] = frozenset(
+    {
+        "branch_protection_rule",
+        "check_run",
+        "check_suite",
+        "create",
+        "delete",
+        "deployment",
+        "deployment_status",
+        "discussion",
+        "discussion_comment",
+        "fork",
+        "gollum",
+        "issue_comment",
+        "issues",
+        "label",
+        "merge_group",
+        "milestone",
+        "page_build",
+        "project",
+        "project_card",
+        "project_column",
+        "public",
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "pull_request_target",
+        "push",
+        "registry_package",
+        "release",
+        "repository_dispatch",
+        "schedule",
+        "status",
+        "watch",
+        "workflow_call",
+        "workflow_dispatch",
+        "workflow_run",
+    }
+)
+
+WORKFLOW_GLOBS: tuple[str, ...] = (
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    "templates/**/.github/workflows/*.yml",
+    "templates/**/.github/workflows/*.yaml",
+)
+
+
+def _iter_workflow_files() -> Iterable[Path]:
+    seen: set[Path] = set()
+    for pattern in WORKFLOW_GLOBS:
+        for path in ROOT.glob(pattern):
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            yield path
+
+
+def _load_workflow(path: Path) -> dict:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - YAML linter handles this
+        pytest.fail(f"{path.relative_to(ROOT)}: YAML parse error: {exc}")
+    if not isinstance(data, dict):
+        pytest.fail(f"{path.relative_to(ROOT)}: top-level YAML is not a mapping")
+    return data
+
+
+def _extract_on_events(on_field: object) -> list[str]:
+    """Return the set of trigger event names referenced in the ``on:`` field.
+
+    ``on:`` can be a string (``on: push``), a list (``on: [push, pull_request]``),
+    or a mapping (``on: { push: { branches: [main] } }``). Handle all three.
+    """
+    if isinstance(on_field, str):
+        return [on_field]
+    if isinstance(on_field, list):
+        return [str(item) for item in on_field if isinstance(item, str)]
+    if isinstance(on_field, dict):
+        return list(on_field.keys())
+    return []
+
+
+def test_at_least_one_workflow_file_is_discovered() -> None:
+    """Guard against the glob silently matching nothing — that would let
+    every other assertion below trivially pass."""
+    files = list(_iter_workflow_files())
+    assert files, (
+        f"No workflow YAML files found under {ROOT} — the glob patterns "
+        f"{WORKFLOW_GLOBS} matched nothing, so this test would trivially pass."
+    )
+
+
+@pytest.mark.parametrize("workflow_path", list(_iter_workflow_files()), ids=lambda p: str(p.relative_to(ROOT)))
+def test_workflow_only_uses_valid_on_triggers(workflow_path: Path) -> None:
+    """Every event listed under ``on:`` must be a real workflow trigger.
+
+    A failure here means a workflow was authored with an event name that
+    GitHub Actions does not recognize as a trigger. The most likely cause
+    is a typo (``pull_resquest_target``), a confusion with a webhook event
+    (``workflow_job`` — the canonical example this test was written to
+    catch, see PR #1528 and 2026-05-14 incident notes), or a draft for an
+    event that doesn't exist.
+    """
+    data = _load_workflow(workflow_path)
+    on_field = data.get("on") if isinstance(data, dict) else None
+    # `on` is a YAML reserved word coerced to Python True if not quoted.
+    # PyYAML safe_load handles `on: <event>` by binding the key True — handle
+    # that too so we still inspect the events.
+    if on_field is None and True in data:
+        on_field = data[True]
+
+    events = _extract_on_events(on_field)
+    assert events, (
+        f"{workflow_path.relative_to(ROOT)}: could not parse `on:` block "
+        f"(field={on_field!r}); a workflow without triggers will never run."
+    )
+
+    invalid = [event for event in events if event not in VALID_WORKFLOW_TRIGGERS]
+    assert not invalid, (
+        f"{workflow_path.relative_to(ROOT)}: uses unknown `on:` event(s) "
+        f"{invalid}. Allowed events are documented at "
+        "https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows. "
+        "If you intend to react to a webhook event delivered to a repo "
+        "subscription, you cannot do so directly — webhook events are NOT "
+        "valid workflow triggers. Consider `workflow_run` (for workflow "
+        "completion) or `check_run`/`check_suite` (for CI lifecycle) instead."
+    )


### PR DESCRIPTION
## Root cause

PR #1528 (merged 2026-02-16) added the following to the consumer-repo `autofix.yml` template:

```yaml
on:
  workflow_job:
    types: [completed]
```

`workflow_job` is a **webhook event** delivered to webhook subscribers; it is **NOT** a valid `on:` trigger for a GitHub Actions workflow. [GitHub's documented trigger event list](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) does not include it.

## Fleet-wide impact

Every push to every consumer repo since the 2026-02-17 sync has recorded a failed Autofix run with the opaque message **"This run likely failed because of a workflow file issue."** Verified via `gh run list`:

| Repo | Recent autofix.yml runs (last 100) |
|---|---|
| Counter_Risk | 100 / 100 failure |
| Inv-Man-Intake | 100 / 100 failure |
| Manager-Database | 100 / 100 failure |
| Pension-Data | 100 / 100 failure |
| Portable-Alpha-Extension-Model | 100 / 100 failure |
| Travel-Plan-Permission | 100 / 100 failure |
| Trend_Model_Project | 100 / 100 failure |
| trip-planner | 100 / 100 failure |
| **Workflows** (root, not template) | **0 / 100 failure** |

The Workflows repo's own `.github/workflows/autofix.yml` was never modified by #1528 — only the consumer template was. The failure mode wasn't load-bearing (the working `workflow_run` path on the same workflow continued to fire), so the breakage went undetected for ~3 months.

## Why CI didn't catch it at PR time

Two compounding reasons:

1. **The workflow only runs via its declared triggers.** PR #1528 didn't fire any of those triggers, so the workflow was never instantiated during PR CI. The "This run likely failed" recording was visible only after merge + sync to consumer repos.
2. **The actionlint static check was explicitly silenced.** PR #1528 added an `.github/actionlint-allowlist.txt` entry for `unknown Webhook event "workflow_job"` (commented "actionlint 1.7.3 doesn't recognize the workflow_job trigger yet"). actionlint was correct — `workflow_job` is genuinely not a trigger — and the allowlist suppressed exactly the check that would have caught this.

## What this PR does

- **Remove** the `workflow_job:` trigger from `templates/consumer-repo/.github/workflows/autofix.yml`
- **Remove** the corresponding ~110 lines of dead JS handler in the `Resolve PR context` step that could never be reached
- **Remove** the dead `workflow_job.pull_requests` reference from the concurrency expression
- **Update** the header comment to record why `workflow_job` is intentionally absent (so this doesn't get reintroduced "fixing" the same imagined gap)
- **Remove** the `unknown Webhook event "workflow_job"` actionlint allowlist line — future re-introduction of any invalid trigger now fails actionlint
- **Add** `tests/workflows/test_workflow_on_triggers_valid.py` — a parametrized static test that loads every workflow YAML (`.github/workflows/*.yml` plus `templates/**/.github/workflows/*.yml`) and asserts each top-level `on:` event is in the documented set of GitHub Actions triggers. Belt-and-suspenders companion to actionlint.

## Verified locally

- `actionlint templates/consumer-repo/.github/workflows/autofix.yml` exits clean.
- A synthetic `/tmp/bad.yml` containing `on: workflow_job: types: [completed]` is correctly flagged by actionlint with a link to the events docs.
- Temporarily re-adding `workflow_job:` makes `test_workflow_only_uses_valid_on_triggers` fail with a clear, actionable message naming the file and the bad event.
- 136 workflow files validated by the new test.
- `pytest tests/workflows/ -q` → **621 passed**, 3 needs-human skipped. (+136 new param tests vs prior baseline of 485, 0 regressions.)

## Expected post-merge behavior

Once this lands + the consumer-sync workflow propagates the fix, every new push to every consumer repo will record a **SKIPPED** (not FAILURE) Autofix run for the standard push path. The `workflow_run`-triggered autofix path (the real, working code path) is untouched.

## Test plan

- [x] `pytest tests/workflows/ -q` — 621 passed
- [x] `pytest tests/workflows/test_workflow_on_triggers_valid.py -q` — 137 passed (136 files + 1 discovery guard)
- [x] `actionlint templates/consumer-repo/.github/workflows/autofix.yml` clean
- [x] Regression check: re-adding `workflow_job:` makes both actionlint AND the new test fail with clear messages
- [ ] CI green on the standard gate (will populate after CI runs)
- [ ] After merge, monitor the next consumer-sync run to confirm propagation across all 8 affected repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)