### PR TITLE
fix: carry forward sync review followups

### DIFF
--- a/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
+++ b/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
@@ -468,10 +468,16 @@ test('runKeepaliveGate converts checklist-complete draft PRs to ready for review
   assert.equal(github.__calls.graphql[0].variables.pullRequestId, 'PR_node_17');
   const readyMutation = github.__calls.graphql[0].query;
   assert.match(readyMutation, /mutation MarkPullRequestReadyForReview\(\$pullRequestId: ID!\) \{/);
-  assert.equal(
-    (readyMutation.match(/\{/g) || []).length,
-    (readyMutation.match(/\}/g) || []).length
-  );
+  let braceBalance = 0;
+  for (const char of readyMutation) {
+    if (char === '{') {
+      braceBalance += 1;
+    } else if (char === '}') {
+      braceBalance -= 1;
+    }
+    assert.ok(braceBalance >= 0);
+  }
+  assert.equal(braceBalance, 0);
   assert.match(readyMutation, /\n\}$/);
   assert.ok(summary.entries.some((entry) => entry.text?.includes('marked ready for review')));
   restore();

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -34,9 +34,9 @@ else:
 PYPROJECT_FILE = Path("pyproject.toml")
 DEV_EXTRA = "dev"
 
-# Stdlib modules that don't need to be installed (keep in sync with
-# tests/test_dependency_enforcement.py)
-STDLIB_MODULES = {
+# Stdlib modules that don't need to be installed. Prefer Python's runtime
+# inventory and keep a fallback for older runtimes/consumer scripts.
+_FALLBACK_STDLIB_MODULES = {
     "abc",
     "argparse",
     "ast",
@@ -75,9 +75,9 @@ STDLIB_MODULES = {
     "re",
     "runpy",
     "email",
-    "secrets",
     "shlex",
     "shutil",
+    "secrets",
     "signal",
     "sitecustomize",
     "socket",
@@ -109,8 +109,7 @@ STDLIB_MODULES = {
     "traceback",
     "pprint",
 }
-if hasattr(sys, "stdlib_module_names"):
-    STDLIB_MODULES.update(sys.stdlib_module_names)
+STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", ())) | _FALLBACK_STDLIB_MODULES
 
 # Known test framework modules
 TEST_FRAMEWORK_MODULES = {

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -34,9 +34,9 @@ else:
 PYPROJECT_FILE = Path("pyproject.toml")
 DEV_EXTRA = "dev"
 
-# Stdlib modules that don't need to be installed (keep in sync with
-# tests/test_dependency_enforcement.py)
-STDLIB_MODULES = {
+# Stdlib modules that don't need to be installed. Prefer Python's runtime
+# inventory and keep a fallback for older runtimes/consumer scripts.
+_FALLBACK_STDLIB_MODULES = {
     "abc",
     "argparse",
     "ast",
@@ -75,9 +75,9 @@ STDLIB_MODULES = {
     "re",
     "runpy",
     "email",
-    "secrets",
     "shlex",
     "shutil",
+    "secrets",
     "signal",
     "sitecustomize",
     "socket",
@@ -101,6 +101,7 @@ STDLIB_MODULES = {
     "weakref",
     "xml",
     "zipfile",
+    "zlib",
     "__future__",
     "dataclasses",
     "enum",
@@ -108,8 +109,7 @@ STDLIB_MODULES = {
     "traceback",
     "pprint",
 }
-if hasattr(sys, "stdlib_module_names"):
-    STDLIB_MODULES.update(sys.stdlib_module_names)
+STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", ())) | _FALLBACK_STDLIB_MODULES
 
 # Known test framework modules
 TEST_FRAMEWORK_MODULES = {

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -218,7 +218,7 @@ def test_find_missing_dependencies_ignores_local_and_mapped_modules(
     assert std.find_missing_dependencies() == {"pandas"}
 
 
-def test_find_missing_dependencies_ignores_stdlib_fnmatch(
+def test_find_missing_dependencies_ignores_reviewed_stdlib_and_maps_jwt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path / "pyproject.toml"
@@ -226,7 +226,9 @@ def test_find_missing_dependencies_ignores_stdlib_fnmatch(
         "\n".join(
             [
                 "[project.optional-dependencies]",
-                "dev = []",
+                "dev = [",
+                '  "PyJWT[crypto]",',
+                "]",
             ]
         )
         + "\n",
@@ -234,12 +236,25 @@ def test_find_missing_dependencies_ignores_stdlib_fnmatch(
     )
     tests_dir = tmp_path / "tests"
     tests_dir.mkdir()
-    (tests_dir / "test_sample.py").write_text("import fnmatch\n", encoding="utf-8")
+    (tests_dir / "test_reviewed_imports.py").write_text(
+        "\n".join(
+            [
+                "import fnmatch",
+                "import html",
+                "from http.server import BaseHTTPRequestHandler",
+                "import secrets",
+                "import jwt",
+                "import pandas",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
 
-    assert std.find_missing_dependencies() == set()
+    assert std.find_missing_dependencies() == {"pandas"}
 
 
 def test_detect_local_project_modules_skips_missing_source_dir(

--- a/tests/scripts/test_sync_test_dependencies_mapping.py
+++ b/tests/scripts/test_sync_test_dependencies_mapping.py
@@ -13,7 +13,7 @@ def _load_module(module_name: str, path: Path):
     return module
 
 
-def test_pptx_maps_to_python_pptx_in_repo_script():
+def test_import_exceptions_map_to_package_names_in_repo_script():
     module = _load_module(
         "sync_test_dependencies_repo",
         Path("scripts/sync_test_dependencies.py"),
@@ -21,9 +21,10 @@ def test_pptx_maps_to_python_pptx_in_repo_script():
 
     assert module.MODULE_TO_PACKAGE["pptx"] == "python-pptx"
     assert module.MODULE_TO_PACKAGE["jwt"] == "PyJWT"
+    assert {"html", "http", "secrets"}.issubset(module.STDLIB_MODULES)
 
 
-def test_pptx_maps_to_python_pptx_in_consumer_template():
+def test_import_exceptions_map_to_package_names_in_consumer_template():
     module = _load_module(
         "sync_test_dependencies_consumer_template",
         Path("templates/consumer-repo/scripts/sync_test_dependencies.py"),


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary
- bring forward the still-relevant #1994 stdlib dependency detection fix onto current main
- keep repo and consumer sync dependency scripts aligned while preserving runtime stdlib inventory plus fallback names
- harden the draft-ready GraphQL mutation test per the outstanding #1985 review comment

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- node --test .github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Supersedes #1994 for the stdlib dependency fix and addresses the remaining actionable #1985 mutation-test review comment.