### PR TITLE
fix: harden sync review context storage

### DIFF
--- a/.github/scripts/__tests__/issue_context_utils.test.js
+++ b/.github/scripts/__tests__/issue_context_utils.test.js
@@ -167,3 +167,25 @@ test('buildCappedIssuePayload removes temporary directories after fallback', () 
     childProcess.execFileSync = originalExec;
   }
 });
+
+test('buildCappedIssuePayload preserves intentionally empty formatted body', () => {
+  const originalExecFileSync = childProcess.execFileSync;
+  childProcess.execFileSync = () =>
+    JSON.stringify({
+      formatted_body: '',
+      truncated: true,
+      estimated_tokens: 0,
+      token_budget: 1,
+    });
+
+  try {
+    const result = buildCappedIssuePayload('## Tasks\n- [ ] raw');
+
+    assert.equal(result.formattedBody, '');
+    assert.equal(result.truncated, true);
+    assert.equal(result.estimatedTokens, 0);
+    assert.equal(result.tokenBudget, 1);
+  } finally {
+    childProcess.execFileSync = originalExecFileSync;
+  }
+});

--- a/.github/scripts/issue_context_utils.js
+++ b/.github/scripts/issue_context_utils.js
@@ -37,7 +37,7 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
     const payload = JSON.parse(output);
     return {
-      formattedBody: String(payload.formatted_body || body),
+      formattedBody: String(payload.formatted_body ?? body),
       truncated: Boolean(payload.truncated),
       estimatedTokens: payload.estimated_tokens,
       tokenBudget: payload.token_budget,

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -411,6 +411,29 @@ def _decode_record_candidate(candidate: str) -> str:
     return value
 
 
+def _marker_safe_text(value: Any, limit: int = 1000) -> str:
+    text = str(value or "")
+    if len(text) > limit:
+        text = f"{text[:limit]}...[truncated {len(text) - limit} chars]"
+    return text.replace("-->", "--\\u003e")
+
+
+def _compact_runner_result_payload(result_payload: dict[str, Any]) -> dict[str, Any]:
+    final_message = str(result_payload.get("final_message") or "")
+    compact: dict[str, Any] = {
+        "schema": "runner-result-summary/v1",
+        "provider": str(result_payload.get("provider") or ""),
+        "success": bool(result_payload.get("success")),
+        "summary": _marker_safe_text(result_payload.get("summary")),
+        "error": _marker_safe_text(result_payload.get("error")),
+        "truncated": bool(result_payload.get("truncated")),
+    }
+    if final_message:
+        compact["final_message_sha256"] = hashlib.sha256(final_message.encode("utf-8")).hexdigest()
+        compact["final_message_chars"] = len(final_message)
+    return compact
+
+
 def _extract_record(value: str | None, pr_number: int, provider: str) -> dict[str, Any] | None:
     if not value:
         return None
@@ -695,17 +718,13 @@ def record_completion(
         dataclasses.asdict(result) if dataclasses.is_dataclass(result) else dict(result)
     )
     status = "completed" if result_payload.get("success") else "error"
+    compact_result = _compact_runner_result_payload(result_payload)
     prior = storage.read_record(pr_number, provider) or {}
     completed_at = (
         prior.get("completed_at")
         if prior.get("key") == key and prior.get("status") in TERMINAL_STATUSES
         else _utc_now()
     )
-    compact_result = {
-        field: result_payload.get(field)
-        for field in ("provider", "success", "summary", "error", "truncated")
-        if field in result_payload
-    }
     record = {
         **prior,
         "provider": provider,

--- a/templates/consumer-repo/.github/scripts/issue_context_utils.js
+++ b/templates/consumer-repo/.github/scripts/issue_context_utils.js
@@ -37,7 +37,7 @@ function buildCappedIssuePayload(issueBody, options = {}) {
     const output = childProcess.execFileSync('python3', args, { encoding: 'utf8' });
     const payload = JSON.parse(output);
     return {
-      formattedBody: String(payload.formatted_body || body),
+      formattedBody: String(payload.formatted_body ?? body),
       truncated: Boolean(payload.truncated),
       estimatedTokens: payload.estimated_tokens,
       tokenBudget: payload.token_budget,

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -200,6 +200,31 @@ def test_record_completion_stores_compact_result_payload() -> None:
 
     assert record["result"]["summary"] == "x" * 500
     assert "final_message" not in record["result"]
+    assert len(record["result"]["final_message_sha256"]) == 64
+    assert record["result"]["final_message_chars"] == 10000
+
+
+def test_record_completion_stores_compact_marker_safe_result() -> None:
+    storage = MemoryRunnerStorage()
+    result = {
+        "provider": "claude",
+        "success": True,
+        "final_message": "full output --> with marker closer",
+        "summary": "summary --> closer",
+        "error": None,
+        "truncated": False,
+    }
+
+    record = record_completion(42, "aaa", "claude", result, storage=storage)
+
+    stored_result = storage.records[(42, "claude")]["result"]
+    assert record["result"] == stored_result
+    assert stored_result["schema"] == "runner-result-summary/v1"
+    assert stored_result["summary"] == "summary --\\u003e closer"
+    assert "final_message" not in stored_result
+    assert stored_result["final_message_chars"] == len(result["final_message"])
+    assert len(stored_result["final_message_sha256"]) == 64
+    assert "-->" not in json.dumps(stored_result)
 
 
 def test_materialize_reference_packs_keeps_token_out_of_git_argv(


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary
- preserve intentionally empty capped issue-context formatted bodies
- store compact marker-safe runner result summaries instead of raw final output
- keep consumer template copy aligned

## Validation
- node --test .github/scripts/__tests__/issue_context_utils.test.js
- uv run pytest tests/scripts/test_runner_lib.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Supersedes #2048 with a clean source-only branch.