### PR TITLE
fix: address sync review follow-ups

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -16,7 +16,7 @@ const {
   updateTrackerBody,
 } = require('../sync_tracker_state');
 
-function mockGithub({ issues = [], pulls = [] } = {}) {
+function mockGithub({ issues = [], issueDetails = null, pulls = [] } = {}) {
   const calls = {
     createdIssues: [],
     issueLists: [],
@@ -51,7 +51,7 @@ function mockGithub({ issues = [], pulls = [] } = {}) {
       issues: {
         listForRepo: async () => ({ data: issues }),
         get: async ({ issue_number }) => ({
-          data: issues.find((issue) => issue.number === issue_number),
+          data: (issueDetails || issues).find((issue) => issue.number === issue_number),
         }),
         create: async (params) => {
           calls.createdIssues.push(params);
@@ -208,7 +208,7 @@ test('findOrCreateTracker discovers an unlabeled tracker by marker', async () =>
   );
 });
 
-test('issueMatchesTracker rejects unlabelled title-only tracker candidates', () => {
+test('issueMatchesTracker rejects unlabelled title-only issues', () => {
   const issue = {
     number: 14,
     title: 'Sync/Dependabot campaign queue',
@@ -225,7 +225,7 @@ test('issueMatchesTracker rejects unlabelled title-only tracker candidates', () 
   );
 });
 
-test('issueMatchesTracker rejects empty title-only candidates when a marker is required', () => {
+test('issueMatchesTracker allows bodyless title candidates only for preliminary marker lookups', () => {
   const issue = {
     number: 15,
     title: 'Consumer repo drift detected',
@@ -238,18 +238,73 @@ test('issueMatchesTracker rejects empty title-only candidates when a marker is r
       label: 'consumer-sync',
       titlePattern: 'Consumer repo drift detected',
       markerPattern: /consumer-sync-drift:v1/,
+      allowBodylessTitleCandidate: true,
+    }),
+    true,
+  );
+  assert.equal(
+    issueMatchesTracker(issue, {
+      label: 'consumer-sync',
+      titlePattern: 'Consumer repo drift detected',
+      markerPattern: /consumer-sync-drift:v1/,
+    }),
+    false,
+  );
+  assert.equal(
+    issueMatchesTracker(issue, {
+      label: 'consumer-sync',
+      markerPattern: /consumer-sync-drift:v1/,
+      allowBodylessTitleCandidate: true,
     }),
     false,
   );
 });
 
-test('findOrCreateTracker ignores unlabelled title-only issues', async () => {
+test('findOrCreateTracker fetches bodyless marker candidates before matching', async () => {
   const github = mockGithub({
     issues: [
       {
         number: 14,
+        title: 'Consumer repo drift detected',
+        body: '',
+        labels: [],
+      },
+    ],
+    issueDetails: [
+      {
+        number: 14,
+        title: 'Consumer repo drift detected',
+        body: '<!-- consumer-sync-drift:v1 {"schema":"consumer-sync-drift-issue/v1"} -->',
+        labels: [],
+      },
+    ],
+  });
+
+  const tracker = await findOrCreateTracker({
+    github,
+    owner: 'stranske',
+    repo: 'Workflows',
+    label: 'consumer-sync',
+    titlePattern: 'Consumer repo drift detected',
+    markerPattern: /consumer-sync-drift:v1/,
+  });
+
+  assert.equal(tracker.number, 14);
+  assert.equal(tracker.sync_tracker_created, false);
+  assert.equal(github.calls.createdIssues.length, 0);
+  assert.equal(
+    github.calls.issueLists.some((params) => !params.labels),
+    true,
+  );
+});
+
+test('findOrCreateTracker does not reuse unrelated title-only issues', async () => {
+  const github = mockGithub({
+    issues: [
+      {
+        number: 16,
         title: 'Sync/Dependabot campaign queue',
-        body: 'existing queue body',
+        body: 'unrelated discussion',
         labels: [],
       },
     ],
@@ -261,15 +316,13 @@ test('findOrCreateTracker ignores unlabelled title-only issues', async () => {
     repo: 'Workflows',
     label: 'campaign:sync-dependabot',
     titlePattern: /^Sync\/Dependabot campaign queue$/,
+    title: 'Sync/Dependabot campaign queue',
+    body: 'new body',
   });
 
   assert.equal(tracker.number, 99);
   assert.equal(tracker.sync_tracker_created, true);
   assert.equal(github.calls.createdIssues.length, 1);
-  assert.equal(
-    github.calls.issueLists.some((params) => !params.labels),
-    true,
-  );
 });
 
 test('findOrCreateTracker creates a durable tracker when none is found', async () => {

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -151,7 +151,10 @@ function issueHasMarker(issue = {}, markerPattern = null) {
   return patternMatches(issue.body || '', markerPattern);
 }
 
-function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+function issueMatchesTracker(
+  issue = {},
+  { label, titlePattern, markerPattern, allowBodylessTitleCandidate = false } = {},
+) {
   if (issue.pull_request) {
     return false;
   }
@@ -160,8 +163,16 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasRequiredLabel = requiredLabels.length === 0 ||
     requiredLabels.some((name) => names.includes(name));
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
-  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasTitle = Boolean(titlePattern) && patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
+  if (
+    allowBodylessTitleCandidate &&
+    markerPattern &&
+    hasTitle &&
+    !cleanString(issue.body)
+  ) {
+    return true;
+  }
   return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
 }
 
@@ -209,7 +220,12 @@ async function findTracker({ github, owner, repo, label, titlePattern, markerPat
     }
   }
   for (const issue of byNumber.values()) {
-    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+    if (!issueMatchesTracker(issue, {
+      label,
+      titlePattern,
+      markerPattern,
+      allowBodylessTitleCandidate: true,
+    })) {
       continue;
     }
     const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });

--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 
@@ -337,14 +338,18 @@ jobs:
               source_type: 'review-thread',
               source_id: value.prNumber || process.env.GITHUB_RUN_ID || 'unknown',
               pr_number: value.prNumber,
-              disposition: value.reusableExpected ? 'reusable-invocation-expected' : 'wrapper-skipped',
+              disposition: value.reusableExpected
+                ? 'reusable-invocation-expected'
+                : 'wrapper-skipped',
               reason: value.reusableExpected
                 ? 'Wrapper resolved an eligible PR and invoked the reusable bot-comment handler.'
                 : value.skipReason,
               workflow: process.env.GITHUB_WORKFLOW || '',
               run_id: process.env.GITHUB_RUN_ID || '',
               run_attempt: process.env.GITHUB_RUN_ATTEMPT || '',
-              artifact_name: `review-thread-terminal-disposition-${process.env.GITHUB_RUN_ID || ''}`,
+              artifact_name: `review-thread-terminal-disposition-${
+                process.env.GITHUB_RUN_ID || ''
+              }`,
               artifact_family: 'review-thread-terminal-disposition',
               actor: process.env.GITHUB_ACTOR || '',
               needs_human: false,
@@ -369,7 +374,8 @@ jobs:
           const record = buildWrapperTerminalDisposition({
             prNumber,
             reusableExpected,
-            skipReason: process.env.SKIP_REASON || 'Wrapper did not find eligible bot-comment work.',
+            skipReason:
+              process.env.SKIP_REASON || 'Wrapper did not find eligible bot-comment work.',
             env: process.env,
           });
           fs.writeFileSync(

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-moderate-connector.yml
+++ b/.github/workflows/agents-moderate-connector.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -412,14 +412,15 @@ def _decode_record_candidate(candidate: str) -> str:
 
 
 def _marker_safe_text(value: Any, limit: int = 1000) -> str:
-    text = str(value or "")
+    text = "" if value is None else str(value)
     if len(text) > limit:
         text = f"{text[:limit]}...[truncated {len(text) - limit} chars]"
     return text.replace("-->", "--\\u003e")
 
 
 def _compact_runner_result_payload(result_payload: dict[str, Any]) -> dict[str, Any]:
-    final_message = str(result_payload.get("final_message") or "")
+    final_message_value = result_payload.get("final_message")
+    final_message = "" if final_message_value is None else str(final_message_value)
     compact: dict[str, Any] = {
         "schema": "runner-result-summary/v1",
         "provider": str(result_payload.get("provider") or ""),

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -151,7 +151,10 @@ function issueHasMarker(issue = {}, markerPattern = null) {
   return patternMatches(issue.body || '', markerPattern);
 }
 
-function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } = {}) {
+function issueMatchesTracker(
+  issue = {},
+  { label, titlePattern, markerPattern, allowBodylessTitleCandidate = false } = {},
+) {
   if (issue.pull_request) {
     return false;
   }
@@ -160,8 +163,16 @@ function issueMatchesTracker(issue = {}, { label, titlePattern, markerPattern } 
   const hasRequiredLabel = requiredLabels.length === 0 ||
     requiredLabels.some((name) => names.includes(name));
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
-  const hasTitle = patternMatches(issue.title || '', titlePattern);
+  const hasTitle = Boolean(titlePattern) && patternMatches(issue.title || '', titlePattern);
   const hasMarker = issueHasMarker(issue, markerPattern);
+  if (
+    allowBodylessTitleCandidate &&
+    markerPattern &&
+    hasTitle &&
+    !cleanString(issue.body)
+  ) {
+    return true;
+  }
   return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
 }
 
@@ -209,7 +220,12 @@ async function findTracker({ github, owner, repo, label, titlePattern, markerPat
     }
   }
   for (const issue of byNumber.values()) {
-    if (!issueMatchesTracker(issue, { label, titlePattern, markerPattern })) {
+    if (!issueMatchesTracker(issue, {
+      label,
+      titlePattern,
+      markerPattern,
+      allowBodylessTitleCandidate: true,
+    })) {
       continue;
     }
     const fullIssue = await getIssue({ github, owner, repo, issueNumber: issue.number, core, withRetry });

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -227,6 +227,25 @@ def test_record_completion_stores_compact_marker_safe_result() -> None:
     assert "-->" not in json.dumps(stored_result)
 
 
+def test_record_completion_preserves_falsy_result_text() -> None:
+    storage = MemoryRunnerStorage()
+    result = {
+        "provider": "claude",
+        "success": False,
+        "final_message": False,
+        "summary": 0,
+        "error": False,
+        "truncated": False,
+    }
+
+    record = record_completion(42, "aaa", "claude", result, storage=storage)
+
+    assert record["result"]["summary"] == "0"
+    assert record["result"]["error"] == "False"
+    assert record["result"]["final_message_chars"] == len("False")
+    assert len(record["result"]["final_message_sha256"]) == 64
+
+
 def test_materialize_reference_packs_keeps_token_out_of_git_argv(
     tmp_path: Path, monkeypatch: Any
 ) -> None:


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary
- checkout local eligibility action from a trusted base ref before running it
- preserve falsy runner result text in compact marker-safe payloads
- restore legacy title-only tracker reuse to avoid duplicate tracker issues

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- uv run pytest tests/scripts/test_runner_lib.py tests/workflows/test_bot_comment_handler.py::test_bot_comment_handler_wrappers_emit_terminal_disposition_artifact -q
- python scripts/validate_workflow_yaml.py <changed workflow files>
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Addresses inline review comments on the current consumer sync PR batch.