### PR TITLE
fix: preserve label-only tracker matching

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -225,6 +225,56 @@ test('issueMatchesTracker rejects unlabelled title-only issues', () => {
   );
 });
 
+test('issueMatchesTracker preserves label-only tracker matching', () => {
+  assert.equal(
+    issueMatchesTracker({
+      number: 15,
+      title: 'Any title',
+      body: 'existing tracker body',
+      labels: [{ name: 'campaign:sync-dependabot' }],
+    }, {
+      label: 'campaign:sync-dependabot',
+    }),
+    true,
+  );
+  assert.equal(
+    issueMatchesTracker({
+      number: 16,
+      title: 'Any title',
+      body: '',
+      labels: [],
+    }, {
+      markerPattern: /sync-dependabot-campaign:v1/,
+      allowBodylessTitleCandidate: true,
+    }),
+    false,
+  );
+  assert.equal(
+    issueMatchesTracker({
+      number: 17,
+      title: 'Any title',
+      body: '',
+      labels: [{ name: 'campaign:sync-dependabot' }],
+    }, {
+      label: 'campaign:sync-dependabot',
+      markerPattern: /sync-dependabot-campaign:v1/,
+    }),
+    false,
+  );
+  assert.equal(
+    issueMatchesTracker({
+      number: 18,
+      title: 'Any title',
+      body: '<!-- sync-dependabot-campaign:v1 {} -->',
+      labels: [{ name: 'campaign:sync-dependabot' }],
+    }, {
+      label: 'campaign:sync-dependabot',
+      markerPattern: /sync-dependabot-campaign:v1/,
+    }),
+    true,
+  );
+});
+
 test('issueMatchesTracker allows bodyless title candidates only for preliminary marker lookups', () => {
   const issue = {
     number: 15,

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -160,20 +160,30 @@ function issueMatchesTracker(
   }
   const names = labelNames(issue);
   const requiredLabels = unique([label]).filter(Boolean);
-  const hasRequiredLabel = requiredLabels.length === 0 ||
+  const hasRequiredLabel = requiredLabels.length > 0 &&
     requiredLabels.some((name) => names.includes(name));
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
-  const hasTitle = Boolean(titlePattern) && patternMatches(issue.title || '', titlePattern);
+  const hasTitleConstraint = Boolean(titlePattern);
+  const hasMarkerConstraint = Boolean(markerPattern);
+  const hasTitle = hasTitleConstraint ? patternMatches(issue.title || '', titlePattern) : true;
   const hasMarker = issueHasMarker(issue, markerPattern);
+  const hasLabelGate = hasDurableLabel || hasRequiredLabel;
   if (
     allowBodylessTitleCandidate &&
+    hasTitleConstraint &&
     markerPattern &&
     hasTitle &&
     !cleanString(issue.body)
   ) {
     return true;
   }
-  return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
+  if (!hasTitleConstraint && hasMarkerConstraint) {
+    return hasMarker;
+  }
+  if (!hasTitleConstraint) {
+    return hasLabelGate;
+  }
+  return (hasLabelGate || hasMarker) && (hasTitle || hasMarker);
 }
 
 async function ensureLabels({

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -160,20 +160,30 @@ function issueMatchesTracker(
   }
   const names = labelNames(issue);
   const requiredLabels = unique([label]).filter(Boolean);
-  const hasRequiredLabel = requiredLabels.length === 0 ||
+  const hasRequiredLabel = requiredLabels.length > 0 &&
     requiredLabels.some((name) => names.includes(name));
   const hasDurableLabel = names.includes(DURABLE_TRACKER_LABEL);
-  const hasTitle = Boolean(titlePattern) && patternMatches(issue.title || '', titlePattern);
+  const hasTitleConstraint = Boolean(titlePattern);
+  const hasMarkerConstraint = Boolean(markerPattern);
+  const hasTitle = hasTitleConstraint ? patternMatches(issue.title || '', titlePattern) : true;
   const hasMarker = issueHasMarker(issue, markerPattern);
+  const hasLabelGate = hasDurableLabel || hasRequiredLabel;
   if (
     allowBodylessTitleCandidate &&
+    hasTitleConstraint &&
     markerPattern &&
     hasTitle &&
     !cleanString(issue.body)
   ) {
     return true;
   }
-  return (hasDurableLabel || hasRequiredLabel || hasMarker) && (hasTitle || hasMarker);
+  if (!hasTitleConstraint && hasMarkerConstraint) {
+    return hasMarker;
+  }
+  if (!hasTitleConstraint) {
+    return hasLabelGate;
+  }
+  return (hasLabelGate || hasMarker) && (hasTitle || hasMarker);
 }
 
 async function ensureLabels({


### PR DESCRIPTION
## Summary
- preserve label-only tracker matching while keeping marker-only empty-body candidates gated
- mirror the tracker matching fix into the consumer template copy
- add regression coverage for label-only and marker-only matching

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

<!-- workflow-source:review_followup -->