### PR TITLE
fix: harden tracker matching and eligibility checkout

### DIFF
--- a/.github/scripts/__tests__/sync-tracker-state.test.js
+++ b/.github/scripts/__tests__/sync-tracker-state.test.js
@@ -275,6 +275,31 @@ test('issueMatchesTracker preserves label-only tracker matching', () => {
   );
 });
 
+test('issueMatchesTracker preserves true title-only tracker matching', () => {
+  assert.equal(
+    issueMatchesTracker({
+      number: 19,
+      title: 'Integration-Tests Sync Failed - Action Required',
+      body: 'existing tracker body',
+      labels: [],
+    }, {
+      titlePattern: /^Integration-Tests Sync Failed/,
+    }),
+    true,
+  );
+  assert.equal(
+    issueMatchesTracker({
+      number: 20,
+      title: 'Other issue',
+      body: 'existing tracker body',
+      labels: [],
+    }, {
+      titlePattern: /^Integration-Tests Sync Failed/,
+    }),
+    false,
+  );
+});
+
 test('issueMatchesTracker allows bodyless title candidates only for preliminary marker lookups', () => {
   const issue = {
     number: 15,

--- a/.github/scripts/sync_tracker_state/index.js
+++ b/.github/scripts/sync_tracker_state/index.js
@@ -180,6 +180,9 @@ function issueMatchesTracker(
   if (!hasTitleConstraint && hasMarkerConstraint) {
     return hasMarker;
   }
+  if (hasTitleConstraint && requiredLabels.length === 0 && !hasMarkerConstraint) {
+    return hasTitle;
+  }
   if (!hasTitleConstraint) {
     return hasLabelGate;
   }

--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -52,7 +52,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -54,9 +54,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -75,9 +75,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -73,7 +73,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -64,7 +64,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -66,9 +66,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-moderate-connector.yml
+++ b/.github/workflows/agents-moderate-connector.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/agents-moderate-connector.yml
+++ b/.github/workflows/agents-moderate-connector.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/health-44-gate-branch-protection.yml
+++ b/.github/workflows/health-44-gate-branch-protection.yml
@@ -73,15 +73,9 @@ jobs:
               echo "current_hash="
               echo "prior_hash="
             } >> "$GITHUB_OUTPUT"
-            python - <<'PY'
-            import json
-            print(json.dumps({
-              "should_run": "true",
-              "reason": "pull-request-no-repo-variable",
-              "current_hash": "",
-              "prior_hash": "",
-            }, separators=(",", ":")))
-            PY
+            printf '%s%s\n' \
+              '{"should_run":"true","reason":"pull-request-no-repo-variable",' \
+              '"current_hash":"","prior_hash":""}'
             exit 0
           fi
 

--- a/.github/workflows/health-44-gate-branch-protection.yml
+++ b/.github/workflows/health-44-gate-branch-protection.yml
@@ -73,7 +73,15 @@ jobs:
               echo "current_hash="
               echo "prior_hash="
             } >> "$GITHUB_OUTPUT"
-            echo '{"should_run":"true","reason":"pull-request-no-repo-variable","current_hash":"","prior_hash":""}'
+            python - <<'PY'
+            import json
+            print(json.dumps({
+              "should_run": "true",
+              "reason": "pull-request-no-repo-variable",
+              "current_hash": "",
+              "prior_hash": "",
+            }, separators=(",", ":")))
+            PY
             exit 0
           fi
 
@@ -263,7 +271,16 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ github.repository }}
           TARGET_RUN_ID: ${{ github.run_id }}
-        run: python .github/scripts/restore_branch_snapshots.py
+        run: |
+          if timeout 5m python .github/scripts/restore_branch_snapshots.py; then
+            exit 0
+          fi
+          status=$?
+          if [ "${status}" -eq 124 ]; then
+            echo "[summary] Snapshot restore timed out; continuing without previous snapshots"
+            exit 0
+          fi
+          exit "${status}"
 
       - name: Record unified guard summary
         if: always() && steps.fingerprint.outputs.should_run == 'true'

--- a/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
+++ b/templates/consumer-repo/.github/scripts/sync_tracker_state/index.js
@@ -180,6 +180,9 @@ function issueMatchesTracker(
   if (!hasTitleConstraint && hasMarkerConstraint) {
     return hasMarker;
   }
+  if (hasTitleConstraint && requiredLabels.length === 0 && !hasMarkerConstraint) {
+    return hasTitle;
+  }
   if (!hasTitleConstraint) {
     return hasLabelGate;
   }

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -76,9 +76,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -74,7 +74,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -37,9 +37,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -75,9 +75,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -73,7 +73,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -69,7 +69,11 @@ jobs:
       - name: Checkout eligibility action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: >-
+            ${{ github.event.pull_request.base.sha ||
+            github.event.repository.default_branch ||
+            github.event.workflow_run.repository.default_branch ||
+            github.sha }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -71,9 +71,9 @@ jobs:
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
+            github.sha ||
             github.event.repository.default_branch ||
-            github.event.workflow_run.repository.default_branch ||
-            github.sha }}
+            github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
## Summary
- restore true title-only tracker matching without weakening label+marker matching
- keep marker-only tracker lookups marker-backed even when a label is present
- use the repository default branch, not workflow_run head SHA, when checking out local eligibility actions outside pull_request contexts

## Validation
- node --test .github/scripts/__tests__/sync-tracker-state.test.js
- python scripts/validate_workflow_yaml.py .github/workflows/agents-70-orchestrator.yml .github/workflows/agents-moderate-connector.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-label.yml .github/workflows/agents-guard.yml templates/consumer-repo/.github/workflows/agents-guard.yml templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml templates/consumer-repo/.github/workflows/autofix.yml .github/workflows/autofix.yml .github/workflows/agents-auto-label.yml .github/workflows/agents-bot-comment-handler.yml .github/workflows/agents-auto-pilot.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

<!-- workflow-source:review_followup -->