### PR TITLE
Capture LangSmith agent trace coverage

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -720,6 +720,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           PYTHONPATH: ${{ github.workspace }}
           ISSUE_PR_CONTEXT_WORKFLOW: agents-auto-pilot
         run: |
@@ -940,6 +943,8 @@ jobs:
           AUTOPILOT_STEP_NAME: format
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
+          LANGSMITH_TRACE_ID: ""
+          LANGSMITH_TRACE_URL: ""
         run: |
           success="${{ steps.format_step.outcome == 'success' }}"
           failure_reason="none"
@@ -972,6 +977,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
@@ -1061,6 +1069,27 @@ jobs:
                   f.write(reason)
               sys.exit(0)
           "
+
+          python - <<'PY'
+          import json
+          import os
+
+          try:
+              with open('/tmp/suggestions.json', encoding='utf-8') as handle:
+                  data = json.load(handle)
+          except Exception:
+              data = {}
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = str(data.get('langsmith_trace_id') or '').strip()
+              trace_url = str(data.get('langsmith_trace_url') or '').strip()
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID={trace_id}\n")
+                  if trace_url:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL={trace_url}\n")
+          PY
 
           # If guard blocked, apply needs-human + pause labels and stop
           if [ -f /tmp/guard_blocked ]; then
@@ -1217,6 +1246,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.optimize_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then
@@ -1327,6 +1358,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
@@ -1406,6 +1440,7 @@ jobs:
           # Extract and apply suggestions
           python -c "
           import json
+          import os
           import sys
           import re
           sys.path.insert(0, 'scripts/langchain')
@@ -1432,6 +1467,16 @@ jobs:
 
           # Apply suggestions
           result = apply_suggestions(issue_body, suggestions, use_llm=True)
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = str(result.get('langsmith_trace_id') or '').strip()
+              trace_url = str(result.get('langsmith_trace_url') or '').strip()
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_ID={trace_id}\n')
+                  if trace_url:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_URL={trace_url}\n')
 
           # Check for guard_blocked
           if result.get('guard_blocked'):
@@ -1574,6 +1619,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_APPLY_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_APPLY_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.apply_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then

--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -92,14 +92,18 @@ jobs:
               echo "  Downloading artifact: $artifact_name (ID: $artifact_id)"
 
               # Download artifact zip
+              zip_path=".metrics-tmp/${run_id}_${artifact_id}_${artifact_name}.zip"
               gh api --method GET \
                 -H "Accept: application/vnd.github+json" \
                 "/repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" \
-                > ".metrics-tmp/${artifact_name}.zip" || continue
+                > "$zip_path" || continue
 
-              # Extract NDJSON from zip
-              unzip -q -o ".metrics-tmp/${artifact_name}.zip" -d ".metrics-tmp/" || continue
-              rm ".metrics-tmp/${artifact_name}.zip"
+              # Extract NDJSON from each artifact into a unique directory so
+              # fixed artifact filenames from multiple runs do not overwrite.
+              artifact_dir=".metrics-tmp/extracted/${run_id}_${artifact_id}"
+              mkdir -p "$artifact_dir"
+              unzip -q -o "$zip_path" -d "$artifact_dir" || continue
+              rm "$zip_path"
 
               COUNT=$((COUNT + 1))
             done < ".metrics-tmp/artifacts_${run_id}.json"

--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -53,39 +53,46 @@ jobs:
           echo "📊 Downloading metrics artifacts from last $DAYS_BACK days..."
           echo "Cutoff date: $CUTOFF_DATE"
 
-          # Get workflow runs from autopilot workflow
-          WORKFLOW_PATH="agents-auto-pilot.yml"
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${{ github.repository }}/actions/workflows/$WORKFLOW_PATH/runs" \
-            -f per_page=100 -f status=completed \
-            --jq ".workflow_runs[] | select(.created_at >= \"$CUTOFF_DATE\") | .id" \
-            > .metrics-tmp/run_ids.txt || echo "No runs found"
+          # Get workflow runs from metric-producing workflows.
+          : > .metrics-tmp/run_ids.txt
+          for WORKFLOW_PATH in agents-auto-pilot.yml reusable-agents-verifier.yml; do
+            gh api --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${{ github.repository }}/actions/workflows/$WORKFLOW_PATH/runs" \
+              -F per_page=100 -F status=completed \
+              --jq ".workflow_runs[] | select(.created_at >= \"$CUTOFF_DATE\") | .id" \
+              >> .metrics-tmp/run_ids.txt || true
+          done
+          sort -u .metrics-tmp/run_ids.txt -o .metrics-tmp/run_ids.txt
 
           # Download artifacts from each run
           COUNT=0
           while IFS= read -r run_id; do
+            if [ -z "$run_id" ]; then
+              continue
+            fi
             echo "Checking run $run_id for metrics artifacts..."
 
             # List artifacts for this run
-            gh api \
+            gh api --method GET \
               -H "Accept: application/vnd.github+json" \
               "/repos/${{ github.repository }}/actions/runs/$run_id/artifacts" \
               --jq '.artifacts[] |
-                select(.name | startswith("autopilot-metrics-")) |
-                {name: .name, id: .id}' \
+                select((.name | startswith("autopilot-metrics-")) or .name == "agents-verifier-metrics") |
+                [.name, .id] | @tsv' \
               > ".metrics-tmp/artifacts_${run_id}.json" || continue
 
             # Download each artifact
-            while IFS= read -r artifact; do
-              artifact_name=$(echo "$artifact" | jq -r '.name')
-              artifact_id=$(echo "$artifact" | jq -r '.id')
+            while IFS=$'\t' read -r artifact_name artifact_id; do
+              if [ -z "$artifact_name" ] || [ -z "$artifact_id" ]; then
+                continue
+              fi
 
               echo "  Downloading artifact: $artifact_name (ID: $artifact_id)"
 
               # Download artifact zip
-              gh api \
+              gh api --method GET \
                 -H "Accept: application/vnd.github+json" \
                 "/repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" \
                 > ".metrics-tmp/${artifact_name}.zip" || continue
@@ -121,14 +128,14 @@ jobs:
 
           # Generate markdown report
           python scripts/aggregate_metrics.py \
-            .metrics-tmp/combined-metrics.ndjson \
-            --format markdown \
+            --metrics-file .metrics-tmp/combined-metrics.ndjson \
+            --output-format markdown \
             > .metrics-tmp/report.md
 
           # Generate JSON summary
           python scripts/aggregate_metrics.py \
-            .metrics-tmp/combined-metrics.ndjson \
-            --format json \
+            --metrics-file .metrics-tmp/combined-metrics.ndjson \
+            --output-format json \
             > .metrics-tmp/summary.json
 
           echo "✅ Generated metrics report"

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -1368,7 +1368,47 @@ jobs:
                   if re.match(r"^\s*[-*]\s+\[[ xX]\]", line):
                       checks_run += 1
 
+          langsmith_traces = []
+          evaluation_json = Path("evaluation.json")
+          comparison_json = Path("comparison.json")
+          if evaluation_json.is_file():
+              try:
+                  data = json.loads(evaluation_json.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  data = {}
+              trace_id = data.get("langsmith_trace_id")
+              trace_url = data.get("langsmith_trace_url")
+              if trace_id or trace_url:
+                  langsmith_traces.append(
+                      {
+                          "operation": "evaluation",
+                          "provider": data.get("provider") or "",
+                          "trace_id": trace_id or "",
+                          "trace_url": trace_url or "",
+                      }
+                  )
+          if comparison_json.is_file():
+              try:
+                  data = json.loads(comparison_json.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  data = {}
+              for index, result in enumerate(data.get("results", [])):
+                  if not isinstance(result, dict):
+                      continue
+                  trace_id = result.get("langsmith_trace_id")
+                  trace_url = result.get("langsmith_trace_url")
+                  if trace_id or trace_url:
+                      langsmith_traces.append(
+                          {
+                              "operation": "comparison",
+                              "provider": result.get("provider") or f"provider-{index}",
+                              "trace_id": trace_id or "",
+                              "trace_url": trace_url or "",
+                          }
+                      )
+
           metrics = {
+              "metric_type": "evaluation",
               "pr_number": pr_number,
               "verdict": verdict,
               "issues_created": issues_created,
@@ -1383,6 +1423,10 @@ jobs:
               "chain_depth": chain_depth,
               "recorded_at": datetime.now(timezone.utc).isoformat(),
           }
+          if langsmith_traces:
+              metrics["langsmith_trace_id"] = langsmith_traces[0].get("trace_id", "")
+              metrics["langsmith_trace_url"] = langsmith_traces[0].get("trace_url", "")
+              metrics["langsmith_traces"] = langsmith_traces
 
           print(json.dumps(metrics, indent=2))
           with open(os.environ["GITHUB_OUTPUT"], "a") as fp:

--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -486,6 +486,14 @@ jobs:
               }
             }
 
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }
+
+            function matchesExpectedArtifact(actual, expected) {
+              return actual === expected || new RegExp(`^${escapeRegExp(expected)}-\\d+$`).test(actual);
+            }
+
             let artifactNames;
             let jobs;
             try {
@@ -540,17 +548,20 @@ jobs:
             const nameSet = new Set(artifactNames);
 
             const matrixJobs = jobs.filter((job) => job.name && job.name.startsWith('Scenario - '));
-            const jobStatusByScenario = Object.fromEntries(
-              matrixJobs.map((job) => {
-                const scenarioName = job.name.replace('Scenario - ', '').trim();
-                const status = job.conclusion === 'success'
-                  ? '✅'
-                  : job.conclusion === 'failure'
-                    ? '❌'
-                    : 'ℹ️';
-                return [scenarioName, status];
-              })
-            );
+            const jobStatusByScenario = {};
+            for (const job of matrixJobs) {
+              const scenarioName = job.name.replace('Scenario - ', '').split('/')[0].trim();
+              if (!scenarioNames.includes(scenarioName)) {
+                continue;
+              }
+              if (job.conclusion === 'failure' || job.conclusion === 'cancelled') {
+                jobStatusByScenario[scenarioName] = '❌';
+              } else if (job.conclusion !== 'success' && job.conclusion !== 'skipped') {
+                jobStatusByScenario[scenarioName] = 'ℹ️';
+              } else if (!jobStatusByScenario[scenarioName]) {
+                jobStatusByScenario[scenarioName] = '✅';
+              }
+            }
 
             const rows = [
               '| Scenario | Status | Missing | Unexpected |',
@@ -566,10 +577,14 @@ jobs:
 
             for (const scenario of scenarioNames) {
               const expected = expectedArtifactsFor(scenario);
-              const missing = expected.filter((name) => !nameSet.has(name));
+              const missing = expected.filter(
+                (name) => !artifactNames.some((actual) => matchesExpectedArtifact(actual, name)),
+              );
               const prefix = `sf-${scenario}-`;
               const actual = artifactNames.filter((name) => name.startsWith(prefix));
-              const unexpected = actual.filter((name) => !expected.includes(name));
+              const unexpected = actual.filter(
+                (name) => !expected.some((expectedName) => matchesExpectedArtifact(name, expectedName)),
+              );
               const ok =
                 missing.length === 0 &&
                 unexpected.length === 0 &&
@@ -591,7 +606,11 @@ jobs:
             }
 
             const stray = artifactNames.filter(
-              (name) => name.startsWith('sf-') && !expectedUniverse.has(name),
+              (name) =>
+                name.startsWith('sf-') &&
+                !Array.from(expectedUniverse).some((expected) =>
+                  matchesExpectedArtifact(name, expected)
+                ),
             );
             if (stray.length) {
               rows.push(`| (stray) | ❌ | (n/a) | ${stray.join('<br>')} |`);

--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -640,6 +640,7 @@ jobs:
   publish:
     name: Publish Results
     needs:
+      - select-scenarios
       - scenarios
       - summarize
     if: ${{ always() }}
@@ -676,6 +677,7 @@ jobs:
           'nightly verification'
         }}
       WORKFLOW_RESULT: ${{ needs.scenarios.result }}
+      SELECTED_COUNT: ${{ needs.select-scenarios.outputs.selected_count || '0' }}
       SUMMARY_TABLE: ${{ needs.summarize.outputs.summary_table }}
       FAILURE_COUNT: ${{ needs.summarize.outputs.failure_count }}
       RUN_ID: ${{ needs.summarize.outputs.run_id }}
@@ -793,6 +795,11 @@ jobs:
           if [ "${FAILURE_COUNT}" != "0" ]; then
             echo "Self-test reported ${FAILURE_COUNT} mismatch(es)." >&2
             exit 1
+          fi
+
+          if [ "${WORKFLOW_RESULT}" = "skipped" ] && [ "${SELECTED_COUNT}" = "0" ]; then
+            echo "Self-test matrix skipped because no scenarios were selected."
+            exit 0
           fi
 
           if [ "${WORKFLOW_RESULT}" != "success" ]; then
@@ -934,6 +941,11 @@ jobs:
           if [ "${FAILURE_COUNT}" != "0" ]; then
             echo "Self-test reported ${FAILURE_COUNT} mismatch(es)." >&2
             exit 1
+          fi
+
+          if [ "${WORKFLOW_RESULT}" = "skipped" ] && [ "${SELECTED_COUNT}" = "0" ]; then
+            echo "Self-test matrix skipped because no scenarios were selected."
+            exit 0
           fi
 
           if [ "${WORKFLOW_RESULT}" != "success" ]; then

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -416,6 +416,15 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _langsmith_trace_count(entry: dict[str, Any]) -> int:
+    count = 1 if entry.get("langsmith_trace_id") else 0
+    traces = entry.get("langsmith_traces")
+    if isinstance(traces, list):
+        list_count = sum(1 for item in traces if isinstance(item, dict) and item.get("trace_id"))
+        return max(count, list_count)
+    return count
+
+
 def _unsupported_verifier_models() -> set[str]:
     raw = ""
     for env_name in (
@@ -592,6 +601,8 @@ def _summarise_verifier(
     issues_created = 0
     acceptance_counts: list[int] = []
     terminal_records = 0
+    langsmith_trace_records = 0
+    langsmith_trace_count = 0
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
         is_verifier_terminal = _is_verifier_terminal_entry(entry)
@@ -662,6 +673,10 @@ def _summarise_verifier(
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+        trace_count = _langsmith_trace_count(entry)
+        if trace_count:
+            langsmith_trace_records += 1
+            langsmith_trace_count += trace_count
     for entry in ledger_entries or []:
         disposition = str(entry.get("disposition") or "unknown")
         ledger_dispositions[disposition] += 1
@@ -695,6 +710,8 @@ def _summarise_verifier(
         "verdicts": verdicts,
         "issues_created": issues_created,
         "avg_acceptance": avg_acceptance,
+        "langsmith_trace_records": langsmith_trace_records,
+        "langsmith_trace_count": langsmith_trace_count,
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,
@@ -735,8 +752,15 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     cycle_steps_completed = 0
     escalation_count = 0
     needs_human_count = 0
+    langsmith_trace_records = 0
+    langsmith_trace_count = 0
 
     for entry in entries:
+        trace_count = _langsmith_trace_count(entry)
+        if trace_count:
+            langsmith_trace_records += 1
+            langsmith_trace_count += trace_count
+
         issue_num = _safe_int(entry.get("issue_number") or entry.get("issue"))
         if issue_num is not None:
             issues.add(issue_num)
@@ -803,6 +827,8 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "escalation_count": escalation_count,
         "escalation_reasons": escalation_reasons,
         "needs_human_count": needs_human_count,
+        "langsmith_trace_records": langsmith_trace_records,
+        "langsmith_trace_count": langsmith_trace_count,
     }
 
 
@@ -1268,6 +1294,11 @@ def build_summary(
             f"- Verdicts: {_format_counter(verifier['verdicts'])}",
             f"- Issues created: {verifier['issues_created']}",
             f"- Avg acceptance criteria: {verifier['avg_acceptance']:.1f}",
+            (
+                "- LangSmith trace coverage: "
+                f"{_format_rate(verifier['langsmith_trace_records'], verifier['runs'])}"
+                f" ({verifier['langsmith_trace_count']} traces)"
+            ),
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
@@ -1342,6 +1373,11 @@ def build_summary(
                 f"- Records: {autopilot['records']}",
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
+                (
+                    "- LangSmith trace coverage: "
+                    f"{_format_rate(autopilot['langsmith_trace_records'], autopilot['records'])}"
+                    f" ({autopilot['langsmith_trace_count']} traces)"
+                ),
                 f"- Cycle records: {autopilot['cycle_records']}",
                 f"- Cycle count distribution: {_format_counter(autopilot['cycle_counts'])}",
                 (

--- a/scripts/aggregate_metrics.py
+++ b/scripts/aggregate_metrics.py
@@ -35,6 +35,15 @@ def load_metrics(metrics_path: Path) -> list[dict[str, Any]]:
     return metrics
 
 
+def _metric_has_trace(metric: dict[str, Any]) -> bool:
+    if metric.get("langsmith_trace_id"):
+        return True
+    traces = metric.get("langsmith_traces")
+    return isinstance(traces, list) and any(
+        isinstance(item, dict) and item.get("trace_id") for item in traces
+    )
+
+
 def aggregate_traces(metrics: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute trace coverage and groupings."""
     total_metrics = len(metrics)
@@ -48,7 +57,7 @@ def aggregate_traces(metrics: list[dict[str, Any]]) -> dict[str, Any]:
         }
 
     # Count metrics with trace IDs
-    with_traces = [m for m in metrics if m.get("langsmith_trace_id")]
+    with_traces = [m for m in metrics if _metric_has_trace(m)]
     total_with_traces = len(with_traces)
     trace_coverage_pct = (total_with_traces / total_metrics) * 100
 
@@ -57,7 +66,7 @@ def aggregate_traces(metrics: list[dict[str, Any]]) -> dict[str, Any]:
     for metric in metrics:
         operation = metric.get("metric_type", "unknown")
         by_operation[operation]["total"] += 1
-        if metric.get("langsmith_trace_id"):
+        if _metric_has_trace(metric):
             by_operation[operation]["with_trace"] += 1
 
     # Calculate coverage per operation
@@ -75,7 +84,7 @@ def aggregate_traces(metrics: list[dict[str, Any]]) -> dict[str, Any]:
     for metric in metrics:
         step = metric.get("step_name", "unknown")
         by_step[step]["total"] += 1
-        if metric.get("langsmith_trace_id"):
+        if _metric_has_trace(metric):
             by_step[step]["with_trace"] += 1
 
     step_summary = {}
@@ -135,13 +144,21 @@ def main() -> None:
         description="Aggregate LangSmith trace metrics from NDJSON logs"
     )
     parser.add_argument(
+        "metrics_path",
+        type=Path,
+        nargs="?",
+        help="Path to NDJSON metrics file (legacy positional form)",
+    )
+    parser.add_argument(
         "--metrics-file",
         type=Path,
-        required=True,
+        required=False,
         help="Path to NDJSON metrics file",
     )
     parser.add_argument(
         "--output-format",
+        "--format",
+        dest="output_format",
         choices=["json", "markdown"],
         default="json",
         help="Output format (default: json)",
@@ -153,9 +170,12 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+    metrics_file = args.metrics_file or args.metrics_path
+    if metrics_file is None:
+        parser.error("one of --metrics-file or metrics_path is required")
 
     # Load and aggregate metrics
-    metrics = load_metrics(args.metrics_file)
+    metrics = load_metrics(metrics_file)
     summary = aggregate_traces(metrics)
 
     # Format output

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -1267,6 +1267,10 @@ def main() -> None:
             if result.get("guard_blocked"):
                 payload["guard_blocked"] = True
                 payload["guard_reason"] = result.get("guard_reason") or ""
+            if result.get("langsmith_trace_id"):
+                payload["langsmith_trace_id"] = result["langsmith_trace_id"]
+            if result.get("langsmith_trace_url"):
+                payload["langsmith_trace_url"] = result["langsmith_trace_url"]
             print(json.dumps(payload, ensure_ascii=True))
         else:
             print(result["formatted_body"])

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -649,6 +649,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           PYTHONPATH: ${{ github.workspace }}
         run: |
 
@@ -868,6 +871,8 @@ jobs:
           AUTOPILOT_STEP_NAME: format
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
+          LANGSMITH_TRACE_ID: ""
+          LANGSMITH_TRACE_URL: ""
         run: |
           success="${{ steps.format_step.outcome == 'success' }}"
           failure_reason="none"
@@ -900,6 +905,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
@@ -988,6 +996,27 @@ jobs:
                   f.write(reason)
               sys.exit(0)
           "
+
+          python - <<'PY'
+          import json
+          import os
+
+          try:
+              with open('/tmp/suggestions.json', encoding='utf-8') as handle:
+                  data = json.load(handle)
+          except Exception:
+              data = {}
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = str(data.get('langsmith_trace_id') or '').strip()
+              trace_url = str(data.get('langsmith_trace_url') or '').strip()
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID={trace_id}\n")
+                  if trace_url:
+                      env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL={trace_url}\n")
+          PY
 
           # If guard blocked, apply needs-human + pause labels and stop
           if [ -f /tmp/guard_blocked ]; then
@@ -1144,6 +1173,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.optimize_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then
@@ -1254,6 +1285,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
           PYTHONPATH: ${{ github.workspace }}
@@ -1332,6 +1366,7 @@ jobs:
           # Extract and apply suggestions
           python -c "
           import json
+          import os
           import sys
           import re
           sys.path.insert(0, 'scripts/langchain')
@@ -1358,6 +1393,16 @@ jobs:
 
           # Apply suggestions
           result = apply_suggestions(issue_body, suggestions, use_llm=True)
+
+          env_path = os.environ.get('GITHUB_ENV')
+          if env_path:
+              trace_id = str(result.get('langsmith_trace_id') or '').strip()
+              trace_url = str(result.get('langsmith_trace_url') or '').strip()
+              with open(env_path, 'a', encoding='utf-8') as env_file:
+                  if trace_id:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_ID={trace_id}\n')
+                  if trace_url:
+                      env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_URL={trace_url}\n')
 
           # Check for guard_blocked
           if result.get('guard_blocked'):
@@ -1500,6 +1545,8 @@ jobs:
           AUTOPILOT_ERROR_CATEGORY: metrics-collector
           AUTOPILOT_METRICS_LOG_PATH: ${{ env.AUTOPILOT_METRICS_LOG_PATH }}
         run: |
+          export LANGSMITH_TRACE_ID="${AUTOPILOT_APPLY_LANGSMITH_TRACE_ID:-}"
+          export LANGSMITH_TRACE_URL="${AUTOPILOT_APPLY_LANGSMITH_TRACE_URL:-}"
           success="${{ steps.apply_step.outcome == 'success' }}"
           failure_reason="none"
           if [ "$success" != "true" ]; then

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -416,6 +416,15 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _langsmith_trace_count(entry: dict[str, Any]) -> int:
+    count = 1 if entry.get("langsmith_trace_id") else 0
+    traces = entry.get("langsmith_traces")
+    if isinstance(traces, list):
+        list_count = sum(1 for item in traces if isinstance(item, dict) and item.get("trace_id"))
+        return max(count, list_count)
+    return count
+
+
 def _unsupported_verifier_models() -> set[str]:
     raw = ""
     for env_name in (
@@ -592,6 +601,8 @@ def _summarise_verifier(
     issues_created = 0
     acceptance_counts: list[int] = []
     terminal_records = 0
+    langsmith_trace_records = 0
+    langsmith_trace_count = 0
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
         is_verifier_terminal = _is_verifier_terminal_entry(entry)
@@ -662,6 +673,10 @@ def _summarise_verifier(
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
+        trace_count = _langsmith_trace_count(entry)
+        if trace_count:
+            langsmith_trace_records += 1
+            langsmith_trace_count += trace_count
     for entry in ledger_entries or []:
         disposition = str(entry.get("disposition") or "unknown")
         ledger_dispositions[disposition] += 1
@@ -695,6 +710,8 @@ def _summarise_verifier(
         "verdicts": verdicts,
         "issues_created": issues_created,
         "avg_acceptance": avg_acceptance,
+        "langsmith_trace_records": langsmith_trace_records,
+        "langsmith_trace_count": langsmith_trace_count,
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,
@@ -735,8 +752,15 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
     cycle_steps_completed = 0
     escalation_count = 0
     needs_human_count = 0
+    langsmith_trace_records = 0
+    langsmith_trace_count = 0
 
     for entry in entries:
+        trace_count = _langsmith_trace_count(entry)
+        if trace_count:
+            langsmith_trace_records += 1
+            langsmith_trace_count += trace_count
+
         issue_num = _safe_int(entry.get("issue_number") or entry.get("issue"))
         if issue_num is not None:
             issues.add(issue_num)
@@ -803,6 +827,8 @@ def _summarise_autopilot(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "escalation_count": escalation_count,
         "escalation_reasons": escalation_reasons,
         "needs_human_count": needs_human_count,
+        "langsmith_trace_records": langsmith_trace_records,
+        "langsmith_trace_count": langsmith_trace_count,
     }
 
 
@@ -1268,6 +1294,11 @@ def build_summary(
             f"- Verdicts: {_format_counter(verifier['verdicts'])}",
             f"- Issues created: {verifier['issues_created']}",
             f"- Avg acceptance criteria: {verifier['avg_acceptance']:.1f}",
+            (
+                "- LangSmith trace coverage: "
+                f"{_format_rate(verifier['langsmith_trace_records'], verifier['runs'])}"
+                f" ({verifier['langsmith_trace_count']} traces)"
+            ),
             f"- Terminal disposition records: {verifier['terminal_records']}",
             f"- Terminal dispositions: {_format_counter(verifier['terminal_dispositions'])}",
             f"- Terminal disposition sources: {_format_counter(verifier['terminal_sources'])}",
@@ -1342,6 +1373,11 @@ def build_summary(
                 f"- Records: {autopilot['records']}",
                 f"- Issues: {autopilot['issues']}",
                 f"- Total step executions: {autopilot['total_steps']}",
+                (
+                    "- LangSmith trace coverage: "
+                    f"{_format_rate(autopilot['langsmith_trace_records'], autopilot['records'])}"
+                    f" ({autopilot['langsmith_trace_count']} traces)"
+                ),
                 f"- Cycle records: {autopilot['cycle_records']}",
                 f"- Cycle count distribution: {_format_counter(autopilot['cycle_counts'])}",
                 (

--- a/templates/consumer-repo/scripts/langchain/issue_optimizer.py
+++ b/templates/consumer-repo/scripts/langchain/issue_optimizer.py
@@ -6,15 +6,32 @@ Run with:
     python scripts/langchain/issue_optimizer.py --input-file issue.md --json
 """
 
+# ruff: noqa: I001
+
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from scripts.langchain.structured_output import (
+    DEFAULT_REPAIR_PROMPT,
+    build_repair_callback,
+    parse_structured_output,
+)
+
+try:
+    from scripts.langchain.injection_guard import check_prompt_injection
+    from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
+except ModuleNotFoundError:
+    from injection_guard import check_prompt_injection
+    from issue_pr_context import ContextOptions, build_issue_context
 
 AGENT_LIMITATIONS = [
     "Cannot modify .github/workflows/*.yml (protected)",
@@ -23,6 +40,27 @@ AGENT_LIMITATIONS = [
     "Cannot make subjective design decisions",
     "Cannot retry CI pipelines",
 ]
+
+
+def _context_token_budget() -> int:
+    raw = os.environ.get("ISSUE_PR_CONTEXT_TOKEN_BUDGET", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else 4000
+
+
+def _context_workflow(default: str) -> str:
+    return os.environ.get("ISSUE_PR_CONTEXT_WORKFLOW") or default
+
+
+def _capped_issue_body(issue_body: str, workflow: str) -> str:
+    context = build_issue_context(
+        {"body": issue_body},
+        ContextOptions(
+            token_budget=_context_token_budget(),
+            downstream_workflow=workflow,
+        ),
+    )
+    return context["formatted_body"]
+
 
 ANALYZE_ISSUE_PROMPT = """
 Analyze this issue for agent compatibility and formatting quality.
@@ -40,9 +78,25 @@ Identify:
 AGENT_LIMITATIONS:
 {agent_limitations}
 
+CRITICAL rules for split_suggestions:
+- Each item MUST be a complete, independently understandable sentence
+- Each item MUST start with an action verb (Create, Add, Update, Fix, Implement, Define, Test)
+- Do NOT split a sentence at commas into fragments
+- Do NOT return single words or noun phrases as sub-tasks
+- BAD: ["methods", "input/output types", "metadata contract"]
+- GOOD: [
+    "Define the EmbeddingProvider interface methods",
+    "Define input/output types",
+    "Define metadata contract"
+  ]
+
 Output JSON with this shape:
 {{
-  "task_splitting": [{{"task": "...", "reason": "...", "split_suggestions": ["..."]}}],
+  "task_splitting": [{{
+    "task": "...",
+    "reason": "...",
+    "split_suggestions": ["Complete actionable sub-task description"]
+  }}],
   "blocked_tasks": [{{"task": "...", "reason": "...", "suggested_action": "..."}}],
   "objective_criteria": [{{"criterion": "...", "issue": "...", "suggestion": "..."}}],
   "missing_sections": ["Scope", "Implementation Notes"],
@@ -68,6 +122,8 @@ following AGENT_ISSUE_TEMPLATE structure. Move blocked tasks to
 a "## Deferred Tasks (Requires Human)" section.
 """.strip()
 
+ISSUE_OPTIMIZER_REPAIR_PROMPT = DEFAULT_REPAIR_PROMPT
+
 SECTION_ALIASES = {
     "why": ["why", "motivation", "summary"],
     "scope": ["scope", "context", "background"],
@@ -86,11 +142,11 @@ SECTION_TITLES = {
     "implementation": "Implementation Notes",
 }
 
-LIST_ITEM_REGEX = re.compile(r"^\s*[-*+]\s+(.*)$")
+LIST_ITEM_REGEX = re.compile(r"^\s*([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[[ xX]\]\s*(.*)$")
 
 SUBJECTIVE_CRITERIA = ("clean", "nice", "good", "fast", "better", "intuitive", "polished")
-SUGGESTIONS_MARKER_PREFIX = "Updated WORKFLOW_OUTPUTS.md suggestions-json:"
+SUGGESTIONS_MARKER_PREFIX = "suggestions-json:"
 
 
 @dataclass
@@ -102,9 +158,13 @@ class IssueOptimizationResult:
     formatting_issues: list[str]
     overall_notes: str | None
     provider_used: str | None = None
+    guard_blocked: bool = False
+    guard_reason: str = ""
+    langsmith_trace_id: str | None = None
+    langsmith_trace_url: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "task_splitting": self.task_splitting,
             "blocked_tasks": self.blocked_tasks,
             "objective_criteria": self.objective_criteria,
@@ -113,6 +173,24 @@ class IssueOptimizationResult:
             "overall_notes": self.overall_notes or "",
             "provider_used": self.provider_used,
         }
+        if self.guard_blocked:
+            payload["guard_blocked"] = True
+            payload["guard_reason"] = self.guard_reason
+        if self.langsmith_trace_id:
+            payload["langsmith_trace_id"] = self.langsmith_trace_id
+        if self.langsmith_trace_url:
+            payload["langsmith_trace_url"] = self.langsmith_trace_url
+        return payload
+
+
+class IssueOptimizationPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    task_splitting: list[dict[str, Any]] = Field(default_factory=list)
+    blocked_tasks: list[dict[str, Any]] = Field(default_factory=list)
+    objective_criteria: list[dict[str, Any]] = Field(default_factory=list)
+    missing_sections: list[str] = Field(default_factory=list)
+    formatting_issues: list[str] = Field(default_factory=list)
+    overall_notes: str | None = None
 
 
 def _format_list_section(title: str, items: list[str]) -> list[str]:
@@ -240,6 +318,85 @@ def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
     return resolved.client, resolved.provider
 
 
+def _build_llm_config(
+    *,
+    operation: str,
+    issue_number: int | None = None,
+) -> dict[str, object]:
+    """Build LangSmith metadata/tags for LLM call."""
+    import os
+
+    try:
+        from tools.llm_provider import build_langsmith_metadata
+
+        return build_langsmith_metadata(
+            operation=operation,
+            issue_number=issue_number,
+        )
+    except ImportError:
+        pass
+
+    # Inline fallback when tools.llm_provider is unavailable
+    repo = os.environ.get("GITHUB_REPOSITORY", "unknown")
+    run_id = os.environ.get("GITHUB_RUN_ID") or os.environ.get("RUN_ID") or "unknown"
+    env_issue = os.environ.get("ISSUE_NUMBER", "")
+    issue_or_pr = (
+        str(issue_number)
+        if issue_number is not None
+        else env_issue if env_issue.isdigit() else "unknown"
+    )
+    metadata = {
+        "repo": repo,
+        "run_id": run_id,
+        "issue_or_pr_number": issue_or_pr,
+        "operation": operation,
+        "issue_number": str(issue_number) if issue_number is not None else None,
+    }
+    tags = [
+        "workflows-agents",
+        f"operation:{operation}",
+        f"repo:{repo}",
+        f"issue_or_pr:{issue_or_pr}",
+        f"run_id:{run_id}",
+    ]
+    return {"metadata": metadata, "tags": tags}
+
+
+def _invoke_llm_with_trace(
+    chain: object,
+    inputs: dict[str, Any],
+    *,
+    operation: str,
+    issue_number: int | None = None,
+) -> tuple[object, str | None, str | None]:
+    """Invoke LLM chain and extract trace information.
+
+    Returns:
+        Tuple of (response, trace_id, trace_url)
+    """
+    config = _build_llm_config(operation=operation, issue_number=issue_number)
+
+    try:
+        response = chain.invoke(inputs, config=config)
+    except TypeError:
+        # Fallback if config not supported
+        response = chain.invoke(inputs)
+
+    # Extract trace ID from response if available
+    trace_id = None
+    trace_url = None
+    try:
+        from tools.llm_provider import derive_langsmith_trace_url, extract_trace_id
+
+        trace_id = extract_trace_id(response)
+        if trace_id:
+            trace_url = derive_langsmith_trace_url(trace_id)
+    except ImportError:
+        pass
+
+    return response, trace_id, trace_url
+
+
 def _normalize_heading(text: str) -> str:
     cleaned = re.sub(r"[#*_:]+", " ", text).strip().lower()
     cleaned = re.sub(r"\s+", " ", cleaned)
@@ -258,13 +415,25 @@ def _resolve_section(label: str) -> str | None:
 def _parse_sections(body: str) -> dict[str, list[str]]:
     sections: dict[str, list[str]] = {key: [] for key in SECTION_TITLES}
     current: str | None = None
+    in_code_block = False
     for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+        if in_code_block:
+            if current:
+                sections[current].append(line)
+            continue
         heading_match = re.match(r"^\s*#{1,6}\s+(.*)$", line)
         if heading_match:
             section_key = _resolve_section(heading_match.group(1))
             if section_key:
                 current = section_key
                 continue
+        section_key = _resolve_section(stripped)
+        if section_key and stripped:
+            current = section_key
+            continue
         if current:
             sections[current].append(line)
     return sections
@@ -275,7 +444,7 @@ def _strip_checkbox(line: str) -> str:
     match = LIST_ITEM_REGEX.match(stripped)
     if not match:
         return stripped
-    content = match.group(1).strip()
+    content = match.group(2).strip()  # Group 2 is the content after list marker
     checkbox = CHECKBOX_REGEX.match(content)
     if checkbox:
         return checkbox.group(1).strip()
@@ -284,10 +453,17 @@ def _strip_checkbox(line: str) -> str:
 
 def _parse_checklist(lines: list[str]) -> list[str]:
     items: list[str] = []
+    in_code_block = False
     for line in lines:
-        if not line.strip():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
             continue
-        if LIST_ITEM_REGEX.match(line.strip()):
+        if in_code_block:
+            continue
+        if not stripped:
+            continue
+        if LIST_ITEM_REGEX.match(stripped):
             value = _strip_checkbox(line)
             if value:
                 items.append(value)
@@ -387,7 +563,7 @@ def _extract_json_payload(text: str) -> str | None:
 def _extract_suggestions_json(comment_body: str) -> dict[str, Any] | None:
     if not comment_body:
         return None
-    marker = "suggestions-json:"
+    marker = SUGGESTIONS_MARKER_PREFIX
     start = comment_body.find(marker)
     if start == -1:
         return None
@@ -409,7 +585,11 @@ def _formatted_output_valid(text: str) -> bool:
 
 
 def _deduplicate_task_lines(formatted: str) -> str:
-    """Remove duplicate task lines from the formatted output."""
+    """Remove duplicate task lines from the formatted output.
+
+    Scans '## Tasks' through the next '## ' heading, deduplicates
+    checkbox lines by normalized text, and returns the cleaned body.
+    """
     lines = formatted.splitlines()
     try:
         header_idx = next(i for i, line in enumerate(lines) if line.strip() == "## Tasks")
@@ -446,7 +626,10 @@ def _deduplicate_task_lines(formatted: str) -> str:
 
 
 def _section_duplication_ratio(formatted: str) -> float:
-    """Return the fraction of section headings that appear more than once."""
+    """Return the fraction of section headings that appear more than once.
+
+    A ratio > 0 indicates the formatter doubled one or more sections.
+    """
     headings = re.findall(r"^##\s+(.+)$", formatted, re.MULTILINE)
     if not headings:
         return 0.0
@@ -457,7 +640,7 @@ def _section_duplication_ratio(formatted: str) -> float:
 
 
 def _strip_task_marker(text: str) -> str:
-    cleaned = re.sub(r"^\s*[-*+]\s*", "", text)
+    cleaned = re.sub(r"^\s*([-*+]|\d+[.)]|[A-Za-z][.)])\s*", "", text)
     cleaned = re.sub(r"^\s*\[[ xX]\]\s*", "", cleaned)
     return cleaned.strip()
 
@@ -490,11 +673,14 @@ def _is_large_task(task: str) -> bool:
         return True
     if any(sep in lowered for sep in (" and ", " + ", " & ", " then ", "; ")):
         return True
-    return bool(re.search(r"\s\+\s", lowered) or ", " in task or "/" in task)
+    return bool(re.search(r"\s\+\s", lowered) or ", " in task or " / " in task)
 
 
 def _detect_task_splitting(tasks: list[str], *, use_llm: bool = False) -> list[dict[str, Any]]:
-    from scripts.langchain import task_decomposer
+    try:
+        from scripts.langchain import task_decomposer
+    except ModuleNotFoundError:
+        import task_decomposer
 
     results: list[dict[str, Any]] = []
     for task in tasks:
@@ -520,7 +706,10 @@ def _ensure_task_decomposition(
     if not task_splitting:
         return task_splitting
 
-    from scripts.langchain import task_decomposer
+    try:
+        from scripts.langchain import task_decomposer
+    except ModuleNotFoundError:
+        import task_decomposer
 
     updated: list[dict[str, Any]] = []
     for entry in task_splitting:
@@ -571,29 +760,61 @@ def _normalize_result(
 
 
 def _process_llm_response(
-    response: Any, provider: str, use_llm: bool
-) -> IssueOptimizationResult | None:
-    """Process LLM response and return normalized result, or None if processing fails."""
+    response: Any,
+    provider: str,
+    use_llm: bool,
+    *,
+    client: object | None = None,
+    trace_id: str | None = None,
+    trace_url: str | None = None,
+) -> tuple[IssueOptimizationResult | None, str | None]:
+    """Process LLM response and return (result, error)."""
     content = getattr(response, "content", None) or str(response)
-    payload = _extract_json_payload(content)
-    if payload:
-        try:
-            data = json.loads(payload)
-        except json.JSONDecodeError:
-            return None
-        if isinstance(data, dict):
-            result = _normalize_result(data, provider)
-            result.task_splitting = _ensure_task_decomposition(
-                result.task_splitting, use_llm=use_llm
-            )
-            return result
-    return None
+    parsed = parse_structured_output(
+        content,
+        IssueOptimizationPayload,
+        repair=(
+            build_repair_callback(client, template=ISSUE_OPTIMIZER_REPAIR_PROMPT)
+            if client is not None
+            else None
+        ),
+        max_repair_attempts=1,
+    )
+    if parsed.payload is None:
+        if parsed.error_stage == "repair_unavailable":
+            return None, "LLM output failed validation and could not be repaired."
+        if parsed.error_stage == "repair_validation":
+            return None, f"LLM repair failed validation: {parsed.error_detail}"
+        return None, f"LLM output failed validation: {parsed.error_detail}"
+
+    result = _normalize_result(parsed.payload.model_dump(), provider)
+    result.task_splitting = _ensure_task_decomposition(result.task_splitting, use_llm=use_llm)
+    result.langsmith_trace_id = trace_id
+    result.langsmith_trace_url = trace_url
+    return result, None
 
 
 def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimizationResult:
     if not issue_body:
         issue_body = ""
 
+    guard_result = check_prompt_injection(issue_body)
+    if guard_result["blocked"]:
+        return IssueOptimizationResult(
+            task_splitting=[],
+            blocked_tasks=[],
+            objective_criteria=[],
+            missing_sections=[],
+            formatting_issues=[],
+            overall_notes="",
+            provider_used=None,
+            guard_blocked=True,
+            guard_reason=guard_result["reason"],
+        )
+
+    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
+
+    last_error: str | None = None
     if use_llm:
         from tools.llm_provider import _is_token_limit_error
 
@@ -609,17 +830,37 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
                 template = ChatPromptTemplate.from_template(prompt)
                 chain = template | client  # type: ignore[operator]
                 try:
-                    response = chain.invoke(
+                    import os
+
+                    issue_num = None
+                    env_issue = os.environ.get("ISSUE_NUMBER", "")
+                    if env_issue.isdigit():
+                        issue_num = int(env_issue)
+
+                    response, trace_id, trace_url = _invoke_llm_with_trace(
+                        chain,
                         {
                             "issue_body": issue_body,
                             "agent_limitations": "\n".join(
                                 f"- {item}" for item in AGENT_LIMITATIONS
                             ),
-                        }
+                        },
+                        operation="analyze_issue",
+                        issue_number=issue_num,
                     )
-                    result = _process_llm_response(response, provider, use_llm)
+                    result, error = _process_llm_response(
+                        response,
+                        provider,
+                        use_llm,
+                        client=client,
+                        trace_id=trace_id,
+                        trace_url=trace_url,
+                    )
                     if result:
                         return result
+                    if error:
+                        last_error = error
+                        print(error, file=sys.stderr)
                 except Exception as e:
                     # If GitHub Models hit token limit, retry with OpenAI API
                     if _is_token_limit_error(e) and provider == "github-models":
@@ -632,16 +873,24 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
                             openai_client, openai_provider = openai_client_info
                             openai_chain = template | openai_client  # type: ignore[operator]
                             try:
-                                response = openai_chain.invoke(
+                                response, trace_id, trace_url = _invoke_llm_with_trace(
+                                    openai_chain,
                                     {
                                         "issue_body": issue_body,
                                         "agent_limitations": "\n".join(
                                             f"- {item}" for item in AGENT_LIMITATIONS
                                         ),
-                                    }
+                                    },
+                                    operation="analyze_issue",
+                                    issue_number=issue_num,
                                 )
-                                result = _process_llm_response(
-                                    response, openai_provider, use_llm=use_llm
+                                result, error = _process_llm_response(
+                                    response,
+                                    openai_provider,
+                                    use_llm=use_llm,
+                                    client=openai_client,
+                                    trace_id=trace_id,
+                                    trace_url=trace_url,
                                 )
                                 if result is not None:
                                     print(
@@ -649,9 +898,14 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
                                         file=sys.stderr,
                                     )
                                     return result
+                                if error:
+                                    last_error = error
+                                    print(error, file=sys.stderr)
                             except Exception as openai_error:
+                                err_type = type(openai_error).__name__
                                 print(
-                                    f"OpenAI API also failed ({type(openai_error).__name__}: {openai_error}), using fallback",
+                                    f"OpenAI API also failed "
+                                    f"({err_type}: {openai_error}), using fallback",
                                     file=sys.stderr,
                                 )
                         else:
@@ -667,6 +921,10 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
                         )
 
     result = _fallback_analysis(issue_body)
+    if last_error:
+        note = result.overall_notes or ""
+        detail = f"LLM structured output failed: {last_error}"
+        result.overall_notes = f"{note} {detail}".strip()
     result.task_splitting = _ensure_task_decomposition(result.task_splitting, use_llm=False)
     return result
 
@@ -707,12 +965,19 @@ def _append_deferred_tasks(formatted_body: str, suggestions: dict[str, Any]) -> 
     return "\n".join(parts).strip()
 
 
-def _apply_task_decomposition(formatted_body: str, suggestions: dict[str, Any]) -> str:
+def _apply_task_decomposition(formatted_body: str | None, suggestions: dict[str, Any]) -> str:
+    # Guard against None input (can happen when issue body is too large)
+    if formatted_body is None:
+        return ""
+
     raw_entries = suggestions.get("task_splitting")
     if not isinstance(raw_entries, list) or not raw_entries:
         return formatted_body
 
-    from scripts.langchain import task_decomposer
+    try:
+        from scripts.langchain import task_decomposer
+    except ModuleNotFoundError:
+        import task_decomposer
 
     decomposition_map: dict[str, list[str]] = {}
     for entry in raw_entries:
@@ -779,6 +1044,18 @@ def apply_suggestions(
     if not issue_body:
         issue_body = ""
 
+    guard_result = check_prompt_injection(issue_body)
+    if guard_result["blocked"]:
+        return {
+            "formatted_body": issue_body,
+            "provider_used": None,
+            "used_llm": False,
+            "guard_blocked": True,
+            "guard_reason": guard_result["reason"],
+        }
+
+    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
+
     if use_llm:
         from tools.llm_provider import _is_token_limit_error
 
@@ -794,13 +1071,23 @@ def apply_suggestions(
                 template = ChatPromptTemplate.from_template(prompt)
                 chain = template | client  # type: ignore[operator]
                 try:
-                    response = chain.invoke(
+                    import os
+
+                    issue_num = None
+                    env_issue = os.environ.get("ISSUE_NUMBER", "")
+                    if env_issue.isdigit():
+                        issue_num = int(env_issue)
+
+                    response, trace_id, trace_url = _invoke_llm_with_trace(
+                        chain,
                         {
                             "original_body": issue_body,
                             "suggestions_json": json.dumps(
                                 suggestions, ensure_ascii=True, indent=2
                             ),
-                        }
+                        },
+                        operation="apply_suggestions",
+                        issue_number=issue_num,
                     )
                     content = getattr(response, "content", None) or str(response)
                     formatted = content.strip()
@@ -808,20 +1095,26 @@ def apply_suggestions(
                         formatted = _deduplicate_task_lines(formatted)
                         if _section_duplication_ratio(formatted) > 0:
                             print(
-                                "LLM output has duplicated sections, " "falling back",
+                                "LLM output has duplicated sections, falling back",
                                 file=sys.stderr,
                             )
                         else:
-                            return {
+                            result = {
                                 "formatted_body": formatted,
                                 "provider_used": provider,
                                 "used_llm": True,
                             }
+                            if trace_id:
+                                result["langsmith_trace_id"] = trace_id
+                            if trace_url:
+                                result["langsmith_trace_url"] = trace_url
+                            return result
                 except Exception as e:
                     # If GitHub Models hit token limit, retry with OpenAI API
                     if _is_token_limit_error(e) and provider == "github-models":
                         print(
-                            "GitHub Models token limit hit in apply_suggestions, retrying with OpenAI API...",
+                            "GitHub Models token limit hit in apply_suggestions, "
+                            "retrying with OpenAI API...",
                             file=sys.stderr,
                         )
                         openai_client_info = _get_llm_client(force_openai=True)
@@ -829,13 +1122,16 @@ def apply_suggestions(
                             openai_client, openai_provider = openai_client_info
                             openai_chain = template | openai_client  # type: ignore[operator]
                             try:
-                                response = openai_chain.invoke(
+                                response, trace_id, trace_url = _invoke_llm_with_trace(
+                                    openai_chain,
                                     {
                                         "original_body": issue_body,
                                         "suggestions_json": json.dumps(
                                             suggestions, ensure_ascii=True, indent=2
                                         ),
-                                    }
+                                    },
+                                    operation="apply_suggestions",
+                                    issue_number=issue_num,
                                 )
                                 content = getattr(response, "content", None) or str(response)
                                 formatted = content.strip()
@@ -843,23 +1139,29 @@ def apply_suggestions(
                                     formatted = _deduplicate_task_lines(formatted)
                                     if _section_duplication_ratio(formatted) > 0:
                                         print(
-                                            "OpenAI output has duplicated "
-                                            "sections, falling back",
+                                            "OpenAI output has duplicated sections, falling back",
                                             file=sys.stderr,
                                         )
                                     else:
                                         print(
-                                            "Successfully applied suggestions " "with OpenAI API",
+                                            "Successfully applied suggestions with OpenAI API",
                                             file=sys.stderr,
                                         )
-                                        return {
+                                        result = {
                                             "formatted_body": formatted,
                                             "provider_used": openai_provider,
                                             "used_llm": True,
                                         }
+                                        if trace_id:
+                                            result["langsmith_trace_id"] = trace_id
+                                        if trace_url:
+                                            result["langsmith_trace_url"] = trace_url
+                                        return result
                             except Exception as openai_error:
+                                err_type = type(openai_error).__name__
                                 print(
-                                    f"OpenAI API also failed ({type(openai_error).__name__}: {openai_error}), using fallback",
+                                    f"OpenAI API also failed "
+                                    f"({err_type}: {openai_error}), using fallback",
                                     file=sys.stderr,
                                 )
                         else:
@@ -874,7 +1176,10 @@ def apply_suggestions(
                             file=sys.stderr,
                         )
 
-    from scripts.langchain import issue_formatter
+    try:
+        from scripts.langchain import issue_formatter
+    except ModuleNotFoundError:
+        import issue_formatter
 
     fallback = issue_formatter.format_issue_body(issue_body, use_llm=False)
     formatted = _apply_task_decomposition(fallback["formatted_body"], suggestions)
@@ -959,6 +1264,13 @@ def main() -> None:
                 "provider_used": result.get("provider_used"),
                 "used_llm": result.get("used_llm", False),
             }
+            if result.get("guard_blocked"):
+                payload["guard_blocked"] = True
+                payload["guard_reason"] = result.get("guard_reason") or ""
+            if result.get("langsmith_trace_id"):
+                payload["langsmith_trace_id"] = result["langsmith_trace_id"]
+            if result.get("langsmith_trace_url"):
+                payload["langsmith_trace_url"] = result["langsmith_trace_url"]
             print(json.dumps(payload, ensure_ascii=True))
         else:
             print(result["formatted_body"])

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -165,6 +165,56 @@ def test_autopilot_needs_human_rate_uses_escalations_not_issue_ids() -> None:
     assert "Needs-human escalation rate: 50.0% (1/2)" in summary
 
 
+def test_langsmith_trace_counts_cover_single_ids_and_trace_lists() -> None:
+    entries = [
+        {
+            "metric_type": "verifier",
+            "run_id": "verify-1",
+            "verdict": "pass",
+            "langsmith_trace_id": "verifier-trace-1",
+        },
+        {
+            "metric_type": "verifier",
+            "run_id": "verify-2",
+            "verdict": "concerns",
+            "langsmith_traces": [
+                {"trace_id": "verifier-trace-2"},
+                {"trace_id": "verifier-trace-3"},
+            ],
+        },
+        {
+            "metric_type": "step",
+            "issue_number": 11,
+            "step_name": "optimize",
+            "success": True,
+            "duration_ms": 100,
+            "langsmith_trace_id": "autopilot-trace-1",
+        },
+        {
+            "metric_type": "step",
+            "issue_number": 11,
+            "step_name": "apply",
+            "success": True,
+            "duration_ms": 200,
+            "langsmith_traces": [
+                {"trace_id": "autopilot-trace-2"},
+                {"trace_id": "autopilot-trace-3"},
+            ],
+        },
+    ]
+
+    summary = aggregate_agent_metrics.build_summary(entries, errors=0)
+
+    assert "LangSmith trace coverage: 100.0% (2/2) (3 traces)" in summary
+    assert summary.count("LangSmith trace coverage: 100.0% (2/2) (3 traces)") == 2
+
+    contract = aggregate_agent_metrics.build_summary_contract(entries, [])
+    assert contract["summaries"]["verifier"]["langsmith_trace_records"] == 2
+    assert contract["summaries"]["verifier"]["langsmith_trace_count"] == 3
+    assert contract["summaries"]["autopilot"]["langsmith_trace_records"] == 2
+    assert contract["summaries"]["autopilot"]["langsmith_trace_count"] == 3
+
+
 def test_main_writes_summary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     keepalive_path = tmp_path / "keepalive.ndjson"
     autofix_path = tmp_path / "autofix.ndjson"

--- a/tests/scripts/test_aggregate_metrics.py
+++ b/tests/scripts/test_aggregate_metrics.py
@@ -97,6 +97,31 @@ def test_aggregate_traces_with_traces() -> None:
     }
 
 
+def test_aggregate_traces_with_trace_lists() -> None:
+    """Test aggregation with compare-mode trace lists."""
+    metrics = [
+        {
+            "metric_type": "evaluation",
+            "langsmith_traces": [
+                {"provider": "openai", "trace_id": "trace-1"},
+                {"provider": "anthropic", "trace_id": "trace-2"},
+            ],
+        },
+        {"metric_type": "evaluation", "langsmith_traces": []},
+    ]
+
+    summary = aggregate_traces(metrics)
+
+    assert summary["total_metrics"] == 2
+    assert summary["total_with_traces"] == 1
+    assert summary["trace_coverage_pct"] == 50.0
+    assert summary["by_operation"]["evaluation"] == {
+        "total": 2,
+        "with_trace": 1,
+        "coverage_pct": 50.0,
+    }
+
+
 def test_aggregate_traces_autopilot_steps() -> None:
     """Test grouping by autopilot step_name."""
     metrics = [

--- a/tests/workflows/test_workflow_selftest_consolidation.py
+++ b/tests/workflows/test_workflow_selftest_consolidation.py
@@ -361,6 +361,13 @@ def test_selftest_runner_jobs_contract() -> None:
     assert (
         verify_env.get("SCENARIO_LIST") == "${{ env.SCENARIO_LIST }}"
     ), "Verification step should read scenario list from aggregate env."
+    verify_script = (verify_step.get("with") or {}).get("script", "")
+    assert (
+        "matchesExpectedArtifact" in verify_script
+    ), "Verification should tolerate upload-artifact uniqueness suffixes."
+    assert (
+        ".split('/')[0]" in verify_script
+    ), "Verification should normalize nested reusable workflow job names."
 
     upload_step = _find_step(lambda step: step.get("name") == "Upload self-test report")
     assert upload_step, "Aggregate job must upload the self-test report artifact."

--- a/tests/workflows/test_workflow_selftest_consolidation.py
+++ b/tests/workflows/test_workflow_selftest_consolidation.py
@@ -391,9 +391,10 @@ def test_selftest_runner_publish_job_contract() -> None:
 
     assert publish, f"{SELFTEST_WORKFLOW_NAME} should retain the publish job."
     assert set(publish.get("needs", [])) == {
+        "select-scenarios",
         "scenarios",
         "summarize",
-    }, "publish should depend on both the matrix execution and aggregation jobs."
+    }, "publish should depend on scenario selection, matrix execution, and aggregation jobs."
     assert (
         publish.get("if") == "${{ always() }}"
     ), "publish should always execute to surface matrix status."
@@ -426,6 +427,7 @@ def test_selftest_runner_publish_job_contract() -> None:
         "COMMENT_TITLE",
         "REASON",
         "WORKFLOW_RESULT",
+        "SELECTED_COUNT",
         "SUMMARY_TABLE",
         "FAILURE_COUNT",
         "RUN_ID",
@@ -485,6 +487,7 @@ def test_selftest_runner_publish_job_contract() -> None:
         "Verification table output missing",
         "Failure count output missing",
         "Self-test reported",
+        "no scenarios were selected",
         "Self-test matrix completed with status",
     ):
         assert (
@@ -501,6 +504,7 @@ def test_selftest_runner_publish_job_contract() -> None:
         "Verification table output missing",
         "Failure count output missing",
         "Self-test reported",
+        "no scenarios were selected",
         "Self-test matrix completed with status",
     ):
         assert snippet in comment_script, f"Comment finalizer guard should mention '{snippet}'."


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- enable LangSmith tracing env for auto-pilot LLM steps and persist optimize/apply trace IDs into metrics
- include verifier comparison/evaluation trace IDs in verifier metrics artifacts
- teach weekly/dashboard aggregators to count trace-list metrics and download verifier metrics artifacts
- keep consumer template workflow/scripts aligned with Workflows source

## Validation
- ruby YAML parse for changed workflows
- python3 scripts/aggregate_metrics.py --metrics-file /dev/null --output-format json
- python3 scripts/aggregate_metrics.py /dev/null --format markdown
- git diff --check
- uv run pytest tests/scripts/test_aggregate_metrics.py tests/scripts/test_aggregate_agent_metrics.py tests/scripts/test_issue_optimizer.py tests/workflows/test_workflow_agents_consolidation.py tests/scripts/test_validate_template_sync.py tests/workflows/test_verifier_terminal_disposition.py
- uv run black --check --line-length 100 scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py
- uv run pytest tests/scripts/test_aggregate_agent_metrics.py tests/scripts/test_aggregate_metrics.py