### PR TITLE
fix: sanitize auto-pilot LangSmith env exports

### DIFF
--- a/.github/scripts/__tests__/token-load-balancer-resolution.test.js
+++ b/.github/scripts/__tests__/token-load-balancer-resolution.test.js
@@ -67,7 +67,7 @@ module.exports = { Octokit };
     }
   });
   const rateLimit = balancer.tokenRegistry.tokens.get('TEST_TOKEN').rateLimit;
-  process.stdout.write(JSON.stringify({ errors, rateLimit }));
+  process.stdout.write(JSON.stringify({ errors, rateLimit }) + '\\n');
 })().catch((error) => {
   console.error(error);
   process.exit(1);
@@ -163,7 +163,7 @@ test('invalid credential warnings are cached across node processes', () => {
   const cache = fs.existsSync(cachePath)
     ? JSON.parse(fs.readFileSync(cachePath, 'utf8'))
     : null;
-  process.stdout.write(JSON.stringify({ warnings, debug, cache, rateLimit }));
+  process.stdout.write(JSON.stringify({ warnings, debug, cache, rateLimit }) + '\\n');
 })().catch((error) => {
   console.error(error);
   process.exit(1);

--- a/.github/scripts/bot_comment_auth_coverage.js
+++ b/.github/scripts/bot_comment_auth_coverage.js
@@ -827,7 +827,7 @@ function main() {
   const markdownSummary = formatBotCommentAuthCoverageMarkdown(report);
   fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
   fs.writeFileSync(options.markdown, markdownSummary);
-  process.stdout.write(markdownSummary);
+  fs.writeFileSync(process.stdout.fd, markdownSummary);
   return report.status === 'fail' ? 1 : 0;
 }
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -1084,10 +1084,13 @@ jobs:
           except Exception:
               data = {}
 
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
           env_path = os.environ.get('GITHUB_ENV')
           if env_path:
-              trace_id = str(data.get('langsmith_trace_id') or '').strip()
-              trace_url = str(data.get('langsmith_trace_url') or '').strip()
+              trace_id = env_value(data.get('langsmith_trace_id'))
+              trace_url = env_value(data.get('langsmith_trace_url'))
               with open(env_path, 'a', encoding='utf-8') as env_file:
                   if trace_id:
                       env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID={trace_id}\n")
@@ -1472,10 +1475,13 @@ jobs:
           # Apply suggestions
           result = apply_suggestions(issue_body, suggestions, use_llm=True)
 
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
           env_path = os.environ.get('GITHUB_ENV')
           if env_path:
-              trace_id = str(result.get('langsmith_trace_id') or '').strip()
-              trace_url = str(result.get('langsmith_trace_url') or '').strip()
+              trace_id = env_value(result.get('langsmith_trace_id'))
+              trace_url = env_value(result.get('langsmith_trace_url'))
               with open(env_path, 'a', encoding='utf-8') as env_file:
                   if trace_id:
                       env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_ID={trace_id}\n')

--- a/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
+++ b/templates/consumer-repo/.github/scripts/bot_comment_auth_coverage.js
@@ -827,7 +827,7 @@ function main() {
   const markdownSummary = formatBotCommentAuthCoverageMarkdown(report);
   fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
   fs.writeFileSync(options.markdown, markdownSummary);
-  process.stdout.write(markdownSummary);
+  fs.writeFileSync(process.stdout.fd, markdownSummary);
   return report.status === 'fail' ? 1 : 0;
 }
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -1011,10 +1011,13 @@ jobs:
           except Exception:
               data = {}
 
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
           env_path = os.environ.get('GITHUB_ENV')
           if env_path:
-              trace_id = str(data.get('langsmith_trace_id') or '').strip()
-              trace_url = str(data.get('langsmith_trace_url') or '').strip()
+              trace_id = env_value(data.get('langsmith_trace_id'))
+              trace_url = env_value(data.get('langsmith_trace_url'))
               with open(env_path, 'a', encoding='utf-8') as env_file:
                   if trace_id:
                       env_file.write(f"AUTOPILOT_OPTIMIZE_LANGSMITH_TRACE_ID={trace_id}\n")
@@ -1398,10 +1401,13 @@ jobs:
           # Apply suggestions
           result = apply_suggestions(issue_body, suggestions, use_llm=True)
 
+          def env_value(value):
+              return str(value or '').replace('\r', '').replace('\n', '').strip()
+
           env_path = os.environ.get('GITHUB_ENV')
           if env_path:
-              trace_id = str(result.get('langsmith_trace_id') or '').strip()
-              trace_url = str(result.get('langsmith_trace_url') or '').strip()
+              trace_id = env_value(result.get('langsmith_trace_id'))
+              trace_url = env_value(result.get('langsmith_trace_url'))
               with open(env_path, 'a', encoding='utf-8') as env_file:
                   if trace_id:
                       env_file.write(f'AUTOPILOT_APPLY_LANGSMITH_TRACE_ID={trace_id}\n')


### PR DESCRIPTION
## Summary
- sanitize LangSmith trace ID/URL values before appending them to GITHUB_ENV in auto-pilot optimize/apply steps
- update both the first-party workflow and consumer template source

## Validation
- python scripts/validate_workflow_yaml.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
- python scripts/validate_template_sync.py
- /opt/homebrew/bin/actionlint .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml

Addresses sync review feedback from stranske/Inv-Man-Intake#436.

<!-- workflow-source:sync_campaign -->