### PR TITLE
fix: gate LangSmith tracing metrics

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -725,7 +725,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           PYTHONPATH: ${{ github.workspace }}
           ISSUE_PR_CONTEXT_WORKFLOW: agents-auto-pilot
@@ -982,7 +982,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
@@ -1363,7 +1363,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -417,12 +417,34 @@ def _safe_int(value: Any) -> int | None:
 
 
 def _langsmith_trace_count(entry: dict[str, Any]) -> int:
-    count = 1 if entry.get("langsmith_trace_id") else 0
+    return len(_langsmith_trace_ids(entry))
+
+
+def _langsmith_trace_ids(entry: dict[str, Any]) -> set[str]:
+    trace_ids: set[str] = set()
+    trace_id = str(entry.get("langsmith_trace_id") or "").strip()
+    if trace_id:
+        trace_ids.add(trace_id)
     traces = entry.get("langsmith_traces")
     if isinstance(traces, list):
-        list_count = sum(1 for item in traces if isinstance(item, dict) and item.get("trace_id"))
-        return max(count, list_count)
-    return count
+        for item in traces:
+            if not isinstance(item, dict):
+                continue
+            trace_id = str(item.get("trace_id") or "").strip()
+            if trace_id:
+                trace_ids.add(trace_id)
+    return trace_ids
+
+
+def _verifier_run_key(entry: dict[str, Any], index: int) -> str:
+    run_id = entry.get("run_id") or entry.get("workflow_run_id")
+    run_attempt = entry.get("run_attempt")
+    pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
+    if run_id:
+        return f"run:{run_id}:attempt:{run_attempt or ''}"
+    if pr_number_for_key is not None:
+        return f"pr:{pr_number_for_key}"
+    return f"entry:{index}"
 
 
 def _unsupported_verifier_models() -> set[str]:
@@ -601,21 +623,15 @@ def _summarise_verifier(
     issues_created = 0
     acceptance_counts: list[int] = []
     terminal_records = 0
-    langsmith_trace_records = 0
-    langsmith_trace_count = 0
+    langsmith_traced_run_keys: set[str] = set()
+    langsmith_trace_ids_by_run_key: dict[str, set[str]] = {}
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
         is_verifier_terminal = _is_verifier_terminal_entry(entry)
+        verifier_run_key = None
         if not is_terminal_disposition:
-            run_id = entry.get("run_id") or entry.get("workflow_run_id")
-            run_attempt = entry.get("run_attempt")
-            pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
-            if run_id:
-                verifier_run_keys.add(f"run:{run_id}:attempt:{run_attempt or ''}")
-            elif pr_number_for_key is not None:
-                verifier_run_keys.add(f"pr:{pr_number_for_key}")
-            else:
-                verifier_run_keys.add(f"entry:{index}")
+            verifier_run_key = _verifier_run_key(entry, index)
+            verifier_run_keys.add(verifier_run_key)
 
         verdict = entry.get("verdict")
         if verdict:
@@ -673,10 +689,10 @@ def _summarise_verifier(
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
-        trace_count = _langsmith_trace_count(entry)
-        if trace_count:
-            langsmith_trace_records += 1
-            langsmith_trace_count += trace_count
+        trace_ids = _langsmith_trace_ids(entry)
+        if trace_ids and verifier_run_key:
+            langsmith_traced_run_keys.add(verifier_run_key)
+            langsmith_trace_ids_by_run_key.setdefault(verifier_run_key, set()).update(trace_ids)
     for entry in ledger_entries or []:
         disposition = str(entry.get("disposition") or "unknown")
         ledger_dispositions[disposition] += 1
@@ -710,8 +726,10 @@ def _summarise_verifier(
         "verdicts": verdicts,
         "issues_created": issues_created,
         "avg_acceptance": avg_acceptance,
-        "langsmith_trace_records": langsmith_trace_records,
-        "langsmith_trace_count": langsmith_trace_count,
+        "langsmith_trace_records": len(langsmith_traced_run_keys),
+        "langsmith_trace_count": sum(
+            len(trace_ids) for trace_ids in langsmith_trace_ids_by_run_key.values()
+        ),
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -654,7 +654,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           PYTHONPATH: ${{ github.workspace }}
         run: |
@@ -910,7 +910,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
@@ -1290,7 +1290,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGCHAIN_TRACING_V2: "true"
+          LANGCHAIN_TRACING_V2: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
           LANGCHAIN_PROJECT: workflows-agents
           LANGCHAIN_PROVIDER: anthropic
           LANGCHAIN_MODEL: claude-sonnet-4-5-20250929

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -417,12 +417,34 @@ def _safe_int(value: Any) -> int | None:
 
 
 def _langsmith_trace_count(entry: dict[str, Any]) -> int:
-    count = 1 if entry.get("langsmith_trace_id") else 0
+    return len(_langsmith_trace_ids(entry))
+
+
+def _langsmith_trace_ids(entry: dict[str, Any]) -> set[str]:
+    trace_ids: set[str] = set()
+    trace_id = str(entry.get("langsmith_trace_id") or "").strip()
+    if trace_id:
+        trace_ids.add(trace_id)
     traces = entry.get("langsmith_traces")
     if isinstance(traces, list):
-        list_count = sum(1 for item in traces if isinstance(item, dict) and item.get("trace_id"))
-        return max(count, list_count)
-    return count
+        for item in traces:
+            if not isinstance(item, dict):
+                continue
+            trace_id = str(item.get("trace_id") or "").strip()
+            if trace_id:
+                trace_ids.add(trace_id)
+    return trace_ids
+
+
+def _verifier_run_key(entry: dict[str, Any], index: int) -> str:
+    run_id = entry.get("run_id") or entry.get("workflow_run_id")
+    run_attempt = entry.get("run_attempt")
+    pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
+    if run_id:
+        return f"run:{run_id}:attempt:{run_attempt or ''}"
+    if pr_number_for_key is not None:
+        return f"pr:{pr_number_for_key}"
+    return f"entry:{index}"
 
 
 def _unsupported_verifier_models() -> set[str]:
@@ -601,21 +623,15 @@ def _summarise_verifier(
     issues_created = 0
     acceptance_counts: list[int] = []
     terminal_records = 0
-    langsmith_trace_records = 0
-    langsmith_trace_count = 0
+    langsmith_traced_run_keys: set[str] = set()
+    langsmith_trace_ids_by_run_key: dict[str, set[str]] = {}
     for index, entry in enumerate(entries):
         is_terminal_disposition = entry.get("schema") == "workflows-terminal-disposition/v1"
         is_verifier_terminal = _is_verifier_terminal_entry(entry)
+        verifier_run_key = None
         if not is_terminal_disposition:
-            run_id = entry.get("run_id") or entry.get("workflow_run_id")
-            run_attempt = entry.get("run_attempt")
-            pr_number_for_key = _safe_int(entry.get("pr_number") or entry.get("pr"))
-            if run_id:
-                verifier_run_keys.add(f"run:{run_id}:attempt:{run_attempt or ''}")
-            elif pr_number_for_key is not None:
-                verifier_run_keys.add(f"pr:{pr_number_for_key}")
-            else:
-                verifier_run_keys.add(f"entry:{index}")
+            verifier_run_key = _verifier_run_key(entry, index)
+            verifier_run_keys.add(verifier_run_key)
 
         verdict = entry.get("verdict")
         if verdict:
@@ -673,10 +689,10 @@ def _summarise_verifier(
         acceptance = _safe_int(entry.get("acceptance_criteria_count"))
         if acceptance is not None:
             acceptance_counts.append(acceptance)
-        trace_count = _langsmith_trace_count(entry)
-        if trace_count:
-            langsmith_trace_records += 1
-            langsmith_trace_count += trace_count
+        trace_ids = _langsmith_trace_ids(entry)
+        if trace_ids and verifier_run_key:
+            langsmith_traced_run_keys.add(verifier_run_key)
+            langsmith_trace_ids_by_run_key.setdefault(verifier_run_key, set()).update(trace_ids)
     for entry in ledger_entries or []:
         disposition = str(entry.get("disposition") or "unknown")
         ledger_dispositions[disposition] += 1
@@ -710,8 +726,10 @@ def _summarise_verifier(
         "verdicts": verdicts,
         "issues_created": issues_created,
         "avg_acceptance": avg_acceptance,
-        "langsmith_trace_records": langsmith_trace_records,
-        "langsmith_trace_count": langsmith_trace_count,
+        "langsmith_trace_records": len(langsmith_traced_run_keys),
+        "langsmith_trace_count": sum(
+            len(trace_ids) for trace_ids in langsmith_trace_ids_by_run_key.values()
+        ),
         "terminal_records": terminal_records,
         "terminal_dispositions": terminal_dispositions,
         "terminal_sources": terminal_sources,

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -215,6 +215,36 @@ def test_langsmith_trace_counts_cover_single_ids_and_trace_lists() -> None:
     assert contract["summaries"]["autopilot"]["langsmith_trace_count"] == 3
 
 
+def test_verifier_langsmith_trace_coverage_deduplicates_run_keys() -> None:
+    entries = [
+        {
+            "metric_type": "verifier",
+            "run_id": "verify-1",
+            "run_attempt": "1",
+            "verdict": "pass",
+            "langsmith_trace_id": "verifier-trace-1",
+        },
+        {
+            "metric_type": "verifier",
+            "run_id": "verify-1",
+            "run_attempt": "1",
+            "verdict": "pass",
+            "langsmith_trace_id": "verifier-trace-1",
+        },
+    ]
+
+    summary = aggregate_agent_metrics.build_summary(entries, errors=0)
+
+    assert "Verifier\n- Runs: 1" in summary
+    assert "LangSmith trace coverage: 100.0% (1/1) (1 traces)" in summary
+
+    contract = aggregate_agent_metrics.build_summary_contract(entries, [])
+    verifier = contract["summaries"]["verifier"]
+    assert verifier["runs"] == 1
+    assert verifier["langsmith_trace_records"] == 1
+    assert verifier["langsmith_trace_count"] == 1
+
+
 def test_main_writes_summary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     keepalive_path = tmp_path / "keepalive.ndjson"
     autofix_path = tmp_path / "autofix.ndjson"


### PR DESCRIPTION
## Summary
- Gate auto-pilot LangSmith tracing on LANGSMITH_API_KEY so consumers without the secret do not force tracing on.
- De-duplicate verifier LangSmith trace coverage by the same run key used for the verifier run denominator.
- Keep the consumer template copies in sync.

## Validation
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q
- python scripts/validate_workflow_yaml.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
- python scripts/validate_template_sync.py

Notes: local actionlint could not run because the checked-in actionlint binary is Linux x86-64 and this host is macOS.

<!-- workflow-source:sync_campaign -->
