### PR TITLE
fix langsmith sync review followups

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -2338,6 +2338,38 @@ jobs:
             let issueLabels = [];
             let branchPrefix = 'codex/issue-';
 
+            const dispatchFirstAvailableWorkflow = async ({
+              workflowIds,
+              prNumber,
+              inputs,
+              description
+            }) => {
+              const failures = [];
+              for (const workflowId of workflowIds) {
+                try {
+                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowId,
+                    ref: baseBranch,
+                    inputs
+                  }));
+                  core.info(`Dispatched ${description} via ${workflowId} for PR #${prNumber}`);
+                  return workflowId;
+                } catch (dispatchError) {
+                  const status = dispatchError?.status;
+                  const message = dispatchError?.message || String(dispatchError);
+                  failures.push(`${workflowId}: ${message}`);
+                  if (status !== 404) {
+                    break;
+                  }
+                  core.info(`Workflow ${workflowId} not found; trying fallback`);
+                }
+              }
+              core.warning(`Could not dispatch ${description}: ${failures.join('; ')}`);
+              return null;
+            };
+
             const toLabelName = (label) => {
               if (!label) return '';
               if (typeof label === 'string') return label;
@@ -2959,38 +2991,26 @@ jobs:
 
               // Dispatch PR meta workflow to build Automated Status Summary
               // (GITHUB_TOKEN actions do not trigger workflow runs automatically)
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-pr-meta.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    debug: 'false'
-                  }
-                }));
-                core.info(`Dispatched PR meta update for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch PR meta update: ${dispatchError?.message}`);
-              }
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-80-pr-event-hub.yml', 'agents-pr-meta-v4.yml'],
+                prNumber: pr.number,
+                description: 'PR meta update',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  debug: 'false'
+                }
+              });
 
               // Dispatch keepalive workflow since GITHUB_TOKEN labels don't trigger it
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-keepalive-loop.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    force_retry: 'true'
-                  }
-                }));
-                core.info(`Dispatched keepalive for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch keepalive: ${dispatchError?.message}`);
-              }
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-81-gate-followups.yml', 'agents-keepalive-loop.yml'],
+                prNumber: pr.number,
+                description: 'keepalive follow-up',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  force_retry: 'true'
+                }
+              });
 
               // Add PR link comment to the issue with full URL for visibility
               // Use GITHUB_SERVER_URL for GHES/AE compatibility instead of hardcoding github.com

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -579,6 +579,8 @@ def validate_tasks(
     Returns:
         ValidationResult with final tasks and full audit trail
     """
+    tasks = [task for task in tasks if task and task.strip()]
+
     if not tasks:
         return ValidationResult(
             tasks=[],

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -68,6 +69,27 @@ def extract_trace_info(response: Any) -> TraceInfo:
         return TraceInfo()
 
 
+def _invoke_accepts_config(invoke: Any) -> bool:
+    try:
+        signature = inspect.signature(invoke)
+    except (TypeError, ValueError):
+        return True
+
+    for param in signature.parameters.values():
+        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
+def _is_unsupported_config_error(exc: TypeError) -> bool:
+    message = str(exc)
+    return "config" in message and (
+        "unexpected keyword argument" in message
+        or "got an unexpected keyword" in message
+        or "positional-only" in message
+    )
+
+
 def invoke_with_trace(
     runnable: Any,
     payload: Any,
@@ -88,13 +110,16 @@ def invoke_with_trace(
         pr_number=pr_number,
         issue_number=issue_number,
     )
-    try:
-        response = runnable.invoke(payload, config=config)
-    except Exception as first_exc:
+    invoke = runnable.invoke
+    if _invoke_accepts_config(invoke):
         try:
-            response = runnable.invoke(payload)
-        except Exception as fallback_exc:
-            raise first_exc from fallback_exc
+            response = invoke(payload, config=config)
+        except TypeError as exc:
+            if not _is_unsupported_config_error(exc):
+                raise
+            response = invoke(payload)
+    else:
+        response = invoke(payload)
     trace = extract_trace_info(response)
     if trace.trace_url:
         LOGGER.info("LangSmith trace: %s", trace.trace_url)

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -2338,6 +2338,38 @@ jobs:
             let issueLabels = [];
             let branchPrefix = 'codex/issue-';
 
+            const dispatchFirstAvailableWorkflow = async ({
+              workflowIds,
+              prNumber,
+              inputs,
+              description
+            }) => {
+              const failures = [];
+              for (const workflowId of workflowIds) {
+                try {
+                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowId,
+                    ref: baseBranch,
+                    inputs
+                  }));
+                  core.info(`Dispatched ${description} via ${workflowId} for PR #${prNumber}`);
+                  return workflowId;
+                } catch (dispatchError) {
+                  const status = dispatchError?.status;
+                  const message = dispatchError?.message || String(dispatchError);
+                  failures.push(`${workflowId}: ${message}`);
+                  if (status !== 404) {
+                    break;
+                  }
+                  core.info(`Workflow ${workflowId} not found; trying fallback`);
+                }
+              }
+              core.warning(`Could not dispatch ${description}: ${failures.join('; ')}`);
+              return null;
+            };
+
             const toLabelName = (label) => {
               if (!label) return '';
               if (typeof label === 'string') return label;
@@ -2959,38 +2991,26 @@ jobs:
 
               // Dispatch PR meta workflow to build Automated Status Summary
               // (GITHUB_TOKEN actions do not trigger workflow runs automatically)
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-pr-meta.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    debug: 'false'
-                  }
-                }));
-                core.info(`Dispatched PR meta update for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch PR meta update: ${dispatchError?.message}`);
-              }
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-80-pr-event-hub.yml', 'agents-pr-meta-v4.yml'],
+                prNumber: pr.number,
+                description: 'PR meta update',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  debug: 'false'
+                }
+              });
 
               // Dispatch keepalive workflow since GITHUB_TOKEN labels don't trigger it
-              try {
-                await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'agents-keepalive-loop.yml',
-                  ref: baseBranch,
-                  inputs: {
-                    pr_number: pr.number.toString(),
-                    force_retry: 'true'
-                  }
-                }));
-                core.info(`Dispatched keepalive for PR #${pr.number}`);
-              } catch (dispatchError) {
-                core.warning(`Could not dispatch keepalive: ${dispatchError?.message}`);
-              }
+              await dispatchFirstAvailableWorkflow({
+                workflowIds: ['agents-81-gate-followups.yml', 'agents-keepalive-loop.yml'],
+                prNumber: pr.number,
+                description: 'keepalive follow-up',
+                inputs: {
+                  pr_number: pr.number.toString(),
+                  force_retry: 'true'
+                }
+              });
 
               // Add PR link comment to the issue with full URL for visibility
               // Use GITHUB_SERVER_URL for GHES/AE compatibility instead of hardcoding github.com

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -237,6 +237,20 @@ class TestValidateTasks:
         assert result.tasks == []
         assert "No tasks" in result.audit_summary
 
+    def test_blank_tasks_filtered_before_audit(self) -> None:
+        tasks = ["", "  ", "Create scripts/metrics.py with timing helpers"]
+        result = validate_tasks(tasks, use_llm=False)
+
+        assert result.tasks == ["Create scripts/metrics.py with timing helpers"]
+        assert "1 input" in result.audit_summary
+        assert "1 output" in result.audit_summary
+
+    def test_all_blank_tasks_are_empty(self) -> None:
+        result = validate_tasks(["", "  "], use_llm=False)
+
+        assert result.tasks == []
+        assert "No tasks" in result.audit_summary
+
     def test_all_clean_tasks(self) -> None:
         tasks = [
             "Create scripts/metrics.py with timing functions",

--- a/tests/scripts/test_trace_utils.py
+++ b/tests/scripts/test_trace_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from scripts.langchain.trace_utils import invoke_with_trace
 
 
@@ -26,6 +27,24 @@ class _LegacyRunnable:
     def invoke(self, payload):
         self.calls += 1
         return _Response()
+
+
+class _ProviderFailureRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, payload, *, config=None):
+        self.calls += 1
+        raise RuntimeError("provider failed")
+
+
+class _ProviderTypeErrorRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, payload, *, config=None):
+        self.calls += 1
+        raise TypeError("provider payload type failed")
 
 
 def test_invoke_with_trace_passes_standard_metadata(monkeypatch):
@@ -59,3 +78,23 @@ def test_invoke_with_trace_retries_legacy_runnable_without_config(monkeypatch):
 
     assert runnable.calls == 1
     assert trace.trace_id == "trace-123"
+
+
+def test_invoke_with_trace_does_not_retry_provider_failures(monkeypatch):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _ProviderFailureRunnable()
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        invoke_with_trace(runnable, "prompt", operation="failure_unit_test")
+
+    assert runnable.calls == 1
+
+
+def test_invoke_with_trace_does_not_retry_unrelated_type_errors(monkeypatch):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _ProviderTypeErrorRunnable()
+
+    with pytest.raises(TypeError, match="provider payload type failed"):
+        invoke_with_trace(runnable, "prompt", operation="type_error_unit_test")
+
+    assert runnable.calls == 1


### PR DESCRIPTION
## Summary
- narrow LangSmith trace fallback so provider failures are not retried as second invocations
- filter blank task inputs before task-validator audit counts
- dispatch the managed consumer workflow names from auto-pilot

## Validation
- uv run ruff check scripts/langchain/trace_utils.py scripts/langchain/task_validator.py tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- uv run pytest tests/scripts/test_trace_utils.py tests/scripts/test_issue_formatter.py tests/scripts/test_context_extractor.py tests/scripts/test_task_validator.py tests/test_structured_output.py tests/scripts/test_aggregate_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- python scripts/validate_workflow_yaml.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
- python scripts/check_workflow_action_pins.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py