### PR TITLE
Fix sync review followups

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -804,7 +804,7 @@ jobs:
 
           # Check for guard_blocked before proceeding
           python -c "
-          import json, sys
+          import json, os, sys
           with open('/tmp/format_result.json') as f:
               result = json.load(f)
           if result.get('guard_blocked'):
@@ -2342,17 +2342,22 @@ jobs:
               workflowIds,
               prNumber,
               inputs,
+              inputsByWorkflow = {},
               description
             }) => {
               const failures = [];
               for (const workflowId of workflowIds) {
                 try {
+                  const workflowInputs = {
+                    ...inputs,
+                    ...(inputsByWorkflow[workflowId] || {})
+                  };
                   await withRetry((client) => client.rest.actions.createWorkflowDispatch({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     workflow_id: workflowId,
                     ref: baseBranch,
-                    inputs
+                    inputs: workflowInputs
                   }));
                   core.info(`Dispatched ${description} via ${workflowId} for PR #${prNumber}`);
                   return workflowId;
@@ -2998,6 +3003,11 @@ jobs:
                 inputs: {
                   pr_number: pr.number.toString(),
                   debug: 'false'
+                },
+                inputsByWorkflow: {
+                  'agents-80-pr-event-hub.yml': {
+                    handler: 'pr-meta'
+                  }
                 }
               });
 

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -137,15 +137,19 @@ class TaskFate:
     result: str | None  # None only for dropped
     reason: str | None = None  # Why dropped/improved/unprocessed
     warnings: list[str] = field(default_factory=list)
+    original_index: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "original": self.original,
             "outcome": self.outcome.value,
             "result": self.result,
             "reason": self.reason,
             "warnings": self.warnings,
         }
+        if self.original_index is not None:
+            payload["original_index"] = self.original_index
+        return payload
 
 
 @dataclass
@@ -241,20 +245,22 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
     """
     clean: list[str] = []
+    clean_items: list[dict[str, Any]] = []
     flagged: list[dict[str, Any]] = []
 
-    for task in tasks:
+    for index, task in enumerate(tasks):
         if not task or not task.strip():
             continue
 
         warnings = [name for name, check in WARNING_SIGNALS.items() if check(task)]
 
         if warnings:
-            flagged.append({"task": task, "warnings": warnings})
+            flagged.append({"task": task, "warnings": warnings, "index": index})
         else:
             clean.append(task)
+            clean_items.append({"task": task, "index": index})
 
-    return {"clean": clean, "flagged": flagged}
+    return {"clean": clean, "flagged": flagged, "clean_items": clean_items}
 
 
 # ---------------------------------------------------------------------------
@@ -305,14 +311,12 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
     fates: list[TaskFate] = []
     response_lines = [line.strip() for line in response.splitlines() if line.strip()]
 
-    # Track which flagged items we've processed
-    processed_indices: set[int] = set()
-
     # Try to match response lines to flagged items in order
     line_idx = 0
-    for item_idx, item in enumerate(flagged):
+    for item in flagged:
         task = item["task"]
         warnings = item.get("warnings", [])
+        original_index = item.get("index")
 
         # Look for a matching response line
         fate: TaskFate | None = None
@@ -332,6 +336,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=task,  # Keep original text
                         reason="LLM confirmed valid",
                         warnings=warnings,
+                        original_index=original_index,
                     )
                 elif action == "IMPROVE":
                     fate = TaskFate(
@@ -340,6 +345,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=content,
                         reason="LLM improved for actionability",
                         warnings=warnings,
+                        original_index=original_index,
                     )
                 elif action == "DROP":
                     fate = TaskFate(
@@ -348,10 +354,10 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=None,
                         reason=content,
                         warnings=warnings,
+                        original_index=original_index,
                     )
 
                 line_idx += 1
-                processed_indices.add(item_idx)
                 break
             else:
                 # Skip non-matching lines
@@ -365,6 +371,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                 result=task,
                 reason="LLM did not respond; keeping original",
                 warnings=warnings,
+                original_index=original_index,
             )
 
         fates.append(fate)
@@ -511,6 +518,7 @@ def merge_with_audit(
     refined: list[str],
     fates: list[TaskFate],
     original_count: int,
+    clean_items: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], str]:
     """
     Merge clean and refined tasks, returning audit summary.
@@ -520,11 +528,22 @@ def merge_with_audit(
         refined: Tasks from LLM refinement
         fates: TaskFate objects from refinement
         original_count: Original number of input tasks
+        clean_items: Optional clean task records with original indexes
 
     Returns:
         Tuple of (final_tasks, audit_summary)
     """
-    final = clean + refined
+    final: list[str]
+    if clean_items is not None and all(fate.original_index is not None for fate in fates):
+        output_by_index: dict[int, str] = {
+            int(item["index"]): str(item["task"]) for item in clean_items
+        }
+        for fate in fates:
+            if fate.result is not None and fate.original_index is not None:
+                output_by_index[int(fate.original_index)] = fate.result
+        final = [output_by_index[index] for index in sorted(output_by_index)]
+    else:
+        final = [*clean, *refined]
 
     # Count outcomes
     dropped = [f for f in fates if f.outcome == TaskOutcome.DROPPED]
@@ -617,6 +636,7 @@ def validate_tasks(
                 result=item["task"],
                 reason="LLM disabled; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]
@@ -625,7 +645,13 @@ def validate_tasks(
         trace = TraceInfo()
 
     # Merge and audit
-    final_tasks, audit = merge_with_audit(clean, refined, fates, original_count)
+    final_tasks, audit = merge_with_audit(
+        clean,
+        refined,
+        fates,
+        original_count,
+        triage_result.get("clean_items"),
+    )
 
     return ValidationResult(
         tasks=final_tasks,

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -804,7 +804,7 @@ jobs:
 
           # Check for guard_blocked before proceeding
           python -c "
-          import json, sys
+          import json, os, sys
           with open('/tmp/format_result.json') as f:
               result = json.load(f)
           if result.get('guard_blocked'):
@@ -2342,17 +2342,22 @@ jobs:
               workflowIds,
               prNumber,
               inputs,
+              inputsByWorkflow = {},
               description
             }) => {
               const failures = [];
               for (const workflowId of workflowIds) {
                 try {
+                  const workflowInputs = {
+                    ...inputs,
+                    ...(inputsByWorkflow[workflowId] || {})
+                  };
                   await withRetry((client) => client.rest.actions.createWorkflowDispatch({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     workflow_id: workflowId,
                     ref: baseBranch,
-                    inputs
+                    inputs: workflowInputs
                   }));
                   core.info(`Dispatched ${description} via ${workflowId} for PR #${prNumber}`);
                   return workflowId;
@@ -2998,6 +3003,11 @@ jobs:
                 inputs: {
                   pr_number: pr.number.toString(),
                   debug: 'false'
+                },
+                inputsByWorkflow: {
+                  'agents-80-pr-event-hub.yml': {
+                    handler: 'pr-meta'
+                  }
                 }
               });
 

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -144,9 +144,9 @@ class TestParseRefinementResponse:
 
     def test_parse_multiple_responses(self) -> None:
         flagged = [
-            {"task": "Fix", "warnings": ["too_short"]},
-            {"task": "### Header", "warnings": ["is_header"]},
-            {"task": "Ensure quality", "warnings": ["subjective_language"]},
+            {"task": "Fix", "warnings": ["too_short"], "index": 0},
+            {"task": "### Header", "warnings": ["is_header"], "index": 1},
+            {"task": "Ensure quality", "warnings": ["subjective_language"], "index": 2},
         ]
         response = """- IMPROVE: Fix the authentication bug in login.py
 - DROP: Section header
@@ -157,6 +157,7 @@ class TestParseRefinementResponse:
         assert fates[0].outcome == TaskOutcome.IMPROVED
         assert fates[1].outcome == TaskOutcome.DROPPED
         assert fates[2].outcome == TaskOutcome.IMPROVED
+        assert [fate.original_index for fate in fates] == [0, 1, 2]
 
     def test_fallback_to_original_on_missing_response(self) -> None:
         flagged = [
@@ -211,6 +212,24 @@ class TestAuditAndMerge:
         assert "3 input" in audit
         assert "3 output" in audit
 
+    def test_merge_with_audit_preserves_original_order(self) -> None:
+        clean = ["Task A", "Task C"]
+        clean_items = [{"task": "Task A", "index": 0}, {"task": "Task C", "index": 2}]
+        refined = ["Task B improved"]
+        fates = [
+            TaskFate(
+                original="Task B",
+                outcome=TaskOutcome.IMPROVED,
+                result="Task B improved",
+                reason="improved",
+                original_index=1,
+            )
+        ]
+
+        final, audit = merge_with_audit(clean, refined, fates, 3, clean_items)
+        assert final == ["Task A", "Task B improved", "Task C"]
+        assert "3 output" in audit
+
     def test_merge_with_audit_with_drops(self) -> None:
         clean = ["Task A"]
         refined = []  # Nothing from refinement kept
@@ -259,6 +278,18 @@ class TestValidateTasks:
         result = validate_tasks(tasks, use_llm=False)
         assert len(result.tasks) == 2
         assert "All clean" in result.audit_summary
+
+    def test_mixed_tasks_preserve_order_without_llm(self) -> None:
+        tasks = [
+            "Create scripts/metrics.py with timing functions",
+            "Fix",
+            "Add unit tests for metrics collection",
+            "### Validation",
+        ]
+
+        result = validate_tasks(tasks, use_llm=False)
+
+        assert result.tasks == tasks
 
     def test_flagged_tasks_without_llm(self) -> None:
         tasks = [

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -136,6 +136,20 @@ def test_auto_pilot_context_and_cycle_reads_defer_on_rate_limit():
     ), "Auto-pilot must not choose a next step after a rate-limited cycle count"
 
 
+def test_auto_pilot_dispatches_pr_event_hub_pr_meta_only():
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-auto-pilot.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-auto-pilot.yml"),
+    ]
+
+    for workflow_path in workflow_paths:
+        text = workflow_path.read_text(encoding="utf-8")
+        assert "import json, os, sys" in text
+        assert "inputsByWorkflow" in text
+        assert "'agents-80-pr-event-hub.yml': {" in text
+        assert "handler: 'pr-meta'" in text
+
+
 def test_orchestrator_bootstrap_label_delegates_fallback():
     text = (WORKFLOWS_DIR / "agents-70-orchestrator.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
## Summary
- add the missing os import for LangSmith trace env export in agents-auto-pilot
- dispatch the consolidated PR event hub with handler=pr-meta while keeping legacy fallback inputs compatible
- preserve task ordering through task validation by carrying original indices

## Validation
- uv run ruff check scripts/langchain/task_validator.py tests/scripts/test_task_validator.py tests/workflows/test_workflow_agents_consolidation.py
- uv run pytest tests/scripts/test_task_validator.py tests/workflows/test_workflow_agents_consolidation.py
- python scripts/validate_workflow_yaml.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/check_workflow_action_pins.py .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml