### PR TITLE
Fix task validator fallback ordering

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -421,6 +421,7 @@ def refine_flagged_tasks(
                 result=item["task"],
                 reason="No LLM available; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]
@@ -440,6 +441,7 @@ def refine_flagged_tasks(
                 result=item["task"],
                 reason="LangChain unavailable; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from scripts.langchain import task_validator as task_validator_module
 from scripts.langchain.task_validator import (
     TaskFate,
     TaskOutcome,
@@ -322,6 +323,23 @@ class TestValidateTasks:
         assert fates == []
         assert provider is None
         assert trace.available is False
+
+    def test_no_llm_refinement_preserves_task_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            task_validator_module,
+            "_get_llm_client",
+            lambda force_openai=False: None,
+        )
+        tasks = [
+            "Create scripts/metrics.py with timing functions",
+            "Fix",
+            "Add unit tests for metrics collection",
+        ]
+
+        result = validate_tasks(tasks, use_llm=True)
+
+        assert result.tasks == tasks
+        assert result.fates[0].original_index == 1
 
 
 class TestTaskFateSerialization:


### PR DESCRIPTION
## Summary
- preserve original task indices in no-LLM and no-LangChain refinement fallbacks
- add regression coverage for no-LLM fallback task ordering

## Validation
- uv run ruff check scripts/langchain/task_validator.py tests/scripts/test_task_validator.py
- uv run pytest tests/scripts/test_task_validator.py
- python scripts/validate_template_sync.py