### PR TITLE
Fix trace fallback sync review followups

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -242,7 +242,9 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         tasks: List of task strings to triage
 
     Returns:
-        Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
+        Dictionary with "clean" (list[str]), "clean_items" (list[dict] with
+        task/index pairs), and "flagged" (list[dict] with task, warnings, and
+        index) keys
     """
     clean: list[str] = []
     clean_items: list[dict[str, Any]] = []

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -82,12 +82,30 @@ def _invoke_accepts_config(invoke: Any) -> bool:
 
 
 def _is_unsupported_config_error(exc: TypeError) -> bool:
-    message = str(exc)
-    return "config" in message and (
-        "unexpected keyword argument" in message
-        or "got an unexpected keyword" in message
-        or "positional-only" in message
+    message = str(exc).lower()
+    no_keyword_support = (
+        "takes no keyword argument" in message
+        or "takes no keyword arguments" in message
+        or "does not take keyword argument" in message
+        or "does not take keyword arguments" in message
+        or "doesn't take keyword argument" in message
+        or "doesn't take keyword arguments" in message
     )
+    unsupported_config_message = no_keyword_support or (
+        "config" in message
+        and (
+            "unexpected keyword argument" in message
+            or "got an unexpected keyword" in message
+            or "positional-only" in message
+        )
+    )
+    return unsupported_config_message and _is_direct_call_type_error(exc)
+
+
+def _is_direct_call_type_error(exc: TypeError) -> bool:
+    """Return true when Python rejected the call before entering invoke()."""
+
+    return exc.__traceback__ is not None and exc.__traceback__.tb_next is None
 
 
 def invoke_with_trace(

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -137,15 +137,19 @@ class TaskFate:
     result: str | None  # None only for dropped
     reason: str | None = None  # Why dropped/improved/unprocessed
     warnings: list[str] = field(default_factory=list)
+    original_index: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "original": self.original,
             "outcome": self.outcome.value,
             "result": self.result,
             "reason": self.reason,
             "warnings": self.warnings,
         }
+        if self.original_index is not None:
+            payload["original_index"] = self.original_index
+        return payload
 
 
 @dataclass
@@ -238,23 +242,27 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         tasks: List of task strings to triage
 
     Returns:
-        Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
+        Dictionary with "clean" (list[str]), "clean_items" (list[dict] with
+        task/index pairs), and "flagged" (list[dict] with task, warnings, and
+        index) keys
     """
     clean: list[str] = []
+    clean_items: list[dict[str, Any]] = []
     flagged: list[dict[str, Any]] = []
 
-    for task in tasks:
+    for index, task in enumerate(tasks):
         if not task or not task.strip():
             continue
 
         warnings = [name for name, check in WARNING_SIGNALS.items() if check(task)]
 
         if warnings:
-            flagged.append({"task": task, "warnings": warnings})
+            flagged.append({"task": task, "warnings": warnings, "index": index})
         else:
             clean.append(task)
+            clean_items.append({"task": task, "index": index})
 
-    return {"clean": clean, "flagged": flagged}
+    return {"clean": clean, "flagged": flagged, "clean_items": clean_items}
 
 
 # ---------------------------------------------------------------------------
@@ -305,14 +313,12 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
     fates: list[TaskFate] = []
     response_lines = [line.strip() for line in response.splitlines() if line.strip()]
 
-    # Track which flagged items we've processed
-    processed_indices: set[int] = set()
-
     # Try to match response lines to flagged items in order
     line_idx = 0
-    for item_idx, item in enumerate(flagged):
+    for item in flagged:
         task = item["task"]
         warnings = item.get("warnings", [])
+        original_index = item.get("index")
 
         # Look for a matching response line
         fate: TaskFate | None = None
@@ -332,6 +338,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=task,  # Keep original text
                         reason="LLM confirmed valid",
                         warnings=warnings,
+                        original_index=original_index,
                     )
                 elif action == "IMPROVE":
                     fate = TaskFate(
@@ -340,6 +347,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=content,
                         reason="LLM improved for actionability",
                         warnings=warnings,
+                        original_index=original_index,
                     )
                 elif action == "DROP":
                     fate = TaskFate(
@@ -348,10 +356,10 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                         result=None,
                         reason=content,
                         warnings=warnings,
+                        original_index=original_index,
                     )
 
                 line_idx += 1
-                processed_indices.add(item_idx)
                 break
             else:
                 # Skip non-matching lines
@@ -365,6 +373,7 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
                 result=task,
                 reason="LLM did not respond; keeping original",
                 warnings=warnings,
+                original_index=original_index,
             )
 
         fates.append(fate)
@@ -414,6 +423,7 @@ def refine_flagged_tasks(
                 result=item["task"],
                 reason="No LLM available; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]
@@ -433,6 +443,7 @@ def refine_flagged_tasks(
                 result=item["task"],
                 reason="LangChain unavailable; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]
@@ -511,6 +522,7 @@ def merge_with_audit(
     refined: list[str],
     fates: list[TaskFate],
     original_count: int,
+    clean_items: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], str]:
     """
     Merge clean and refined tasks, returning audit summary.
@@ -520,11 +532,22 @@ def merge_with_audit(
         refined: Tasks from LLM refinement
         fates: TaskFate objects from refinement
         original_count: Original number of input tasks
+        clean_items: Optional clean task records with original indexes
 
     Returns:
         Tuple of (final_tasks, audit_summary)
     """
-    final = clean + refined
+    final: list[str]
+    if clean_items is not None and all(fate.original_index is not None for fate in fates):
+        output_by_index: dict[int, str] = {
+            int(item["index"]): str(item["task"]) for item in clean_items
+        }
+        for fate in fates:
+            if fate.result is not None and fate.original_index is not None:
+                output_by_index[int(fate.original_index)] = fate.result
+        final = [output_by_index[index] for index in sorted(output_by_index)]
+    else:
+        final = [*clean, *refined]
 
     # Count outcomes
     dropped = [f for f in fates if f.outcome == TaskOutcome.DROPPED]
@@ -579,6 +602,8 @@ def validate_tasks(
     Returns:
         ValidationResult with final tasks and full audit trail
     """
+    tasks = [task for task in tasks if task and task.strip()]
+
     if not tasks:
         return ValidationResult(
             tasks=[],
@@ -615,6 +640,7 @@ def validate_tasks(
                 result=item["task"],
                 reason="LLM disabled; keeping original",
                 warnings=item.get("warnings", []),
+                original_index=item.get("index"),
             )
             for item in flagged
         ]
@@ -623,7 +649,13 @@ def validate_tasks(
         trace = TraceInfo()
 
     # Merge and audit
-    final_tasks, audit = merge_with_audit(clean, refined, fates, original_count)
+    final_tasks, audit = merge_with_audit(
+        clean,
+        refined,
+        fates,
+        original_count,
+        triage_result.get("clean_items"),
+    )
 
     return ValidationResult(
         tasks=final_tasks,

--- a/templates/consumer-repo/scripts/langchain/trace_utils.py
+++ b/templates/consumer-repo/scripts/langchain/trace_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -68,6 +69,45 @@ def extract_trace_info(response: Any) -> TraceInfo:
         return TraceInfo()
 
 
+def _invoke_accepts_config(invoke: Any) -> bool:
+    try:
+        signature = inspect.signature(invoke)
+    except (TypeError, ValueError):
+        return True
+
+    for param in signature.parameters.values():
+        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
+def _is_unsupported_config_error(exc: TypeError) -> bool:
+    message = str(exc).lower()
+    no_keyword_support = (
+        "takes no keyword argument" in message
+        or "takes no keyword arguments" in message
+        or "does not take keyword argument" in message
+        or "does not take keyword arguments" in message
+        or "doesn't take keyword argument" in message
+        or "doesn't take keyword arguments" in message
+    )
+    unsupported_config_message = no_keyword_support or (
+        "config" in message
+        and (
+            "unexpected keyword argument" in message
+            or "got an unexpected keyword" in message
+            or "positional-only" in message
+        )
+    )
+    return unsupported_config_message and _is_direct_call_type_error(exc)
+
+
+def _is_direct_call_type_error(exc: TypeError) -> bool:
+    """Return true when Python rejected the call before entering invoke()."""
+
+    return exc.__traceback__ is not None and exc.__traceback__.tb_next is None
+
+
 def invoke_with_trace(
     runnable: Any,
     payload: Any,
@@ -88,13 +128,16 @@ def invoke_with_trace(
         pr_number=pr_number,
         issue_number=issue_number,
     )
-    try:
-        response = runnable.invoke(payload, config=config)
-    except Exception as first_exc:
+    invoke = runnable.invoke
+    if _invoke_accepts_config(invoke):
         try:
-            response = runnable.invoke(payload)
-        except Exception as fallback_exc:
-            raise first_exc from fallback_exc
+            response = invoke(payload, config=config)
+        except TypeError as exc:
+            if not _is_unsupported_config_error(exc):
+                raise
+            response = invoke(payload)
+    else:
+        response = invoke(payload)
     trace = extract_trace_info(response)
     if trace.trace_url:
         LOGGER.info("LangSmith trace: %s", trace.trace_url)

--- a/tests/scripts/test_trace_utils.py
+++ b/tests/scripts/test_trace_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from scripts.langchain import trace_utils
 from scripts.langchain.trace_utils import invoke_with_trace
 
 
@@ -47,6 +48,26 @@ class _ProviderTypeErrorRunnable:
         raise TypeError("provider payload type failed")
 
 
+class _NoKeywordCallable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, payload, **kwargs):
+        self.calls += 1
+        if kwargs:
+            raise TypeError("invoke() takes no keyword arguments")
+        return _Response()
+
+
+class _NoKeywordErrorRunnable:
+    def __init__(self) -> None:
+        self.invoke = _NoKeywordCallable()
+
+
+class _BuiltinNoKeywordRunnable:
+    invoke = staticmethod(len)
+
+
 def test_invoke_with_trace_passes_standard_metadata(monkeypatch):
     monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
     runnable = _Runnable()
@@ -78,6 +99,40 @@ def test_invoke_with_trace_retries_legacy_runnable_without_config(monkeypatch):
 
     assert runnable.calls == 1
     assert trace.trace_id == "trace-123"
+
+
+def test_invoke_with_trace_retries_builtin_no_keyword_callable_without_config(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    monkeypatch.setattr(trace_utils, "_invoke_accepts_config", lambda _invoke: True)
+    runnable = _BuiltinNoKeywordRunnable()
+
+    response, trace = invoke_with_trace(
+        runnable,
+        "prompt",
+        operation="builtin_no_keyword_unit_test",
+    )
+
+    assert response == len("prompt")
+    assert not trace.available
+
+
+def test_invoke_with_trace_does_not_retry_internal_no_keyword_type_error(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    monkeypatch.setattr(trace_utils, "_invoke_accepts_config", lambda _invoke: True)
+    runnable = _NoKeywordErrorRunnable()
+
+    with pytest.raises(TypeError, match="takes no keyword arguments"):
+        invoke_with_trace(
+            runnable,
+            "prompt",
+            operation="no_keyword_unit_test",
+        )
+
+    assert runnable.invoke.calls == 1
 
 
 def test_invoke_with_trace_does_not_retry_provider_failures(monkeypatch):


### PR DESCRIPTION
## Summary
- Treat no-keyword-argument TypeErrors as unsupported config fallbacks in trace invocation
- Update task triage return-shape documentation
- Add regression coverage for no-keyword fallback behavior

## Validation
- uv run ruff check scripts/langchain/trace_utils.py scripts/langchain/task_validator.py tests/scripts/test_trace_utils.py
- uv run pytest tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- python scripts/validate_template_sync.py