### PR TITLE
Tighten trace fallback TypeError detection

### DIFF
--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -105,7 +105,12 @@ def _is_unsupported_config_error(exc: TypeError) -> bool:
 def _is_direct_call_type_error(exc: TypeError) -> bool:
     """Return true when Python rejected the call before entering invoke()."""
 
-    return exc.__traceback__ is not None and exc.__traceback__.tb_next is None
+    tb = exc.__traceback__
+    # TypeErrors raised by the runnable include an inner traceback frame.
+    # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return (
+        tb is not None and tb.tb_frame.f_code is invoke_with_trace.__code__ and tb.tb_next is None
+    )
 
 
 def invoke_with_trace(

--- a/templates/consumer-repo/scripts/langchain/trace_utils.py
+++ b/templates/consumer-repo/scripts/langchain/trace_utils.py
@@ -105,7 +105,12 @@ def _is_unsupported_config_error(exc: TypeError) -> bool:
 def _is_direct_call_type_error(exc: TypeError) -> bool:
     """Return true when Python rejected the call before entering invoke()."""
 
-    return exc.__traceback__ is not None and exc.__traceback__.tb_next is None
+    tb = exc.__traceback__
+    # TypeErrors raised by the runnable include an inner traceback frame.
+    # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return (
+        tb is not None and tb.tb_frame.f_code is invoke_with_trace.__code__ and tb.tb_next is None
+    )
 
 
 def invoke_with_trace(


### PR DESCRIPTION
## Summary
- verify unsupported config TypeErrors come from the invoke_with_trace call site before retrying without config
- mirror the fallback predicate into the consumer template

## Validation
- uv run ruff check scripts/langchain/trace_utils.py templates/consumer-repo/scripts/langchain/trace_utils.py tests/scripts/test_trace_utils.py
- uv run pytest tests/scripts/test_trace_utils.py
- python scripts/validate_template_sync.py