### PR TITLE
Handle delegated trace fallback wrappers

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 try:
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
@@ -152,6 +153,29 @@ class TaskFate:
         return payload
 
 
+class TriageCleanItem(TypedDict):
+    """Clean task record with the original input position."""
+
+    task: str
+    index: int
+
+
+class TriageFlaggedItem(TypedDict):
+    """Flagged task record with heuristic warnings and original position."""
+
+    task: str
+    warnings: list[str]
+    index: int
+
+
+class TriageResult(TypedDict):
+    """Structured result returned by ``triage_tasks``."""
+
+    clean: list[str]
+    clean_items: list[TriageCleanItem]
+    flagged: list[TriageFlaggedItem]
+
+
 @dataclass
 class ValidationResult:
     """Complete result of task validation."""
@@ -234,7 +258,7 @@ WARNING_SIGNALS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
+def triage_tasks(tasks: list[str]) -> TriageResult:
     """
     Separate tasks into clean vs flagged for review.
 
@@ -247,8 +271,8 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         index) keys
     """
     clean: list[str] = []
-    clean_items: list[dict[str, Any]] = []
-    flagged: list[dict[str, Any]] = []
+    clean_items: list[TriageCleanItem] = []
+    flagged: list[TriageFlaggedItem] = []
 
     for index, task in enumerate(tasks):
         if not task or not task.strip():
@@ -304,7 +328,10 @@ def _load_refinement_prompt() -> str:
 REFINEMENT_PATTERN = re.compile(r"^\s*[-*]?\s*(KEEP|IMPROVE|DROP)\s*:\s*(.+)$", re.IGNORECASE)
 
 
-def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> list[TaskFate]:
+def _parse_refinement_response(
+    response: str,
+    flagged: Sequence[Mapping[str, Any]],
+) -> list[TaskFate]:
     """
     Parse LLM refinement response into TaskFate objects.
 
@@ -387,13 +414,13 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
 
 
 def refine_flagged_tasks(
-    flagged: list[dict[str, Any]], context: str = ""
+    flagged: Sequence[Mapping[str, Any]], context: str = ""
 ) -> tuple[list[str], list[TaskFate], str | None, TraceInfo]:
     """
     Send flagged tasks to LLM for refinement decision.
 
     Args:
-        flagged: List of {"task": str, "warnings": list[str]} dicts
+        flagged: Sequence of mappings with "task", optional "warnings", and optional "index" keys.
         context: Optional issue context for LLM
 
     Returns:
@@ -522,7 +549,7 @@ def merge_with_audit(
     refined: list[str],
     fates: list[TaskFate],
     original_count: int,
-    clean_items: list[dict[str, Any]] | None = None,
+    clean_items: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[list[str], str]:
     """
     Merge clean and refined tasks, returning audit summary.

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import dis
 import inspect
+import linecache
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 LOGGER = logging.getLogger(__name__)
+
+ConfigSupport = Literal["explicit", "variadic", "unknown", "none"]
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,13 @@ class TraceInfo:
         if self.trace_url:
             payload["langsmith_trace_url"] = self.trace_url
         return payload
+
+
+@dataclass(frozen=True)
+class _TracebackFrame:
+    code: Any
+    lineno: int
+    lasti: int
 
 
 def build_trace_config(
@@ -69,19 +80,22 @@ def extract_trace_info(response: Any) -> TraceInfo:
         return TraceInfo()
 
 
-def _invoke_accepts_config(invoke: Any) -> bool:
+def _invoke_config_support(invoke: Any) -> ConfigSupport:
     try:
         signature = inspect.signature(invoke)
     except (TypeError, ValueError):
-        return True
+        return "unknown"
 
+    accepts_variadic_kwargs = False
     for param in signature.parameters.values():
-        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-    return False
+        if param.name == "config":
+            return "explicit"
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            accepts_variadic_kwargs = True
+    return "variadic" if accepts_variadic_kwargs else "none"
 
 
-def _is_unsupported_config_error(exc: TypeError) -> bool:
+def _is_unsupported_config_error(exc: TypeError, *, allow_delegated: bool = False) -> bool:
     message = str(exc).lower()
     no_keyword_support = (
         "takes no keyword argument" in message
@@ -99,17 +113,64 @@ def _is_unsupported_config_error(exc: TypeError) -> bool:
             or "positional-only" in message
         )
     )
-    return unsupported_config_message and _is_direct_call_type_error(exc)
+    if not unsupported_config_message:
+        return False
+    if _is_direct_call_type_error(exc):
+        return True
+    return allow_delegated and "config" in message and _is_delegated_call_type_error(exc)
+
+
+def _traceback_frames(exc: TypeError) -> list[_TracebackFrame]:
+    frames: list[_TracebackFrame] = []
+    tb = exc.__traceback__
+    while tb is not None:
+        frames.append(
+            _TracebackFrame(
+                code=tb.tb_frame.f_code,
+                lineno=tb.tb_lineno,
+                lasti=tb.tb_lasti,
+            )
+        )
+        tb = tb.tb_next
+    return frames
+
+
+def _is_call_instruction(frame: _TracebackFrame) -> bool:
+    for instruction in dis.get_instructions(frame.code):
+        if instruction.offset == frame.lasti:
+            return instruction.opname.startswith("CALL")
+    return False
+
+
+def _is_forwarding_invoke_call(frame: _TracebackFrame) -> bool:
+    if not _is_call_instruction(frame):
+        return False
+
+    source = " ".join(
+        linecache.getline(frame.code.co_filename, lineno).strip()
+        for lineno in range(frame.lineno, frame.lineno + 6)
+    )
+    return "invoke(" in source or "__call__(" in source
 
 
 def _is_direct_call_type_error(exc: TypeError) -> bool:
     """Return true when Python rejected the call before entering invoke()."""
 
-    tb = exc.__traceback__
+    frames = _traceback_frames(exc)
     # TypeErrors raised by the runnable include an inner traceback frame.
     # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return len(frames) == 1 and frames[0].code is invoke_with_trace.__code__
+
+
+def _is_delegated_call_type_error(exc: TypeError) -> bool:
+    """Return true for ``invoke(**kwargs)`` wrappers rejected below the wrapper."""
+
+    frames = _traceback_frames(exc)
     return (
-        tb is not None and tb.tb_frame.f_code is invoke_with_trace.__code__ and tb.tb_next is None
+        len(frames) > 1
+        and frames[0].code is invoke_with_trace.__code__
+        and all(frame.code.co_name in {"invoke", "__call__"} for frame in frames[1:])
+        and _is_forwarding_invoke_call(frames[-1])
     )
 
 
@@ -134,11 +195,15 @@ def invoke_with_trace(
         issue_number=issue_number,
     )
     invoke = runnable.invoke
-    if _invoke_accepts_config(invoke):
+    config_support = _invoke_config_support(invoke)
+    if config_support != "none":
         try:
             response = invoke(payload, config=config)
         except TypeError as exc:
-            if not _is_unsupported_config_error(exc):
+            if not _is_unsupported_config_error(
+                exc,
+                allow_delegated=config_support == "variadic",
+            ):
                 raise
             response = invoke(payload)
     else:

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 try:
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
@@ -152,6 +153,29 @@ class TaskFate:
         return payload
 
 
+class TriageCleanItem(TypedDict):
+    """Clean task record with the original input position."""
+
+    task: str
+    index: int
+
+
+class TriageFlaggedItem(TypedDict):
+    """Flagged task record with heuristic warnings and original position."""
+
+    task: str
+    warnings: list[str]
+    index: int
+
+
+class TriageResult(TypedDict):
+    """Structured result returned by ``triage_tasks``."""
+
+    clean: list[str]
+    clean_items: list[TriageCleanItem]
+    flagged: list[TriageFlaggedItem]
+
+
 @dataclass
 class ValidationResult:
     """Complete result of task validation."""
@@ -234,7 +258,7 @@ WARNING_SIGNALS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
+def triage_tasks(tasks: list[str]) -> TriageResult:
     """
     Separate tasks into clean vs flagged for review.
 
@@ -247,8 +271,8 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         index) keys
     """
     clean: list[str] = []
-    clean_items: list[dict[str, Any]] = []
-    flagged: list[dict[str, Any]] = []
+    clean_items: list[TriageCleanItem] = []
+    flagged: list[TriageFlaggedItem] = []
 
     for index, task in enumerate(tasks):
         if not task or not task.strip():
@@ -304,7 +328,10 @@ def _load_refinement_prompt() -> str:
 REFINEMENT_PATTERN = re.compile(r"^\s*[-*]?\s*(KEEP|IMPROVE|DROP)\s*:\s*(.+)$", re.IGNORECASE)
 
 
-def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> list[TaskFate]:
+def _parse_refinement_response(
+    response: str,
+    flagged: Sequence[Mapping[str, Any]],
+) -> list[TaskFate]:
     """
     Parse LLM refinement response into TaskFate objects.
 
@@ -387,13 +414,13 @@ def _parse_refinement_response(response: str, flagged: list[dict[str, Any]]) -> 
 
 
 def refine_flagged_tasks(
-    flagged: list[dict[str, Any]], context: str = ""
+    flagged: Sequence[Mapping[str, Any]], context: str = ""
 ) -> tuple[list[str], list[TaskFate], str | None, TraceInfo]:
     """
     Send flagged tasks to LLM for refinement decision.
 
     Args:
-        flagged: List of {"task": str, "warnings": list[str]} dicts
+        flagged: Sequence of mappings with "task", optional "warnings", and optional "index" keys.
         context: Optional issue context for LLM
 
     Returns:
@@ -522,7 +549,7 @@ def merge_with_audit(
     refined: list[str],
     fates: list[TaskFate],
     original_count: int,
-    clean_items: list[dict[str, Any]] | None = None,
+    clean_items: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[list[str], str]:
     """
     Merge clean and refined tasks, returning audit summary.

--- a/templates/consumer-repo/scripts/langchain/trace_utils.py
+++ b/templates/consumer-repo/scripts/langchain/trace_utils.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import dis
 import inspect
+import linecache
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 LOGGER = logging.getLogger(__name__)
+
+ConfigSupport = Literal["explicit", "variadic", "unknown", "none"]
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,13 @@ class TraceInfo:
         if self.trace_url:
             payload["langsmith_trace_url"] = self.trace_url
         return payload
+
+
+@dataclass(frozen=True)
+class _TracebackFrame:
+    code: Any
+    lineno: int
+    lasti: int
 
 
 def build_trace_config(
@@ -69,19 +80,22 @@ def extract_trace_info(response: Any) -> TraceInfo:
         return TraceInfo()
 
 
-def _invoke_accepts_config(invoke: Any) -> bool:
+def _invoke_config_support(invoke: Any) -> ConfigSupport:
     try:
         signature = inspect.signature(invoke)
     except (TypeError, ValueError):
-        return True
+        return "unknown"
 
+    accepts_variadic_kwargs = False
     for param in signature.parameters.values():
-        if param.name == "config" or param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-    return False
+        if param.name == "config":
+            return "explicit"
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            accepts_variadic_kwargs = True
+    return "variadic" if accepts_variadic_kwargs else "none"
 
 
-def _is_unsupported_config_error(exc: TypeError) -> bool:
+def _is_unsupported_config_error(exc: TypeError, *, allow_delegated: bool = False) -> bool:
     message = str(exc).lower()
     no_keyword_support = (
         "takes no keyword argument" in message
@@ -99,17 +113,64 @@ def _is_unsupported_config_error(exc: TypeError) -> bool:
             or "positional-only" in message
         )
     )
-    return unsupported_config_message and _is_direct_call_type_error(exc)
+    if not unsupported_config_message:
+        return False
+    if _is_direct_call_type_error(exc):
+        return True
+    return allow_delegated and "config" in message and _is_delegated_call_type_error(exc)
+
+
+def _traceback_frames(exc: TypeError) -> list[_TracebackFrame]:
+    frames: list[_TracebackFrame] = []
+    tb = exc.__traceback__
+    while tb is not None:
+        frames.append(
+            _TracebackFrame(
+                code=tb.tb_frame.f_code,
+                lineno=tb.tb_lineno,
+                lasti=tb.tb_lasti,
+            )
+        )
+        tb = tb.tb_next
+    return frames
+
+
+def _is_call_instruction(frame: _TracebackFrame) -> bool:
+    for instruction in dis.get_instructions(frame.code):
+        if instruction.offset == frame.lasti:
+            return instruction.opname.startswith("CALL")
+    return False
+
+
+def _is_forwarding_invoke_call(frame: _TracebackFrame) -> bool:
+    if not _is_call_instruction(frame):
+        return False
+
+    source = " ".join(
+        linecache.getline(frame.code.co_filename, lineno).strip()
+        for lineno in range(frame.lineno, frame.lineno + 6)
+    )
+    return "invoke(" in source or "__call__(" in source
 
 
 def _is_direct_call_type_error(exc: TypeError) -> bool:
     """Return true when Python rejected the call before entering invoke()."""
 
-    tb = exc.__traceback__
+    frames = _traceback_frames(exc)
     # TypeErrors raised by the runnable include an inner traceback frame.
     # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return len(frames) == 1 and frames[0].code is invoke_with_trace.__code__
+
+
+def _is_delegated_call_type_error(exc: TypeError) -> bool:
+    """Return true for ``invoke(**kwargs)`` wrappers rejected below the wrapper."""
+
+    frames = _traceback_frames(exc)
     return (
-        tb is not None and tb.tb_frame.f_code is invoke_with_trace.__code__ and tb.tb_next is None
+        len(frames) > 1
+        and frames[0].code is invoke_with_trace.__code__
+        and all(frame.code.co_name in {"invoke", "__call__"} for frame in frames[1:])
+        and _is_forwarding_invoke_call(frames[-1])
     )
 
 
@@ -134,11 +195,15 @@ def invoke_with_trace(
         issue_number=issue_number,
     )
     invoke = runnable.invoke
-    if _invoke_accepts_config(invoke):
+    config_support = _invoke_config_support(invoke)
+    if config_support != "none":
         try:
             response = invoke(payload, config=config)
         except TypeError as exc:
-            if not _is_unsupported_config_error(exc):
+            if not _is_unsupported_config_error(
+                exc,
+                allow_delegated=config_support == "variadic",
+            ):
                 raise
             response = invoke(payload)
     else:

--- a/tests/scripts/test_trace_utils.py
+++ b/tests/scripts/test_trace_utils.py
@@ -48,6 +48,15 @@ class _ProviderTypeErrorRunnable:
         raise TypeError("provider payload type failed")
 
 
+class _ProviderConfigTypeErrorRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, payload, *, config=None):
+        self.calls += 1
+        raise TypeError("provider got an unexpected keyword argument 'config'")
+
+
 class _NoKeywordCallable:
     def __init__(self) -> None:
         self.calls = 0
@@ -66,6 +75,25 @@ class _NoKeywordErrorRunnable:
 
 class _BuiltinNoKeywordRunnable:
     invoke = staticmethod(len)
+
+
+class _DelegatingRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.inner = _LegacyRunnable()
+
+    def invoke(self, payload, **kwargs):
+        self.calls += 1
+        return self.inner.invoke(payload, **kwargs)
+
+
+class _VariadicWrapperProviderConfigTypeErrorRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke(self, payload, **kwargs):
+        self.calls += 1
+        raise TypeError("provider got an unexpected keyword argument 'config'")
 
 
 def test_invoke_with_trace_passes_standard_metadata(monkeypatch):
@@ -105,7 +133,7 @@ def test_invoke_with_trace_retries_builtin_no_keyword_callable_without_config(
     monkeypatch,
 ):
     monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
-    monkeypatch.setattr(trace_utils, "_invoke_accepts_config", lambda _invoke: True)
+    monkeypatch.setattr(trace_utils, "_invoke_config_support", lambda _invoke: "unknown")
     runnable = _BuiltinNoKeywordRunnable()
 
     response, trace = invoke_with_trace(
@@ -122,7 +150,6 @@ def test_invoke_with_trace_does_not_retry_internal_no_keyword_type_error(
     monkeypatch,
 ):
     monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
-    monkeypatch.setattr(trace_utils, "_invoke_accepts_config", lambda _invoke: True)
     runnable = _NoKeywordErrorRunnable()
 
     with pytest.raises(TypeError, match="takes no keyword arguments"):
@@ -133,6 +160,23 @@ def test_invoke_with_trace_does_not_retry_internal_no_keyword_type_error(
         )
 
     assert runnable.invoke.calls == 1
+
+
+def test_invoke_with_trace_retries_delegating_variadic_wrapper_without_config(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _DelegatingRunnable()
+
+    _response, trace = invoke_with_trace(
+        runnable,
+        "prompt",
+        operation="delegating_unit_test",
+    )
+
+    assert runnable.calls == 2
+    assert runnable.inner.calls == 1
+    assert trace.trace_id == "trace-123"
 
 
 def test_invoke_with_trace_does_not_retry_provider_failures(monkeypatch):
@@ -151,5 +195,29 @@ def test_invoke_with_trace_does_not_retry_unrelated_type_errors(monkeypatch):
 
     with pytest.raises(TypeError, match="provider payload type failed"):
         invoke_with_trace(runnable, "prompt", operation="type_error_unit_test")
+
+    assert runnable.calls == 1
+
+
+def test_invoke_with_trace_does_not_retry_explicit_config_provider_type_error(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _ProviderConfigTypeErrorRunnable()
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'config'"):
+        invoke_with_trace(runnable, "prompt", operation="config_type_error_unit_test")
+
+    assert runnable.calls == 1
+
+
+def test_invoke_with_trace_does_not_retry_variadic_provider_config_type_error(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _VariadicWrapperProviderConfigTypeErrorRunnable()
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'config'"):
+        invoke_with_trace(runnable, "prompt", operation="variadic_config_type_error_unit_test")
 
     assert runnable.calls == 1


### PR DESCRIPTION
## Summary
- support variadic invoke wrappers that forward config to older runnables by retrying without config for delegated config-binding TypeErrors
- keep explicit-config provider TypeErrors fail-fast
- define a typed triage result for task validation and mirror both changes to the consumer template

## Validation
- uv run ruff check scripts/langchain/trace_utils.py scripts/langchain/task_validator.py templates/consumer-repo/scripts/langchain/trace_utils.py templates/consumer-repo/scripts/langchain/task_validator.py tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- uv run pytest tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- python scripts/validate_template_sync.py