### PR TITLE
fix sync review helper followups

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -629,9 +629,9 @@ def validate_tasks(
     Returns:
         ValidationResult with final tasks and full audit trail
     """
-    tasks = [task for task in tasks if task and task.strip()]
+    indexed_tasks = [(index, task) for index, task in enumerate(tasks) if task and task.strip()]
 
-    if not tasks:
+    if not indexed_tasks:
         return ValidationResult(
             tasks=[],
             fates=[],
@@ -639,10 +639,16 @@ def validate_tasks(
             provider_used=None,
         )
 
+    original_indexes = [index for index, _task in indexed_tasks]
+    tasks = [task for _index, task in indexed_tasks]
     original_count = len(tasks)
 
     # Pass 1: Heuristic triage
     triage_result = triage_tasks(tasks)
+    for item in triage_result["clean_items"]:
+        item["index"] = original_indexes[item["index"]]
+    for item in triage_result["flagged"]:
+        item["index"] = original_indexes[item["index"]]
     clean = triage_result["clean"]
     flagged = triage_result["flagged"]
 

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -169,7 +169,7 @@ def _is_delegated_call_type_error(exc: TypeError) -> bool:
     return (
         len(frames) > 1
         and frames[0].code is invoke_with_trace.__code__
-        and all(frame.code.co_name in {"invoke", "__call__"} for frame in frames[1:])
+        and frames[1].code.co_name in {"invoke", "__call__"}
         and _is_forwarding_invoke_call(frames[-1])
     )
 

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -629,9 +629,9 @@ def validate_tasks(
     Returns:
         ValidationResult with final tasks and full audit trail
     """
-    tasks = [task for task in tasks if task and task.strip()]
+    indexed_tasks = [(index, task) for index, task in enumerate(tasks) if task and task.strip()]
 
-    if not tasks:
+    if not indexed_tasks:
         return ValidationResult(
             tasks=[],
             fates=[],
@@ -639,10 +639,16 @@ def validate_tasks(
             provider_used=None,
         )
 
+    original_indexes = [index for index, _task in indexed_tasks]
+    tasks = [task for _index, task in indexed_tasks]
     original_count = len(tasks)
 
     # Pass 1: Heuristic triage
     triage_result = triage_tasks(tasks)
+    for item in triage_result["clean_items"]:
+        item["index"] = original_indexes[item["index"]]
+    for item in triage_result["flagged"]:
+        item["index"] = original_indexes[item["index"]]
     clean = triage_result["clean"]
     flagged = triage_result["flagged"]
 

--- a/templates/consumer-repo/scripts/langchain/trace_utils.py
+++ b/templates/consumer-repo/scripts/langchain/trace_utils.py
@@ -169,7 +169,7 @@ def _is_delegated_call_type_error(exc: TypeError) -> bool:
     return (
         len(frames) > 1
         and frames[0].code is invoke_with_trace.__code__
-        and all(frame.code.co_name in {"invoke", "__call__"} for frame in frames[1:])
+        and frames[1].code.co_name in {"invoke", "__call__"}
         and _is_forwarding_invoke_call(frames[-1])
     )
 

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -341,6 +341,25 @@ class TestValidateTasks:
         assert result.tasks == tasks
         assert result.fates[0].original_index == 1
 
+    def test_blank_filtering_preserves_original_input_indexes(self) -> None:
+        tasks = [
+            "",
+            "Create scripts/metrics.py with timing functions",
+            "  ",
+            "Fix",
+            "Add unit tests for metrics collection",
+        ]
+
+        result = validate_tasks(tasks, use_llm=False)
+
+        assert result.tasks == [
+            "Create scripts/metrics.py with timing functions",
+            "Fix",
+            "Add unit tests for metrics collection",
+        ]
+        assert result.fates[0].original_index == 3
+        assert "3 input" in result.audit_summary
+
 
 class TestTaskFateSerialization:
     """Test TaskFate dataclass serialization."""

--- a/tests/scripts/test_trace_utils.py
+++ b/tests/scripts/test_trace_utils.py
@@ -87,12 +87,41 @@ class _DelegatingRunnable:
         return self.inner.invoke(payload, **kwargs)
 
 
+class _HelperDelegatingRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.helper_calls = 0
+        self.inner = _LegacyRunnable()
+
+    def invoke(self, payload, **kwargs):
+        self.calls += 1
+        return self._forward(payload, **kwargs)
+
+    def _forward(self, payload, **kwargs):
+        self.helper_calls += 1
+        return self.inner.invoke(payload, **kwargs)
+
+
 class _VariadicWrapperProviderConfigTypeErrorRunnable:
     def __init__(self) -> None:
         self.calls = 0
 
     def invoke(self, payload, **kwargs):
         self.calls += 1
+        raise TypeError("provider got an unexpected keyword argument 'config'")
+
+
+class _HelperProviderConfigTypeErrorRunnable:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.helper_calls = 0
+
+    def invoke(self, payload, **kwargs):
+        self.calls += 1
+        return self._forward(payload, **kwargs)
+
+    def _forward(self, payload, **kwargs):
+        self.helper_calls += 1
         raise TypeError("provider got an unexpected keyword argument 'config'")
 
 
@@ -179,6 +208,24 @@ def test_invoke_with_trace_retries_delegating_variadic_wrapper_without_config(
     assert trace.trace_id == "trace-123"
 
 
+def test_invoke_with_trace_retries_helper_delegating_wrapper_without_config(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _HelperDelegatingRunnable()
+
+    _response, trace = invoke_with_trace(
+        runnable,
+        "prompt",
+        operation="helper_delegating_unit_test",
+    )
+
+    assert runnable.calls == 2
+    assert runnable.helper_calls == 2
+    assert runnable.inner.calls == 1
+    assert trace.trace_id == "trace-123"
+
+
 def test_invoke_with_trace_does_not_retry_provider_failures(monkeypatch):
     monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
     runnable = _ProviderFailureRunnable()
@@ -221,3 +268,16 @@ def test_invoke_with_trace_does_not_retry_variadic_provider_config_type_error(
         invoke_with_trace(runnable, "prompt", operation="variadic_config_type_error_unit_test")
 
     assert runnable.calls == 1
+
+
+def test_invoke_with_trace_does_not_retry_helper_provider_config_type_error(
+    monkeypatch,
+):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-key")
+    runnable = _HelperProviderConfigTypeErrorRunnable()
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'config'"):
+        invoke_with_trace(runnable, "prompt", operation="helper_config_type_error_unit_test")
+
+    assert runnable.calls == 1
+    assert runnable.helper_calls == 1


### PR DESCRIPTION
## Summary
- allow trace config fallback through helper-based delegating wrappers while still avoiding provider TypeError retries
- preserve task validator original_index values across blank-task filtering
- mirror consumer template updates and add focused regression coverage

## Validation
- uv run black --line-length 100 scripts/langchain/trace_utils.py scripts/langchain/task_validator.py templates/consumer-repo/scripts/langchain/trace_utils.py templates/consumer-repo/scripts/langchain/task_validator.py tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- uv run ruff check scripts/langchain/trace_utils.py scripts/langchain/task_validator.py templates/consumer-repo/scripts/langchain/trace_utils.py templates/consumer-repo/scripts/langchain/task_validator.py tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- uv run pytest tests/scripts/test_trace_utils.py tests/scripts/test_task_validator.py
- python scripts/validate_template_sync.py