### PR TITLE
fix: bump shared consumer workflow actions

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}

--- a/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Mint GitHub App token (preferred)
         id: app_token
         if: ${{ env.WORKFLOWS_APP_ID != '' && env.WORKFLOWS_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ env.WORKFLOWS_APP_ID }}
           private-key: ${{ env.WORKFLOWS_APP_PRIVATE_KEY }}

--- a/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -64,6 +64,7 @@ jobs:
             }
             const shaNote = headSha ? `, headSha=${headSha}` : '';
             const trace = `gateRunId=${gateRunId}${shaNote}`;
-            core.info(
-              `Autofix for PR #${prNumber} is handled by agents-81-gate-followups via Gate workflow_run (${trace}).`
-            );
+            const message =
+              `Autofix for PR #${prNumber} is handled by agents-81-gate-followups ` +
+              `via Gate workflow_run (${trace}).`;
+            core.info(message);

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Mint GitHub App Token
         if: steps.eligibility.outputs.should-run == 'true'
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -93,7 +93,7 @@ jobs:
         id: app_token
         if: steps.check.outputs.should_run == 'true'
         continue-on-error: true
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -19,7 +19,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -99,7 +99,12 @@ jobs:
           fi
           while IFS=$'\t' read -r id name; do
             echo "Downloading artifact $id ($name)"
-            safe_name="$(node -e 'const { safeArtifactPathSegment } = require("./.github/scripts/weekly_metrics_download_manifest.js"); process.stdout.write(safeArtifactPathSegment(process.argv[1] || ""));' "$name")"
+            safe_name="$(
+              node -e '
+              const m = require("./.github/scripts/weekly_metrics_download_manifest.js");
+              process.stdout.write(m.safeArtifactPathSegment(process.argv[1] || ""));
+              ' "$name"
+            )"
             artifact_dir="artifacts/$safe_name/$id"
             mkdir -p "$artifact_dir"
             # shellcheck disable=SC1009,SC1073,SC1039,SC1072

--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
+        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -26,7 +26,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -109,7 +109,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -44,7 +44,10 @@ jobs:
       cache: ${{ steps.python_ci_toggles.outputs.cache || 'true' }}
       pytest_markers: >-
         ${{ steps.python_ci_toggles.outputs.pytest_markers || 'not quarantine and not slow' }}
-      workflow_changed: ${{ steps.classify.outputs.is-workflow-change || steps.diff.outputs.workflow_changed || 'false' }}
+      workflow_changed: >-
+        ${{ steps.classify.outputs.is-workflow-change
+        || steps.diff.outputs.workflow_changed
+        || 'false' }}
       is_docs_only: ${{ steps.classify.outputs.is-docs-only || 'false' }}
       is_python_code: ${{ steps.classify.outputs.is-python-code || 'true' }}
       is_workflow_change: ${{ steps.classify.outputs.is-workflow-change || 'false' }}
@@ -58,7 +61,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -262,7 +265,7 @@ jobs:
     steps:
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
@@ -325,7 +328,7 @@ jobs:
       # Mint GitHub App token early to use for API calls (avoids rate limits)
       - name: Mint GitHub App Token
         id: app_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}

--- a/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
+++ b/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
@@ -145,7 +145,7 @@ jobs:
         id: app_token
         # Use continue-on-error to handle missing secrets gracefully
         continue-on-error: true
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.WORKFLOWS_APP_ID }}
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- bump synced consumer workflow templates to actions/create-github-app-token 3.2.0
- bump synced Claude code review workflow to anthropics/claude-code-action 1.0.124
- fold three existing long template lines so targeted workflow YAML validation passes

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml templates/consumer-repo/.github/workflows/reusable-pr-context.yml templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml templates/consumer-repo/.github/workflows/agents-guard.yml templates/consumer-repo/.github/workflows/pr-00-gate.yml
- git diff --check