### PR TITLE
fix: group runtime dependency bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "packaging>=26.1",
 
     # Required by repo dependency checks / CI fallback checks
-    "hypothesis>=6.152.2",
+    "hypothesis>=6.152.7",
     "pandas",
     "numpy<3.0",
     "pydantic>=2.13.4",
@@ -59,8 +59,8 @@ dev = [
 # Install with: pip install -e ".[langchain]"
 # Versions auto-updated by scripts/update_langchain_versions.py
 langchain = [
-    "langchain>=1.2.18,<1.3",
-    "langchain-core>=1.3.3,<1.4",
+    "langchain>=1.3.1,<1.4",
+    "langchain-core>=1.4.0,<1.5",
     "langchain-community>=0.4,<0.5",
     "langchain-openai>=1.2.1,<1.3",
     "langchain-anthropic>=1.4.3,<1.5",

--- a/requirements.lock
+++ b/requirements.lock
@@ -88,7 +88,7 @@ httpx==0.28.1
     #   openai
 httpx-sse==0.4.3
     # via langchain-community
-hypothesis==6.152.6
+hypothesis==6.152.9
     # via workflows (pyproject.toml)
 identify==2.6.19
     # via pre-commit
@@ -114,7 +114,7 @@ jsonschema==4.26.0
     # via workflows (pyproject.toml)
 jsonschema-specifications==2025.9.1
     # via jsonschema
-langchain==1.2.18
+langchain==1.3.1
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -128,7 +128,7 @@ langchain-community==0.4.1
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-core==1.3.3
+langchain-core==1.4.0
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -149,13 +149,13 @@ langchain-protocol==0.0.15
     # via langchain-core
 langchain-text-splitters==1.1.2
     # via langchain-classic
-langgraph==1.1.10
+langgraph==1.2.1
     # via langchain
 langgraph-checkpoint==4.1.0
     # via
     #   langgraph
     #   langgraph-prebuilt
-langgraph-prebuilt==1.0.13
+langgraph-prebuilt==1.1.0
     # via langgraph
 langgraph-sdk==0.3.14
     # via langgraph
@@ -183,7 +183,7 @@ mypy-extensions==1.1.0
     #   typing-inspect
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.4
+numpy==2.4.5
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -207,7 +207,7 @@ packaging==26.2
     #   langsmith
     #   marshmallow
     #   pytest
-pandas==3.0.2
+pandas==3.0.3
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -285,7 +285,7 @@ referencing==0.37.0
     #   jsonschema-specifications
 regex==2026.5.9
     # via tiktoken
-requests==2.34.0
+requests==2.34.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # Core runtime dependencies
-requests==2.34.0
+requests==2.34.2
 pytest==9.0.3
 pyyaml==6.0.3
 pydantic==2.13.4
 numpy==2.4.5
-pandas==3.0.2
+pandas==3.0.3
 tomlkit==0.14.0
 
 # LangChain integration
-langchain==1.2.18
-langchain-core==1.3.3
+langchain==1.3.1
+langchain-core==1.4.0
 langchain-community==0.4.1
 langchain-openai==1.2.1
 langchain-anthropic==1.4.3

--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -7,9 +7,9 @@
 # - Use strict X.Y.Z pins for direct workflow dependencies.
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
-langchain==1.2.18
+langchain==1.3.1
 langchain-community==0.4.1
 langchain-openai==1.2.1
 langchain-anthropic==1.4.3
 pydantic==2.13.4
-requests==2.34.0
+requests==2.34.2

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -7,9 +7,9 @@
 # - Use strict X.Y.Z pins for direct workflow dependencies.
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
-langchain==1.2.18
+langchain==1.3.1
 langchain-community==0.4.1
 langchain-openai==1.2.1
 langchain-anthropic==1.4.3
 pydantic==2.13.4
-requests==2.34.0
+requests==2.34.2


### PR DESCRIPTION
## Summary
- group runtime dependency bumps for requests, pandas, hypothesis, langchain, and langchain-core
- regenerate requirements.lock so pinned transitive versions match the manifest updates
- keep root and consumer template tools/requirements-llm.txt in sync

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
- git diff --check
- uv run pytest tests/test_dependency_version_alignment.py tests/workflows/test_workflow_llm_installs.py -q