### PR TITLE
fix: bump shared llm dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ dev = [
 langchain = [
     "langchain>=1.3.1,<1.4",
     "langchain-core>=1.4.0,<1.5",
-    "langchain-community>=0.4,<0.5",
-    "langchain-openai>=1.2.1,<1.3",
+    "langchain-community>=0.4.2,<0.5",
+    "langchain-openai>=1.2.2,<1.3",
     "langchain-anthropic>=1.4.3,<1.5",
     "faiss-cpu>=1.13.2,<2.0",  # Vector store for dedup workflow
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,8 +46,6 @@ coverage==7.14.0
     # via
     #   workflows (pyproject.toml)
     #   pytest-cov
-dataclasses-json==0.6.7
-    # via langchain-community
 distlib==0.4.0
     # via virtualenv
 distro==1.9.0
@@ -124,7 +122,7 @@ langchain-anthropic==1.4.3
     #   workflows (pyproject.toml)
 langchain-classic==1.0.7
     # via langchain-community
-langchain-community==0.4.1
+langchain-community==0.4.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -141,7 +139,7 @@ langchain-core==1.4.0
     #   langgraph
     #   langgraph-checkpoint
     #   langgraph-prebuilt
-langchain-openai==1.2.1
+langchain-openai==1.2.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -159,15 +157,13 @@ langgraph-prebuilt==1.1.0
     # via langgraph
 langgraph-sdk==0.3.14
     # via langgraph
-langsmith==0.8.3
+langsmith==0.8.5
     # via
     #   langchain-classic
     #   langchain-community
     #   langchain-core
 librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
-marshmallow==3.26.2
-    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
 multidict==6.7.1
@@ -180,7 +176,6 @@ mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
-    #   typing-inspect
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.5
@@ -205,7 +200,6 @@ packaging==26.2
     #   faiss-cpu
     #   langchain-core
     #   langsmith
-    #   marshmallow
     #   pytest
 pandas==3.0.3
     # via
@@ -339,10 +333,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   referencing
     #   sqlalchemy
-    #   typing-inspect
     #   typing-inspection
-typing-inspect==0.9.0
-    # via dataclasses-json
 typing-inspection==0.4.2
     # via
     #   pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tomlkit==0.14.0
 # LangChain integration
 langchain==1.3.1
 langchain-core==1.4.0
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 faiss-cpu==1.13.2

--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -8,8 +8,8 @@
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
 langchain==1.3.1
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 pydantic==2.13.4
 requests==2.34.2

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -8,8 +8,8 @@
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
 langchain==1.3.1
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
## Summary
- bump shared LLM workflow pins for langchain-community and langchain-openai
- refresh Workflows requirements and lockfile, including langsmith 0.8.5
- keep the consumer template requirements-llm copy in sync

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m pytest tests/test_dependency_version_alignment.py tests/workflows/test_workflow_llm_installs.py -q
- git diff --check