### PR TITLE
docs: clarify LangSmith fleet contract rollout

### DIFF
--- a/config/langsmith_fleet_registry.json
+++ b/config/langsmith_fleet_registry.json
@@ -27,7 +27,7 @@
       "surface": "planner-runtime",
       "operations": ["conversation", "tool-call", "itinerary-generation"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "planning_mode",
         "planner_action",
@@ -43,7 +43,7 @@
       "surface": "nl-to-sql",
       "operations": ["sql-generation", "validation", "execution", "replay"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "query_category",
         "sql_validation_status",
@@ -59,7 +59,7 @@
       "surface": "ai-api",
       "operations": ["nl-query", "holdings-analysis", "rag"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "endpoint",
         "request_category",
@@ -75,7 +75,7 @@
       "surface": "risk-reporting",
       "operations": ["data-quality", "risk-proxy", "limit-monitoring", "report-generation"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "as_of_date",
         "scenario",
@@ -91,7 +91,7 @@
       "surface": "intake-extraction",
       "operations": ["package-intake", "extraction", "validation", "review-routing"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented-followup-open",
       "required_domain_fields": [
         "package_id",
         "document_type",
@@ -107,7 +107,7 @@
       "surface": "llm-replay",
       "operations": ["chain", "replay", "validation", "config-analysis"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "dataset_id",
         "config_fingerprint",
@@ -123,7 +123,7 @@
       "surface": "scenario-analysis",
       "operations": ["scenario-run", "result-explanation", "run-comparison", "config-patch"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "planned",
+      "rollout_status": "implemented",
       "required_domain_fields": [
         "scenario_id",
         "config_hash",

--- a/docs/contracts/langsmith-fleet-v1.md
+++ b/docs/contracts/langsmith-fleet-v1.md
@@ -5,6 +5,47 @@ LangSmith observability artifacts. Consumer repos own domain instrumentation;
 Workflows owns the common record shape, registry, validation, and dashboard
 status rollup.
 
+## Design Decision
+
+The fleet design is contract-first, not package-first:
+
+- Workflows owns the canonical `langsmith-fleet/v1` record contract, JSON Schema,
+  registry, validator, fixtures, and dashboard status rollup.
+- Consumer repos own their local emitters, adapters, and domain instrumentation.
+  They may implement local validation helpers as long as emitted
+  `langsmith-fleet.ndjson` records conform to this contract and the registry's
+  required domain fields.
+- A consumer-local "subset" validator is not a design violation by itself. It is
+  only incomplete if it allows records that fail the Workflows canonical schema,
+  uses unsafe raw prompt/output payloads, misses registry-required domain fields,
+  or emits unregistered repo/surface/operation combinations.
+- Workflows does not currently publish a Python package for consumers to import.
+  That design would only be worth changing to if the fleet starts seeing repeated
+  schema drift, duplicated validator defects, or cross-repo release coordination
+  failures that outweigh the packaging and version-management overhead.
+
+Closer/verifier agents should consult this section before pausing for a human
+decision about local validators. If the current repo artifacts conform to the
+canonical schema and registry, advance or close the lane instead of halting on
+implementation shape alone.
+
+## Current Rollout State
+
+The parent contract shipped through `stranske/Workflows#2150` /
+`stranske/Workflows#2151`. The first fleet wave then implemented repo-local
+emitters against the contract:
+
+| Repo | Issue | Implementation PR | State |
+| --- | --- | --- | --- |
+| `stranske/Workflows` | `#2150` | `#2151` | Contract owner merged. |
+| `stranske/Counter_Risk` | `#610` | `#629` | Repo-local emitter merged. |
+| `stranske/Inv-Man-Intake` | `#438` | `#454` | Repo-local emitter merged; follow-up `#455` tracks contract-validation cleanup. |
+| `stranske/Pension-Data` | `#445` | `#460`, `#461` | Repo-local emitter and trace-sink follow-up merged. |
+| `stranske/trip-planner` | `#1208` | `#1226` | Repo-local emitter merged. |
+| `stranske/Trend_Model_Project` | `#5311` | `#5328` | Repo-local emitter merged. |
+| `stranske/Portable-Alpha-Extension-Model` | `#1802` | `#1819` | Repo-local emitter merged. |
+| `stranske/Manager-Database` | `#1048` | `#1067` | Repo-local emitter merged. |
+
 ## Artifact
 
 Each participating repo emits NDJSON at the artifact name registered in

--- a/docs/dashboards/README.md
+++ b/docs/dashboards/README.md
@@ -54,6 +54,12 @@ The dashboard aggregates metrics from:
 - 14-day artifact retention window
 - All completed autopilot runs in the specified time period
 
+The fleet artifacts follow a contract-first design: Workflows owns the
+`langsmith-fleet/v1` schema, registry, validator, and dashboard rollup, while
+each consumer repo owns its local emitter and domain instrumentation. See
+[`docs/contracts/langsmith-fleet-v1.md`](../contracts/langsmith-fleet-v1.md)
+before treating a consumer-local validator as a design blocker.
+
 #### How It Works
 
 1. **Download** - Fetches metrics artifacts from recent autopilot runs


### PR DESCRIPTION
## Summary

- Clarifies that LangSmith fleet is contract-first, not package-first: Workflows owns the schema/registry/validator/dashboard rollup while consumers own repo-local emitters and validators.
- Records current rollout state for Workflows and each consumer implementation PR.
- Updates registry rollout statuses from planned to implemented where the implementation PRs have merged, and flags Inv-Man-Intake as implemented with follow-up open.
- Points dashboard docs at the contract before treating consumer-local validators as a design blocker.

## Validation

- python -m pytest tests/scripts/test_langsmith_fleet.py -q
- git diff --check