### PR TITLE
fix(template): unblock consumer-repo bootstrap (default_workflow_permissions, ci.yml pull_request trigger, guard allowlist)

### DIFF
--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -42,6 +42,17 @@ const CONSUMER_ONLY_ALLOW_REMOVED_PATHS = [
   '.github/workflows/agents-verify-to-issue-v2.yml',
   // The verify-to-new-pr autopilot bridge was collapsed into the main workflow.
   '.github/workflows/agents-verify-to-new-pr-autopilot.yml',
+  // Legacy keepalive orchestrator superseded by the consolidated
+  // agents-80-pr-event-hub.yml + agents-81-gate-followups.yml hubs (controlled
+  // by USE_CONSOLIDATED_WORKFLOWS=true). The Template repo's pre-installed
+  // copy lingered on fresh consumer repos; this allowlist entry lets the
+  // first-PR template sync remove it without tripping the guard. Discovered
+  // during stranske/learning-management-system bootstrap (2026-05).
+  '.github/workflows/agents-70-orchestrator.yml',
+  // The consumer-template name (without the 70- prefix). Some Template-based
+  // consumer repos shipped this version; allow removal alongside the prefixed
+  // form so either spelling can be cleaned up.
+  '.github/workflows/agents-orchestrator.yml',
 ];
 
 const ALLOW_REMOVED_PATHS = new Set(

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -82,6 +82,7 @@ env:
     stranske/Portable-Alpha-Extension-Model
     stranske/Trend_Model_Project
     stranske/Collab-Admin
+    stranske/learning-management-system
 
 concurrency:
   group: sync-consumer-repos-${{ github.repository }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a narrative of how the repo evolved through five development phases (bootstr
 
 ### First-party Consumers
 
-11 repos are currently registered as first-party consumers (synced via [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml)):
+12 repos are currently registered as first-party consumers (synced via [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml)):
 
 - [Travel-Plan-Permission](https://github.com/stranske/Travel-Plan-Permission)
 - [Template](https://github.com/stranske/Template)
@@ -26,6 +26,7 @@ For a narrative of how the repo evolved through five development phases (bootstr
 - [Pension-Data](https://github.com/stranske/Pension-Data)
 - [Inv-Man-Intake](https://github.com/stranske/Inv-Man-Intake)
 - [Ready](https://github.com/stranske/Ready)
+- [learning-management-system](https://github.com/stranske/learning-management-system)
 
 [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml) is the authoritative list — `REGISTERED_CONSUMER_REPOS` env var. The [Workflows-Integration-Tests](https://github.com/stranske/Workflows-Integration-Tests) harness validates the consumer surface separately.
 

--- a/config/repo_review_profiles.json
+++ b/config/repo_review_profiles.json
@@ -115,5 +115,20 @@
       "Existing code breadth can hide missing end-to-end proof.",
       "Fixture-only planner or approval checks should not count as readiness."
     ]
+  },
+  "stranske/learning-management-system": {
+    "progress_summary": "Newly created repo bootstrapped from stranske/Template with design docs, an architecture index, and a 31-issue Phase-1 implementation queue covering Milestones 0-4 (the path to the Minimum Demo). Implementation work begins from a fresh consumer-template scaffolding; runtime code does not yet exist.",
+    "readiness_summary": "Ready for issue-driven implementation against the agreed Phase 1 design. The Minimum Demo Criterion at the end of Milestone 4 (8-item pre-registered day-30 retention protocol) is the v1 thesis-validation gate; treat Milestone 5+ scope as out of bounds until the demo runs.",
+    "review_focus": [
+      "Confirm Phase 1 schema decisions land coherently: verbose EvidenceRecord, MasteryEstimate as a computed view over evidence (not a written table), SourceReference as a first-class entity with content_hash and drift_status.",
+      "Verify SchedulerEvidenceAdapter implementation matches the 5-row rule table in docs/product/project-plan.md Review Scheduler.",
+      "Verify ownership_scope enforcement (repository pattern + CHECK constraints + aggregation tests) lands before any analytics work that aggregates across scopes.",
+      "Verify LLM trace privacy enforces local-first redaction before any external (LangSmith) trace export."
+    ],
+    "concerns": [
+      "Capability/certification entities (CapabilityTarget, CapabilityEstimate, GapAnalysis, MaintenancePlan, CertificationSnapshot) are explicitly Milestone 5+, NOT Phase 1; flag any PR that introduces /capability/* in Milestones 0-4.",
+      "Research-registry stays as YAML in docs/research/registry/ for v1; do not introduce runtime /research/* APIs or SQLAlchemy tables until a product feature reads them.",
+      "Local-only SourceReference bodies (e.g., Math Academy paraphrase content, personal Kindle highlights) must never appear in default exports or LangSmith traces."
+    ]
   }
 }

--- a/config/repo_review_registry.json
+++ b/config/repo_review_registry.json
@@ -88,6 +88,13 @@
       "decision_anchor": "Trip planner app and related planning workflow; include in weekly repo review and issue-draft generation."
     },
     {
+      "repo": "stranske/learning-management-system",
+      "local_path": "learning-management-system",
+      "status": "active",
+      "cadence": "weekly",
+      "decision_anchor": "Learning-engine v1: evidence-based mastery (verbose EvidenceRecord schema, computed MasteryEstimate view), source-grounded prompts with content-hash drift detection, formative LLM interaction with local-first redaction, FSRS-4.5 scheduler with explicit evidence-adapter rule table, and the Minimum Demo Criterion as the Milestone 4 thesis-validation gate."
+    },
+    {
       "repo": "stranske/tim-bot",
       "local_path": "tim-bot",
       "status": "ignored",

--- a/config/source_of_truth_docs.yml
+++ b/config/source_of_truth_docs.yml
@@ -133,3 +133,14 @@ repos:
         focus: model identifiers in current use, refresh cadence
       - path: docs/WORKFLOW_GUIDE.md
         focus: workflow authoring guidance and reusable-workflow references
+  stranske/learning-management-system:
+    local_path: learning-management-system
+    docs:
+      - path: README.md
+        focus: operational overview and execution entry points
+      - path: AGENTS.md
+        focus: agent runtime constraints and repo-specific guardrails
+      - path: docs/product/project-plan.md
+        focus: design plan; Phase 1 Minimum Core, Minimum Demo Criterion, Milestone 0-4 deliverables and acceptance criteria, SchedulerEvidenceAdapter, ownership-boundary enforcement, export/import contract
+      - path: docs/product/early-design-decisions.md
+        focus: segmented decision queue; especially Segments 2 (mastery), 7 (stack), 8 (sustainability), 9 (privacy), 10 (LLM cost/routing)

--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -365,9 +365,52 @@ Navigate to: **Settings** → **Secrets and variables** → **Actions** → **Va
 | Variable Name | Description | Example Value |
 |---------------|-------------|---------------|
 | `ALLOWED_KEEPALIVE_LOGINS` | GitHub usernames allowed to trigger keepalive | `stranske` |
+| `USE_CONSOLIDATED_WORKFLOWS` | Use the consolidated `agents-80-pr-event-hub.yml` + `agents-81-gate-followups.yml` hubs instead of the legacy split workflows. Set `true` for all new repos. | `true` |
 
-Add the variable:
+Add the variables:
 - [ ] `ALLOWED_KEEPALIVE_LOGINS` — Comma-separated list of usernames
+- [ ] `USE_CONSOLIDATED_WORKFLOWS=true` — recommended for all new repos
+
+### 3.3.1 Workflow Token Permissions (CRITICAL)
+
+> **Critical**: GitHub creates new repos with `default_workflow_permissions=read`,
+> which causes Gate to fail with `startup_failure` before any job runs (the
+> `Gate / gate` commit status job needs `write` to publish the status). Every
+> consumer repo must be flipped to `write` before its first PR runs through Gate.
+
+**Symptom if skipped:** Gate workflow shows `startup_failure` (or shows the file
+path `.github/workflows/pr-00-gate.yml` instead of `Gate` as the run name
+because the workflow file can't even be parsed under the restricted permissions).
+The `agents-81-gate-followups.yml` hub then skips the keepalive dispatch because
+Gate never succeeded, and the entire automation pipeline is silently blocked.
+
+**One-shot fix via gh CLI:**
+
+```bash
+gh api -X PUT /repos/<owner>/<repo>/actions/permissions/workflow \
+  -F default_workflow_permissions=write \
+  -F can_approve_pull_request_reviews=true
+```
+
+**Verify:**
+
+```bash
+gh api /repos/<owner>/<repo>/actions/permissions/workflow
+# Expect: {"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}
+```
+
+**Or via the UI:** **Settings** → **Actions** → **General** → **Workflow permissions**
+→ select **"Read and write permissions"** and check **"Allow GitHub Actions to
+create and approve pull requests"** → **Save**.
+
+Discovered during `stranske/learning-management-system` bootstrap (2026-05).
+Counter_Risk, Inv-Man-Intake, Trend_Model_Project, etc. all have `write` per
+their `actions/permissions/workflow` settings.
+
+**Checklist:**
+
+- [ ] `default_workflow_permissions=write` on this repo
+- [ ] `can_approve_pull_request_reviews=true` on this repo
 
 ### 3.4 Install GitHub Apps on Repository
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ dev = [
 langchain = [
     "langchain>=1.3.1,<1.4",
     "langchain-core>=1.4.0,<1.5",
-    "langchain-community>=0.4,<0.5",
-    "langchain-openai>=1.2.1,<1.3",
+    "langchain-community>=0.4.2,<0.5",
+    "langchain-openai>=1.2.2,<1.3",
     "langchain-anthropic>=1.4.3,<1.5",
     "faiss-cpu>=1.13.2,<2.0",  # Vector store for dedup workflow
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,8 +46,6 @@ coverage==7.14.0
     # via
     #   workflows (pyproject.toml)
     #   pytest-cov
-dataclasses-json==0.6.7
-    # via langchain-community
 distlib==0.4.0
     # via virtualenv
 distro==1.9.0
@@ -124,7 +122,7 @@ langchain-anthropic==1.4.3
     #   workflows (pyproject.toml)
 langchain-classic==1.0.7
     # via langchain-community
-langchain-community==0.4.1
+langchain-community==0.4.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -141,7 +139,7 @@ langchain-core==1.4.0
     #   langgraph
     #   langgraph-checkpoint
     #   langgraph-prebuilt
-langchain-openai==1.2.1
+langchain-openai==1.2.2
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -159,15 +157,13 @@ langgraph-prebuilt==1.1.0
     # via langgraph
 langgraph-sdk==0.3.14
     # via langgraph
-langsmith==0.8.3
+langsmith==0.8.5
     # via
     #   langchain-classic
     #   langchain-community
     #   langchain-core
 librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
-marshmallow==3.26.2
-    # via dataclasses-json
 mccabe==0.7.0
     # via flake8
 multidict==6.7.1
@@ -180,7 +176,6 @@ mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
-    #   typing-inspect
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.5
@@ -205,7 +200,6 @@ packaging==26.2
     #   faiss-cpu
     #   langchain-core
     #   langsmith
-    #   marshmallow
     #   pytest
 pandas==3.0.3
     # via
@@ -339,10 +333,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   referencing
     #   sqlalchemy
-    #   typing-inspect
     #   typing-inspection
-typing-inspect==0.9.0
-    # via dataclasses-json
 typing-inspection==0.4.2
     # via
     #   pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tomlkit==0.14.0
 # LangChain integration
 langchain==1.3.1
 langchain-core==1.4.0
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 faiss-cpu==1.13.2

--- a/templates/consumer-repo/.github/scripts/agents-guard.js
+++ b/templates/consumer-repo/.github/scripts/agents-guard.js
@@ -42,6 +42,17 @@ const CONSUMER_ONLY_ALLOW_REMOVED_PATHS = [
   '.github/workflows/agents-verify-to-issue-v2.yml',
   // The verify-to-new-pr autopilot bridge was collapsed into the main workflow.
   '.github/workflows/agents-verify-to-new-pr-autopilot.yml',
+  // Legacy keepalive orchestrator superseded by the consolidated
+  // agents-80-pr-event-hub.yml + agents-81-gate-followups.yml hubs (controlled
+  // by USE_CONSOLIDATED_WORKFLOWS=true). The Template repo's pre-installed
+  // copy lingered on fresh consumer repos; this allowlist entry lets the
+  // first-PR template sync remove it without tripping the guard. Discovered
+  // during stranske/learning-management-system bootstrap (2026-05).
+  '.github/workflows/agents-70-orchestrator.yml',
+  // The consumer-template name (without the 70- prefix). Some Template-based
+  // consumer repos shipped this version; allow removal alongside the prefixed
+  // form so either spelling can be cleaned up.
+  '.github/workflows/agents-orchestrator.yml',
 ];
 
 const ALLOW_REMOVED_PATHS = new Set(

--- a/templates/consumer-repo/.github/workflows/ci.yml
+++ b/templates/consumer-repo/.github/workflows/ci.yml
@@ -11,14 +11,20 @@
 # startup_failure when calling reusable workflows. The reusable workflow
 # defines its own permissions.
 #
+# NOTE: Do NOT add a 'pull_request:' trigger here. Gate (pr-00-gate.yml)
+# already runs the same reusable Python CI on every pull request. Adding
+# a parallel pull_request trigger here causes a second concurrent
+# invocation of the reusable workflow that hits a startup_failure
+# (interaction between secrets: inherit and pull_request from same-repo
+# branches). Production consumers (Counter_Risk, Inv-Man-Intake,
+# Trend_Model_Project, etc.) all omit pull_request: from ci.yml.
+#
 # Copy this file to: .github/workflows/ci.yml
 # Also copy: autofix-versions.env to .github/workflows/autofix-versions.env
 name: CI
 
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -8,8 +8,8 @@
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
 langchain==1.3.1
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 pydantic==2.13.4
 requests==2.34.2

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -8,8 +8,8 @@
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
 langchain==1.3.1
-langchain-community==0.4.1
-langchain-openai==1.2.1
+langchain-community==0.4.2
+langchain-openai==1.2.2
 langchain-anthropic==1.4.3
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
## Summary

Three quiet failures that silently blocked the keepalive automation on a fresh consumer repo cloned from \`stranske/Template\`. Found during the \`stranske/learning-management-system\` bootstrap (2026-05-25).

- \`templates/consumer-repo/.github/workflows/ci.yml\` — remove \`pull_request:\` trigger. Gate already runs the same reusable Python CI on every PR; the parallel \`pull_request:\` trigger here hits \`startup_failure\` (\`secrets: inherit\` + \`pull_request\` + reusable workflow interaction). Production consumers (Counter_Risk, Inv-Man-Intake, Trend_Model_Project, Manager-Database, trip-planner) all omit this trigger.
- \`.github/scripts/agents-guard.js\` — add \`agents-70-orchestrator.yml\` and \`agents-orchestrator.yml\` to \`CONSUMER_ONLY_ALLOW_REMOVED_PATHS\`. The Template repo's pre-installed copy of the legacy keepalive orchestrator lingers on fresh consumer repos. With \`USE_CONSOLIDATED_WORKFLOWS=true\` the agents-80/agents-81 hubs supersede the orchestrator entirely; the first-PR template sync needs to be able to remove the stale copy without tripping the guard. Existing Wave-0 cleanup entries already cover other retired keepalive workflows.
- \`docs/templates/SETUP_CHECKLIST.md\` — add §3.3.1 "Workflow Token Permissions (CRITICAL)" documenting the \`default_workflow_permissions=write\` requirement. GitHub creates new repos with \`read\`; Gate needs \`write\` to publish the \`Gate / gate\` commit status. Without this, Gate startup_failure cascades into agents-81-gate-followups skipping keepalive dispatch, and the entire pipeline is silently blocked. Also adds \`USE_CONSOLIDATED_WORKFLOWS=true\` to the Required Variables table.

## Test plan

- [ ] CI green on this PR
- [ ] Existing \`__tests__/agents-guard.test.js\` covers the allowlist behavior; new entries follow the same pattern as the existing Wave-0 cleanup entries
- [ ] Manual: a fresh repo cloned from \`stranske/Template\` after this lands should be able to: (a) set \`default_workflow_permissions=write\` via the SETUP_CHECKLIST guidance, (b) remove the stale \`agents-70-orchestrator.yml\` on the first sync PR without guard blocking, (c) avoid the \`ci.yml\` startup_failure that bit \`stranske/learning-management-system\` PR #32

## Related

These three fixes don't address the deeper design questions surfaced during the same rollout:
- \`stranske/Template\` workflow files lag behind canonical (sync_mode: create_only in sync-manifest.yml means Gate/CI never refresh after initial creation) — filed as separate issue
- consumer-template pr-00-gate.yml at main HEAD has expanded detect-job outputs that trigger startup_failure on a fresh consumer; production consumers run a simpler older version — filed as separate issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)