### PR TITLE
docs: mark expanded consumer Gate bootstrap risk

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -29,8 +29,8 @@ version: 1
 workflows:
   # Core CI/CD
   - source: .github/workflows/pr-00-gate.yml
-    description: "Gate workflow - runs tests, lint, type checking before merge"
-    sync_mode: create_only  # Don't overwrite - repos customize coverage-min, python versions
+    description: "Gate workflow - runs tests, lint, type checking before merge. Bootstrap note: the expanded template Gate is not yet fresh-consumer deployable; see issue #2158 before seeding it into new repos."
+    sync_mode: create_only  # Don't overwrite; also prevents the expanded Gate from seeding fresh consumers until #2158 proves it deployable.
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -30,7 +30,7 @@ workflows:
   # Core CI/CD
   - source: .github/workflows/pr-00-gate.yml
     description: "Gate workflow - runs tests, lint, type checking before merge. Bootstrap note: the expanded template Gate is not yet fresh-consumer deployable; see issue #2158 before seeding it into new repos."
-    sync_mode: create_only  # Don't overwrite; also prevents the expanded Gate from seeding fresh consumers until #2158 proves it deployable.
+    sync_mode: create_only  # Don't overwrite existing consumer Gate files; fresh repos can still receive this file, so follow #2158 before first seeding.
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -663,6 +663,14 @@ concurrency:
 2. Set "Workflow permissions" to **"Read and write permissions"**
 3. Enable **"Allow GitHub Actions to create and approve pull requests"**
 
+**Capture the hidden startup error (file-parse / job-graph phase):**
+```bash
+python scripts/workflow_startup_failure_diagnostic.py --repo OWNER/REPO --run-id RUN_ID
+```
+
+This inspects check-runs for the same head SHA/run ID and prints the parser error
+title/summary text that is not visible in `actions/runs/<id>/jobs`.
+
 
 ### Startup Failure (Caller Workflow Permissions)
 

--- a/scripts/gate_detect_output_diff.py
+++ b/scripts/gate_detect_output_diff.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Compare Gate detect-job outputs and flag invalid step-output references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+STEP_OUTPUT_REF_RE = re.compile(r"steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a YAML mapping")
+    return data
+
+
+def _detect_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        raise ValueError("workflow missing jobs mapping")
+    detect = jobs.get("detect")
+    if not isinstance(detect, dict):
+        raise ValueError("workflow missing jobs.detect")
+    return detect
+
+
+def _step_ids(detect_job: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    steps = detect_job.get("steps", [])
+    if not isinstance(steps, list):
+        return ids
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        step_id = step.get("id")
+        if isinstance(step_id, str) and step_id.strip():
+            ids.add(step_id.strip())
+    return ids
+
+
+def _detect_outputs(detect_job: dict[str, Any]) -> dict[str, str]:
+    outputs = detect_job.get("outputs", {})
+    if not isinstance(outputs, dict):
+        return {}
+    normalized: dict[str, str] = {}
+    for key, value in outputs.items():
+        if isinstance(key, str):
+            normalized[key] = str(value)
+    return normalized
+
+
+def _output_refs(expr: str) -> list[tuple[str, str]]:
+    return STEP_OUTPUT_REF_RE.findall(expr)
+
+
+def compare_gate_detect_outputs(candidate_path: Path, baseline_path: Path) -> dict[str, Any]:
+    candidate = _detect_job(_load_yaml(candidate_path))
+    baseline = _detect_job(_load_yaml(baseline_path))
+
+    candidate_outputs = _detect_outputs(candidate)
+    baseline_outputs = _detect_outputs(baseline)
+
+    candidate_keys = set(candidate_outputs.keys())
+    baseline_keys = set(baseline_outputs.keys())
+    candidate_step_ids = _step_ids(candidate)
+
+    invalid_refs: dict[str, list[str]] = {}
+    for output_name, expr in candidate_outputs.items():
+        missing = sorted(
+            {step_id for step_id, _ in _output_refs(expr) if step_id not in candidate_step_ids}
+        )
+        if missing:
+            invalid_refs[output_name] = missing
+
+    return {
+        "candidate_path": str(candidate_path),
+        "baseline_path": str(baseline_path),
+        "candidate_output_count": len(candidate_keys),
+        "baseline_output_count": len(baseline_keys),
+        "added_outputs_vs_baseline": sorted(candidate_keys - baseline_keys),
+        "removed_outputs_vs_baseline": sorted(baseline_keys - candidate_keys),
+        "candidate_step_ids": sorted(candidate_step_ids),
+        "invalid_step_output_references": invalid_refs,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidate", required=True, type=Path, help="Candidate Gate workflow path"
+    )
+    parser.add_argument(
+        "--baseline", required=True, type=Path, help="Known-green Gate workflow path"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = compare_gate_detect_outputs(args.candidate, args.baseline)
+    print(json.dumps(report, indent=2))
+    return 1 if report["invalid_step_output_references"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from typing import Any
@@ -54,6 +55,14 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
     findings: list[dict[str, Any]] = []
     for check in startup_failures:
         output = check.get("output") if isinstance(check.get("output"), dict) else {}
+        summary = str(output.get("summary", ""))
+        title = str(output.get("title", ""))
+        text = str(output.get("text", ""))
+        phase, suspected_root_cause = _classify_startup_failure(
+            summary=summary,
+            title=title,
+            text=text,
+        )
         findings.append(
             {
                 "id": check.get("id"),
@@ -64,9 +73,11 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
                 "completed_at": check.get("completed_at"),
                 "details_url": check.get("details_url"),
                 "html_url": check.get("html_url"),
-                "title": output.get("title", ""),
-                "summary": output.get("summary", ""),
-                "text": output.get("text", ""),
+                "title": title,
+                "summary": summary,
+                "text": text,
+                "failure_phase": phase,
+                "suspected_root_cause": suspected_root_cause,
             }
         )
 
@@ -82,6 +93,26 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
         "jobs_count": jobs_count,
         "startup_failures": findings,
     }
+
+
+def _classify_startup_failure(summary: str, title: str, text: str) -> tuple[str, str]:
+    """Best-effort classification for parse-time startup failures."""
+    blob = "\n".join((title, summary, text)).lower()
+    if "workflow is not valid" in blob or "line " in blob:
+        return ("workflow_parse_or_graph", _guess_parse_cause(blob))
+    if "unable to resolve action" in blob or "repository not found" in blob:
+        return ("action_resolution", "action_reference_or_access")
+    return ("unknown", "unknown")
+
+
+def _guess_parse_cause(blob: str) -> str:
+    if "unrecognized named-value" in blob:
+        return "invalid_expression_context_reference"
+    if re.search(r"unexpected value|mapping values are not allowed", blob):
+        return "yaml_structure_or_syntax"
+    if "fromjson" in blob and "invalid" in blob:
+        return "expression_type_or_json_coercion"
+    return "workflow_parse_or_job_graph_construction"
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Capture startup_failure details for a workflow run via GitHub check-runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def _gh_api(path: str) -> dict[str, Any]:
+    cmd = ["gh", "api", path]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    data = json.loads(result.stdout)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected JSON object from gh api {path}")
+    return data
+
+
+def _collect_startup_failures(
+    check_runs_payload: dict[str, Any], run_id: int
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    check_runs = check_runs_payload.get("check_runs", [])
+    if not isinstance(check_runs, list):
+        return matches
+
+    run_marker = f"/actions/runs/{run_id}"
+    for check in check_runs:
+        if not isinstance(check, dict):
+            continue
+        if check.get("conclusion") != "startup_failure":
+            continue
+        details_url = str(check.get("details_url", ""))
+        if run_marker not in details_url:
+            continue
+        matches.append(check)
+    return matches
+
+
+def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
+    run_payload = _gh_api(f"repos/{repo}/actions/runs/{run_id}")
+    jobs_payload = _gh_api(f"repos/{repo}/actions/runs/{run_id}/jobs")
+
+    head_sha = str(run_payload.get("head_sha", "")).strip()
+    if not head_sha:
+        raise ValueError(f"Run {run_id} in {repo} is missing head_sha")
+
+    check_runs_payload = _gh_api(f"repos/{repo}/commits/{head_sha}/check-runs")
+    startup_failures = _collect_startup_failures(check_runs_payload, run_id)
+
+    findings: list[dict[str, Any]] = []
+    for check in startup_failures:
+        output = check.get("output") if isinstance(check.get("output"), dict) else {}
+        findings.append(
+            {
+                "id": check.get("id"),
+                "name": check.get("name"),
+                "status": check.get("status"),
+                "conclusion": check.get("conclusion"),
+                "started_at": check.get("started_at"),
+                "completed_at": check.get("completed_at"),
+                "details_url": check.get("details_url"),
+                "html_url": check.get("html_url"),
+                "title": output.get("title", ""),
+                "summary": output.get("summary", ""),
+                "text": output.get("text", ""),
+            }
+        )
+
+    jobs = jobs_payload.get("jobs", [])
+    jobs_count = len(jobs) if isinstance(jobs, list) else 0
+    return {
+        "repo": repo,
+        "run_id": run_id,
+        "run_name": run_payload.get("name", ""),
+        "run_conclusion": run_payload.get("conclusion", ""),
+        "run_status": run_payload.get("status", ""),
+        "head_sha": head_sha,
+        "jobs_count": jobs_count,
+        "startup_failures": findings,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Repository in owner/name format")
+    parser.add_argument("--run-id", required=True, type=int, help="Workflow run ID")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        report = diagnose_startup_failure(args.repo, args.run_id)
+    except (subprocess.CalledProcessError, ValueError, json.JSONDecodeError) as exc:
+        print(f"workflow_startup_failure_diagnostic: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, indent=2))
+    if report["jobs_count"] == 0 and report["startup_failures"]:
+        return 0
+    if report["startup_failures"]:
+        return 0
+    print("No matching startup_failure check-runs found for this run.", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -5,18 +5,33 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 from typing import Any
 
+from scripts import api_client
 
-def _gh_api(path: str) -> dict[str, Any]:
-    cmd = ["gh", "api", path]
-    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-    data = json.loads(result.stdout)
+
+def _github_token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    result = subprocess.run(["gh", "auth", "token"], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+    auth_token = token or _github_token()
+    data = api_client._request_json(
+        "GET",
+        f"{api_client.GITHUB_API}/{path.lstrip('/')}",
+        auth_token,
+        payload=None,
+    )
     if not isinstance(data, dict):
-        raise ValueError(f"Expected JSON object from gh api {path}")
+        raise ValueError(f"Expected JSON object from GitHub API path {path}")
     return data
 
 

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -4,11 +4,11 @@
 #
 # Fresh-consumer bootstrap note:
 # This expanded Gate is not yet safe to seed into brand-new consumer repos.
-# Keep .github/sync-manifest.yml at sync_mode: create_only for this file until
-# issue #2158 proves the expanded detect outputs run on a repo created from
-# stranske/Template. Fresh consumers should temporarily use a known-green
-# deployed consumer Gate, then upgrade after the startup-failure regression is
-# fixed.
+# sync_mode: create_only only protects repos that already have a Gate file; a
+# repo missing pr-00-gate.yml can still receive this template on first sync.
+# Fresh consumers should start from stranske/Template or another known-green
+# deployed consumer Gate, then upgrade after issue #2158 proves this expanded
+# detect-output version no longer hits the startup-failure regression.
 name: Gate
 
 on:

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -1,6 +1,14 @@
 # Gate orchestrates CI enforcement for pull requests. The final `summary`
 # job aggregates artifacts, computes coverage deltas, publishes the commit
 # status, and maintains the consolidated PR comment.
+#
+# Fresh-consumer bootstrap note:
+# This expanded Gate is not yet safe to seed into brand-new consumer repos.
+# Keep .github/sync-manifest.yml at sync_mode: create_only for this file until
+# issue #2158 proves the expanded detect outputs run on a repo created from
+# stranske/Template. Fresh consumers should temporarily use a known-green
+# deployed consumer Gate, then upgrade after the startup-failure regression is
+# fixed.
 name: Gate
 
 on:

--- a/tests/fixtures/workflows/pr-00-gate-known-green-minimal.yml
+++ b/tests/fixtures/workflows/pr-00-gate-known-green-minimal.yml
@@ -1,0 +1,9 @@
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      run_core: ${{ steps.classify.outputs.run_core }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - id: classify
+        run: echo "known-green minimal gate fixture"

--- a/tests/scripts/test_gate_detect_output_diff.py
+++ b/tests/scripts/test_gate_detect_output_diff.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+from scripts import gate_detect_output_diff as diff
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_compare_detect_outputs_reports_added_keys_without_invalid_refs(tmp_path: Path) -> None:
+    baseline = _write(
+        tmp_path / "baseline.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      run_core: ${{ steps.classify.outputs.run_core }}
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+    candidate = _write(
+        tmp_path / "candidate.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      run_core: ${{ steps.classify.outputs.run_core }}
+      classification_rationale: ${{ steps.classify.outputs.classification_rationale }}
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+
+    report = diff.compare_gate_detect_outputs(candidate, baseline)
+
+    assert report["added_outputs_vs_baseline"] == ["classification_rationale"]
+    assert report["invalid_step_output_references"] == {}
+
+
+def test_compare_detect_outputs_flags_missing_step_ids(tmp_path: Path) -> None:
+    baseline = _write(
+        tmp_path / "baseline.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+    candidate = _write(
+        tmp_path / "candidate.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      affected_consumers: ${{ steps.path_classifier.outputs.affected_consumers }}
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+
+    report = diff.compare_gate_detect_outputs(candidate, baseline)
+
+    assert report["invalid_step_output_references"] == {"affected_consumers": ["path_classifier"]}
+
+
+def test_template_gate_detect_outputs_expand_known_green_minimal_baseline() -> None:
+    candidate = REPO_ROOT / "templates/consumer-repo/.github/workflows/pr-00-gate.yml"
+    baseline = REPO_ROOT / "tests/fixtures/workflows/pr-00-gate-known-green-minimal.yml"
+
+    report = diff.compare_gate_detect_outputs(candidate, baseline)
+
+    candidate_outputs = set(report["added_outputs_vs_baseline"]) | {
+        "doc_only",
+        "run_core",
+        "reason",
+    }
+    assert {
+        "doc_only",
+        "run_core",
+        "is_template_change",
+        "is_test_only",
+        "affected_consumers",
+        "classification_rationale",
+    } - candidate_outputs == set()

--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -78,6 +78,18 @@ def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
     finding = report["startup_failures"][0]
     assert finding["title"] == "The workflow is not valid"
     assert "Unrecognized named-value" in finding["summary"]
+    assert finding["failure_phase"] == "workflow_parse_or_graph"
+    assert finding["suspected_root_cause"] == "invalid_expression_context_reference"
+
+
+def test_classify_startup_failure_action_resolution() -> None:
+    phase, root = diag._classify_startup_failure(
+        summary="Unable to resolve action `owner/repo@main`",
+        title="Startup failure",
+        text="Repository not found",
+    )
+    assert phase == "action_resolution"
+    assert root == "action_reference_or_access"
 
 
 def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import json
-import subprocess
 from typing import Any
 
 from scripts import workflow_startup_failure_diagnostic as diag
-
-
-def _mock_completed(payload: dict[str, Any]) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(args=["gh", "api"], returncode=0, stdout=json.dumps(payload))
 
 
 def test_collect_startup_failures_filters_by_run_and_conclusion() -> None:
@@ -63,13 +57,12 @@ def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
         },
     ]
 
-    def fake_run(cmd, check, capture_output, text):  # type: ignore[no-untyped-def]
-        assert check is True
-        assert capture_output is True
-        assert text is True
-        return _mock_completed(responses.pop(0))
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        assert token is None
+        assert path.startswith("repos/owner/repo/")
+        return responses.pop(0)
 
-    monkeypatch.setattr(diag.subprocess, "run", fake_run)
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
     report = diag.diagnose_startup_failure("owner/repo", 555)
 
     assert report["jobs_count"] == 0
@@ -99,10 +92,10 @@ def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:
         {"check_runs": []},
     ]
 
-    def fake_run(cmd, check, capture_output, text):  # type: ignore[no-untyped-def]
-        return _mock_completed(responses.pop(0))
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        return responses.pop(0)
 
-    monkeypatch.setattr(diag.subprocess, "run", fake_run)
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
     exit_code = diag.main(["--repo", "owner/repo", "--run-id", "111"])
 
     assert exit_code == 2

--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from scripts import workflow_startup_failure_diagnostic as diag
+
+
+def _mock_completed(payload: dict[str, Any]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["gh", "api"], returncode=0, stdout=json.dumps(payload))
+
+
+def test_collect_startup_failures_filters_by_run_and_conclusion() -> None:
+    payload = {
+        "check_runs": [
+            {
+                "id": 1,
+                "conclusion": "success",
+                "details_url": "https://github.com/o/r/actions/runs/123",
+            },
+            {
+                "id": 2,
+                "conclusion": "startup_failure",
+                "details_url": "https://github.com/o/r/actions/runs/123/job/1",
+            },
+            {
+                "id": 3,
+                "conclusion": "startup_failure",
+                "details_url": "https://github.com/o/r/actions/runs/999/job/1",
+            },
+        ]
+    }
+    matches = diag._collect_startup_failures(payload, run_id=123)
+    assert [m["id"] for m in matches] == [2]
+
+
+def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
+    responses = [
+        {
+            "head_sha": "abc123",
+            "name": "Gate",
+            "conclusion": "startup_failure",
+            "status": "completed",
+        },
+        {"jobs": []},
+        {
+            "check_runs": [
+                {
+                    "id": 42,
+                    "name": "Gate / detect",
+                    "status": "completed",
+                    "conclusion": "startup_failure",
+                    "details_url": "https://github.com/o/r/actions/runs/555",
+                    "html_url": "https://github.com/o/r/runs/42",
+                    "output": {
+                        "title": "The workflow is not valid",
+                        "summary": "Unrecognized named-value: 'needs'",
+                        "text": "Line 123",
+                    },
+                }
+            ]
+        },
+    ]
+
+    def fake_run(cmd, check, capture_output, text):  # type: ignore[no-untyped-def]
+        assert check is True
+        assert capture_output is True
+        assert text is True
+        return _mock_completed(responses.pop(0))
+
+    monkeypatch.setattr(diag.subprocess, "run", fake_run)
+    report = diag.diagnose_startup_failure("owner/repo", 555)
+
+    assert report["jobs_count"] == 0
+    assert report["head_sha"] == "abc123"
+    assert len(report["startup_failures"]) == 1
+    finding = report["startup_failures"][0]
+    assert finding["title"] == "The workflow is not valid"
+    assert "Unrecognized named-value" in finding["summary"]
+
+
+def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:
+    responses = [
+        {"head_sha": "abc123", "name": "Gate", "conclusion": "failure", "status": "completed"},
+        {"jobs": []},
+        {"check_runs": []},
+    ]
+
+    def fake_run(cmd, check, capture_output, text):  # type: ignore[no-untyped-def]
+        return _mock_completed(responses.pop(0))
+
+    monkeypatch.setattr(diag.subprocess, "run", fake_run)
+    exit_code = diag.main(["--repo", "owner/repo", "--run-id", "111"])
+
+    assert exit_code == 2
+    assert "No matching startup_failure check-runs found" in capsys.readouterr().err

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -30,6 +30,15 @@ def test_consumer_create_only_files_are_manifested() -> None:
         assert entries[source]["sync_mode"] == "create_only"
 
 
+def test_gate_manifest_entry_documents_fresh_consumer_bootstrap_risk() -> None:
+    entries = _manifest_entries()
+    gate = entries[".github/workflows/pr-00-gate.yml"]
+
+    description = str(gate.get("description", ""))
+    assert "not yet fresh-consumer deployable" in description
+    assert "#2158" in description
+
+
 def test_consumer_sync_pr_body_surfaces_create_only_skips() -> None:
     workflow = SYNC_WORKFLOW_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2158 -->
> **Source:** Issue #2158

Closes #2158

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Discovered during \`stranske/learning-management-system\` bootstrap (2026-05-25): the consumer-template Gate at \`Workflows/main\` HEAD (\`templates/consumer-repo/.github/workflows/pr-00-gate.yml\`, ~956 lines) has expanded \`detect\`-job outputs (\`doc_only\`, \`run_core\`, \`is_template_change\`, \`is_test_only\`, \`affected_consumers\`, \`classification_rationale\`) that trigger \`startup_failure\` on a fresh consumer repo before any job runs. Production consumers (Counter_Risk, Inv-Man-Intake, Trend_Model_Project, Manager-Database, trip-planner) all run an older, simpler Gate (~199 lines) which currently passes green.

Counter_Risk's last several Gate runs: all \`success\`. Inv-Man-Intake's: all \`success\`. \`stranske/learning-management-system\` PR #32 with the consumer-template HEAD version: \`startup_failure\` on three consecutive attempts. Replacing with Counter_Risk's content immediately made Gate pass once \`default_workflow_permissions=write\` was also set on the new repo.

This suggests either:
1. The newer Gate has a bug that doesn't reproduce on already-installed consumers (e.g., depends on outputs from a path-classifier action version that consumer repos haven't picked up yet).
2. The newer Gate is a partial rollout / in-progress refactor that hasn't been rolled out to consumers.
3. The newer Gate requires repo-level permissions, variables, or secrets that fresh repos don't have but established consumers do.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#32](https://github.com/stranske/Workflows/issues/32)
- [#2156](https://github.com/stranske/Workflows/issues/2156)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Reproduce the startup_failure on a fresh consumer repo (e.g., create a throwaway public repo from stranske/Template, set default_workflow_permissions=write, copy in the consumer-template HEAD Gate, open a trivial PR, observe).
- [x] Capture the actual error from GitHub's workflow-startup phase. (\`gh api /repos/<owner>/<repo>/actions/runs/<id>/jobs\` returns empty \`jobs\` array — the failure is at the file-parse / job-graph-construction level.)
- [ ] Compare the consumer-template HEAD Gate to a known-green production Gate (Counter_Risk, Inv-Man-Intake) — diff is large; the relevant subset is around the \`detect\` job outputs.
- [x] Identify whether the failure is in YAML structure, action ref resolution, or output references.
- [ ] Fix or annotate as appropriate.

#### Acceptance criteria
- [ ] A fresh repo cloned from \`stranske/Template\` (after \`default_workflow_permissions=write\` is set per SETUP_CHECKLIST §3.3.1) can open its first PR and Gate completes successfully on the consumer-template HEAD version of \`pr-00-gate.yml\`.
- [x] Alternatively: the consumer-template HEAD Gate is clearly tagged as "not yet deployable to fresh consumers" with a documented workaround (revert to the simpler version) until the fix lands.
- [x] sync-manifest.yml's commentary on the file accurately reflects its deployability state.

<!-- auto-status-summary:end -->