### PR TITLE
fix(sync): keep Template create-only workflows current

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -22,6 +22,8 @@
 #   - description: What this file does (required for documentation)
 #   - skip_repos: Optional list of repo-specific exclusions with a reason.
 #       Use only when a consumer has an intentional incompatible path or policy.
+#   - overwrite_repos: Optional list of repos that should ignore create_only and
+#       stay byte-aligned with the canonical template (for example stranske/Template).
 
 version: 1
 
@@ -31,10 +33,14 @@ workflows:
   - source: .github/workflows/pr-00-gate.yml
     description: "Gate workflow - runs tests, lint, type checking before merge. Bootstrap note: the expanded template Gate is not yet fresh-consumer deployable; see issue #2158 before seeding it into new repos."
     sync_mode: create_only  # Don't overwrite existing consumer Gate files; fresh repos can still receive this file, so follow #2158 before first seeding.
+    overwrite_repos:
+      - stranske/Template
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"
     sync_mode: create_only  # Don't overwrite - repos customize coverage-min, python versions
+    overwrite_repos:
+      - stranske/Template
 
   - source: .github/workflows/autofix.yml
     description: "Autofix workflow - automatically fixes lint/format issues"

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -162,6 +162,8 @@ removals:
     description: "Remove deprecated verify-to-issue v1 template workflow past the 2026-02-15 removal deadline (replaced by agents-80-pr-event-hub.yml)"
   - target: .github/workflows/agents-verify-to-issue-v2.yml
     description: "Remove deprecated verify-to-issue v2 template workflow past the 2026-02-15 removal deadline (replaced by agents-80-pr-event-hub.yml)"
+  - target: .github/workflows/agents-70-orchestrator.yml
+    description: "Remove deprecated orchestrator workflow from template consumers (replaced by agents-80-pr-event-hub.yml and agents-81-gate-followups.yml)"
 # Codex prompts for agent operations
 prompts:
   - source: .github/codex/prompts/keepalive_next_task.md

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -430,6 +430,10 @@ jobs:
                   return str(rule.get('reason', '')).strip() or 'Manifest skip for repo'
               return ''
 
+          def repo_overwrites_create_only(item, repo):
+              """Return whether repo should ignore create_only for this manifest item."""
+              return repo in (item.get('overwrite_repos', []) or [])
+
           def comparable_lines(path):
               """Return file lines after leading comment/blank header lines."""
               lines = path.read_text().splitlines()
@@ -547,7 +551,11 @@ jobs:
 
               def skip_create_only():
                   """File exists and sync_mode is create_only"""
-                  return sync_mode == 'create_only' and consumer_dst.exists()
+                  return (
+                      sync_mode == 'create_only'
+                      and consumer_dst.exists()
+                      and not repo_overwrites_create_only(item, current_repo)
+                  )
 
               # Determine skip function: check create_only first (covers most cases),
               # then custom_gate for legacy repos that have completely custom Gates

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -305,7 +305,8 @@ jobs:
       - name: Compute result artifact name
         id: repo_meta
         run: |
-          safe_name=$(printf '%s' '${{ matrix.repo }}' | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^-+|-+$//g')
+          safe_name=$(printf '%s' '${{ matrix.repo }}' \
+            | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^-+|-+$//g')
           echo "artifact_name=${safe_name:-unknown-repo}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Workflows
@@ -432,7 +433,8 @@ jobs:
 
           def repo_overwrites_create_only(item, repo):
               """Return whether repo should ignore create_only for this manifest item."""
-              return repo in (item.get('overwrite_repos', []) or [])
+              overwrite_repos = item.get('overwrite_repos', [])
+              return isinstance(overwrite_repos, list) and repo in overwrite_repos
 
           def comparable_lines(path):
               """Return file lines after leading comment/blank header lines."""
@@ -818,7 +820,9 @@ jobs:
           branch_name="sync/workflows-${{ needs.prepare.outputs.template_hash }}"
 
           if [ "$EXISTING_SYNC_PR" = "true" ]; then
-            existing_pr=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
+            existing_pr=$(
+              gh pr list --head "$branch_name" --json number -q '.[0].number' || echo ""
+            )
             echo "PR #$existing_pr already exists for this sync"
             echo "::notice::Existing PR: #$existing_pr"
             {

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -179,6 +179,12 @@ Maint 68 is manifest-driven:
 
 Custom Gate repos are a special-case skip: their `pr-00-gate.yml` stays local.
 
+The `Template` repository is the canonical source for new consumer repos, so it
+must not preserve stale copies of files that are `create_only` for real
+consumers. Manifest entries can set `overwrite_repos: [stranske/Template]` to
+keep those files aligned in Template while still preserving customizations in
+production consumers.
+
 ### Reusable Workflow Versioning
 
 First-party consumer repos currently call reusable workflows via `@main`.
@@ -236,7 +242,8 @@ Workflows runs **Health 68 Consumer Sync Drift Check** to detect divergence betw
 templates/manifest entries and the registered consumer repos. It runs daily and
 after template/manifest/script changes.
 
-- Files marked with `sync_mode: create_only` are excluded.
+- Files marked with `sync_mode: create_only` are excluded, except for repos
+  listed in the entry's `overwrite_repos` override.
 - The uploaded `consumer-sync-drift-report` artifact uses
   `workflows-consumer-sync-drift/v1` and includes safe
   `token_diagnostics` (`workflows-drift-token-selection/v1`) so permission or

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -130,6 +130,12 @@ def manifest_skip_reason(entry: dict[str, object], repo: str) -> str:
     return ""
 
 
+def repo_overwrites_create_only(entry: dict[str, object], repo: str) -> bool:
+    """Return whether repo should be drift-checked for create_only entries."""
+    overwrite_repos = entry.get("overwrite_repos", [])
+    return isinstance(overwrite_repos, list) and repo in overwrite_repos
+
+
 def token_candidates(env: dict[str, str] | None = None) -> list[dict[str, str]]:
     """Return deduplicated token candidates without exposing token values."""
     values = env if env is not None else os.environ
@@ -781,8 +787,6 @@ def main() -> int:
             source = entry.get("source")
             if not source:
                 continue
-            if entry.get("sync_mode") == "create_only":
-                continue
             target = entry.get("target", source)
             is_directory = entry.get("is_directory", False)
             local_path = local_path_for(source, section)
@@ -791,6 +795,10 @@ def main() -> int:
                 continue
 
             for repo in remote_trees:
+                if entry.get("sync_mode") == "create_only" and not repo_overwrites_create_only(
+                    entry, repo
+                ):
+                    continue
                 skip_reason = manifest_skip_reason(entry, repo)
                 if skip_reason:
                     skipped.add(f"{repo}: {target} ({skip_reason})")

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -107,9 +107,7 @@ def test_repo_overwrites_create_only_supports_template_override() -> None:
     }
 
     assert check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Template")
-    assert not check_consumer_sync_drift.repo_overwrites_create_only(
-        entry, "stranske/Counter_Risk"
-    )
+    assert not check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Counter_Risk")
 
 
 def test_build_report_surfaces_manifest_skips_without_failing() -> None:

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -100,6 +100,18 @@ def test_manifest_skip_reason_supports_repo_specific_policy() -> None:
     assert check_consumer_sync_drift.manifest_skip_reason(entry, "owner/standard") == ""
 
 
+def test_repo_overwrites_create_only_supports_template_override() -> None:
+    entry = {
+        "sync_mode": "create_only",
+        "overwrite_repos": ["stranske/Template"],
+    }
+
+    assert check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Template")
+    assert not check_consumer_sync_drift.repo_overwrites_create_only(
+        entry, "stranske/Counter_Risk"
+    )
+
+
 def test_build_report_surfaces_manifest_skips_without_failing() -> None:
     report = check_consumer_sync_drift.build_report(
         repos=["owner/custom"],

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -110,6 +110,15 @@ def test_repo_overwrites_create_only_supports_template_override() -> None:
     assert not check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Counter_Risk")
 
 
+def test_repo_overwrites_create_only_fails_closed_for_malformed_value() -> None:
+    entry = {
+        "sync_mode": "create_only",
+        "overwrite_repos": "stranske/Template",
+    }
+
+    assert not check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Template")
+
+
 def test_build_report_surfaces_manifest_skips_without_failing() -> None:
     report = check_consumer_sync_drift.build_report(
         repos=["owner/custom"],

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -50,6 +50,7 @@ def test_consumer_sync_pr_body_surfaces_create_only_skips() -> None:
 
     assert "sync_mode == 'create_only'" in workflow
     assert "repo_overwrites_create_only" in workflow
+    assert "isinstance(overwrite_repos, list)" in workflow
     assert "File exists and sync_mode is create_only" in workflow
     assert "### Files Skipped" in workflow
     assert 'f.write(f"- {s}\\n")' in workflow

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -54,3 +54,11 @@ def test_consumer_sync_pr_body_surfaces_create_only_skips() -> None:
     assert "### Files Skipped" in workflow
     assert 'f.write(f"- {s}\\n")' in workflow
     assert "sync_summary.md" in workflow
+
+
+def test_manifest_removals_include_legacy_agents_orchestrator() -> None:
+    manifest = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8")) or {}
+    removals = manifest.get("removals", []) or []
+    removal_targets = {entry.get("target") for entry in removals if isinstance(entry, dict)}
+
+    assert ".github/workflows/agents-70-orchestrator.yml" in removal_targets

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -29,6 +29,12 @@ def test_consumer_create_only_files_are_manifested() -> None:
         assert source in entries
         assert entries[source]["sync_mode"] == "create_only"
 
+    for source in (
+        ".github/workflows/pr-00-gate.yml",
+        ".github/workflows/ci.yml",
+    ):
+        assert entries[source]["overwrite_repos"] == ["stranske/Template"]
+
 
 def test_gate_manifest_entry_documents_fresh_consumer_bootstrap_risk() -> None:
     entries = _manifest_entries()
@@ -43,6 +49,7 @@ def test_consumer_sync_pr_body_surfaces_create_only_skips() -> None:
     workflow = SYNC_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "sync_mode == 'create_only'" in workflow
+    assert "repo_overwrites_create_only" in workflow
     assert "File exists and sync_mode is create_only" in workflow
     assert "### Files Skipped" in workflow
     assert 'f.write(f"- {s}\\n")' in workflow


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2159 -->
> **Source:** Issue #2159

Closes #2159

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Discovered during \`stranske/learning-management-system\` bootstrap (2026-05-25): a fresh consumer repo cloned from \`stranske/Template\` via \`gh repo create --template stranske/Template --public\` inherits stale workflow files (specifically \`pr-00-gate.yml\` and the legacy \`agents-70-orchestrator.yml\` that's been superseded by the consolidated agents-80/agents-81 hubs).

The design intent — per the user — is that Template should track the canonical \`templates/consumer-repo/\` files in Workflows, so new consumer repos start from current truth. In practice, \`stranske/Template\` IS in \`REGISTERED_CONSUMER_REPOS\` of \`maint-68-sync-consumer-repos.yml\` (so the sync workflow targets it), but \`pr-00-gate.yml\` and \`ci.yml\` are marked \`sync_mode: create_only\` in \`.github/sync-manifest.yml\`:

\`\`\`yaml
- source: .github/workflows/pr-00-gate.yml
  description: "Gate workflow - runs tests, lint, type checking before merge"
  sync_mode: create_only  # Don't overwrite - repos customize coverage-min, python versions
\`\`\`

The \`create_only\` mode is correct for production consumer repos (preserves local customizations like custom test jobs, coverage minimums, Python version pins). It's wrong for the Template repo, because Template by definition should be a pure unmodified copy of the canonical template — it's not supposed to have customizations to preserve.

#### Tasks
- [x] Decide the mechanism: per-repo \`sync_mode\` override in \`sync-manifest.yml\` (e.g., \`overwrite_for: [stranske/Template]\`), or a dedicated Template-refresh workflow, or another approach.
- [ ] Implement the chosen mechanism.
- [ ] Run it to refresh \`stranske/Template\` to the current canonical state (Gate, CI, all the agents-* workflows the consumer-template defines).
- [ ] Add a CI check (or extend \`health-74-template-drift.yml\`) that fails when Template's workflow files diverge from canonical.

#### Acceptance criteria
- [ ] \`gh repo create --template stranske/Template --public\` produces a repo with workflow files identical to the current \`templates/consumer-repo/.github/workflows/\` contents.
- [ ] Subsequent canonical changes (e.g., a Gate update merged into Workflows/main) propagate to \`stranske/Template\` automatically.
- [ ] Existing consumer repos with \`sync_mode: create_only\` continue to preserve their customizations (no regression in protection for real consumers).

<!-- auto-status-summary:end -->