### PR TITLE
fix: require coverage artifacts for coverage guard run

### DIFF
--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -151,9 +151,7 @@ jobs:
                 new Date(a.run_started_at || a.created_at || 0),
             );
             let candidate = null;
-            for (const run of runs.filter((item) =>
-              ['success', 'neutral'].includes(item.conclusion || ''),
-            )) {
+            for (const run of runs) {
               const artifacts = await withRetry(() =>
                 github.rest.actions.listWorkflowRunArtifacts({
                   owner,

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -126,7 +126,7 @@ jobs:
                   paginateWithRetry: (githubInstance, method, params) =>
                     githubInstance.paginate(method, params),
                 };
-            const { paginateWithRetry } = retryHelpers;
+            const { paginateWithRetry, withRetry } = retryHelpers;
 
             const runs = await paginateWithRetry(
               github, github.rest.actions.listWorkflowRuns,
@@ -150,11 +150,32 @@ jobs:
                 new Date(b.run_started_at || b.created_at || 0) -
                 new Date(a.run_started_at || a.created_at || 0),
             );
-            const candidate =
-              runs.find((run) => ['success', 'neutral'].includes(run.conclusion || '')) || runs[0];
+            let candidate = null;
+            for (const run of runs.filter((item) =>
+              ['success', 'neutral'].includes(item.conclusion || ''),
+            )) {
+              const artifacts = await withRetry(() =>
+                github.rest.actions.listWorkflowRunArtifacts({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                }),
+              );
+              const hasCoverageTrend = artifacts.data.artifacts.some(
+                (artifact) =>
+                  artifact.name === 'gate-coverage-trend' && !artifact.expired,
+              );
+              if (hasCoverageTrend) {
+                candidate = run;
+                break;
+              }
+            }
 
             if (!candidate) {
-              core.warning('Unable to locate a completed Gate workflow run.');
+              core.warning(
+                'Unable to locate a completed Gate workflow run with coverage artifacts.',
+              );
               core.setOutput('run_id', '');
               return;
             }

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -161,9 +161,7 @@ jobs:
                 new Date(a.run_started_at || a.created_at || 0),
             );
             let candidate = null;
-            for (const run of runs.filter((item) =>
-              ['success', 'neutral'].includes(item.conclusion || ''),
-            )) {
+            for (const run of runs) {
               const artifacts = await withRetry(() =>
                 github.rest.actions.listWorkflowRunArtifacts({
                   owner,

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -136,7 +136,7 @@ jobs:
                   paginateWithRetry: (githubInstance, method, params) =>
                     githubInstance.paginate(method, params),
                 };
-            const { paginateWithRetry } = retryHelpers;
+            const { paginateWithRetry, withRetry } = retryHelpers;
 
             const runs = await paginateWithRetry(
               github, github.rest.actions.listWorkflowRuns,
@@ -160,11 +160,32 @@ jobs:
                 new Date(b.run_started_at || b.created_at || 0) -
                 new Date(a.run_started_at || a.created_at || 0),
             );
-            const candidate =
-              runs.find((run) => ['success', 'neutral'].includes(run.conclusion || '')) || runs[0];
+            let candidate = null;
+            for (const run of runs.filter((item) =>
+              ['success', 'neutral'].includes(item.conclusion || ''),
+            )) {
+              const artifacts = await withRetry(() =>
+                github.rest.actions.listWorkflowRunArtifacts({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                }),
+              );
+              const hasCoverageTrend = artifacts.data.artifacts.some(
+                (artifact) =>
+                  artifact.name === 'gate-coverage-trend' && !artifact.expired,
+              );
+              if (hasCoverageTrend) {
+                candidate = run;
+                break;
+              }
+            }
 
             if (!candidate) {
-              core.warning('Unable to locate a completed Gate workflow run.');
+              core.warning(
+                'Unable to locate a completed Gate workflow run with coverage artifacts.',
+              );
               core.setOutput('run_id', '');
               return;
             }


### PR DESCRIPTION
## Summary
- Require maint-coverage-guard to select a completed Gate run with a live gate-coverage-trend artifact before setting run_id.
- Apply the same source fix to the consumer template copy so replacement sync PRs do not silently skip coverage monitoring.

## Validation
- python scripts/validate_workflow_yaml.py .github/workflows/maint-coverage-guard.yml templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check
