### PR TITLE
Register Fine-Art-Archive consumer + refresh SETUP_CHECKLIST

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -83,6 +83,7 @@ env:
     stranske/Trend_Model_Project
     stranske/Collab-Admin
     stranske/learning-management-system
+    stranske/Fine-Art-Archive
 
 concurrency:
   group: sync-consumer-repos-${{ github.repository }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a narrative of how the repo evolved through five development phases (bootstr
 
 ### First-party Consumers
 
-12 repos are currently registered as first-party consumers (synced via [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml)):
+13 repos are currently registered as first-party consumers (synced via [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml)):
 
 - [Travel-Plan-Permission](https://github.com/stranske/Travel-Plan-Permission)
 - [Template](https://github.com/stranske/Template)
@@ -27,6 +27,7 @@ For a narrative of how the repo evolved through five development phases (bootstr
 - [Inv-Man-Intake](https://github.com/stranske/Inv-Man-Intake)
 - [Ready](https://github.com/stranske/Ready)
 - [learning-management-system](https://github.com/stranske/learning-management-system)
+- [Fine-Art-Archive](https://github.com/stranske/Fine-Art-Archive)
 
 [`.github/workflows/maint-68-sync-consumer-repos.yml`](.github/workflows/maint-68-sync-consumer-repos.yml) is the authoritative list — `REGISTERED_CONSUMER_REPOS` env var. The [Workflows-Integration-Tests](https://github.com/stranske/Workflows-Integration-Tests) harness validates the consumer surface separately.
 

--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -22,6 +22,8 @@ Before starting, ensure you have:
 - [ ] Admin access to create repository secrets and variables
 - [ ] Claude Code login/session available if you want Claude-run workflows
 - [ ] Python 3.12+ installed locally for testing
+- [ ] GitHub CLI (`gh`) installed + authenticated (`brew install gh`; `gh auth status`) — the repo/label/secret steps below use it
+- [ ] Access to the team credentials store (e.g. `Code/Numbers/values.txt`), labeled by secret name — source for the Phase 3 secrets the table marks "contact admin"
 
 ---
 
@@ -35,11 +37,12 @@ Before starting, ensure you have:
 - [ ] Create the consumer repo from your chosen template source:
   - [ ] Preferred: start from the consumer repo template under `stranske/Workflows/templates/consumer-repo/` (copied into a new repo)
   - [ ] Alternative: use a dedicated template repo (for example [stranske/Template](https://github.com/stranske/Template)) if your org maintains one
-- [ ] Click **Use this template** → **Create a new repository**
-- [ ] Choose owner: `stranske` (or your organization)
-- [ ] Enter repository name
-- [ ] Select **Private** or **Public** as appropriate
-- [ ] Click **Create repository**
+- [ ] Create via GitHub CLI (the UI "Use this template" path still works too):
+  ```bash
+  gh repo create stranske/<your-repo> --public --template stranske/Template \
+    --description "<short description>"
+  ```
+  Use `--private` if appropriate. `stranske/Template` is a GitHub *template* repo, so `--template` copies its full scaffold in one step.
 
 ### 1.2 Clone and Verify Structure
 


### PR DESCRIPTION
Registers stranske/Fine-Art-Archive as a first-party consumer (REGISTERED_CONSUMER_REPOS in maint-68 + README 12->13). Refreshes docs/templates/SETUP_CHECKLIST.md to current practice: gh-based repo creation, secret sourcing from the team values store, and marks GH_APP_*/WORKFLOWS_APP_CLIENT_ID optional (existing consumers do not set them). The Fine-Art-Archive repo, 26 labels, and 17 secrets are already provisioned at parity with Manager-Database.