### PR TITLE
[DRAFT — human review] Add fleet-review skill (.claude/skills/fleet-review)

### DIFF
--- a/.claude/skills/fleet-review/SKILL.md
+++ b/.claude/skills/fleet-review/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: fleet-review
+description: >-
+  Run an on-demand, multi-agent fleet/repo review across the supported stranske
+  repos: fan out one Markdown-returning reviewer per repo, synthesize in the main
+  loop, and emit Issue-Gate-quality candidates. Use for a manual design-vs-implementation
+  review, applying a new cross-cutting concern (blueprint feasibility, dev-process,
+  prior-art) across repos, or walking through how to deploy/test an app privately
+  (the deployment decision-tree "shoulder tap"). Complements — does not replace —
+  the scheduled scripts/repo_review_coordinator.py.
+---
+
+# Fleet Review
+
+On-demand, human-driven multi-repo review and per-app deployment walkthrough.
+This is the manual, conversational counterpart to the scheduled Python coordinator.
+
+## When to use
+
+Trigger this skill when the user asks for any of:
+
+- A manual / on-demand **fleet review** or **design-vs-implementation review** of the supported repos (or a named subset).
+- Applying a **new cross-cutting concern** across repos in one pass — e.g. blueprint feasibility, dev-process/adoption, prior-art research, observability.
+- A **deployment / "how do I test this app privately"** decision — the per-app walkthrough (see `references/deployment-decision-tree.md`).
+- Help **synthesizing** many per-repo reviews into one prioritized issue set.
+
+## When NOT to use
+
+- **Routine scheduled reviews.** The weekly packet is owned by `scripts/repo_review_coordinator.py` (round-1/round-2 fan-out, convergence, `human-decision-packet.md`, `approved-issue-queue.json`). Do not reimplement it here. This skill is for *ad hoc* runs, *new* concern overlays, and the *interactive* deployment walkthrough the coordinator doesn't do.
+- When the answer is a single documented fact — read the doc, don't spin up agents.
+
+Relationship: the coordinator produces the standing weekly queue from `config/repo_review_feedback.json`; this skill runs extra/interactive passes on demand and feeds candidates into that same human-decision step.
+
+## Supported repos (the fleet)
+
+`stranske/Workflows`, `Travel-Plan-Permission`, `Trend_Model_Project`, `Portable-Alpha-Extension-Model`, `Counter_Risk`, `Manager-Database`, `Inv-Man-Intake`, `Pension-Data`, `trip-planner`, `learning-management-system`. Authoritative roster: `config/repo_review_registry.json` (status `active`). Per-repo interpretation: `config/repo_review_profiles.json`.
+
+## The review recipe
+
+1. **Fan out one reviewer per repo.** Spawn one sub-agent per `active` repo, in parallel. Each reviewer reviews exactly one repo against the standard dimensions and **returns its final answer as Markdown in the final message** — NOT enforced structured output.
+   - **Hard-won lesson:** forcing `StructuredOutput` / strict JSON schemas on heavy analysis agents failed on **26 of 32 agents** in the 2026-05-29 run. Markdown final-message returns are reliable. Ask for a consistent Markdown *shape* (headings below), not a validated schema.
+   - Ask each reviewer for **file:line-grounded** evidence, not generic "code exists" statements.
+2. **Standard dimensions** (every repo, same five — from `docs/ops/REPO_REVIEW_PROCESS.md`):
+   - `design_contract` — intended product/workflow from README/docs + registry anchor.
+   - `implementation_coverage` — real working behavior vs scaffolds/seams/fixtures/advisory-only.
+   - `test_and_live_readiness` — do tests/smoke paths prove the user journey the design requires.
+   - `integration_and_state` — cross-repo contracts, providers, persistence, reload, source authority, artifacts, workflow handoffs.
+   - `issue_generation` — convert verified gaps into drafts (see Issue Gate).
+   - Suggested reviewer Markdown shape: one `##` per dimension, a short **Verdict**, then bulleted **Evidence (file:line)**, then **Candidate issues** each with Why / what's missing / acceptance.
+3. **Main-loop synthesis.** Collect all reviewer Markdown and synthesize in the main loop (the 1M context holds every review at once). Produce: a fleet summary, readiness tiers, and a single prioritized cross-repo issue list. Do not just concatenate the reviews.
+4. **Issue candidates must clear the Issue Gate / Definition of Ready.** See `references/issue-quality-bar.md`. Anything that doesn't clear it is a note, not an issue. Output candidates only — **never push to GitHub or change automation in this skill**; they flow into the same human-decision step the coordinator uses (`config/repo_review_feedback.json` → approved queue → uploader).
+
+## Monitoring discipline (load-bearing)
+
+The harness only notifies you on **completion**, not on death or stall. A silent background run is the #1 failure mode (an agent went silent for ~2h in the 2026-05-29 run).
+
+- **Attach a stall-watcher to every long background run.** Poll log/output mtime; if it stops advancing, treat the run as stuck — terminate and retry on a fresh process rather than waiting on the wall timeout.
+- **Process every notification immediately** when a run completes or stalls; don't batch.
+- **Report proactively.** Surface progress, partial results, and any stall to the user as it happens. Never go silent — if you have nothing new, say so.
+- Prefer many short, observable passes over one long opaque one.
+
+## Concern overlays
+
+To add a new cross-cutting concern, run it as an **extra pass** layered on the same fan-out, not a rewrite of the standard dimensions:
+
+- Keep the per-repo, Markdown-return, file:line-grounded pattern.
+- Give each reviewer the concern as one added dimension/question (e.g. **blueprint feasibility** — can this repo's core run headlessly and emit a run-contract; **dev-process/adoption** — is there a browser-reachable instance and a no-terminal way in; **prior-art** — what off-the-shelf tool would replace building this).
+- Synthesize the overlay separately, then fold its issue candidates into the same Issue-Gate filter.
+- Examples and verdict format mirror the 2026-05-29 review's FEASIBILITY / DEVPROCESS / RESEARCH passes.
+
+## Grounding rules
+
+- **Read the Workflows docs first.** Ground every system-level claim in a named doc — `README.md`, `docs/ops/REPO_REVIEW_PROCESS.md`, `docs/INTEGRATION_GUIDE.md`, `docs/keepalive/GoalsAndPlumbing.md`, `docs/LABELS.md`. If you can't name the doc, go read it before concluding.
+- **Check the sync-manifest for source-of-truth.** Many files in consumer repos are synced copies; the original lives in Workflows (`.github/sync-manifest.yml` + `templates/consumer-repo/`). Don't flag "drift" or fix in a consumer what is owned here. (E.g. LangSmith/langchain scripts: Workflows is source, consumers hold copies.)
+- **Never conclude from one truncated or isolated signal.** An empty queue, a stale warning, a `head`-truncated grep, or one idle lane is downstream of a pipeline — read the owning doc before drawing a system conclusion. Idle lanes never *prove* "nothing to do"; the opener also draws from already-open GitHub issues.
+
+## Deployment decision-tree walkthrough (the "shoulder tap")
+
+When a repo first becomes **testable**, before sharing a tool with a colleague, when **adding/enabling an LLM feature**, or when onboarding someone — run the interactive per-app walkthrough in `references/deployment-decision-tree.md` *with the user*. It encodes the two boundaries (network + LLM), the five privacy-safe deploy options, the decision tree, and per-app starting recommendations. Walk one app at a time, ask the gating questions, and record the chosen path.
+
+## References
+
+- `references/deployment-decision-tree.md` — the per-app deployment walkthrough (5 options, decision tree, per-app table, when to tap on the shoulder).
+- `references/issue-quality-bar.md` — the Issue Gate / Definition of Ready every candidate must clear, with required/recommended sections.
+
+## Related (in-repo)
+
+- `docs/ops/REPO_REVIEW_PROCESS.md` — the standard process, dimensions, registry, Issue Gate, human decision point.
+- `scripts/repo_review_coordinator.py` — the scheduled coordinator this skill complements.
+- `templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md` — the canonical issue body format.
+- `.github/sync-manifest.yml` — consumer source-of-truth map.

--- a/.claude/skills/fleet-review/references/deployment-decision-tree.md
+++ b/.claude/skills/fleet-review/references/deployment-decision-tree.md
@@ -1,0 +1,80 @@
+# Deployment decision-tree walkthrough (the "shoulder tap")
+
+Run this interactively, **one app at a time, with the user**, when a repo first
+becomes testable, before sharing a tool with a colleague, when adding/enabling an
+LLM feature, or when onboarding someone. Ask the gating questions, pick the path,
+and record the chosen path for that app. Written to be usable by a non-programmer.
+
+## The one rule: two separate boundaries
+
+- **Network boundary** — proprietary/internal data must not leave the org or be stored outside it.
+- **LLM boundary** — proprietary data must not go to an LLM without specific authorization.
+
+The org has **no objection to ordinary programs processing data**. So keep both
+boundaries explicit and isolated: a tool's deterministic math can run on real data
+freely; only the "leaves the building" and "talks to an LLM" parts are restricted.
+
+## The five privacy-safe options (the toolkit)
+
+1. **Client-side WebAssembly** — `stlite` (Streamlit-in-browser), `Pyodide`, `JupyterLite`. App runs entirely in the work browser tab: no install, no terminal, no server, data never leaves the machine, no LLM in this path. **Default best option now — needs nothing from the tech team.**
+2. **In-perimeter browser hosting** — Power Apps/Power BI (M365), an internal server / Azure web app, or Streamlit-in-Snowflake. Browser-reachable, data stays inside. *Needs IT.* **Future** (M365 + internal server flagged worth tracking).
+3. **Isolate the LLM boundary** — split each tool into a deterministic core (runs on real data) and LLM features behind a switch (redact-first, or disabled, until an authorized endpoint exists).
+4. **Two-track: synthetic for show, real for work** — demo to colleagues on a public host using *fake* fixture data; do real runs only via Option 1 or 2.
+5. **Authorized no-train LLM endpoint** (e.g. Azure OpenAI in-tenant) — *future*; depends on tech-team progress.
+
+Only Streamlit Cloud / Cloudflare Pages / an existing deployed URL / viewable CI
+artifacts need **nothing but a browser**. GitHub Codespaces is the universal
+*dev* fallback (a terminal in a browser tab) — external cloud, so synthetic /
+non-proprietary data only.
+
+## The decision tree — ask these per app
+
+1. **Does this app need REAL internal data to do its job?**
+   - **No** → it's *public-safe*. Use a public browser path (GitHub Codespaces, or a deployed demo). Easiest; great for adoption demos. **Done.**
+   - **Yes** → go to 2.
+2. **For testing/demos, can you use synthetic/fixture data instead of real?**
+   - **Yes** → demo on a public path with synthetic data (Option 4); do real runs via step 3.
+   - **No** → go to 3.
+3. **Does the task need LLM features, or just computation?**
+   - **Just computation** → **Option 1 (stlite/WASM)** — runs in the work browser, nothing leaves. Best now.
+   - **Needs an LLM on proprietary data** → no authorized endpoint yet → **Option 3**: disable/redact the LLM part for now; revisit when Option 5 lands.
+
+## When to tap on the shoulder (trigger this walkthrough)
+
+- When a repo first becomes **testable** (has a usable entry point).
+- **Before** deploying or sharing a tool with a colleague.
+- When **adding or enabling an LLM feature**.
+- When **onboarding** someone to a tool.
+
+## Per-app starting recommendations (confirm the bold gate live)
+
+| App | Needs real internal data? | Recommended path now |
+|---|---|---|
+| **trip-planner** | **No** (confirmed) | Public — Codespaces or a deployed demo. Best first adoption demo. |
+| **Pension-Data** | Public filings — likely **No** (confirm) | Public path; internal only if joined to private data. |
+| **Trend_Model_Project** | **Yes** (return data) | Option 1 (stlite) for real runs; synthetic demo for show. |
+| **Portable-Alpha-Extension-Model** | **Yes** | Option 1 (stlite); synthetic demo. |
+| **Counter_Risk** | **Yes** | Option 1 (stlite) after the console-script fix; synthetic demo. |
+| **Manager-Database** | **Yes** + LLM | Deterministic/search core → Option 2 (later) or stlite; LLM features Option 3 (off/redacted) now; synthetic demo now. |
+| **Inv-Man-Intake** | **Yes** + LLM | Deterministic parsing via WASM/local; LLM gated (Option 3). |
+| **learning-management-system** | **Yes** (already does local-first redaction) | Option 1/3; its redaction path is the template. |
+| **Travel-Plan-Permission** | **Confirm** (may hold personnel data) | Default to internal/Option 1 until confirmed. |
+| **Workflows** | N/A (dev infrastructure) | Observe in the browser via GitHub; not a data app. |
+
+Adopt **Streamlit as the house UI pattern**; don't rewrite to React. Treat "no
+live URL" as a release blocker — ship a browser-reachable instance the moment a
+tool is usable, and verify it live in-session (never "the next cron tick will confirm").
+
+## Cross-location consistency (work PC web Claude Code ↔ Mac at home)
+
+Local skills/automations/memory live in `~/.claude` / `~/.codex`, which web Claude
+Code on the work PC can't see. To make capability travel:
+
+1. **Put shared skills *inside a repo*** (committed `.claude/skills/`) — they travel to web Claude Code when the repo is opened. (This skill is built that way on purpose.)
+2. Keep key knowledge in committed files (`CLAUDE.md`, `docs/`), not only local memory.
+3. Commit shared settings/permissions to `.claude/settings.json`.
+4. **GitHub Codespaces** gives an identical browser dev environment anywhere (synthetic data only).
+5. (Bigger move) Migrate the local-cron opener/closer/handoff automations to cloud-scheduled remote agents or GitHub Actions so they run regardless of which machine is on. Flag for later.
+
+Bottom line: shift capability out of the Mac's home folder into **the repo (git)**
+and **the cloud (Codespaces / scheduled remote agents)**.

--- a/.claude/skills/fleet-review/references/issue-quality-bar.md
+++ b/.claude/skills/fleet-review/references/issue-quality-bar.md
@@ -1,0 +1,51 @@
+# Issue Gate / Definition of Ready
+
+Every candidate issue produced by a fleet review must clear this bar before it is
+offered for human approval. Anything that doesn't clear it is a note, not an issue.
+Source: `docs/ops/REPO_REVIEW_PROCESS.md` (Issue Gate) and
+`templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md` (issue body format).
+
+## The gate — a candidate must state
+
+- **The design commitment or readiness goal** it serves.
+- **Current evidence** from code, docs, tests, or archives (file:line, not "code exists").
+- **What behavior is missing.**
+- **Non-goals** that prevent a scaffold-only "done" claim.
+- **Tasks** a coding agent can actually complete.
+- **Acceptance criteria** with a failing test, a smoke test, or a documented live-verification gate.
+
+If any of the six is absent, the candidate is not ready.
+
+## Required body sections (enforced)
+
+- `## Tasks` — checkboxes; each task specific, small, actionable (starts with a verb).
+- `## Acceptance Criteria` — checkboxes; each verifiable, specific, independent.
+
+## Recommended body sections (the weekly queue includes these)
+
+- `## Why` — context/rationale.
+- `## Scope` — what the issue covers and its boundaries.
+- `## Non-Goals` — explicit exclusions (blocks scope creep and scaffold-only claims).
+- `## Implementation Notes` — file paths, constraints, technical guidance.
+
+## Quality checks
+
+- **Tasks** are specific / small / actionable. Reject "Fix bugs", "Improve code".
+- **Acceptance criteria** are verifiable / specific / independent. If you can't write a test for it, rephrase it. Reject "Works correctly".
+- **File paths** named explicitly in Implementation Notes.
+
+## Scope rule for consumer repos
+
+Consumer-repo reviews must **not** generate issues for Workflows maintenance,
+template sync, or cross-repo lane-management work unless that work directly
+implements repo-local behavior the consumer's design requires. Those maintenance
+tasks belong in `stranske/Workflows`.
+
+## After candidates exist (not this skill's job to execute)
+
+Candidates flow into the same human step the coordinator uses:
+human approval recorded in `config/repo_review_feedback.json` → evaluator
+regenerates `approved-issue-queue.json` → upload via
+`scripts/upload_repo_review_issues.py` (dry-run by default; `--apply` to create,
+which skips exact-title-duplicate open issues). This skill **outputs candidates
+only** — it never pushes issues or changes automation.


### PR DESCRIPTION
## What this is

Adds a **project-scope** Claude Code skill at `.claude/skills/fleet-review/`. Because it is committed inside the repo (not in `~/.claude/skills/`), it travels to **web-based Claude Code** automatically when this repo is opened — the same pattern as the existing `langsmith-integration` skill.

## What the skill does

Encodes the on-demand, human-driven multi-repo review recipe **and** the per-app deployment decision-tree walkthrough:

- **Review recipe** — fan out one reviewer per `active` repo, each returning **Markdown** (not enforced StructuredOutput; strict schemas broke 26/32 agents in the 2026-05-29 run), against the five standard dimensions; synthesize in the main loop; emit issue candidates that must clear the Issue Gate / Definition of Ready.
- **Monitoring discipline** — attach a stall-watcher to every long background run (the harness only notifies on completion, not death/stall), process notifications immediately, report proactively, never go silent.
- **Concern overlays** — how to add a new cross-cutting concern (blueprint feasibility, dev-process, prior-art) as an extra pass on the same fan-out.
- **Grounding rules** — read the Workflows docs first; check `.github/sync-manifest.yml` for source-of-truth; never conclude from one truncated signal.
- **Deployment decision-tree walkthrough** (the interactive "shoulder tap") — the two boundaries (network + LLM), the 5 privacy-safe deploy options (client-side WASM/stlite default; in-perimeter hosting future; synthetic-for-external; isolate the LLM boundary; authorized no-train endpoint), the decision tree, and per-app starting recommendations.

## Files

- `.claude/skills/fleet-review/SKILL.md` (frontmatter: `name` + `description`)
- `.claude/skills/fleet-review/references/deployment-decision-tree.md`
- `.claude/skills/fleet-review/references/issue-quality-bar.md`

Self-contained inside the repo — no runtime dependency on files outside Workflows.

## Scope / relationship

**Complements, does not replace** `scripts/repo_review_coordinator.py`. The coordinator still owns the standing weekly packet from `config/repo_review_feedback.json`; this skill is for ad-hoc runs, new concern overlays, and the interactive deployment walkthrough. The skill **outputs candidates only** — it never pushes issues or changes automation.

## Please do not auto-merge

Draft for human review. No `agent:*` labels.