### PR TITLE
Fix Maint 83 bootstrap workflow action versions

### DIFF
--- a/.github/workflows/maint-83-bootstrap-consumer.yml
+++ b/.github/workflows/maint-83-bootstrap-consumer.yml
@@ -40,10 +40,10 @@ jobs:
       GH_TOKEN: ${{ secrets.OWNER_PR_PAT || secrets.SERVICE_BOT_PAT }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/tests/workflows/test_workflow_naming.py
+++ b/tests/workflows/test_workflow_naming.py
@@ -125,6 +125,16 @@ def test_health_44_pull_requests_do_not_use_repo_variable_fingerprints():
     assert source.index("pull-request-no-repo-variable") < source.index("--storage repo-variable")
 
 
+def test_maint_83_bootstrap_uses_published_action_versions():
+    workflow = WORKFLOW_DIR / "maint-83-bootstrap-consumer.yml"
+    source = workflow.read_text(encoding="utf-8")
+
+    assert "actions/checkout@v4" in source
+    assert "actions/setup-python@v5" in source
+    assert "actions/checkout@v6" not in source
+    assert "actions/setup-python@v6" not in source
+
+
 def test_inventory_docs_list_all_workflows():
     docs = {
         "docs/ci/WORKFLOW_SYSTEM.md": pathlib.Path("docs/ci/WORKFLOW_SYSTEM.md").read_text(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2175 -->
> **Source:** Issue #2175

Closes #2175

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Post-merge verifier output on PR #2171 reported a concrete runtime blocker in `.github/workflows/maint-83-bootstrap-consumer.yml`: the workflow uses `actions/checkout@v6` and `actions/setup-python@v6`. Those versions do not exist, so manual dispatch of the new bootstrap workflow can fail before the bootstrap script runs. This is verifier follow-up debt for source issue #2170.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Workflows#2171](https://github.com/stranske/Workflows/issues/2171)
- [#2171](https://github.com/stranske/Workflows/issues/2171)
- [#2170](https://github.com/stranske/Workflows/issues/2170)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Update `.github/workflows/maint-83-bootstrap-consumer.yml` to use valid action versions.
- [ ] Add a test/assertion that the Maint 83 workflow pins `checkout` and `setup-python` to supported stable versions.
- [ ] Run focused workflow validation and tests.

#### Acceptance criteria
- [ ] `rg "actions/(checkout|setup-python)@v6" .github/workflows/maint-83-bootstrap-consumer.yml` returns no matches.
- [ ] Focused workflow tests pass.
- [ ] `python scripts/validate_workflow_yaml.py .github/workflows/maint-83-bootstrap-consumer.yml` passes.

<!-- auto-status-summary:end -->