### PR TITLE
Fix issue-optimizer/formatter runaway expansion (idempotency + decomposition caps + anti-rewrap)

### DIFF
--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -19,16 +19,66 @@ from typing import Any
 
 try:
     from scripts.langchain.injection_guard import check_prompt_injection
-    from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
+    from scripts.langchain.issue_pr_context import (
+        ContextOptions,
+        already_conformant,
+        build_formatted_body_marker,
+        build_issue_context,
+        reuse_formatted_body,
+    )
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ImportError:  # pragma: no cover - fallback for direct invocation
     from injection_guard import check_prompt_injection
-    from issue_pr_context import ContextOptions, build_issue_context
+    from issue_pr_context import (
+        ContextOptions,
+        already_conformant,
+        build_formatted_body_marker,
+        build_issue_context,
+        reuse_formatted_body,
+    )
     from trace_utils import TraceInfo, invoke_with_trace
 
 # Maximum issue body size to prevent OpenAI rate limit errors (30k TPM limit)
 # ~4 chars per token, so 50k chars ≈ 12.5k tokens, leaving headroom for prompt + output
 MAX_ISSUE_BODY_SIZE = 50000
+
+# Workflow tags written into the reuse marker. Tagging every stage of the
+# auto-pilot format -> optimize -> apply chain lets any stage detect a body it (or
+# a sibling stage) already formatted and skip re-deriving it, which is the
+# primary defense against re-run amplification.
+REUSE_MARKER_WORKFLOWS = (
+    "agents-auto-pilot",
+    "agents-issue-optimizer",
+    "agents-63-issue-intake",
+    "issue_formatter",
+    "issue_optimizer",
+)
+
+
+def _with_reuse_marker(formatted: str) -> str:
+    """Append (or refresh) the reuse marker that lets later stages skip re-formatting.
+
+    The marker stores a sha256 fingerprint of the formatted body (hash-only). A
+    stale marker (body edited after formatting) simply fails the hash check
+    downstream and is ignored, so this is always safe to (re)write.
+    """
+    body = _strip_reuse_marker(formatted).rstrip()
+    marker = build_formatted_body_marker(
+        workflows=list(REUSE_MARKER_WORKFLOWS),
+        formatted_body=body,
+        embed_body=False,  # hash-only: the formatted body is written back in full anyway
+    )
+    return f"{body}\n\n{marker}\n"
+
+
+def _strip_reuse_marker(text: str) -> str:
+    try:
+        from scripts.langchain.issue_pr_context import MARKER_RE
+    except ImportError:  # pragma: no cover - fallback for direct invocation
+        from issue_pr_context import MARKER_RE
+
+    return MARKER_RE.sub("", text).rstrip()
+
 
 ISSUE_FORMATTER_PROMPT = """
 You are a formatting assistant. Convert the raw GitHub issue body into the
@@ -49,6 +99,14 @@ Rules:
 - If a section lacks content, use "_Not provided._" (or "- [ ] _Not provided._"
   for Tasks/Acceptance).
 - Output ONLY the formatted markdown with these sections (no extra commentary).
+
+Length & scope discipline (improve clarity, do NOT inflate):
+- Improve clarity WITHOUT increasing total length. Do not add a task, criterion,
+  or sentence unless it fills a genuinely missing mandatory section.
+- Preserve scope; do NOT invent file paths, functions, tests, or criteria the
+  source does not imply, and do NOT manufacture prose to fill placeholders.
+- Never restate the same point under two headings; never split a task that is
+  already a single ~10-minute action.
 
 Raw issue body:
 {issue_body}
@@ -350,14 +408,76 @@ def _select_code_fence(text: str) -> str:
     return "`" * fence_len
 
 
+ORIGINAL_ISSUE_SUMMARY = "<summary>Original Issue</summary>"
+# Matches an Original-Issue <details> block (and trailing whitespace) so it can
+# be replaced rather than nested. Non-greedy body, anchored to the closing tag.
+_ORIGINAL_ISSUE_BLOCK_RE = re.compile(
+    r"<details>\s*<summary>Original Issue</summary>.*?</details>[ \t]*\n?",
+    re.DOTALL | re.IGNORECASE,
+)
+# Captures the verbatim text fenced inside an Original-Issue block, so an
+# already-embedded original can be recovered (and re-embedded once) instead of
+# being wrapped again.
+_ORIGINAL_ISSUE_INNER_RE = re.compile(
+    r"<details>\s*<summary>Original Issue</summary>\s*"
+    r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_original_issue_blocks(text: str) -> str:
+    """Remove any embedded Original-Issue <details> block(s) from ``text``."""
+    return _ORIGINAL_ISSUE_BLOCK_RE.sub("", text).rstrip()
+
+
+def _innermost_original_issue(text: str) -> str | None:
+    """Return the deepest verbatim Original-Issue payload embedded in ``text``.
+
+    Nested blocks (from prior runaway cycles) are unwrapped layer by layer so the
+    true original is recovered, not a copy-of-a-copy.
+    """
+    inner: str | None = None
+    current = text
+    while True:
+        match = _ORIGINAL_ISSUE_INNER_RE.search(current)
+        if not match:
+            break
+        inner = match.group("inner")
+        current = inner
+    return inner
+
+
 def _append_raw_issue_section(formatted: str, issue_body: str) -> str:
-    raw = issue_body.strip()
+    """Embed the verbatim original issue once, idempotently.
+
+    Earlier behavior only checked whether the *input* already contained an
+    Original-Issue block, which let the block nest across auto-pilot cycles
+    (each pass re-wrapped the whole prior body — the 5-level nesting seen in
+    incident #1135). This version is idempotent: it recovers the innermost
+    verbatim original (from either the raw source or an already-embedded block),
+    strips every Original-Issue block from the formatted output, then appends
+    exactly one fresh block. Re-running on already-embedded output reproduces the
+    same single block.
+    """
+    # Recover the verbatim original, preferring the most authoritative source:
+    #   1. the innermost embedded original in the raw source (the canonical input),
+    #   2. the raw source minus any Original-Issue wrapper,
+    #   3. the innermost embedded original in the formatted output (covers the
+    #      edge where the output already carries a block but the raw arg does not
+    #      — the exact pre-fix nesting vector).
+    # This preserves the true original instead of re-embedding reformatted text.
+    raw = _innermost_original_issue(issue_body)
+    if raw is None:
+        raw = _strip_original_issue_blocks(issue_body.strip())
+    raw = raw.strip()
     if not raw:
-        return formatted
-    marker = "<summary>Original Issue</summary>"
-    # Check INPUT body, not output - if input already has Original Issue, don't nest another
-    if marker in raw:
-        return formatted
+        recovered = _innermost_original_issue(formatted)
+        raw = recovered.strip() if recovered else ""
+    formatted_wo_block = _strip_original_issue_blocks(formatted)
+    if not raw:
+        # Nothing to embed. If the formatted body already had a block it has been
+        # stripped above; return the cleaned form so no stale nested copy remains.
+        return formatted_wo_block if ORIGINAL_ISSUE_SUMMARY in formatted else formatted
     fence = _select_code_fence(raw)
     details = (
         "\n\n<details>\n"
@@ -365,7 +485,7 @@ def _append_raw_issue_section(formatted: str, issue_body: str) -> str:
         f"{fence}text\n{raw}\n{fence}\n"
         "</details>"
     )
-    return f"{formatted.rstrip()}{details}\n"
+    return f"{formatted_wo_block.rstrip()}{details}\n"
 
 
 def _extract_tasks_from_formatted(body: str) -> list[str]:
@@ -468,6 +588,39 @@ def _is_github_models_auth_error(exc: Exception) -> bool:
     return "401" in exc_str and "models" in exc_str
 
 
+def _reuse_already_formatted(issue_body: str, workflow: str) -> dict[str, Any] | None:
+    """Return a short-circuit result if ``issue_body`` is already formatted.
+
+    Two idempotency signals, in order of trust:
+
+    1. A reuse marker whose embedded hash matches the visible body — the body is
+       byte-identical to a prior formatter output for this workflow chain.
+    2. The body is structurally conformant (all template sections + an embedded
+       Original-Issue block).
+
+    In either case the body is returned unchanged (modulo a refreshed marker) so
+    no LLM rewrite occurs. Returns ``None`` when the body still needs formatting.
+    """
+    reused = reuse_formatted_body({"body": issue_body}, workflow)
+    if reused is not None:
+        return {
+            "formatted_body": _with_reuse_marker(reused),
+            "provider_used": None,
+            "used_llm": False,
+            "skipped": "reused_marker",
+            "validation_audit": None,
+        }
+    if already_conformant(issue_body):
+        return {
+            "formatted_body": _with_reuse_marker(issue_body),
+            "provider_used": None,
+            "used_llm": False,
+            "skipped": "already_conformant",
+            "validation_audit": None,
+        }
+    return None
+
+
 def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any]:
     if not issue_body:
         issue_body = ""
@@ -482,7 +635,17 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
             "guard_reason": guard_result["reason"],
         }
 
-    issue_body = _capped_issue_body(issue_body, _context_workflow("issue_formatter"))
+    # Idempotency / anti-amplification: before re-deriving anything, check whether
+    # this body has already been formatted. Re-formatting an already-conformant
+    # body only paraphrases prior output and is the primary runaway-expansion
+    # vector (incidents #1135/#1143). Done on the *uncapped* body so detection
+    # still works on large already-formatted issues.
+    workflow = _context_workflow("issue_formatter")
+    reuse = _reuse_already_formatted(issue_body, workflow)
+    if reuse is not None:
+        return reuse
+
+    issue_body = _capped_issue_body(issue_body, workflow)
 
     # Check size before processing to avoid rate limit errors
     if len(issue_body) > MAX_ISSUE_BODY_SIZE:
@@ -539,6 +702,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                     # splitting here - it causes task explosion (issue #805, #1143).
                     formatted, audit = _validate_and_refine_tasks(formatted, use_llm=use_llm)
                     formatted = _append_raw_issue_section(formatted, issue_body)
+                    formatted = _with_reuse_marker(formatted)
                     result = {
                         "formatted_body": formatted,
                         "provider_used": provider,
@@ -557,6 +721,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
     # splitting here - it causes task explosion (issue #805, #1143).
     formatted, audit = _validate_and_refine_tasks(formatted, use_llm=use_llm)
     formatted = _append_raw_issue_section(formatted, issue_body)
+    formatted = _with_reuse_marker(formatted)
     return {
         "formatted_body": formatted,
         "provider_used": None,

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -90,6 +90,17 @@ CRITICAL rules for split_suggestions:
     "Define metadata contract"
   ]
 
+Length & scope discipline (do NOT inflate the issue):
+- Only propose a split when a task genuinely contains 2+ independent deliverables.
+  Propose at most 3 sub-tasks per task. Do NOT split a task that is already a
+  single ~10-minute action.
+- Preserve the author's scope. Do NOT invent file paths, function names, tests,
+  or acceptance criteria that the source does not imply.
+- Do NOT duplicate sections that already exist, and do NOT repeat the same point
+  under two headings.
+- If a section has no source content, leave it empty (a placeholder); do NOT
+  manufacture prose to fill it.
+
 Output JSON with this shape:
 {{
   "task_splitting": [{{
@@ -109,17 +120,33 @@ PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "analyze_issue.md"
 APPLY_PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "apply_suggestions.md"
 
 APPLY_SUGGESTIONS_PROMPT = """
-Reformat this issue applying the approved suggestions.
+Apply the approved suggestions to this already-structured issue as a PATCH.
 
-Original issue:
+The issue is ALREADY in AGENT_ISSUE_TEMPLATE form. Your job is to apply ONLY the
+listed suggestions — NOT to re-format, re-paraphrase, re-order, or re-derive the
+issue. This is the single most important rule: re-writing already-good content
+is what makes issues balloon.
+
+Current issue body:
 {original_body}
 
 Approved suggestions:
 {suggestions_json}
 
-Apply ALL suggestions and output the complete reformatted issue
-following AGENT_ISSUE_TEMPLATE structure. Move blocked tasks to
-a "## Deferred Tasks (Requires Human)" section.
+Rules:
+- Change ONLY the specific tasks/criteria/sections named in the suggestions.
+- Preserve ALL other text VERBATIM, including the existing section structure and
+  the trailing "<details>Original Issue</details>" block.
+- Apply each task split in place (replace the one task with its named sub-tasks);
+  do not also restate the parent.
+- Move blocked tasks to a "## Deferred Tasks (Requires Human)" section (create it
+  once if absent; never duplicate it).
+- Do NOT increase total length except by the minimum needed to apply a suggestion.
+  Do NOT invent file paths, function names, tests, or criteria the source does not
+  imply, and do NOT fill empty/placeholder sections with manufactured prose.
+
+Output the full issue body with the suggestions applied and everything else
+unchanged.
 """.strip()
 
 ISSUE_OPTIMIZER_REPAIR_PROMPT = DEFAULT_REPAIR_PROMPT
@@ -605,24 +632,116 @@ def _deduplicate_task_lines(formatted: str) -> str:
         len(lines),
     )
 
+    decomposer = _decomposer_module()
     seen: set[str] = set()
+    seen_token_sets: list[frozenset[str]] = []
     deduped: list[str] = []
     for line in lines[header_idx + 1 : end_idx]:
         stripped = line.strip()
         if not stripped:
             deduped.append(line)
             continue
-        norm = _normalize_task_text(_strip_task_marker(stripped))
+        # Never collapse elision sentinels (they are bookkeeping, and two
+        # different counts must not be treated as duplicates).
+        if decomposer.is_elision_sentinel(stripped):
+            deduped.append(line)
+            continue
+        task_text = _strip_task_marker(stripped)
+        norm = _normalize_task_text(task_text)
         if not norm:
             deduped.append(line)
             continue
-        if norm in seen:
+        tokens = _task_token_set(task_text)
+        if norm in seen or _is_near_duplicate(tokens, seen_token_sets):
             continue
         seen.add(norm)
+        seen_token_sets.append(tokens)
         deduped.append(line)
 
     result = lines[: header_idx + 1] + deduped + lines[end_idx:]
     return "\n".join(result)
+
+
+def _section_bounds(lines: list[str], header: str) -> tuple[int, int] | None:
+    """Return ``(header_idx, end_idx)`` for ``header`` (e.g. ``## Tasks``), or None."""
+    try:
+        header_idx = next(i for i, line in enumerate(lines) if line.strip() == header)
+    except StopIteration:
+        return None
+    end_idx = next(
+        (
+            i
+            for i in range(header_idx + 1, len(lines))
+            if lines[i].startswith("## ") and lines[i].strip() != header
+        ),
+        len(lines),
+    )
+    return header_idx, end_idx
+
+
+def _cap_section_items(formatted: str, header: str, max_items: int, *, kind: str) -> str:
+    """Cap the checkbox items under ``header`` at ``max_items`` with an elision sentinel."""
+    lines = formatted.splitlines()
+    bounds = _section_bounds(lines, header)
+    if bounds is None:
+        return formatted
+    header_idx, end_idx = bounds
+    capped, _elided = _cap_checkbox_lines(lines[header_idx + 1 : end_idx], max_items, kind=kind)
+    result = lines[: header_idx + 1] + capped + lines[end_idx:]
+    return "\n".join(result)
+
+
+def _enforce_count_caps(formatted: str) -> str:
+    """Apply MAX_TASKS / MAX_ACCEPTANCE ceilings, emitting elision sentinels.
+
+    This is the missing *ceiling* that complements the template-completeness
+    *floor*. Capped items are not silently dropped: a single explicit
+    "(N further items elided)" checkbox is appended so the no-silent-loss audit
+    still balances.
+    """
+    decomposer = _decomposer_module()
+    formatted = _cap_section_items(formatted, "## Tasks", decomposer.MAX_TASKS, kind="tasks")
+    formatted = _cap_section_items(
+        formatted, "## Acceptance Criteria", decomposer.MAX_ACCEPTANCE, kind="criteria"
+    )
+    return formatted
+
+
+# Reuse the formatter's body-size ceiling so the optimizer refuses ballooned
+# input rather than silently truncating it.
+try:
+    from scripts.langchain.issue_formatter import MAX_ISSUE_BODY_SIZE
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct invocation
+    try:
+        from issue_formatter import MAX_ISSUE_BODY_SIZE
+    except ModuleNotFoundError:
+        MAX_ISSUE_BODY_SIZE = 50000
+
+
+def _reset_oversized_body(issue_body: str, workflow: str) -> str | None:
+    """If ``issue_body`` is oversized, return the embedded verbatim original to re-format.
+
+    A ballooned body (the runaway-expansion failure mode) preserves the true
+    original inside its innermost Original-Issue ``<details>`` block. Recovering
+    that and re-formatting it is the signal-preserving reset documented as the
+    manual recovery in AUTOPILOT_FIX_HISTORY. Returns ``None`` when the body is
+    within budget or no embedded original is available.
+    """
+    if len(issue_body) <= MAX_ISSUE_BODY_SIZE:
+        return None
+    try:
+        from scripts.langchain import issue_formatter
+    except ModuleNotFoundError:  # pragma: no cover - fallback for direct invocation
+        import issue_formatter
+    original = issue_formatter._innermost_original_issue(issue_body)
+    if original and original.strip():
+        print(
+            f"Issue body oversized ({len(issue_body):,} chars); "
+            "resetting to embedded Original Issue before optimizing.",
+            file=sys.stderr,
+        )
+        return original.strip()
+    return None
 
 
 def _section_duplication_ratio(formatted: str) -> float:
@@ -648,6 +767,75 @@ def _strip_task_marker(text: str) -> str:
 def _normalize_task_text(text: str) -> str:
     cleaned = re.sub(r"\s+", " ", text.strip())
     return cleaned.lower()
+
+
+# Near-duplicate threshold (token-set Jaccard). Lines this similar are collapsed,
+# catching paraphrases like "Add tests for X" vs "Add unit tests for X" that
+# exact-match dedup misses.
+NEAR_DUPLICATE_JACCARD = 0.85
+# Trailing verification suffix the decomposer appends; ignored when comparing task
+# similarity so "(verify: ...)" boilerplate doesn't keep near-duplicates apart.
+_VERIFY_SUFFIX_RE = re.compile(r"\s*\(verify:[^)]*\)\s*$", re.IGNORECASE)
+
+
+def _task_token_set(text: str) -> frozenset[str]:
+    body = _VERIFY_SUFFIX_RE.sub("", text)
+    return frozenset(re.findall(r"[a-z0-9']+", body.lower()))
+
+
+def _is_near_duplicate(tokens: frozenset[str], seen_token_sets: list[frozenset[str]]) -> bool:
+    if not tokens:
+        return False
+    for prior in seen_token_sets:
+        if not prior:
+            continue
+        union = tokens | prior
+        if not union:
+            continue
+        if len(tokens & prior) / len(union) >= NEAR_DUPLICATE_JACCARD:
+            return True
+    return False
+
+
+def _decomposer_module() -> Any:
+    try:
+        from scripts.langchain import task_decomposer
+    except ModuleNotFoundError:  # pragma: no cover - fallback for direct invocation
+        import task_decomposer
+    return task_decomposer
+
+
+def _cap_checkbox_lines(lines: list[str], max_items: int, *, kind: str) -> tuple[list[str], int]:
+    """Trim a list of checkbox lines to ``max_items``, replacing the overflow.
+
+    Top-level checkbox items beyond the cap are dropped and a single explicit
+    elision sentinel is appended so the no-silent-loss audit still reconciles.
+    Nested sub-task lines, blank lines, and existing sentinels are preserved as
+    structure and do not count toward the cap. Returns ``(new_lines, elided)``.
+    """
+    decomposer = _decomposer_module()
+    kept: list[str] = []
+    top_level_count = 0
+    elided = 0
+    for line in lines:
+        stripped = line.strip()
+        indent = line[: len(line) - len(line.lstrip())]
+        is_top_checkbox = (
+            bool(LIST_ITEM_REGEX.match(stripped))
+            and not indent
+            and not decomposer.is_elision_sentinel(stripped)
+        )
+        if not is_top_checkbox:
+            kept.append(line)
+            continue
+        if top_level_count < max_items:
+            kept.append(line)
+            top_level_count += 1
+        else:
+            elided += 1
+    if elided:
+        kept.append(f"- [ ] {decomposer.elision_sentinel(elided, kind=kind)}")
+    return kept, elided
 
 
 def _coerce_split_suggestions(entry: dict[str, Any]) -> list[str]:
@@ -811,6 +999,12 @@ def analyze_issue(issue_body: str, *, use_llm: bool = True) -> IssueOptimization
             guard_blocked=True,
             guard_reason=guard_result["reason"],
         )
+
+    # Size pre-check: analyze the embedded original instead of a silently
+    # truncated ballooned body (see _reset_oversized_body).
+    reset = _reset_oversized_body(issue_body, _context_workflow("issue_optimizer"))
+    if reset is not None:
+        issue_body = reset
 
     issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
 
@@ -1030,12 +1224,37 @@ def _apply_task_decomposition(formatted_body: str | None, suggestions: dict[str,
         indent = indent_match.group(0)
         sub_indent = f"{indent}  "
         for sub_task in sub_tasks:
+            # Preserve elision sentinels verbatim — stripping markers would
+            # mangle the "(N further sub-tasks elided)" bookkeeping line.
+            if task_decomposer.is_elision_sentinel(sub_task):
+                updated.append(f"{sub_indent}- [ ] {sub_task.strip()}")
+                continue
             cleaned = _strip_task_marker(sub_task)
             if cleaned:
                 updated.append(f"{sub_indent}- [ ] {cleaned}")
 
     updated.extend(lines[end_idx:])
     return "\n".join(updated).strip()
+
+
+def _finalize_apply_body(formatted: str) -> str:
+    """Cap + re-mark an already-deduplicated applied body.
+
+    Callers run ``_deduplicate_task_lines`` first (the section-duplication guard
+    needs the deduped form), so this only enforces the count ceilings and writes
+    the reuse marker that keeps re-runs idempotent.
+    """
+    formatted = _enforce_count_caps(formatted)
+    return _mark_optimized_body(formatted)
+
+
+def _mark_optimized_body(formatted: str) -> str:
+    """Refresh the reuse marker on an optimizer output (delegates to the formatter)."""
+    try:
+        from scripts.langchain import issue_formatter
+    except ModuleNotFoundError:  # pragma: no cover - fallback for direct invocation
+        import issue_formatter
+    return issue_formatter._with_reuse_marker(formatted)
 
 
 def apply_suggestions(
@@ -1053,6 +1272,14 @@ def apply_suggestions(
             "guard_blocked": True,
             "guard_reason": guard_result["reason"],
         }
+
+    # Size pre-check: refuse to operate on an already-ballooned body. Instead of
+    # silently truncating to the token budget and re-embedding the rest (which
+    # grows the document), reset to the embedded verbatim original and re-format
+    # that — the documented manual recovery, automated.
+    reset = _reset_oversized_body(issue_body, _context_workflow("issue_optimizer"))
+    if reset is not None:
+        issue_body = reset
 
     issue_body = _capped_issue_body(issue_body, _context_workflow("issue_optimizer"))
 
@@ -1100,7 +1327,7 @@ def apply_suggestions(
                             )
                         else:
                             result = {
-                                "formatted_body": formatted,
+                                "formatted_body": _finalize_apply_body(formatted),
                                 "provider_used": provider,
                                 "used_llm": True,
                             }
@@ -1148,7 +1375,7 @@ def apply_suggestions(
                                             file=sys.stderr,
                                         )
                                         result = {
-                                            "formatted_body": formatted,
+                                            "formatted_body": _finalize_apply_body(formatted),
                                             "provider_used": openai_provider,
                                             "used_llm": True,
                                         }
@@ -1186,7 +1413,7 @@ def apply_suggestions(
     formatted = _append_deferred_tasks(formatted, suggestions)
     formatted = _deduplicate_task_lines(formatted)
     return {
-        "formatted_body": formatted,
+        "formatted_body": _finalize_apply_body(formatted),
         "provider_used": None,
         "used_llm": False,
     }

--- a/scripts/langchain/issue_pr_context.py
+++ b/scripts/langchain/issue_pr_context.py
@@ -24,6 +24,20 @@ MARKER_RE = re.compile(
     re.DOTALL,
 )
 
+# The canonical AGENT_ISSUE_TEMPLATE section headers, in order. A body that
+# already carries all of these (in order) plus an embedded Original-Issue block
+# has already been through the formatter; re-formatting it from scratch is the
+# re-run amplification that ballooned issues, so callers treat it as a no-op.
+CONFORMANT_SECTIONS = (
+    "Why",
+    "Scope",
+    "Non-Goals",
+    "Tasks",
+    "Acceptance Criteria",
+    "Implementation Notes",
+)
+ORIGINAL_ISSUE_SUMMARY = "<summary>Original Issue</summary>"
+
 
 @dataclass(frozen=True)
 class ContextOptions:
@@ -148,18 +162,76 @@ def build_formatted_body_marker(
     downstream_workflow: str | None = None,
     workflows: list[str] | tuple[str, ...] | None = None,
     formatted_body: str | None = None,
+    embed_body: bool = True,
 ) -> str:
-    """Build a compact marker that downstream callers can store with a body."""
+    """Build a compact marker that downstream callers can store with a body.
+
+    With ``embed_body=True`` (default) the marker carries a base64 copy of the
+    formatted body so it can be restored verbatim. Pass ``embed_body=False`` to
+    store only the sha256 fingerprint: ``reuse_formatted_body`` then validates the
+    visible body against the hash and returns it cleaned, which proves idempotency
+    without ~doubling the body size. The lightweight form is preferred when the
+    formatted body is written back into the issue in full anyway.
+    """
     payload: dict[str, Any] = {}
     if downstream_workflow:
         payload["workflow"] = downstream_workflow
     if workflows:
         payload["workflows"] = list(workflows)
     if formatted_body is not None:
-        payload["body_b64"] = base64.b64encode(formatted_body.encode("utf-8")).decode("ascii")
+        if embed_body:
+            payload["body_b64"] = base64.b64encode(formatted_body.encode("utf-8")).decode("ascii")
         payload["sha256"] = hashlib.sha256(formatted_body.encode("utf-8")).hexdigest()
     marker_payload = json.dumps(payload, separators=(",", ":"), sort_keys=True)
     return f"<!-- {MARKER_PREFIX}:{MARKER_VERSION} {marker_payload} -->"
+
+
+def already_conformant(body: str | None, *, require_original_issue: bool = True) -> bool:
+    """Return True when ``body`` is already in AGENT_ISSUE_TEMPLATE form.
+
+    A body is conformant when every ``CONFORMANT_SECTIONS`` heading is present as
+    a top-level ``##`` heading, in canonical order, and (unless disabled) the
+    embedded Original-Issue ``<details>`` block is present. Such a body has
+    already been formatted; re-running the formatter on it only paraphrases
+    prior output and is the primary re-run amplification vector. Headings inside
+    fenced code blocks (e.g. the Original-Issue verbatim copy) are ignored.
+    """
+    text = _text(body)
+    if not text:
+        return False
+
+    headings = _top_level_headings(text)
+    expected = [section.lower() for section in CONFORMANT_SECTIONS]
+    # Subsequence match in order: every expected heading appears, in sequence.
+    idx = 0
+    for heading in headings:
+        if idx < len(expected) and heading == expected[idx]:
+            idx += 1
+    if idx != len(expected):
+        return False
+
+    return not (require_original_issue and ORIGINAL_ISSUE_SUMMARY not in text)
+
+
+def _top_level_headings(body: str) -> list[str]:
+    """Return normalized ``##``-level headings, skipping fenced code blocks."""
+    headings: list[str] = []
+    code_fence: str | None = None
+    for line in body.splitlines():
+        stripped = line.strip()
+        fence_match = re.match(r"^(`{3,})", stripped)
+        if fence_match:
+            if code_fence is None:
+                code_fence = fence_match.group(1)
+            elif len(fence_match.group(1)) >= len(code_fence):
+                code_fence = None
+            continue
+        if code_fence is not None:
+            continue
+        heading_match = re.match(r"^##\s+(.+?)\s*$", line)
+        if heading_match:
+            headings.append(heading_match.group(1).strip().lower())
+    return headings
 
 
 def _build_payload(

--- a/scripts/langchain/prompts/apply_suggestions.md
+++ b/scripts/langchain/prompts/apply_suggestions.md
@@ -1,22 +1,43 @@
-Reformat this issue applying the approved suggestions.
+Apply the approved suggestions to this already-structured issue as a PATCH.
 
-Original issue:
+The issue is ALREADY in AGENT_ISSUE_TEMPLATE form. Your job is to apply ONLY the
+listed suggestions — NOT to re-format, re-paraphrase, re-order, or re-derive the
+issue. This is the single most important rule: re-writing already-good content is
+what makes issues balloon.
+
+Current issue body:
 {original_body}
 
 Approved suggestions:
 {suggestions_json}
 
-Apply ALL suggestions and output the complete reformatted issue
-following AGENT_ISSUE_TEMPLATE structure. Move blocked tasks to
-a "## Deferred Tasks (Requires Human)" section.
+Rules:
+- Change ONLY the specific tasks/criteria/sections named in the suggestions.
+- Preserve ALL other text VERBATIM, including the existing section structure and
+  the trailing "<details>Original Issue</details>" block.
+- Apply each task split in place (replace the one task with its named sub-tasks);
+  do not also restate the parent.
+- Move blocked tasks to a "## Deferred Tasks (Requires Human)" section (create it
+  once if absent; never duplicate it).
 
-CRITICAL - Tasks must be ACTIONABLE:
+CRITICAL - Length & Scope Discipline:
+- Do NOT increase total length except by the minimum needed to apply a suggestion.
+- Do NOT invent file paths, function names, tests, or acceptance criteria the
+  source does not imply, and do NOT fill empty/placeholder sections with
+  manufactured prose.
+- Never restate the same point under two headings.
+
+When a suggestion DOES add or rewrite a task, that task must be ACTIONABLE:
 - Start with a CODING ACTION VERB: Create, Add, Update, Fix, Implement, Write, Test
-- Reference CONCRETE DELIVERABLES: file paths, function names, test cases
+- Reference CONCRETE DELIVERABLES already implied by the source
 - Be completable by a coding agent in ~10 minutes
 - NEVER turn section headers (### Something) into checkbox tasks
 - NEVER include human-only activities: "Train staff", "Conduct meeting"
 
-CRITICAL - Acceptance Criteria must be VERIFIABLE:
+When a suggestion DOES add or rewrite an acceptance criterion, it must be
+VERIFIABLE:
 - Have MEASURABLE outcomes: "tests pass", "file exists", "lint passes"
 - AVOID subjective language: "clean", "nice", "quality", "properly"
+
+Output the full issue body with the suggestions applied and everything else
+unchanged.

--- a/scripts/langchain/prompts/decompose_task.md
+++ b/scripts/langchain/prompts/decompose_task.md
@@ -18,6 +18,15 @@ FORBIDDEN patterns (DO NOT OUTPUT):
 - Sentence fragments (single words, punctuation only)
 - Nested prefixes like "Define scope for: Define scope for: ..." (recursion)
 
+LENGTH & SCOPE DISCIPLINE (do NOT inflate):
+- Output AT MOST 3 sub-tasks. Fewer is better; only emit as many as the task
+  genuinely contains as independent deliverables.
+- Preserve scope: do NOT invent file paths, functions, tests, or steps the task
+  does not already imply.
+- Do NOT decompose a task that is already a single ~10-minute action — return it
+  as a single bullet unchanged.
+- Prefer the shortest faithful phrasing; never restate the same step twice.
+
 Return sub-tasks as a markdown bullet list.
 Each task should be ONE action a coding agent can complete and verify.
 

--- a/scripts/langchain/prompts/format_issue.md
+++ b/scripts/langchain/prompts/format_issue.md
@@ -27,5 +27,16 @@ CRITICAL - Acceptance Criteria must be VERIFIABLE:
 - AVOID subjective language: "clean", "nice", "quality", "properly"
 - Each criterion should be checkable by running a command or inspecting output
 
+CRITICAL - Length & Scope Discipline (improve clarity, do NOT inflate):
+- Improve clarity and structure WITHOUT increasing total length. Do not add a
+  task, criterion, or sentence unless it is required to fill a genuinely missing
+  mandatory section.
+- Preserve the author's scope. Do NOT invent file paths, function names, tests,
+  or acceptance criteria that the source does not imply.
+- If a section has no source content, leave the "_Not provided._" placeholder; do
+  NOT manufacture prose to fill it.
+- Prefer the shortest faithful phrasing. Never restate the same point under two
+  headings, and never split a task that is already a single ~10-minute action.
+
 Raw issue body:
 {issue_body}

--- a/scripts/langchain/task_decomposer.py
+++ b/scripts/langchain/task_decomposer.py
@@ -31,6 +31,11 @@ Each sub-task should:
 - Have a clear verification condition
 - Not depend on un-merged work from other sub-tasks
 
+Length & scope discipline (do NOT inflate):
+- Output AT MOST 3 sub-tasks; fewer is better.
+- Preserve scope; do not invent steps the task does not already imply.
+- If the task is already a single ~10-minute action, return it unchanged.
+
 Return the sub-tasks as a markdown bullet list.
 """.strip()
 
@@ -78,6 +83,38 @@ EXPANSION_PREFIXES = (
     "define approach for:",
 )
 MAX_CHILD_TITLE_LEN = 96
+
+# Anti-bloat caps. The pipeline already enforces a quality *floor* (required
+# sections, no-silent-loss audit); these are the missing *ceiling*. They bound
+# how far a single decomposition pass can multiply task/criteria counts so an
+# already-large issue cannot balloon (incidents #805, #862, #873, #1135, #1143,
+# #4191). When a cap trims items, callers emit an explicit elision sentinel so
+# nothing is silently dropped.
+MAX_TASKS = 20
+MAX_ACCEPTANCE = 15
+# Maximum sub-tasks emitted per parent task in one normalization pass. The
+# mechanical scope/implement/validate triple is 3 lines, so this still allows a
+# couple of genuine splits while stopping the 3xN fan-out runaway.
+MAX_SUBTASKS_PER_PARENT = 6
+
+
+def elision_sentinel(remaining: int, *, kind: str = "items") -> str:
+    """Return the explicit elided-items marker used when a cap trims a list.
+
+    The no-silent-loss audit reconciles input vs output counts; emitting this
+    sentinel keeps the elided items accounted for instead of vanishing.
+    """
+    return f"_({remaining} further {kind} elided; split this issue)_"
+
+
+ELISION_RE = re.compile(r"^_\(\d+ further [\w \-]+ elided; split this issue\)_$")
+
+
+def is_elision_sentinel(text: str) -> bool:
+    """Return True when ``text`` is an elision sentinel line (marker-insensitive)."""
+    stripped = re.sub(r"^\s*([-*+]|\d+[.)]|[A-Za-z][.)])\s*", "", text.strip())
+    stripped = re.sub(r"^\s*\[[ xX]\]\s*", "", stripped).strip()
+    return bool(ELISION_RE.match(stripped))
 
 
 def _load_prompt() -> str:
@@ -265,30 +302,69 @@ def _rewrite_dependency_task(task: str) -> str:
     return f"Document dependency for: {cleaned} (verify: dependency recorded)"
 
 
-def _normalize_subtasks(sub_tasks: list[str]) -> list[str]:
-    normalized: list[str] = []
+def _collect_cleaned_parts(sub_tasks: list[str]) -> list[str]:
+    """Split + de-duplicate sub-task inputs into cleaned, dependency-rewritten parts."""
+    parts: list[str] = []
     seen: set[str] = set()
     for task in sub_tasks:
+        # Pass elision sentinels through verbatim — they are bookkeeping markers,
+        # not tasks, and must not be split, expanded, or verification-tagged.
+        if is_elision_sentinel(task):
+            norm_key = re.sub(r"\s+", " ", task.strip().lower())
+            if norm_key not in seen:
+                seen.add(norm_key)
+                parts.append(task.strip())
+            continue
         cleaned_task = _strip_dependency_clause(task.strip())
         for part in _split_task_parts(cleaned_task):
             cleaned = _strip_dependency_clause(part.strip())
             if not cleaned:
                 continue
-            # Deduplicate by normalized text
             norm_key = re.sub(r"\s+", " ", cleaned.lower().strip())
             if norm_key in seen:
                 continue
             seen.add(norm_key)
             if _contains_dependency_phrase(cleaned):
                 cleaned = _rewrite_dependency_task(cleaned)
-            if _is_large_task(cleaned) and not cleaned.lower().startswith("document dependency"):
-                for scoped_task in _expand_large_task(cleaned):
-                    normalized.append(_ensure_verification(scoped_task))
-                continue
-            normalized.append(_ensure_verification(cleaned))
-    # Second dedupe pass on final output — catches duplicates introduced by
-    # _rewrite_dependency_task / _ensure_verification rewriting different
-    # inputs to the same canonical form.
+            parts.append(cleaned)
+    return parts
+
+
+def _normalize_subtasks(
+    sub_tasks: list[str], *, max_subtasks: int = MAX_SUBTASKS_PER_PARENT
+) -> list[str]:
+    """Normalize sub-tasks with bounded fan-out.
+
+    The mechanical scope/implement/validate triple (``_expand_large_task``) is
+    the main multiplication vector behind the runaway-expansion incidents. It is
+    now gated: a single large input is still expanded into the triple (its
+    intended decomposition), but once splitting has already produced multiple
+    parts we do NOT additionally triple each part — that is the 3xN fan-out that
+    ballooned issues. The final list is capped at ``max_subtasks``; any trimmed
+    remainder is replaced with an explicit elision sentinel so the no-silent-loss
+    audit still balances.
+    """
+    parts = _collect_cleaned_parts(sub_tasks)
+    # Only expand the mechanical triple when the input was effectively a single
+    # task; multiple parts already represent a decomposition and must not be
+    # tripled again (that 3xN fan-out is what ballooned issues).
+    allow_triple = len(parts) == 1
+
+    normalized: list[str] = []
+    for cleaned in parts:
+        if is_elision_sentinel(cleaned):
+            normalized.append(cleaned)
+            continue
+        is_large = _is_large_task(cleaned) and not cleaned.lower().startswith("document dependency")
+        if is_large and allow_triple:
+            for scoped_task in _expand_large_task(cleaned):
+                normalized.append(_ensure_verification(scoped_task))
+            continue
+        normalized.append(_ensure_verification(cleaned))
+
+    # Dedupe final output — catches duplicates introduced by
+    # _rewrite_dependency_task / _ensure_verification rewriting different inputs
+    # to the same canonical form.
     final: list[str] = []
     seen_final: set[str] = set()
     for entry in normalized:
@@ -296,11 +372,21 @@ def _normalize_subtasks(sub_tasks: list[str]) -> list[str]:
         if key not in seen_final:
             seen_final.add(key)
             final.append(entry)
+
+    # Bound fan-out. Emit an elided sentinel for the trimmed remainder so nothing
+    # is silently dropped.
+    cap = max(1, max_subtasks)
+    if len(final) > cap:
+        elided = len(final) - (cap - 1)
+        final = final[: cap - 1]
+        final.append(elision_sentinel(elided, kind="sub-tasks"))
     return final
 
 
-def normalize_subtasks(sub_tasks: list[str]) -> list[str]:
-    return _normalize_subtasks(sub_tasks)
+def normalize_subtasks(
+    sub_tasks: list[str], *, max_subtasks: int = MAX_SUBTASKS_PER_PARENT
+) -> list[str]:
+    return _normalize_subtasks(sub_tasks, max_subtasks=max_subtasks)
 
 
 def _truncate_title(text: str, max_len: int = MAX_CHILD_TITLE_LEN) -> str:
@@ -391,7 +477,12 @@ def build_child_issues(
     milestone: str | int | None = None,
     max_children: int | None = None,
 ) -> list[dict[str, Any]]:
-    normalized = _normalize_subtasks(sub_tasks)
+    # Honor the caller's child cap as the per-parent fan-out budget so the
+    # normalized list and the child count agree.
+    cap = max_children if max_children is not None else MAX_SUBTASKS_PER_PARENT
+    normalized = _normalize_subtasks(sub_tasks, max_subtasks=cap)
+    # Sentinels are in-body bookkeeping markers, never real child issues.
+    normalized = [task for task in normalized if not is_elision_sentinel(task)]
     if len(normalized) <= 1:
         return []
     if max_children is not None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 from scripts.langchain import issue_formatter
+from scripts.langchain.issue_pr_context import reuse_formatted_body
 
 
 def _install_fake_langchain(monkeypatch: pytest.MonkeyPatch, mock_chain: mock.MagicMock) -> None:
@@ -378,3 +379,159 @@ def test_format_issue_body_caps_oversized_input() -> None:
     assert result["formatted_body"] is not None
     assert len(result["formatted_body"]) < len(oversized_body)
     assert "context exceeded token budget" in result["formatted_body"]
+
+
+# ---------------------------------------------------------------------------
+# Anti-bloat: idempotency / byte-stability (incident #1127 -> #1135, ~78x)
+# ---------------------------------------------------------------------------
+
+
+def test_format_issue_twice_is_byte_stable() -> None:
+    """Formatting an already-formatted body must NOT grow it.
+
+    Re-running the formatter on its own output was the primary re-run
+    amplification vector. A reuse marker + already-conformant guard now make the
+    second pass a byte-stable no-op.
+    """
+    raw = (
+        "Why: ship portfolio constraint validation\n\n"
+        "Tasks:\n"
+        "- Define common constraints (weight bounds, leverage, concentration)\n"
+        "- Implement ConstraintValidator class\n"
+        "- Add validation hooks in portfolio construction\n\n"
+        "Acceptance:\n"
+        "- tests pass\n"
+    )
+    first = issue_formatter.format_issue_body(raw, use_llm=False)["formatted_body"]
+    second = issue_formatter.format_issue_body(first, use_llm=False)
+    third = issue_formatter.format_issue_body(second["formatted_body"], use_llm=False)
+
+    assert second["formatted_body"] == first  # byte-stable on re-format
+    assert third["formatted_body"] == first  # and stays stable
+    assert second["used_llm"] is False
+    assert second.get("skipped") in {"reused_marker", "already_conformant"}
+
+
+def test_format_issue_reuse_marker_written_and_honored() -> None:
+    """A formatter output carries a reuse marker that later stages can detect."""
+    raw = "Why: do it\n\nTasks:\n- add a thing\n\nAcceptance:\n- it works"
+    formatted = issue_formatter.format_issue_body(raw, use_llm=False)["formatted_body"]
+
+    assert "issue-pr-context:formatted-body" in formatted
+    # The marker round-trips for any of the auto-pilot chain workflow tags.
+    for workflow in ("agents-auto-pilot", "issue_optimizer"):
+        assert (
+            reuse_formatted_body({"body": formatted}, workflow) is not None
+        ), f"marker should be reusable for {workflow}"
+
+
+def test_format_issue_already_conformant_body_skipped() -> None:
+    """A structurally conformant body (no marker) is detected and not re-formatted."""
+    conformant = "\n".join(
+        [
+            "## Why",
+            "",
+            "Ship it.",
+            "",
+            "## Scope",
+            "",
+            "_Not provided._",
+            "",
+            "## Non-Goals",
+            "",
+            "_Not provided._",
+            "",
+            "## Tasks",
+            "",
+            "- [ ] do a thing",
+            "",
+            "## Acceptance Criteria",
+            "",
+            "- [ ] it works",
+            "",
+            "## Implementation Notes",
+            "",
+            "_Not provided._",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "```text",
+            "Why: ship it",
+            "```",
+            "</details>",
+        ]
+    )
+    result = issue_formatter.format_issue_body(conformant, use_llm=False)
+    assert result["skipped"] == "already_conformant"
+    assert result["used_llm"] is False
+
+
+def test_append_raw_issue_section_replaces_not_nests() -> None:
+    """_append_raw_issue_section keeps exactly one Original-Issue block.
+
+    Previously, when the formatted output already had a block but the raw source
+    did not, a second block was nested (the #1135 nesting vector).
+    """
+    formatted_with_block = "\n".join(
+        [
+            "## Tasks",
+            "",
+            "- [ ] Task 1",
+            "",
+            "## Acceptance Criteria",
+            "",
+            "- [ ] Done",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "```text",
+            "TRUE ORIGINAL",
+            "```",
+            "</details>",
+        ]
+    )
+    # Re-format case: format_issue_body passes the already-formatted body (block
+    # and all) back in as issue_body. The block must be replaced once, not nested,
+    # and the verbatim innermost original preserved.
+    out = issue_formatter._append_raw_issue_section(formatted_with_block, formatted_with_block)
+    assert out.count("<summary>Original Issue</summary>") == 1
+    assert "TRUE ORIGINAL" in out
+
+    # Edge: the formatted OUTPUT carries a block but the raw arg is empty. The
+    # original is still recovered from the output rather than dropped or nested.
+    out_empty_raw = issue_formatter._append_raw_issue_section(formatted_with_block, "")
+    assert out_empty_raw.count("<summary>Original Issue</summary>") == 1
+    assert "TRUE ORIGINAL" in out_empty_raw
+
+
+def test_append_raw_issue_section_collapses_nested_blocks() -> None:
+    """Pre-existing nested blocks collapse to a single block on the next pass."""
+    nested = "\n".join(
+        [
+            "## Tasks",
+            "",
+            "- [ ] x",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "````text",
+            "## Tasks",
+            "- [ ] x",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "```text",
+            "TRUE ORIGINAL",
+            "```",
+            "</details>",
+            "````",
+            "</details>",
+        ]
+    )
+    out = issue_formatter._append_raw_issue_section("## Tasks\n\n- [ ] x", nested)
+    assert out.count("<summary>Original Issue</summary>") == 1
+    assert out.count("TRUE ORIGINAL") == 1

--- a/tests/scripts/test_issue_optimizer.py
+++ b/tests/scripts/test_issue_optimizer.py
@@ -665,3 +665,193 @@ def test_apply_suggestions_langsmith_trace_fields(monkeypatch: pytest.MonkeyPatc
     assert result["langsmith_trace_id"] == "apply-trace-xyz789"
     assert "apply-trace-xyz789" in result["langsmith_trace_url"]
     assert result["provider_used"] == "test-provider"
+
+
+# ---------------------------------------------------------------------------
+# Anti-bloat: decomposition caps, idempotency, no-silent-loss with sentinels
+# ---------------------------------------------------------------------------
+
+
+def _top_level_task_lines(body: str) -> list[str]:
+    lines = body.splitlines()
+    header_idx = next(i for i, line in enumerate(lines) if line.strip() == "## Tasks")
+    end_idx = next(
+        (
+            i
+            for i in range(header_idx + 1, len(lines))
+            if lines[i].startswith("## ") and lines[i].strip() != "## Tasks"
+        ),
+        len(lines),
+    )
+    return [
+        line
+        for line in lines[header_idx + 1 : end_idx]
+        if line.strip().startswith(("- [", "* [", "1.", "a)")) and not line.startswith("  ")
+    ]
+
+
+def test_apply_six_task_issue_stays_within_max_tasks_no_triple() -> None:
+    """A 6-task issue must not explode into per-task scope/implement/validate triples."""
+    from scripts.langchain import task_decomposer
+
+    tasks = [
+        "Define common constraints for weight bounds",
+        "Implement ConstraintValidator class",
+        "Add validation hooks in portfolio construction",
+        "Generate suggestions for constraint violations",
+        "Add a --validate-only CLI flag",
+        "Document the supported constraints",
+    ]
+    body = (
+        "## Tasks\n"
+        + "\n".join(f"- [ ] {t}" for t in tasks)
+        + "\n\n## Acceptance Criteria\n- [ ] tests pass\n"
+    )
+    # No split suggestions provided: tasks should pass through unmultiplied.
+    result = issue_optimizer.apply_suggestions(body, {}, use_llm=False)
+    formatted = result["formatted_body"]
+
+    top = _top_level_task_lines(formatted)
+    # Six tasks in, at most six top-level tasks out (well under the cap), no triple.
+    assert len(top) == len(tasks)
+    assert len(top) <= task_decomposer.MAX_TASKS
+    assert "focused slice for" not in formatted.lower()
+    # Each original task appears exactly once in the Tasks section (no triple,
+    # no near-duplicate). It may also appear in the preserved Original-Issue block.
+    for task in tasks:
+        assert sum(1 for line in top if task in line) == 1
+
+
+def test_apply_caps_tasks_at_max_with_elision_sentinel() -> None:
+    """Over-cap task lists are trimmed but emit an explicit elided sentinel.
+
+    The elision keeps the no-silent-loss contract: nothing vanishes silently.
+    """
+    from scripts.langchain import task_decomposer
+
+    over = task_decomposer.MAX_TASKS + 5
+    body = (
+        "## Tasks\n"
+        + "\n".join(f"- [ ] Task number {i} does distinct work item {i}" for i in range(over))
+        + "\n\n## Acceptance Criteria\n- [ ] it works\n"
+    )
+    formatted = issue_optimizer.apply_suggestions(body, {}, use_llm=False)["formatted_body"]
+    top = _top_level_task_lines(formatted)
+
+    # MAX_TASKS real items + 1 sentinel line accounting for the remainder.
+    assert len([line for line in top if not task_decomposer.is_elision_sentinel(line)]) == (
+        task_decomposer.MAX_TASKS
+    )
+    sentinels = [line for line in top if task_decomposer.is_elision_sentinel(line)]
+    assert len(sentinels) == 1
+    assert "elided" in sentinels[0]
+
+
+def test_apply_three_cycles_single_original_issue_block() -> None:
+    """Three apply cycles must leave exactly one Original-Issue <details> block."""
+    suggestions = {
+        "task_splitting": [
+            {
+                "task": "Update docs and add tests",
+                "split_suggestions": [
+                    "Update the documentation pages thoroughly",
+                    "Add unit tests for the new code path",
+                ],
+            }
+        ]
+    }
+    body = "## Tasks\n- [ ] Update docs and add tests\n\n## Acceptance Criteria\n- [ ] tests pass\n"
+    c1 = issue_optimizer.apply_suggestions(body, suggestions, use_llm=False)["formatted_body"]
+    c2 = issue_optimizer.apply_suggestions(c1, suggestions, use_llm=False)["formatted_body"]
+    c3 = issue_optimizer.apply_suggestions(c2, suggestions, use_llm=False)["formatted_body"]
+
+    assert c1.count("<summary>Original Issue</summary>") == 1
+    assert c3.count("<summary>Original Issue</summary>") == 1
+    # And the body stabilizes rather than growing each cycle.
+    assert c3 == c2
+
+
+def test_apply_is_byte_stable_across_reruns() -> None:
+    """Re-applying the same suggestions must not keep growing the body."""
+    suggestions = {
+        "task_splitting": [
+            {
+                "task": "Update docs and add tests",
+                "split_suggestions": [
+                    "Update the documentation pages thoroughly",
+                    "Add unit tests for the new code path",
+                ],
+            }
+        ]
+    }
+    body = "## Tasks\n- [ ] Update docs and add tests\n\n## Acceptance Criteria\n- [ ] tests pass\n"
+    a1 = issue_optimizer.apply_suggestions(body, suggestions, use_llm=False)["formatted_body"]
+    a2 = issue_optimizer.apply_suggestions(a1, suggestions, use_llm=False)["formatted_body"]
+    a3 = issue_optimizer.apply_suggestions(a2, suggestions, use_llm=False)["formatted_body"]
+    assert a2 == a3
+    assert len(a3) <= len(a2)
+
+
+def test_deduplicate_task_lines_collapses_near_duplicates() -> None:
+    """Near-duplicate tasks (paraphrases) collapse, not just exact matches."""
+    formatted = "\n".join(
+        [
+            "## Tasks",
+            "- [ ] Add tests for the parser module",
+            "- [ ] Add unit tests for the parser module",
+            "- [ ] Document the public API surface",
+            "## Acceptance Criteria",
+            "- [ ] it works",
+        ]
+    )
+    deduped = issue_optimizer._deduplicate_task_lines(formatted)
+    top = _top_level_task_lines(deduped)
+    # The two near-identical "Add ... tests for the parser module" collapse to one.
+    assert sum(1 for line in top if "parser module" in line) == 1
+    assert any("public API surface" in line for line in top)
+
+
+def test_apply_resets_oversized_body_to_embedded_original() -> None:
+    """An oversized ballooned body is reset to its embedded Original Issue."""
+    original = "Why: real intent\n\nTasks:\n- do the real thing\n\nAcceptance:\n- it works"
+    n_padding = 3000
+    bloated = (
+        "## Tasks\n"
+        + "\n".join(f"- [ ] padding task {i}" for i in range(n_padding))
+        + "\n\n## Acceptance Criteria\n- [ ] x\n\n<details>\n<summary>Original Issue</summary>\n\n"
+        + f"```text\n{original}\n```\n</details>"
+    )
+    assert len(bloated) > issue_optimizer.MAX_ISSUE_BODY_SIZE
+    formatted = issue_optimizer.apply_suggestions(bloated, {}, use_llm=False)["formatted_body"]
+    # The reset re-formats the small original, so the result is far smaller and
+    # carries the real task, not the thousands of padding tasks.
+    assert len(formatted) < len(bloated)
+    assert "do the real thing" in formatted
+    assert f"padding task {n_padding - 1}" not in formatted
+
+
+def test_apply_no_silent_loss_audit_passes_with_caps() -> None:
+    """Capping must never trip the no-silent-loss audit; sentinels keep it balanced.
+
+    Re-formatting a capped body routes its Tasks (including the elision sentinel)
+    through task_validator.validate_tasks / merge_with_audit. That audit raises on
+    unaccounted loss; this asserts it does not.
+    """
+    from scripts.langchain import issue_formatter, task_decomposer
+
+    over = task_decomposer.MAX_TASKS + 8
+    body = (
+        "## Tasks\n"
+        + "\n".join(f"- [ ] Distinct work item number {i} to complete" for i in range(over))
+        + "\n\n## Acceptance Criteria\n- [ ] it works\n"
+    )
+    capped = issue_optimizer.apply_suggestions(body, {}, use_llm=False)["formatted_body"]
+
+    # Sentinel must be present (the elided remainder is accounted for, not dropped).
+    assert any(task_decomposer.is_elision_sentinel(line) for line in _top_level_task_lines(capped))
+
+    # Re-formatting the capped body must not raise the audit ValueError.
+    reformatted = issue_formatter.format_issue_body(capped, use_llm=False)
+    assert reformatted["formatted_body"] is not None
+    # The sentinel survives the validator round-trip.
+    assert "elided" in reformatted["formatted_body"]

--- a/tests/scripts/test_issue_pr_context.py
+++ b/tests/scripts/test_issue_pr_context.py
@@ -5,6 +5,7 @@ import hashlib
 
 from scripts.langchain.issue_pr_context import (
     ContextOptions,
+    already_conformant,
     build_formatted_body_marker,
     build_issue_context,
     build_pr_context,
@@ -230,3 +231,118 @@ def test_cli_outputs_json_payload(tmp_path, capsys) -> None:
     assert exit_code == 0
     assert '"kind": "issue"' in captured.out
     assert "Use helper" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Anti-bloat: hash-only reuse marker + already_conformant guard
+# ---------------------------------------------------------------------------
+
+CONFORMANT_BODY = "\n".join(
+    [
+        "## Why",
+        "",
+        "Ship it.",
+        "",
+        "## Scope",
+        "",
+        "_Not provided._",
+        "",
+        "## Non-Goals",
+        "",
+        "_Not provided._",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] do a thing",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] it works",
+        "",
+        "## Implementation Notes",
+        "",
+        "_Not provided._",
+        "",
+        "<details>",
+        "<summary>Original Issue</summary>",
+        "",
+        "```text",
+        "## Tasks",
+        "- [ ] do a thing",
+        "## Acceptance Criteria",
+        "```",
+        "</details>",
+    ]
+)
+
+
+def test_build_marker_hash_only_omits_body_b64() -> None:
+    """embed_body=False stores only the sha256, not a (size-doubling) base64 copy."""
+    formatted = "## Tasks\n- [ ] keep it small\n"
+    marker = build_formatted_body_marker(
+        workflows=["agents-auto-pilot"],
+        formatted_body=formatted,
+        embed_body=False,
+    )
+    assert "body_b64" not in marker
+    assert '"sha256":"' in marker
+
+
+def test_hash_only_marker_round_trips_via_visible_body() -> None:
+    """A hash-only marker validates against the visible body and returns it cleaned."""
+    formatted = "## Tasks\n- [ ] keep it small\n## Acceptance Criteria\n- [ ] ok"
+    marker = build_formatted_body_marker(
+        workflows=["agents-auto-pilot"],
+        formatted_body=formatted,
+        embed_body=False,
+    )
+    body = f"{formatted}\n\n{marker}"
+    assert reuse_formatted_body({"body": body}, "agents-auto-pilot") == formatted
+    # A body edited after the marker was written fails the hash check (no false reuse).
+    tampered = f"{formatted}\n- [ ] sneaky extra\n\n{marker}"
+    assert reuse_formatted_body({"body": tampered}, "agents-auto-pilot") is None
+
+
+def test_already_conformant_detects_full_template_with_original_block() -> None:
+    assert already_conformant(CONFORMANT_BODY) is True
+
+
+def test_already_conformant_ignores_headings_inside_original_block() -> None:
+    """Headings inside the fenced Original-Issue block must not satisfy conformance."""
+    # The fenced block contains '## Tasks'/'## Acceptance Criteria' but the visible
+    # body has none -> not conformant.
+    body = "\n".join(
+        [
+            "Some raw text",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "```text",
+            "## Why",
+            "## Scope",
+            "## Non-Goals",
+            "## Tasks",
+            "## Acceptance Criteria",
+            "## Implementation Notes",
+            "```",
+            "</details>",
+        ]
+    )
+    assert already_conformant(body) is False
+
+
+def test_already_conformant_requires_all_sections_in_order() -> None:
+    partial = "## Tasks\n- [ ] x\n## Acceptance Criteria\n- [ ] y"
+    assert already_conformant(partial) is False
+
+
+def test_already_conformant_original_issue_optional_flag() -> None:
+    no_block = CONFORMANT_BODY.split("<details>")[0].rstrip()
+    assert already_conformant(no_block) is False
+    assert already_conformant(no_block, require_original_issue=False) is True
+
+
+def test_already_conformant_handles_empty_and_none() -> None:
+    assert already_conformant("") is False
+    assert already_conformant(None) is False

--- a/tests/scripts/test_task_decomposer.py
+++ b/tests/scripts/test_task_decomposer.py
@@ -802,3 +802,73 @@ def test_main_module_invocation(monkeypatch) -> None:
         runpy.run_path(task_decomposer.__file__, run_name="__main__")
     output = captured.getvalue()
     assert output.startswith("-")
+
+
+# ---------------------------------------------------------------------------
+# Anti-bloat: bounded fan-out + elision sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_subtasks_caps_fan_out_with_sentinel() -> None:
+    """A long multi-part input is capped at MAX_SUBTASKS_PER_PARENT with a sentinel."""
+    parts = [
+        "alpha one, bravo two, charlie three, delta four, "
+        "echo five, foxtrot six, golf seven, hotel eight"
+    ]
+    result = task_decomposer.normalize_subtasks(parts)
+    assert len(result) == task_decomposer.MAX_SUBTASKS_PER_PARENT
+    sentinels = [t for t in result if task_decomposer.is_elision_sentinel(t)]
+    assert len(sentinels) == 1
+    assert "sub-tasks elided" in sentinels[0]
+
+
+def test_normalize_subtasks_does_not_triple_multi_part_input() -> None:
+    """Multiple parts must NOT each be tripled (the 3xN fan-out vector)."""
+    result = task_decomposer.normalize_subtasks(
+        ["Update docs and add tests and refactor the parser"]
+    )
+    assert not any("focused slice for" in t.lower() for t in result)
+    # Three independent parts -> three tasks, not nine.
+    assert len(result) == 3
+
+
+def test_normalize_subtasks_single_large_task_still_expands_to_triple() -> None:
+    """A single genuinely-large task still gets the intended scope/implement/validate triple."""
+    result = task_decomposer.normalize_subtasks(
+        ["Implement end-to-end constraint validation across the entire system"]
+    )
+    assert len(result) == 3
+    assert any(t.lower().startswith("define scope for:") for t in result)
+    assert any(t.lower().startswith("implement focused slice for:") for t in result)
+    assert any(t.lower().startswith("validate focused slice for:") for t in result)
+
+
+def test_normalize_subtasks_is_idempotent_on_capped_output() -> None:
+    """Re-normalizing capped output is stable and preserves the sentinel verbatim."""
+    parts = [
+        "alpha one, bravo two, charlie three, delta four, "
+        "echo five, foxtrot six, golf seven, hotel eight"
+    ]
+    once = task_decomposer.normalize_subtasks(parts)
+    twice = task_decomposer.normalize_subtasks(once)
+    assert twice == once
+    # The sentinel did not get a "(verify: ...)" suffix or get re-split.
+    assert any(task_decomposer.is_elision_sentinel(t) for t in twice)
+
+
+def test_is_elision_sentinel_recognizes_generated_marker() -> None:
+    """The sentinel emitted by elision_sentinel is recognized by is_elision_sentinel."""
+    marker = task_decomposer.elision_sentinel(7, kind="tasks")
+    assert task_decomposer.is_elision_sentinel(marker)
+    assert task_decomposer.is_elision_sentinel(f"- [ ] {marker}")
+    assert not task_decomposer.is_elision_sentinel("Add tests for the parser")
+
+
+def test_build_child_issues_excludes_sentinel() -> None:
+    """Elision sentinels are bookkeeping markers, never materialized as child issues."""
+    many = [f"Implement distinct feature module number {i} for the system" for i in range(10)]
+    children = task_decomposer.build_child_issues(many, parent_title="Parent", max_children=3)
+    assert len(children) <= 3
+    for child in children:
+        assert not task_decomposer.is_elision_sentinel(child["title"])
+        assert "elided; split this issue" not in child["body"]


### PR DESCRIPTION
## Problem

Auto-pilot's `format -> optimize -> apply` path ballooned issues with no upper bound. Reproduced cleanly: PAEM **#1127** (1,712 chars, 6 clean tasks) -> **#1135** (**133,085 chars**, 510 "focused slice" lines, 5 nested `<details>`) — identical information, **~78x larger**. Four prior incidents (#805, #873, #1143, #4191) and #862 (135,021 chars) are the same failure. The pipeline had a quality *floor* (required sections, no-silent-loss audit) but **no ceiling**.

Scope: this is the **auto-pilot lane only** (`agents:formatted` + `agents:apply-suggestions`). The repo-review pipeline is unaffected (uploaded issues are byte-identical to their drafts; no "focused slice" signature).

## The 5 fixes

1. **Idempotency (highest leverage).** Added `already_conformant(body)` + a hash-only reuse marker, wiring the previously-unused `build_formatted_body_marker`/`reuse_formatted_body`. An already-formatted body is no longer re-formatted from scratch. `apply_suggestions` is converted from a full re-format ("output the complete reformatted issue") into an **apply-only patch** (prompt + caller).
2. **Decomposition caps.** Gated the mechanical "Define scope / Implement focused slice / Validate focused slice" triple behind a single-task budget (multi-part inputs are no longer tripled — the 3xN vector). Added `MAX_TASKS` (20) / `MAX_ACCEPTANCE` (15) and a per-parent `MAX_SUBTASKS_PER_PARENT` (6) cap (reuses `build_child_issues(max_children=)`). Capping emits an explicit `(N further items elided)` sentinel.
3. **Anti-rewrap.** `_append_raw_issue_section` now **replaces** an existing Original-Issue `<details>` block (and collapses nested ones down to the innermost verbatim original) instead of nesting a new one each cycle — the #1135 nesting vector.
4. **Prompt guardrails.** Added "preserve scope / improve clarity WITHOUT increasing length / don't fill placeholders with invented content" blocks to `format_issue.md`, `apply_suggestions.md`, `decompose_task.md`, and synced the matching inline prompt constants.
5. **Signal validation + size pre-check.** Optimizer-side size pre-check that, on trip, resets a ballooned body to its embedded Original Issue (the documented manual recovery, automated). Task dedup upgraded from exact-match to near-duplicate (token-set Jaccard >= 0.85).

## No silent loss preserved

`task_validator.validate_no_items_lost` still passes: every cap emits an elision sentinel so input/output counts reconcile. The sentinel survives the validator round-trip and is never re-split, re-expanded, or materialized as a child issue.

## Verification

- End-to-end repro of the #1127 scenario across 4 auto-pilot cycles: **stabilizes at a bounded ~3.3x** (one-time 6-section template + a single embedded original) and is **byte-stable from cycle 2 onward** — no compounding, 1 Original-Issue block, 0 "focused slice" triples.
- **+25 unit tests** covering: byte-stable second format pass; 6-task issue stays under `MAX_TASKS` with no per-task triple; 3 apply cycles -> exactly one Original-Issue block; no-silent-loss audit passes with caps (sentinel present); near-duplicate dedup; hash-only marker round-trip; `already_conformant`; oversized-body reset.
- Full test suite: **2647 passed, 3 skipped (needs-human), 3 xfailed (intentional fixtures)**; 2 deselected are a pre-existing PyPI-version network test unrelated to this change. `ruff check` and `black --check` clean on all changed files.

## Consumer sync

`scripts/langchain/*` and `scripts/langchain/prompts/*` are consumer-synced and **already listed in `.github/sync-manifest.yml`** (no manifest change). **Merging this will generate consumer sync PRs** for Manager-Database, trip-planner, etc.

## Coordination

This **changes auto-pilot issue-generation behavior** (issues will be smaller and idempotent). Coordinated to avoid PR #2174's region: no edits to `_detect_objective_criteria` in `issue_optimizer.py` or to `templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md`; diff hunks do not overlap #2174's.

## Reviewer should scrutinize

- **Marker on every formatted body.** Hash-only (sha256, no base64 copy) to avoid doubling body size; a body edited after the marker fails the hash check and is ignored (no false reuse). `REUSE_MARKER_WORKFLOWS` tags all auto-pilot chain stages so any stage can reuse — confirm that set matches the live `ISSUE_PR_CONTEXT_WORKFLOW` values.
- **`already_conformant` requires all 6 sections in order + an Original-Issue block** (headings inside the fenced original are ignored). Bodies missing a section still get formatted; confirm this matches intent.
- **`build_formatted_body_marker` gained `embed_body=False`** (default True preserves existing callers/tests).
- The bounded **~3.3x** is one-time structural overhead, not a regression — verify that's acceptable vs. raw issue size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)