### PR TITLE
docs: clarify GitHub settings wording

### DIFF
--- a/templates/consumer-repo/docs/SETUP_CHECKLIST.md
+++ b/templates/consumer-repo/docs/SETUP_CHECKLIST.md
@@ -225,7 +225,7 @@ gh label create "verify:create-new-pr" --color "5319E7" --description "Creates f
 
 > **Critical**: Keepalive automation will fail silently without these secrets.
 
-> **Automation shortcut**: The GitHub-settings toggles in §3.1, §3.3, and §3.3.1
+> **Automation shortcut**: The GitHub settings toggles in §3.1, §3.3, and §3.3.1
 > (bot collaborator, `USE_CONSOLIDATED_WORKFLOWS` / `ALLOWED_KEEPALIVE_LOGINS`
 > variables, and `default_workflow_permissions=write`) can be applied in one shot
 > from the canonical Workflows repo by running the **Maint 83 Bootstrap Consumer**


### PR DESCRIPTION
## Summary
- Clarify the automation shortcut wording in the consumer setup checklist from “GitHub-settings toggles” to “GitHub settings toggles”.

## Validation
- `python -m pytest tests/test_setup_checklist_ci_scripts.py -q`
- Verified `templates/consumer-repo/docs/SETUP_CHECKLIST.md` contains `GitHub settings toggles` and no `GitHub-settings toggles`.