### PR TITLE
docs: normalize setup checklist references

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -670,7 +670,7 @@ docs:
 
   - source: docs/SETUP_CHECKLIST.md
     target: docs/SETUP_CHECKLIST.md
-    description: "Consumer repo setup checklist. Includes the default_workflow_permissions=write step (§3.3.1) that prevents a Gate startup_failure on fresh consumers (see #2157). Synced so it no longer drifts across the fleet."
+    description: "Consumer repo setup checklist. Includes the default_workflow_permissions=write step in section 3.3.1 that prevents a Gate startup_failure on fresh consumers (see #2157). Synced so it no longer drifts across the fleet."
 
 # Issue templates synced to consumer repos
 issue_templates:

--- a/templates/consumer-repo/docs/SETUP_CHECKLIST.md
+++ b/templates/consumer-repo/docs/SETUP_CHECKLIST.md
@@ -225,12 +225,12 @@ gh label create "verify:create-new-pr" --color "5319E7" --description "Creates f
 
 > **Critical**: Keepalive automation will fail silently without these secrets.
 
-> **Automation shortcut**: The GitHub-settings toggles in §3.1, §3.3, and §3.3.1
+> **Automation shortcut**: The GitHub settings toggles in sections 3.1, 3.3, and 3.3.1
 > (bot collaborator, `USE_CONSOLIDATED_WORKFLOWS` / `ALLOWED_KEEPALIVE_LOGINS`
 > variables, and `default_workflow_permissions=write`) can be applied in one shot
 > from the canonical Workflows repo by running the **Maint 83 Bootstrap Consumer**
-> workflow (`scripts/bootstrap_consumer_settings.py`) against this repo. Secrets
-> (§3.2) still require manual setup. The collaborator invite still has to be
+> workflow (`scripts/bootstrap_consumer_settings.py`) against this repo. Secrets in
+> section 3.2 still require manual setup. The collaborator invite still has to be
 > accepted by the bot account.
 
 ### 3.1 Bot Collaborator Access


### PR DESCRIPTION
## Summary
- Reword the consumer setup checklist automation shortcut to use plain "GitHub settings" wording and section numbers.
- Update the sync manifest description to avoid section-symbol references in generated sync PR summaries.

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py --strict --manifest .github/sync-manifest.yml --source local-review-fix
- python -c 'import yaml; yaml.safe_load(open(".github/sync-manifest.yml", encoding="utf-8")); print("sync-manifest.yml parsed")'
- git diff --check