### PR TITLE
Fix ARG001 unused-arg in issue_optimizer (unblocks stricter-ruff consumer sync, e.g. Travel-Plan-Permission)

### DIFF
--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -736,7 +736,7 @@ def _reset_oversized_body(issue_body: str, workflow: str) -> str | None:
     original = issue_formatter._innermost_original_issue(issue_body)
     if original and original.strip():
         print(
-            f"Issue body oversized ({len(issue_body):,} chars); "
+            f"Issue body oversized ({len(issue_body):,} chars) for {workflow}; "
             "resetting to embedded Original Issue before optimizing.",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Problem

A merged change introduced an unused `workflow` parameter on `_reset_oversized_body` at `scripts/langchain/issue_optimizer.py:721`. Workflows' own ruff config does **not** enable the `ARG` (flake8-unused-arguments) rule family, so this passed CI in Workflows. But consumer repo **Travel-Plan-Permission** has a stricter ruff config — its `[tool.ruff.lint] select` includes `ARG` (full set: `E, W, F, I, B, C4, UP, ARG, SIM`) — so the synced copy trips **`ARG001 Unused function argument: workflow`**, blocking TPP's sync PR.

## Fix

Used the parameter for diagnostic context in the existing stderr message rather than dropping it:

```
-            f"Issue body oversized ({len(issue_body):,} chars); "
+            f"Issue body oversized ({len(issue_body):,} chars) for {workflow}; "
```

This is the least-disruptive option and adds genuine diagnostic value. It also matches the sibling helper `_capped_issue_body(issue_body, workflow)`, which already threads the same `_context_workflow("issue_optimizer")` value into `build_issue_context(downstream_workflow=...)`. Both call sites (`analyze_issue`, `apply_suggestions`) are unchanged — they already pass the workflow context. **Behavior is otherwise identical**: same stderr print, same return values, same control flow.

## Sibling check

Ran ruff with the `ARG` family plus TPP's full select set (`E W F I B C4 UP SIM`) across the four langchain files most likely to share the pattern:
`issue_optimizer.py`, `issue_formatter.py`, `task_decomposer.py`, `issue_pr_context.py` → **All checks passed** (the other three had no violations; only `issue_optimizer.py` needed the fix).

## Validation

- `python -m ruff check --select ARG --select E/W/F/I/B/C4/UP/SIM` on the four files → clean.
- Workflows default `python -m ruff check` on the changed file → clean.
- `pytest tests/ -k "optimizer or formatter or decompos or issue_pr_context"` → **165 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)