### PR TITLE
chore(sync): schedule sync-PR janitor + stop consumer CI failing the fleet flush

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -735,15 +735,13 @@ excluded:
     reason: "Each repo maintains its own coverage baseline - template provided for reference"
   - path: scripts/__pycache__
     reason: "Python bytecode cache - never synced"
+  - path: .github/workflows/autofix-versions.env
+    reason: "Repo-specific CI version pins; consumers copy or override per docs/ci/WORKFLOWS.md. Intentionally not synced (see CLAUDE.md)."
 
 # Copilot configuration - skills and instructions for AI assistants
 copilot_config:
   - source: .github/copilot-instructions.md
     description: "Repository-specific instructions for GitHub Copilot"
-
-  - source: .github/actions/export-load-balancer-tokens/
-    is_directory: true
-    description: "Local action for exporting load balancer tokens"
 
   # Skills folder - synced as a directory
   - source: .github/copilot-skills/

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -18,6 +18,13 @@
 name: Merge Sync PRs
 
 on:
+  schedule:
+    # Daily janitor pass: auto-merge ready sync PRs, close superseded ones, and prune
+    # leftover branches without waiting for a manual dispatch. Runs just after Health 68's
+    # drift scan (cron '10 5') so it acts on a fresh picture. A schedule event carries no
+    # inputs, so the script's parseBooleanInput defaults apply unchanged:
+    # auto_merge=true, dry_run=false, cleanup_branches=true, repos=all.
+    - cron: '30 5 * * *'
   repository_dispatch:
     types: [merge-sync-prs]
   workflow_dispatch:
@@ -596,14 +603,25 @@ jobs:
             const merged = report.summary.merged;
             const stale = report.summary.stale_closed;
             const branchesDeleted = report.summary.branch_deleted;
+            // A consumer's own red CI (checks_failed) is outside this workflow's control,
+            // so it must NOT fail the fleet janitor run — otherwise one red consumer turns
+            // every scheduled flush red and forces re-runs. Only genuine sync-system action
+            // failures (merge/cleanup/missing-target) are blocking; consumer CI health is
+            // surfaced via the merge report and Health 68 instead.
             const blockingFailures = results.filter(
               (r) =>
-                r.status === 'checks_failed' ||
                 r.status === 'merge_failed' ||
                 r.status === 'stale_close_failed' ||
                 r.status === 'branch_delete_failed' ||
                 r.status === 'target_missing',
             );
+            const checksFailed = results.filter((r) => r.status === 'checks_failed');
+            if (checksFailed.length > 0) {
+              core.notice(
+                `${checksFailed.length} consumer sync PR(s) have failing checks (consumer CI); ` +
+                  `left open, not treated as a janitor failure.`,
+              );
+            }
             const failed = dryRun ? 0 : blockingFailures.length;
             const pending = report.summary.checks_pending;
             const ready = report.summary.ready;


### PR DESCRIPTION
## Sync-system review — PR-A (robustness + hygiene)

First of two PRs from the sync-system review (`docs/review-2026-05-29/sync-system/SYNC-SYSTEM-REVIEW.md`). Intentionally low-risk; does **not** touch the core sync branch/flow — that is PR-B (debounce maint-68 + durable one-PR-per-consumer + header-strip parity).

### What & why
The review found the operational root cause of sync-PR pileup: **the producer (maint-68) is automatic but the janitor (maint-71) is manual** — maint-71 had no `schedule:`, so superseded PRs accumulate until a human runs the flush, and that flush was fragile (one consumer's red CI failed the whole run).

**maint-71:**
- **Daily `schedule:`** (`cron '30 5'`, just after Health 68's `10 5`) so the janitor merges ready sync PRs, closes superseded ones, and prunes branches unattended. No-input event → existing `parseBooleanInput` defaults (auto_merge=true, dry_run=false, cleanup_branches=true, repos=all). Owner-approved unattended auto-merge.
- **Consumer `checks_failed` is no longer a fleet failure** — only genuine sync-system action failures (merge/cleanup/missing-target) set the run failed; a red consumer no longer forces a re-run.

**sync-manifest.yml hygiene:** declare `autofix-versions.env` under `excluded:` (was the only undeclared template file; repo-specific per CLAUDE.md); drop the duplicate `export-load-balancer-tokens` (still declared under `actions:`).

### Validation
`validate_template_sync.py` ✅ · `validate_template_completeness.py` ✅ · YAML parses.

### Deferred to PR-B / later
debounce maint-68 (drop `push`, add schedule/release/manual), durable one-PR-per-consumer branch, header-strip parity (E1) + truncation→warning (E6) in the drift checker, `custom_gate_repos`→`skip_repos`. G3/#2158 (template gate reusables) left for separate confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
