### PR TITLE
chore(sync): debounce maint-68 to a daily schedule (drop per-push sync waves)

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -11,44 +11,17 @@ name: Maint 68 Sync Consumer Repos
 on:
   release:
     types: [published]
-  push:
-    branches: [main]
-    paths:
-      - 'templates/consumer-repo/**'
-      - '.github/sync-manifest.yml'
-      # All directories referenced by sync-manifest.yml as source paths.
-      # The sync is idempotent (hash-compares before creating PRs), so extra
-      # triggers only cost a ~30s no-op run when nothing actually changed.
-      - '.github/scripts/**'
-      - '.github/codex/**'
-      - '.github/actions/setup-api-client/**'
-      - '.github/actions/export-load-balancer-tokens/**'
-      - '.github/actions/path-classifier/**'
-      - '.github/path-classification.yml'
-      - '.github/copilot-instructions.md'
-      - '.github/copilot-skills/**'
-      - '.github/dependabot.yml'
-      - '.github/templates/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'scripts/langchain/**'
-      - 'scripts/sync_dev_dependencies.py'
-      - 'scripts/sync_test_dependencies.py'
-      - 'scripts/check_test_dependencies.sh'
-      - 'scripts/autopilot_step_timer.py'
-      - 'scripts/autopilot_metrics_collector.py'
-      - 'scripts/ci_*.py'
-      - 'scripts/coverage_history_append.py'
-      - 'tools/resolve_mypy_pin.py'
-      - 'tools/coverage_trend.py'
-      - 'tools/llm_provider.py'
-      - 'tools/langchain_client.py'
-      - 'config/llm_slots.json'
-      - 'config/model_registry.json'
-      - 'docs/AGENT_ISSUE_FORMAT.md'
-      - 'docs/CI_SYSTEM_GUIDE.md'
-      - 'docs/LABELS.md'
-      - 'docs/CODEX_TOKEN_REFRESH.md'
-      - '.gitattributes'
+  schedule:
+    # Debounced sync: coalesce template changes into ONE daily run rather than a
+    # per-push PR wave across the consumer fleet (the dominant sync-PR-volume driver,
+    # per docs/review-2026-05-29/sync-system/). The prepare job hash-compares before
+    # creating any PR, so a scheduled run with nothing to sync is a ~30s no-op (zero
+    # PRs). Runtime behavior already reaches consumers instantly via @main; only the
+    # synced file COPIES wait for this run. For an immediate sync, use the manual
+    # workflow_dispatch below (or publish a release). Daily ordering:
+    #   05:00 maint-68 sync  ->  05:10 Health 68 drift scan  ->  05:30 maint-71 janitor.
+    # (Removing the push trigger also moots the G2 push-allowlist-vs-manifest drift.)
+    - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
       repos:


### PR DESCRIPTION
## Sync-system review — PR-B (debounce maint-68)

Second PR from the sync-system review (`docs/review-2026-05-29/sync-system/`). One focused, low-risk change: **stop syncing on every push to main; sync on a daily schedule instead.**

### Why
maint-68 fired on every push to `main` touching a synced path, creating a new sync PR per consumer on a new content-hash branch each time — the dominant volume driver (**407 sync PRs in one day**; **~64%** all-time closed unmerged).

### Change
`on:` — replace `push: {branches:[main], paths:[…]}` with `schedule: cron '0 5 * * *'`; keep `release: published` and `workflow_dispatch`.
- The prepare job hash-compares, so a scheduled run with nothing to sync is a ~30s no-op (zero PRs) — **daily, but conditional on an actual change**.
- A schedule event carries no inputs → existing defaults (all repos, `inputs.dry_run != true` → real run, no force → hash-gated). No plumbing change.
- **Manual "sync now"** stays via `workflow_dispatch`; `release` also triggers an immediate sync.
- Removing the push trigger moots the **G2** push-allowlist-vs-manifest drift.

Combined with PR-A's scheduled janitor: a 51-PR/consumer/day burst → ≤1/consumer/day, auto-merged/closed daily. Ordering: **05:00** sync → **05:10** drift → **05:30** janitor.

### Validation
YAML parses; trigger block = `release` + `schedule` + `workflow_dispatch` (no `push`).

### Deferred to PR-C (carefully, after A/B)
Durable one-PR-per-consumer branch (the zero-churn refactor — spans 6 files incl. Dependabot coupling + ~5 test files), drift-checker header-strip parity (E1) + truncation→skipped (E6), `custom_gate_repos`→`skip_repos` (E5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
