### PR TITLE
chore(sync): drift parity (E1) + custom_gate->manifest skip_repos (E5) + template gate @main (G3)

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -35,6 +35,9 @@ workflows:
     sync_mode: create_only  # Don't overwrite existing consumer Gate files; fresh repos can still receive this file, so follow #2158 before first seeding.
     overwrite_repos:
       - stranske/Template
+    skip_repos:
+      - repo: stranske/Manager-Database
+        reason: "Maintains a fully custom Gate workflow; never overwrite (replaces the hard-coded custom_gate_repos list in maint-68)."
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -386,8 +386,6 @@ jobs:
           dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
           force = os.environ.get('FORCE', 'false') == 'true'
 
-          # Repos with custom Gate workflows
-          custom_gate_repos = ['stranske/Manager-Database']
           changes = []
           skipped = []
 
@@ -521,10 +519,6 @@ jobs:
               consumer_dst = Path('consumer') / source
 
               # Skip conditions
-              def skip_custom_gate():
-                  """Repo has custom Gate workflow"""
-                  return 'pr-00-gate' in source and current_repo in custom_gate_repos
-
               def skip_create_only():
                   """File exists and sync_mode is create_only"""
                   return (
@@ -533,13 +527,10 @@ jobs:
                       and not repo_overwrites_create_only(item, current_repo)
                   )
 
-              # Determine skip function: check create_only first (covers most cases),
-              # then custom_gate for legacy repos that have completely custom Gates
-              skip_fn = None
-              if sync_mode == 'create_only':
-                  skip_fn = skip_create_only
-              elif 'pr-00-gate' in source and current_repo in custom_gate_repos:
-                  skip_fn = skip_custom_gate
+              # Determine skip function. Repo-specific exclusions (e.g. Manager-Database's
+              # fully custom Gate) now come from the manifest's skip_repos and are enforced
+              # inside sync_file via manifest_skip_reason, so no per-file special-casing here.
+              skip_fn = skip_create_only if sync_mode == 'create_only' else None
 
               sync_file(template_src, consumer_dst, description, skip_fn, item)
 

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -105,6 +106,37 @@ def git_blob_hash(content: bytes) -> str:
     """Return the Git object SHA for file content without fetching the remote blob."""
     header = f"blob {len(content)}\0".encode()
     return hashlib.sha1(header + content).hexdigest()
+
+
+def comparable_lines(text: str) -> list[str]:
+    """Lines after leading comment/blank header lines, matching maint-68's
+    `comparable_lines`. The syncer compares files header-insensitively, so a
+    difference only in leading blank/`#` lines is something it never rewrites.
+    EOL-insensitive via splitlines()."""
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped == "" or stripped.startswith("#"):
+            index += 1
+            continue
+        break
+    return lines[index:]
+
+
+def remote_blob_text(session: requests.Session, repo: str, sha: str) -> str | None:
+    """Fetch a remote blob's UTF-8 text by SHA, or None if it can't be fetched or
+    decoded (e.g. binary, API error) -- caller falls back to the raw-bytes verdict."""
+    try:
+        response = session.get(f"https://api.github.com/repos/{repo}/git/blobs/{sha}")
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        if data.get("encoding") != "base64":
+            return None
+        return base64.b64decode(data.get("content", "")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError, requests.RequestException):
+        return None
 
 
 def sorted_items(values: set[str]) -> list[str]:
@@ -779,7 +811,23 @@ def main() -> int:
         if remote_entry.get("type") != "blob" or not remote_entry.get("sha"):
             errors.add(f"{repo}: {remote_target} (unexpected remote tree entry)")
             return
-        if str(remote_entry["sha"]) != git_blob_hash(local_file.read_bytes()):
+        local_bytes = local_file.read_bytes()
+        if str(remote_entry["sha"]) == git_blob_hash(local_bytes):
+            return
+        # Raw bytes differ -- but maint-68 syncs using a header-insensitive comparison
+        # (comparable_lines), so a difference only in leading comment/blank headers is
+        # something the syncer will NEVER rewrite; reporting it as drift would be an
+        # eternal false positive (review E1). Confirm real drift the same way before
+        # flagging. On any fetch/decode failure, fall back to the raw-bytes verdict.
+        remote_text = remote_blob_text(session, repo, str(remote_entry["sha"]))
+        try:
+            local_text = local_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            local_text = None
+        if remote_text is None or local_text is None:
+            drift.add(f"{repo}: {remote_target}")
+            return
+        if comparable_lines(local_text) != comparable_lines(remote_text):
             drift.add(f"{repo}: {remote_target}")
 
     for section in sections:

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -174,7 +174,7 @@ jobs:
         needs.detect.outputs.is_python_code == 'true' &&
         needs.detect.outputs.run_core == 'true'
       }}
-    uses: ./.github/workflows/reusable-10-ci-python.yml
+    uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     secrets: inherit
     permissions:
       contents: read
@@ -262,7 +262,7 @@ jobs:
         fromJSON(needs.detect.outputs.run_core || 'true') &&
         fromJSON(needs.detect.outputs.docker_changed || 'false')
       }}
-    uses: ./.github/workflows/reusable-12-ci-docker.yml
+    uses: stranske/Workflows/.github/workflows/reusable-12-ci-docker.yml@main
 
   ledger-validation:
     name: ledger validation

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -3,6 +3,27 @@ import json
 from scripts import check_consumer_sync_drift
 
 
+def test_comparable_lines_ignores_leading_comment_and_blank_headers() -> None:
+    """maint-68 syncs header-insensitively; the drift checker must match so a
+    header-only difference is not reported as eternal drift (review E1)."""
+    a = "# header one\n\n# header two\nbody 1\nbody 2\n"
+    b = "# a DIFFERENT header\nbody 1\nbody 2\n"
+    assert check_consumer_sync_drift.comparable_lines(
+        a
+    ) == check_consumer_sync_drift.comparable_lines(b)
+    # A real body difference is still detected.
+    c = "# header\nbody 1\nCHANGED\n"
+    assert check_consumer_sync_drift.comparable_lines(
+        a
+    ) != check_consumer_sync_drift.comparable_lines(c)
+    # Only LEADING comment/blank lines are stripped; mid-file comments are kept.
+    assert check_consumer_sync_drift.comparable_lines("body\n# mid\nmore\n") == [
+        "body",
+        "# mid",
+        "more",
+    ]
+
+
 def test_build_report_returns_machine_readable_counts() -> None:
     token_diagnostics = {
         "schema": "workflows-drift-token-selection/v1",


### PR DESCRIPTION
## Sync-system review — PR-C (drift parity + hygiene; durable-branch deliberately skipped)

Third PR from the sync-system review. **Scope note:** the durable one-PR-per-consumer refactor (#8) is **intentionally not included** — A+B (#2186 debounce + #2187 scheduled janitor) already eliminated the sync-PR churn (verified: ≤1 PR/consumer/day, auto-merged), so #8's marginal benefit no longer justified its 6-file + Dependabot-coupling risk. This is the independently-valuable remainder.

### E1 — drift-checker header-strip parity (the real correctness fix)
`maint-68` compares files **header-insensitively** (`comparable_lines` strips leading blank/`#` lines), but `check_consumer_sync_drift.py` hashed **raw bytes** — so a file differing *only* in its leading comment header would read as drift **forever** (the syncer never rewrites it). Now, on a raw-SHA mismatch, the checker fetches the remote blob and re-compares with the same `comparable_lines` logic; only a real body difference is flagged, with a raw-bytes fallback on fetch/decode failure. Latent today, but closes the asymmetry. **+ unit test.**

### E5 — `custom_gate_repos` → manifest `skip_repos`
Moves the Manager-Database custom-Gate exception out of a hard-coded list in `maint-68` into the manifest's `pr-00-gate` `skip_repos` (already enforced by `sync_file`). Removes a script/manifest drift hazard + the now-redundant `skip_custom_gate` code.

### G3 — template gate `./` → `@main` reusable refs
The template `pr-00-gate.yml` referenced two reusables by local `./` path that don't exist in a fresh consumer; switched to the `@main` form deployed consumers already use. Removes one fresh-bootstrap blocker. (Gate stays `create_only`; the **#2158** caveat for the expanded detect-job outputs still applies, so this isn't a complete fresh-deploy fix alone.)

### Validation
drift-checker pytest **26 passed** (incl. new E1 test) · `py_compile` clean · YAML parses · `validate_template_sync` + `validate_template_completeness` pass.

### Not in scope
Durable one-PR-per-consumer (#8), truncation→skipped (E6) — deferred; revisit #8 only if residual churn appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
