### PR TITLE
Fix LangSmith metrics dashboard live dispatch

### DIFF
--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -177,11 +177,14 @@ jobs:
           while IFS=$'\t' read -r repo artifact_name; do
             [ -z "$repo" ] && continue
             echo "🔎 Resolving $artifact_name in $repo ..."
-            artifact_id=$(gh api --paginate --slurp --method GET \
+            artifacts_json=$(gh api --paginate --slurp --method GET \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/repos/$repo/actions/artifacts?per_page=100" \
-              --jq "[.[].artifacts[]? | select(.name == \"$artifact_name\" and .expired == false)] | sort_by(.created_at) | last | .id" \
+              2>> .metrics-tmp/fleet/fleet_errors.log || echo "")
+            artifact_id=$(printf '%s' "$artifacts_json" | jq -r \
+              --arg artifact_name "$artifact_name" \
+              '[.[].artifacts[]? | select(.name == $artifact_name and .expired == false)] | sort_by(.created_at) | last | .id // empty' \
               2>> .metrics-tmp/fleet/fleet_errors.log || echo "")
             if [ -z "$artifact_id" ] || [ "$artifact_id" = "null" ]; then
               echo "  ↪ no current artifact for $repo (missing)"
@@ -372,7 +375,7 @@ jobs:
           gh issue create \
             --title "📊 LangSmith Trace Coverage Report - Week of $START_DATE" \
             --body-file .metrics-tmp/issue-body.md \
-            --label "metrics,langsmith,automated"
+            --label "metrics,automated"
 
       - name: Update dashboard file
         if: env.REPORT_AVAILABLE == 'true'
@@ -462,7 +465,7 @@ jobs:
             echo "  - Dashboard file: docs/dashboards/langsmith-metrics.md"
             if [ "${{ github.event_name }}" == "schedule" ] || \
                [ "${{ inputs.create_issue }}" == "true" ]; then
-              echo "  - Issue: Created with label 'langsmith,metrics'"
+              echo "  - Issue: Created with labels 'metrics,automated'"
             fi
           else
             echo "⚠️ No metrics data available for the specified period"

--- a/docs/dashboards/README.md
+++ b/docs/dashboards/README.md
@@ -21,7 +21,7 @@ This directory contains automated dashboard reports for monitoring repository me
 #### Where to View
 
 1. **Dashboard file:** `docs/dashboards/langsmith-metrics.md` (updated weekly, committed to main)
-2. **Weekly issues:** Created automatically with label `langsmith,metrics`
+2. **Weekly issues:** Created automatically with labels `metrics,automated`
 3. **Workflow artifacts:** Downloadable JSON + markdown reports (90-day retention)
 
 #### Manual Triggers

--- a/tests/scripts/test_metrics_dashboard_generator.py
+++ b/tests/scripts/test_metrics_dashboard_generator.py
@@ -353,3 +353,10 @@ def test_build_dashboard_from_path_mixed_fleet_status(tmp_path: Path) -> None:
     assert (
         "| stranske/Pension-Data | nl-to-sql | stranske/Pension-Data#445 | missing |" in dashboard
     )
+    fleet_section = dashboard.split("## LangSmith Fleet Artifact Status", maxsplit=1)[1]
+    status_rows = [
+        line
+        for line in fleet_section.splitlines()
+        if line.startswith("| stranske/") and line.endswith(" |")
+    ]
+    assert len(status_rows) == 8

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -19,3 +19,11 @@ def test_dashboard_issue_uses_existing_labels() -> None:
     assert '--label "metrics,automated"' in source
     assert "metrics,langsmith,automated" not in source
     assert "labels 'metrics,automated'" in source
+
+
+def test_fleet_status_is_warning_only_and_appended_to_report() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "::warning title=LangSmith fleet artifacts incomplete::" in source
+    assert "cat .metrics-tmp/fleet/fleet-status.md" in source
+    assert "if [ -f .metrics-tmp/fleet/fleet-status.md ]; then" in source

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -27,3 +27,17 @@ def test_fleet_status_is_warning_only_and_appended_to_report() -> None:
     assert "::warning title=LangSmith fleet artifacts incomplete::" in source
     assert "cat .metrics-tmp/fleet/fleet-status.md" in source
     assert "if [ -f .metrics-tmp/fleet/fleet-status.md ]; then" in source
+
+
+def test_fleet_rollup_and_publication_paths_are_wired() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    # Fleet rollup is generated from combined records via the validator summary output.
+    assert "python scripts/langsmith_fleet.py .metrics-tmp/fleet/combined-fleet.ndjson" in source
+    assert '--registry "$REGISTRY" --summary --format markdown' in source
+    assert '--registry "$REGISTRY" --summary --format json' in source
+
+    # The same report payload feeds both issue body and committed dashboard file.
+    assert "REPORT=$(cat .metrics-tmp/report.md)" in source
+    assert "$REPORT" in source
+    assert "$(cat .metrics-tmp/report.md)" in source

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maint-80-langsmith-metrics-dashboard.yml")
+
+
+def test_fleet_artifact_lookup_does_not_mix_slurp_with_jq() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--paginate --slurp --method GET" in source
+    assert "--arg artifact_name" in source
+    assert "select(.name == $artifact_name and .expired == false)" in source
+    assert "--slurp --method GET \\\n" in source
+    assert '--jq "[.[].artifacts' not in source
+
+
+def test_dashboard_issue_uses_existing_labels() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert '--label "metrics,automated"' in source
+    assert "metrics,langsmith,automated" not in source
+    assert "labels 'metrics,automated'" in source


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2183 -->
> **Source:** Issue #2183

Closes #2183

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The fleet contract `langsmith-fleet/v1`, its validator (`scripts/langsmith_fleet.py`), the registry (`config/langsmith_fleet_registry.json`), and the rollup function (`scripts/metrics_dashboard_generator.py`) are all built and unit-tested, but **no running workflow invokes them**. `docs/dashboards/README.md:64-65` documents step 4 of the dashboard as "Validate fleet artifacts - Runs `scripts/langsmith_fleet.py` ... so the dashboard can distinguish missing, invalid, stale, and valid repo artifacts" — yet `maint-80-langsmith-metrics-dashboard.yml` only fetches Workflows-internal `autopilot-metrics-*` / `agents-verifier-metrics` artifacts and runs `aggregate_metrics.py` (trace-presence counting). The fleet adoption/freshness feedback loop the docs claim is live does not run at runtime. This is documentation/implementation drift on the source-of-truth pipeline, and it leaves the fleet rollup orphaned from CI.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1324](https://github.com/stranske/Workflows/issues/1324)
- [#4](https://github.com/stranske/Workflows/issues/4)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] In `maint-80-langsmith-metrics-dashboard.yml`, add a step that assembles the fleet records to validate. Because **no consumer repo currently uploads `langsmith-fleet.ndjson`** (verified: grep of all 7 consumer `.github/workflows/` returns none), implement the transport defensively: iterate `repos[].repo` from `config/langsmith_fleet_registry.json`, attempt a cross-repo `gh api .../actions/artifacts` download per repo, and treat any repo with no artifact as `missing` rather than failing the job.
- [ ] Run the rollup over the combined records: call `python scripts/metrics_dashboard_generator.py --langsmith-fleet-records-path <combined.ndjson> --langsmith-fleet-registry-path config/langsmith_fleet_registry.json ...` (reusing the already-tested code path) or `python scripts/langsmith_fleet.py <combined.ndjson> --summary --format markdown`.
- [ ] Append the resulting status table to the weekly issue body and to the committed `docs/dashboards/langsmith-metrics.md` dashboard file the workflow already publishes.
- [ ] Emit a `::warning` (not a hard failure) when any registered repo resolves to `invalid` or `missing`, mirroring the existing warning-only precedent already in this workflow (`::warning title=LangSmith workflow lookup failed` near line 89).
- [ ] Update `docs/dashboards/README.md:60-72` "Data Sources" and "How It Works" to state exactly which artifacts are fetched (`autopilot-metrics-*`, `agents-verifier-metrics`, and per-repo `langsmith-fleet.ndjson`) and that fleet validation is performed.
- [ ] Update `docs/LANGSMITH_INTEGRATION_STATUS.md` so fleet rollup readiness is stated honestly (live vs pending-consumer-uploads).

#### Acceptance criteria
- [x] **Existing unit tests still pass and a new integration assertion is added.** The generator-level behavior is already covered by `tests/scripts/test_metrics_dashboard_generator.py::test_build_dashboard_from_path_includes_langsmith_fleet_status` (line 231) and `::test_build_dashboard_from_path_marks_invalid_langsmith_fleet_records` (line 261). Add a new test (workflow-rendering helper or a `tests/scripts/` case) that feeds a mixed input (≥1 `valid`, ≥1 `invalid`, ≥1 `missing`) and asserts the produced section text contains the per-repo status rows and correct counts (e.g. `- Invalid: 1`), mirroring the assertions at lines 254-258 and 280-283.
- [ ] **Documented live-verification gate:** a `workflow_dispatch` run of `maint-80-langsmith-metrics-dashboard.yml` produces a "LangSmith Fleet Status" section in the issue/dashboard with a non-empty registry table (8 rows, one per registered repo) and at least the honest current state (most repos `missing`). Capture the run URL in the PR, mirroring the live-verify precedent in `docs/LANGSMITH_E2E_VALIDATION.md:16` (run #1324).
- [ ] `docs/dashboards/README.md` no longer describes a `langsmith_fleet.py` validation step the workflow does not perform — verified by reading the updated "How It Works" against the workflow steps.

<!-- auto-status-summary:end -->