### PR TITLE
Issue #2182: harden selftest CI contract coverage

### DIFF
--- a/.github/workflows/selftest-ci.yml
+++ b/.github/workflows/selftest-ci.yml
@@ -70,11 +70,26 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-cov pyyaml requests numpy pandas
+          pip install pytest pytest-cov pyyaml requests numpy pandas pydantic
 
       - name: Run Python tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
-          python -m pytest tests/workflows/ -v
+          python -m pytest \
+            tests/workflows/ \
+            tests/test_verdict_policy.py \
+            tests/test_verdict_extract.py \
+            tests/test_verdict_policy_integration.py \
+            tests/test_structured_output.py \
+            tests/scripts/test_pr_verifier_compare.py \
+            tests/scripts/test_pr_verifier_fallback.py \
+            tests/scripts/test_pr_verifier_chain_depth.py \
+            tests/scripts/test_pr_verifier_comparison_report.py \
+            tests/scripts/test_pr_verifier_structured_output.py \
+            tests/scripts/test_pr_verifier_infra_detection.py \
+            tests/scripts/test_pr_verifier_issue_creation.py \
+            -v
 
   lint-and-validate:
     name: Lint, Format & YAML Validation

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -216,7 +216,7 @@ Together these workflows define the CI surface area referenced by Gate and the G
 
 * [`selftest-reusable-ci.yml`](../../.github/workflows/selftest-reusable-ci.yml) exercises `reusable-10-ci-python.yml` across curated scenarios, publishing summaries or PR comments so maintainers can validate reusable changes before they ship.
 
-* [`selftest-ci.yml`](../../.github/workflows/selftest-ci.yml) runs the repository's own test suite (JS + Python tests, linting, YAML validation), including the langchain verdict, verifier, and structured-output contract tests on push and PR.
+* [`selftest-ci.yml`](../../.github/workflows/selftest-ci.yml) runs the repository's own test suite (JS + Python tests, linting, YAML validation) on push and PR, including the langchain verdict, verifier, and structured-output contract tests.
 * [`health-keepalive-e2e.yml`](../../.github/workflows/health-keepalive-e2e.yml) path-filtered E2E test for the keepalive system. Runs only when keepalive-related files change. Supports two modes: orchestration-only (default) and real Codex ping (via `e2e:codex-ping` label).
 * [`health-keepalive-auth-diagnostic.yml`](../../.github/workflows/health-keepalive-auth-diagnostic.yml) 4-part diagnostic suite for keepalive auth: GitHub App tokens, Claude CLI auth, Codex auth, and PAT availability. Run on `workflow_dispatch`.
 * [`health-claude-cli-auth-debug.yml`](../../.github/workflows/health-claude-cli-auth-debug.yml) isolated Claude Code CLI auth test (temporary, delete after validation).

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -216,7 +216,7 @@ Together these workflows define the CI surface area referenced by Gate and the G
 
 * [`selftest-reusable-ci.yml`](../../.github/workflows/selftest-reusable-ci.yml) exercises `reusable-10-ci-python.yml` across curated scenarios, publishing summaries or PR comments so maintainers can validate reusable changes before they ship.
 
-* [`selftest-ci.yml`](../../.github/workflows/selftest-ci.yml) runs the repository's own test suite (JS + Python tests, linting, YAML validation) on push and PR.
+* [`selftest-ci.yml`](../../.github/workflows/selftest-ci.yml) runs the repository's own test suite (JS + Python tests, linting, YAML validation), including the langchain verdict, verifier, and structured-output contract tests on push and PR.
 * [`health-keepalive-e2e.yml`](../../.github/workflows/health-keepalive-e2e.yml) path-filtered E2E test for the keepalive system. Runs only when keepalive-related files change. Supports two modes: orchestration-only (default) and real Codex ping (via `e2e:codex-ping` label).
 * [`health-keepalive-auth-diagnostic.yml`](../../.github/workflows/health-keepalive-auth-diagnostic.yml) 4-part diagnostic suite for keepalive auth: GitHub App tokens, Claude CLI auth, Codex auth, and PAT availability. Run on `workflow_dispatch`.
 * [`health-claude-cli-auth-debug.yml`](../../.github/workflows/health-claude-cli-auth-debug.yml) isolated Claude Code CLI auth test (temporary, delete after validation).

--- a/scripts/metrics_dashboard_generator.py
+++ b/scripts/metrics_dashboard_generator.py
@@ -365,6 +365,7 @@ def build_dashboard_from_path(
     thresholds: dict[str, dict[str, Any]] | None = None,
     fleet_records_path: Path | None = None,
     fleet_registry_path: Path | None = None,
+    fleet_now: _dt.datetime | None = None,
 ) -> tuple[str, int]:
     entries, errors = _read_ndjson(metrics_path)
     fleet_summary = None
@@ -378,7 +379,11 @@ def build_dashboard_from_path(
             registry=registry,
             schema=schema,
         )
-        fleet_summary = langsmith_fleet.summarize_fleet_records(fleet_records, registry=registry)
+        fleet_summary = langsmith_fleet.summarize_fleet_records(
+            fleet_records,
+            registry=registry,
+            now=fleet_now,
+        )
         if fleet_parse_errors or fleet_validation_errors:
             rows_by_key = {
                 (row["repo"], row["surface"]): row for row in fleet_summary.get("rows", [])

--- a/tests/scripts/test_metrics_dashboard_generator.py
+++ b/tests/scripts/test_metrics_dashboard_generator.py
@@ -1,7 +1,10 @@
+import datetime as dt
 from pathlib import Path
 
 import pytest
 from scripts import metrics_dashboard_generator as generator
+
+_FLEET_FIXTURE_NOW = dt.datetime(2026, 5, 25, tzinfo=dt.UTC)
 
 
 def test_build_dashboard_includes_repo_sections() -> None:
@@ -244,6 +247,7 @@ def test_build_dashboard_from_path_includes_langsmith_fleet_status(tmp_path: Pat
         numeric_fields=["duration_ms"],
         fleet_records_path=fleet_path,
         fleet_registry_path=Path("config/langsmith_fleet_registry.json"),
+        fleet_now=_FLEET_FIXTURE_NOW,
     )
 
     assert errors == 0
@@ -274,6 +278,7 @@ def test_build_dashboard_from_path_marks_invalid_langsmith_fleet_records(tmp_pat
         numeric_fields=["duration_ms"],
         fleet_records_path=fleet_path,
         fleet_registry_path=Path("config/langsmith_fleet_registry.json"),
+        fleet_now=_FLEET_FIXTURE_NOW,
     )
 
     assert "## LangSmith Fleet Artifact Status" in dashboard
@@ -297,6 +302,18 @@ def test_main_langsmith_fleet_noops_without_langsmith_api_key(
     fleet_path = tmp_path / "langsmith-fleet.ndjson"
     fleet_path.write_text(fleet_src.read_text(encoding="utf-8"), encoding="utf-8")
     monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    original_summarize = generator.langsmith_fleet.summarize_fleet_records
+
+    def summarize_with_fixed_now(*args: object, **kwargs: object) -> dict[str, object]:
+        if kwargs.get("now") is None:
+            kwargs["now"] = _FLEET_FIXTURE_NOW
+        return original_summarize(*args, **kwargs)
+
+    monkeypatch.setattr(
+        generator.langsmith_fleet,
+        "summarize_fleet_records",
+        summarize_with_fixed_now,
+    )
 
     exit_code = generator.main(
         [
@@ -336,6 +353,7 @@ def test_build_dashboard_from_path_mixed_fleet_status(tmp_path: Path) -> None:
         numeric_fields=["duration_ms"],
         fleet_records_path=fleet_path,
         fleet_registry_path=Path("config/langsmith_fleet_registry.json"),
+        fleet_now=_FLEET_FIXTURE_NOW,
     )
 
     assert errors == 0

--- a/tests/test_verdict_policy.py
+++ b/tests/test_verdict_policy.py
@@ -40,6 +40,15 @@ def test_select_verdict_worst_case_policy():
     assert select_verdict(verdicts, policy="worst") == "CONCERNS"
 
 
+def test_select_verdict_worst_case_prefers_fail_over_concerns():
+    verdicts = [
+        ProviderVerdict("openai", "gpt-5.2", "CONCERNS", 86),
+        ProviderVerdict("anthropic", "claude-sonnet-4-5", "FAIL", 85),
+    ]
+
+    assert select_verdict(verdicts, policy="worst") == "FAIL"
+
+
 def test_select_verdict_majority_policy():
     verdicts = [
         ProviderVerdict("openai", "gpt-5.2", "PASS", 86),

--- a/tests/workflows/test_issue2_excluded_tests_enabled.py
+++ b/tests/workflows/test_issue2_excluded_tests_enabled.py
@@ -137,7 +137,22 @@ def test_issue2_selftest_ci_runs_all_workflow_tests() -> None:
         if step.get("name") == "Run Python tests"
     ]
 
-    assert python_test_steps == ["python -m pytest tests/workflows/ -v\n"]
+    assert python_test_steps == [
+        "python -m pytest \\\n"
+        "  tests/workflows/ \\\n"
+        "  tests/test_verdict_policy.py \\\n"
+        "  tests/test_verdict_extract.py \\\n"
+        "  tests/test_verdict_policy_integration.py \\\n"
+        "  tests/test_structured_output.py \\\n"
+        "  tests/scripts/test_pr_verifier_compare.py \\\n"
+        "  tests/scripts/test_pr_verifier_fallback.py \\\n"
+        "  tests/scripts/test_pr_verifier_chain_depth.py \\\n"
+        "  tests/scripts/test_pr_verifier_comparison_report.py \\\n"
+        "  tests/scripts/test_pr_verifier_structured_output.py \\\n"
+        "  tests/scripts/test_pr_verifier_infra_detection.py \\\n"
+        "  tests/scripts/test_pr_verifier_issue_creation.py \\\n"
+        "  -v\n"
+    ]
     assert not re.search(
         r"--ignore(?:-glob)?(?:=|\s+)tests/workflows/?(?:\s|$)", python_test_steps[0]
     )

--- a/tests/workflows/test_issue2_excluded_tests_enabled.py
+++ b/tests/workflows/test_issue2_excluded_tests_enabled.py
@@ -137,22 +137,13 @@ def test_issue2_selftest_ci_runs_all_workflow_tests() -> None:
         if step.get("name") == "Run Python tests"
     ]
 
-    assert python_test_steps == [
-        "python -m pytest \\\n"
-        "  tests/workflows/ \\\n"
-        "  tests/test_verdict_policy.py \\\n"
-        "  tests/test_verdict_extract.py \\\n"
-        "  tests/test_verdict_policy_integration.py \\\n"
-        "  tests/test_structured_output.py \\\n"
-        "  tests/scripts/test_pr_verifier_compare.py \\\n"
-        "  tests/scripts/test_pr_verifier_fallback.py \\\n"
-        "  tests/scripts/test_pr_verifier_chain_depth.py \\\n"
-        "  tests/scripts/test_pr_verifier_comparison_report.py \\\n"
-        "  tests/scripts/test_pr_verifier_structured_output.py \\\n"
-        "  tests/scripts/test_pr_verifier_infra_detection.py \\\n"
-        "  tests/scripts/test_pr_verifier_issue_creation.py \\\n"
-        "  -v\n"
-    ]
+    assert len(python_test_steps) == 1
+    assert "tests/workflows/" in python_test_steps[0]
+    assert "tests/test_verdict_policy.py" in python_test_steps[0]
+    assert "tests/test_verdict_extract.py" in python_test_steps[0]
+    assert "tests/test_structured_output.py" in python_test_steps[0]
+    assert "tests/scripts/test_pr_verifier_compare.py" in python_test_steps[0]
+    assert "tests/scripts/test_update_versions_from_pypi.py" not in python_test_steps[0]
     assert not re.search(
         r"--ignore(?:-glob)?(?:=|\s+)tests/workflows/?(?:\s|$)", python_test_steps[0]
     )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2182 -->
> **Source:** Issue #2182

Closes #2182

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is the DEFER system-of-record repo whose standing design commitment is "keep the tool contracts stable" (the langchain verdict/verifier/structured-output layer that every consumer's auto-pilot depends on). The repo ships a workflow named "Selftest CI" whose documented purpose is to run "the repository's own test suite (JS + Python tests, linting, YAML validation)" (`docs/ci/WORKFLOWS.md:215`). But its Python leg runs exactly one command — `python -m pytest tests/workflows/ -v` (`.github/workflows/selftest-ci.yml:77`). I verified that this command collects **zero** of the load-bearing tool-contract tests: `pytest tests/workflows/ --collect-only` returns 0 matches for `test_verdict_policy.py`, `test_verdict_extract.py`, `test_structured_output.py`, and `test_pr_verifier_compare.py`. Those tests live at the `tests/` root and under `tests/scripts/`, not under `tests/workflows/`.

Today these contracts are guarded only by the required Gate, which runs the full suite via `reusable-10-ci-python.yml:1906` honoring `pyproject.toml:171` `testpaths = ["tests"]`. The missing behavior: the workflow that *names itself* the repo self-test does not actually cover the contracts it exists to protect. If Gate's Python leg is ever skipped for a diff, or `testpaths` is narrowed, a regression in `scripts/langchain/verdict_policy.py` (e.g. the `VERDICT_SEVERITY` map at `verdict_policy.py:12-17`) could merge with a green named self-test. This is latent fragility, not a current break — I ran all 12 targeted contract files and 92 tests pass.

A secondary, lower-severity install gap reinforces this: the Python leg installs only `pytest pytest-cov pyyaml requests numpy pandas` (`selftest-ci.yml:73`) and sets no `PYTHONPATH`. The contract tests import `from scripts.langchain.structured_output import ...`, and `scripts/langchain/structured_output.py:8` does `from pydantic import BaseModel, ValidationError`. So even adding the test paths would fail to import without also adding `pydantic` and putting the repo root on the path.

#### Tasks
- [ ] In `.github/workflows/selftest-ci.yml`, replace the single-line Python run step (`selftest-ci.yml:75-77`, currently `python -m pytest tests/workflows/ -v`) so it also runs the verified contract files. Use an explicit file list, not `tests/scripts/`: `python -m pytest tests/workflows/ tests/test_verdict_policy.py tests/test_verdict_extract.py tests/test_verdict_policy_integration.py tests/test_structured_output.py tests/scripts/test_pr_verifier_compare.py tests/scripts/test_pr_verifier_fallback.py tests/scripts/test_pr_verifier_chain_depth.py tests/scripts/test_pr_verifier_comparison_report.py tests/scripts/test_pr_verifier_structured_output.py tests/scripts/test_pr_verifier_infra_detection.py tests/scripts/test_pr_verifier_issue_creation.py -v`.
- [ ] In the install step (`selftest-ci.yml:71-73`), add `pydantic` to the `pip install` line so `scripts/langchain/structured_output.py:8` (and the pr_verifier tests that import it) resolve under the slim selftest environment.
- [ ] Add `env: PYTHONPATH: ${{ github.workspace }}` to the Python run step so `from scripts.langchain...` and `from tools.llm_provider...` imports resolve, matching how Gate's reusable workflow sets it at `reusable-10-ci-python.yml:1876`.
- [ ] Update `docs/ci/WORKFLOWS.md:215` so the selftest-ci bullet states it now also runs the langchain verdict/verifier/structured-output contract tests, not only `tests/workflows/`.
- [ ] Trigger the updated job via `workflow_dispatch` (or reproduce the exact command locally) and capture the per-file collected/passed counts as evidence in the PR.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert the break before requesting review.

#### Acceptance criteria
- [ ] The `test-python` job of `selftest-ci.yml`, run via `workflow_dispatch`, collects and passes the four named groups with a non-zero count each: `tests/test_verdict_policy.py`, `tests/test_verdict_extract.py`, `tests/test_structured_output.py`, and the `tests/scripts/test_pr_verifier_*` files. Demonstrated by the run log showing the collected count (baseline locally: the 12 targeted files collect 92 tests, all passing), not just a green check mark.
- [ ] Deliberate-break gate (concrete failing test): temporarily edit `scripts/langchain/verdict_policy.py:12-17` to swap the `VERDICT_SEVERITY` ranks of `"concerns": 2` and `"fail": 3`. With this change, `tests/test_verdict_policy.py::test_select_verdict_worst_policy` (asserts `select_verdict(..., policy="worst") == "CONCERNS"`, `tests/test_verdict_policy.py:40`) must FAIL in the selftest-ci Python job — proving the contract is now guarded by the self-test and not only by Gate. Revert the edit after capturing the failure.
- [ ] The selftest-ci Python job does NOT invoke `tests/scripts/test_update_versions_from_pypi.py` (verify it is absent from the run log), so the self-test has no live-PyPI network dependency and cannot fail on version drift.
- [ ] `docs/ci/WORKFLOWS.md` self-test section reflects the broadened coverage (mentions the verdict/verifier/structured-output contracts).
- [ ] `./scripts/dev_check.sh` (or at minimum `python -m yaml` validation in `lint-and-validate`) passes on the edited `selftest-ci.yml`, confirming the YAML is still valid.

<!-- auto-status-summary:end -->