### PR TITLE
Add shared app-baseline-kit package + repo-review baseline-signals hook

### DIFF
--- a/docs/ops/REPO_REVIEW_ROUND1_PROMPT.md
+++ b/docs/ops/REPO_REVIEW_ROUND1_PROMPT.md
@@ -26,6 +26,7 @@ You are NOT writing GitHub issues. You are NOT running scripts that mutate the r
    - `archive-progress.md` — recently-discussed topics from prior review sessions.
 3. The repo itself at the local path named in `review-inputs.md`. Read `README.md`, the design source files listed in the brief, and inspect the implementation areas. Use `grep`/`rg` and `git log` as needed; do NOT modify any file.
 4. `docs/ops/REPO_REVIEW_ROUND1_SCHEMA.md` — the findings schema you must conform to.
+5. Any reports under `docs/reports/` listed in the "Reports & Baseline Signals" section of your brief (coverage manifests, baseline-drift, test-quality). A coverage regression, drift alarm, or untested/unwired parameter named there — confirmed against current code — is a verified gap worth raising as a candidate.
 
 ## GitNexus (optional, when the map is current)
 
@@ -55,7 +56,7 @@ GitNexus indexes call-graph relationships, **not SQL strings or file contents**.
    - `missing` — the design commits to it but the implementation does not exist (cite where you verified the absence — e.g., a referenced module that doesn't exist, a documented endpoint that's never registered)
    - `stale-or-conflicting` — code or docs exist but disagree with the design (e.g., README claims X but the code does Y)
    
-   Each classification needs concrete file refs as evidence. File counts and keyword hits do NOT count.
+   Each classification needs concrete file refs as evidence. File counts and keyword hits do NOT count. Baseline coverage/drift reports in `docs/reports/` are corroborating evidence: a parameter flagged there as untested or unwired, confirmed against the code, supports a `partial` classification; a drift alarm supports `stale-or-conflicting`.
 
 3. **Decide readiness for testing or live-style use.** Name the exact tests, smoke checks, verifier commands, or missing proof that would (or do) demonstrate the user journey end-to-end. Generic phrases like "ready for normal coding-agent implementation" fail the gate. The answer must differ across repos because the design target differs.
 

--- a/packages/app-baseline-kit/README.md
+++ b/packages/app-baseline-kit/README.md
@@ -1,0 +1,55 @@
+# app-baseline-kit
+
+The shared, app-agnostic core of the "app behavior baseline" harness:
+scenario-driven **wiring**, **economic sensibility**, and **regression**
+testing, reusable across apps.
+
+## The one contract
+
+Each app writes a small **adapter** that reduces a run to a flat dict of named
+scalar metrics (`dict[str, float | int]`). Everything else is generic and lives
+here:
+
+| Module | What it gives you |
+|---|---|
+| `directional` | `evaluate_direction(direction, left, right)` — metamorphic comparisons. Works for both control-vs-variant (temporal) and entity-vs-entity (ordering) framings. |
+| `invariants` | `InvariantResult` + `assert_invariants` — error severity fails, warn severity reports. |
+| `manifest` | `CoverageManifest` — input-parameter → scenario coverage, typo/priority-gap detection, markdown report. |
+| `golden` | `check_metrics(num_regression, metrics)` — golden masters via pytest-regressions, float tolerance, `--force-regen` to re-bless. |
+| `catalog` | `load_catalog(path)` — YAML scenario catalog loader. |
+
+## Proven consumers
+
+- **Trend_Model_Project** (`tests/baseline/`) — config-patch adapter over a
+  Streamlit/CLI quant model; golden masters of metrics/weights, directional
+  control-vs-variant checks, economic invariants, Streamlit AppTest smoke.
+- **trip-planner** (`tests/baseline/`) — fixture-compute adapter over
+  deterministic transport-option evaluation; golden masters per fixture,
+  cross-option ordering checks, signal/cost invariants.
+
+## Install
+
+This package lives as a subdirectory of `stranske/Workflows`. Consumers install
+it as a normal pip dependency pinned to a git ref:
+
+```bash
+pip install "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+```
+
+(Pin to a tag/SHA in `requirements`/`pyproject` for reproducibility.) Local
+development: `pip install -e packages/app-baseline-kit` from a Workflows checkout.
+
+It is **not** distributed via the sync-manifest — a Python library is installed,
+not copied into consumer trees. If/when independent release cadence matters, it
+can be promoted to its own repo without changing this contract.
+
+## Writing an adapter (sketch)
+
+```python
+def metrics_for(case) -> dict[str, float]:
+    out = run_my_app(case)          # call the LOGIC layer, not the UI
+    return {"sharpe": out.sharpe, "max_weight": out.weights.max(), ...}
+```
+
+Then a catalog of orderings/scenarios + a few `InvariantResult`-returning
+checks, and the generic test modules drive golden/directional/invariant/manifest.

--- a/packages/app-baseline-kit/baseline_kit/__init__.py
+++ b/packages/app-baseline-kit/baseline_kit/__init__.py
@@ -1,0 +1,37 @@
+"""app-baseline-kit: the generic, app-agnostic core of the baseline harness.
+
+The kit splits cleanly into:
+
+  * GENERIC (this package) -- the catalog format, directional ("metamorphic")
+    comparison engine, invariant result type + assertion helper, the
+    coverage-manifest, and golden-master glue. Identical across apps.
+
+  * APP-SPECIFIC (each consuming repo) -- an "adapter" that turns an input
+    (a config patch, a fixture, a request) into a flat ``metrics`` dict
+    (``dict[str, float | int]``), plus the catalog content and invariant bounds.
+
+The contract between them is just the metrics dict: every app reduces its run
+to named scalars, and the generic machinery compares, bounds, baselines, and
+reports those scalars.
+
+Proven on two consumers: a Streamlit/CLI quant model (config-patch adapter) and
+a trip-planner (fixture-compute adapter).
+"""
+
+from .catalog import load_catalog
+from .directional import DIRECTIONS, evaluate_direction
+from .golden import DEFAULT_TOLERANCE, check_metrics
+from .invariants import InvariantResult, assert_invariants, split_results
+from .manifest import CoverageManifest
+
+__all__ = [
+    "load_catalog",
+    "DIRECTIONS",
+    "evaluate_direction",
+    "DEFAULT_TOLERANCE",
+    "check_metrics",
+    "InvariantResult",
+    "assert_invariants",
+    "split_results",
+    "CoverageManifest",
+]

--- a/packages/app-baseline-kit/baseline_kit/catalog.py
+++ b/packages/app-baseline-kit/baseline_kit/catalog.py
@@ -1,0 +1,14 @@
+"""Catalog loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_catalog(path: str | Path) -> dict[str, Any]:
+    """Load a scenario catalog YAML file into a dict."""
+    with Path(path).open() as fh:
+        return yaml.safe_load(fh)

--- a/packages/app-baseline-kit/baseline_kit/directional.py
+++ b/packages/app-baseline-kit/baseline_kit/directional.py
@@ -1,0 +1,47 @@
+"""Directional ("metamorphic") comparison engine.
+
+A directional check compares two metric values -- a ``left`` and a ``right`` --
+and asserts the relationship a domain expert expects. The same comparison serves
+two framings:
+
+  * temporal (one app, two configs): left=variant, right=control
+    e.g. "raising target vol INCREASEs realized vol"
+  * ordering (two entities): left vs right
+    e.g. "a car costs LESS_THAN a flight"
+
+Both reduce to comparing two numbers, so both naming sets map to one engine.
+"""
+
+from __future__ import annotations
+
+DEFAULT_TOL = 1e-9
+
+# direction name -> comparator(left, right, tol) -> bool
+DIRECTIONS = {
+    # temporal framing (variant vs control)
+    "increase": lambda l, r, t: l > r + t,
+    "decrease": lambda l, r, t: l < r - t,
+    "increase_or_equal": lambda l, r, t: l >= r - t,
+    "decrease_or_equal": lambda l, r, t: l <= r + t,
+    "change": lambda l, r, t: abs(l - r) > t,
+    "unchanged": lambda l, r, t: abs(l - r) <= t,
+    # ordering framing (entity vs entity) -- aliases of the same logic
+    "less_than": lambda l, r, t: l < r - t,
+    "greater_than": lambda l, r, t: l > r + t,
+    "less_or_equal": lambda l, r, t: l <= r + t,
+    "greater_or_equal": lambda l, r, t: l >= r - t,
+}
+
+
+def evaluate_direction(direction: str, left: float, right: float, tol: float = DEFAULT_TOL) -> bool:
+    """Return True if (left, right) satisfy ``direction``.
+
+    Non-finite inputs always fail (a NaN/inf result is never "sensible").
+    """
+    import math
+
+    if direction not in DIRECTIONS:
+        raise KeyError(f"unknown direction {direction!r}; known: {sorted(DIRECTIONS)}")
+    if not (math.isfinite(left) and math.isfinite(right)):
+        return False
+    return bool(DIRECTIONS[direction](left, right, tol))

--- a/packages/app-baseline-kit/baseline_kit/directional.py
+++ b/packages/app-baseline-kit/baseline_kit/directional.py
@@ -19,17 +19,17 @@ DEFAULT_TOL = 1e-9
 # direction name -> comparator(left, right, tol) -> bool
 DIRECTIONS = {
     # temporal framing (variant vs control)
-    "increase": lambda l, r, t: l > r + t,
-    "decrease": lambda l, r, t: l < r - t,
-    "increase_or_equal": lambda l, r, t: l >= r - t,
-    "decrease_or_equal": lambda l, r, t: l <= r + t,
-    "change": lambda l, r, t: abs(l - r) > t,
-    "unchanged": lambda l, r, t: abs(l - r) <= t,
+    "increase": lambda lo, hi, tol: lo > hi + tol,
+    "decrease": lambda lo, hi, tol: lo < hi - tol,
+    "increase_or_equal": lambda lo, hi, tol: lo >= hi - tol,
+    "decrease_or_equal": lambda lo, hi, tol: lo <= hi + tol,
+    "change": lambda lo, hi, tol: abs(lo - hi) > tol,
+    "unchanged": lambda lo, hi, tol: abs(lo - hi) <= tol,
     # ordering framing (entity vs entity) -- aliases of the same logic
-    "less_than": lambda l, r, t: l < r - t,
-    "greater_than": lambda l, r, t: l > r + t,
-    "less_or_equal": lambda l, r, t: l <= r + t,
-    "greater_or_equal": lambda l, r, t: l >= r - t,
+    "less_than": lambda lo, hi, tol: lo < hi - tol,
+    "greater_than": lambda lo, hi, tol: lo > hi + tol,
+    "less_or_equal": lambda lo, hi, tol: lo <= hi + tol,
+    "greater_or_equal": lambda lo, hi, tol: lo >= hi - tol,
 }
 
 

--- a/packages/app-baseline-kit/baseline_kit/golden.py
+++ b/packages/app-baseline-kit/baseline_kit/golden.py
@@ -1,0 +1,19 @@
+"""Golden-master glue over pytest-regressions.
+
+Apps reduce a run to a flat metrics dict and pass it here; the baseline is
+stored on disk and diffed with float tolerance. Re-bless with ``--force-regen``.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+DEFAULT_TOLERANCE = dict(atol=1e-9, rtol=1e-6)
+
+
+def check_metrics(num_regression, metrics: Mapping[str, float], tolerance: dict | None = None) -> None:
+    """Golden-master a flat dict of scalar metrics via the num_regression fixture."""
+    num_regression.check(
+        {str(k): [float(v)] for k, v in metrics.items()},
+        default_tolerance=tolerance or DEFAULT_TOLERANCE,
+    )

--- a/packages/app-baseline-kit/baseline_kit/golden.py
+++ b/packages/app-baseline-kit/baseline_kit/golden.py
@@ -6,12 +6,14 @@ stored on disk and diffed with float tolerance. Re-bless with ``--force-regen``.
 
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 
 DEFAULT_TOLERANCE = dict(atol=1e-9, rtol=1e-6)
 
 
-def check_metrics(num_regression, metrics: Mapping[str, float], tolerance: dict | None = None) -> None:
+def check_metrics(
+    num_regression, metrics: Mapping[str, float], tolerance: dict | None = None
+) -> None:
     """Golden-master a flat dict of scalar metrics via the num_regression fixture."""
     num_regression.check(
         {str(k): [float(v)] for k, v in metrics.items()},

--- a/packages/app-baseline-kit/baseline_kit/golden.py
+++ b/packages/app-baseline-kit/baseline_kit/golden.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-DEFAULT_TOLERANCE = dict(atol=1e-9, rtol=1e-6)
+DEFAULT_TOLERANCE = {"atol": 1e-9, "rtol": 1e-6}
 
 
 def check_metrics(

--- a/packages/app-baseline-kit/baseline_kit/invariants.py
+++ b/packages/app-baseline-kit/baseline_kit/invariants.py
@@ -1,0 +1,40 @@
+"""Invariant result type and assertion helper.
+
+Apps write their own invariant functions (the bounds are domain-specific), but
+they all return ``InvariantResult`` objects, and they all assert the same way:
+``error`` severity fails the suite; ``warn`` severity is reported via the
+warnings system but never fails.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+ERROR = "error"
+WARN = "warn"
+
+
+@dataclass
+class InvariantResult:
+    name: str
+    ok: bool
+    severity: str = ERROR  # "error" | "warn"
+    detail: str = ""
+
+
+def split_results(results: list[InvariantResult]) -> tuple[list[InvariantResult], list[InvariantResult]]:
+    """Return (failing errors, failing warnings)."""
+    errors = [r for r in results if r.severity == ERROR and not r.ok]
+    warns = [r for r in results if r.severity == WARN and not r.ok]
+    return errors, warns
+
+
+def assert_invariants(results: list[InvariantResult], *, context: str = "") -> None:
+    """Raise AssertionError on any failing error-invariant; warn on soft ones."""
+    errors, warns = split_results(results)
+    for r in warns:
+        warnings.warn(f"[soft]{(' ' + context) if context else ''} {r.name}: {r.detail}", stacklevel=2)
+    if errors:
+        head = f"Invariant violations{(' (' + context + ')') if context else ''}:"
+        raise AssertionError(head + "\n" + "\n".join(f"  - {r.name}: {r.detail}" for r in errors))

--- a/packages/app-baseline-kit/baseline_kit/invariants.py
+++ b/packages/app-baseline-kit/baseline_kit/invariants.py
@@ -23,7 +23,9 @@ class InvariantResult:
     detail: str = ""
 
 
-def split_results(results: list[InvariantResult]) -> tuple[list[InvariantResult], list[InvariantResult]]:
+def split_results(
+    results: list[InvariantResult],
+) -> tuple[list[InvariantResult], list[InvariantResult]]:
     """Return (failing errors, failing warnings)."""
     errors = [r for r in results if r.severity == ERROR and not r.ok]
     warns = [r for r in results if r.severity == WARN and not r.ok]
@@ -34,7 +36,9 @@ def assert_invariants(results: list[InvariantResult], *, context: str = "") -> N
     """Raise AssertionError on any failing error-invariant; warn on soft ones."""
     errors, warns = split_results(results)
     for r in warns:
-        warnings.warn(f"[soft]{(' ' + context) if context else ''} {r.name}: {r.detail}", stacklevel=2)
+        warnings.warn(
+            f"[soft]{(' ' + context) if context else ''} {r.name}: {r.detail}", stacklevel=2
+        )
     if errors:
         head = f"Invariant violations{(' (' + context + ')') if context else ''}:"
         raise AssertionError(head + "\n" + "\n".join(f"  - {r.name}: {r.detail}" for r in errors))

--- a/packages/app-baseline-kit/baseline_kit/manifest.py
+++ b/packages/app-baseline-kit/baseline_kit/manifest.py
@@ -1,0 +1,62 @@
+"""Generic input-coverage manifest.
+
+The app supplies:
+  * ``all_keys``      -- every input parameter (from a JSON schema, Pydantic /
+                         dataclass fields, etc.)
+  * ``touched_keys``  -- the keys exercised by at least one catalog scenario
+  * ``priority_params`` -- the must-cover subset
+  * ``read_keys``     -- (optional) keys observed read at runtime
+
+The manifest computes coverage, flags typos (catalog keys absent from the
+schema) and priority gaps, and renders a markdown report for the issue
+automation to consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CoverageManifest:
+    all_keys: set[str]
+    touched_keys: set[str]
+    priority_params: list[str] = field(default_factory=list)
+    read_keys: set[str] = field(default_factory=set)
+    title: str = "Baseline coverage manifest"
+
+    @property
+    def unknown_catalog_keys(self) -> set[str]:
+        return {k for k in self.touched_keys if k not in self.all_keys}
+
+    @property
+    def priority_gaps(self) -> list[str]:
+        return [p for p in self.priority_params if p not in self.touched_keys]
+
+    @property
+    def coverage_pct(self) -> float:
+        if not self.all_keys:
+            return 0.0
+        return 100.0 * len(self.touched_keys & self.all_keys) / len(self.all_keys)
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# {self.title}",
+            "",
+            f"- Input parameters: **{len(self.all_keys)}**",
+            f"- Exercised by a scenario: **{len(self.touched_keys & self.all_keys)}** "
+            f"({self.coverage_pct:.1f}%)",
+            f"- Observed read at runtime: **{len(self.read_keys)}**",
+            "",
+            "## Priority parameters",
+            "",
+        ]
+        for p in self.priority_params:
+            lines.append(f"- [{'x' if p in self.touched_keys else ' '}] `{p}`")
+        if self.priority_gaps:
+            lines += ["", "## Priority gaps (no scenario yet)", ""]
+            lines += [f"- `{p}`" for p in self.priority_gaps]
+        if self.unknown_catalog_keys:
+            lines += ["", "## Catalog keys not found in schema (check spelling)", ""]
+            lines += [f"- `{k}`" for k in sorted(self.unknown_catalog_keys)]
+        return "\n".join(lines) + "\n"

--- a/packages/app-baseline-kit/pyproject.toml
+++ b/packages/app-baseline-kit/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "app-baseline-kit"
+version = "0.1.0"
+description = "Shared harness for scenario-driven wiring/sensibility/regression baselines across apps."
+requires-python = ">=3.10"
+dependencies = [
+    "PyYAML>=6.0",
+    "pytest>=7.0",
+    "pytest-regressions>=2.8",
+]
+
+[tool.setuptools.packages.find]
+include = ["baseline_kit*"]

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -1581,7 +1581,7 @@ def collect_repo_state(
     design_files = collect_design_files(repo_path)
     implementation_areas = collect_implementation_areas(repo_path)
     report_files = (
-        sorted((repo_path / "docs" / "reports").glob("*.md"))
+        sorted((repo_path / "docs" / "reports").rglob("*.md"))
         if (repo_path / "docs" / "reports").is_dir()
         else []
     )
@@ -3062,6 +3062,18 @@ def write_review_inputs(repo_dir: Path, state: dict[str, Any]) -> None:
         f"- Indexed at: `{gitnexus.get('indexed_at') or 'unknown'}`",
         f"- Indexed commit: `{(gitnexus.get('indexed_commit') or 'unknown')[:12]}`",
         f"- Head commit: `{(gitnexus.get('head_commit') or 'unknown')[:12]}`",
+        "",
+        "## Reports & Baseline Signals",
+        "",
+        "Generated reports under `docs/reports/` (coverage manifests, baseline-drift, "
+        "test-quality signals). Treat a coverage regression, drift alarm, or an "
+        "untested/unwired parameter flagged here as a VERIFIED candidate source when "
+        "current code does not explain or correct it:",
+        "",
+        (
+            "\n".join(f"- `{p}`" for p in (state.get("report_files") or []))
+            or "_None detected._"
+        ),
         "",
         "## Dedup References",
         "",

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -3070,10 +3070,7 @@ def write_review_inputs(repo_dir: Path, state: dict[str, Any]) -> None:
         "untested/unwired parameter flagged here as a VERIFIED candidate source when "
         "current code does not explain or correct it:",
         "",
-        (
-            "\n".join(f"- `{p}`" for p in (state.get("report_files") or []))
-            or "_None detected._"
-        ),
+        ("\n".join(f"- `{p}`" for p in (state.get("report_files") or [])) or "_None detected._"),
         "",
         "## Dedup References",
         "",


### PR DESCRIPTION
## Why

The generic core of the app behavior baseline harness — proven on Trend_Model_Project, trip-planner, and Portable-Alpha-Extension-Model — needs a home so consumers can install it and so the weekly repo-review can act on the reports it emits.

## Scope

- `packages/app-baseline-kit/`: the shared `baseline_kit` package (directional engine, InvariantResult + assert_invariants, CoverageManifest, golden glue, catalog loader). Installable via `pip install "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"`.
- repo-review hook: `scripts/repo_review_evaluator.py` now rglobs `docs/reports/` and surfaces a "Reports & Baseline Signals" section to the round-1 reviewer; `docs/ops/REPO_REVIEW_ROUND1_PROMPT.md` tells the reviewer to treat coverage/drift signals as candidate sources.

## Non-Goals

- Per-app scenario catalogs (live in consumer repos)
- The weekly regression-report artifact (separate follow-up)

## Tasks

- [x] Add `packages/app-baseline-kit/` package
- [x] rglob `docs/reports/` + "Reports & Baseline Signals" review-inputs section
- [x] Round-1 prompt: treat coverage/drift/unwired-params as candidate sources

## Acceptance Criteria

- [ ] Gate green
- [ ] `baseline_kit` importable after `pip install` from the documented git ref
- [ ] `repo_review_evaluator.py` compiles and surfaces report files to the reviewer brief

## Implementation Notes

Package modules: `directional`, `invariants`, `manifest`, `golden`, `catalog`. Hook verified by `py_compile`. Consumers (TMP/trip-planner/PAEM) install this from `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)