### PR TITLE
fix(app-baseline-kit): ship PEP 561 py.typed marker

### DIFF
--- a/packages/app-baseline-kit/pyproject.toml
+++ b/packages/app-baseline-kit/pyproject.toml
@@ -15,3 +15,8 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 include = ["baseline_kit*"]
+
+# Ship the PEP 561 marker so consumers' type checkers (mypy) analyze
+# baseline_kit instead of treating it as an untyped third-party import.
+[tool.setuptools.package-data]
+baseline_kit = ["py.typed"]


### PR DESCRIPTION
## What

`baseline_kit` shipped without a PEP 561 `py.typed` marker, so consumers running mypy over code importing it got:

```
error: Skipping analyzing "baseline_kit": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

This adds an empty `baseline_kit/py.typed` marker and declares it via `[tool.setuptools.package-data]` so it ships in the wheel **and** sdist.

## Changes

- `packages/app-baseline-kit/baseline_kit/py.typed` — empty PEP 561 marker.
- `packages/app-baseline-kit/pyproject.toml` — `[tool.setuptools.package-data] baseline_kit = ["py.typed"]`.

## Verification

`python -m build` in an isolated venv — confirmed `baseline_kit/py.typed` is present in both:
- `app_baseline_kit-0.1.0-py3-none-any.whl`
- `app_baseline_kit-0.1.0.tar.gz`

End-to-end against trip-planner: installed the typed package into its venv and ran mypy over `tests/baseline/*` — the `import-untyped` error is gone with the marker present, and reappears when the marker is removed (control).

## Follow-up

Once on `main`, consumers (e.g. trip-planner) can drop their `ignore_missing_imports` workaround for `baseline_kit` / `baseline_kit.*`. (trip-planner cleanup PR to follow, gated on this landing.)

Part of the app-baseline-kit rollout (package merged in #2203).