### PR TITLE
docs(consumer): no-emit lock convention for monorepo @main deps

### DIFF
--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -369,6 +369,12 @@ Copy from `/templates/` and customize:
 | `dependency-refresh.yml` | Keep `requirements.lock` updated |
 | `cosmetic-repair.yml` | Auto-fix formatting issues |
 
+> **Consuming a `packages/` monorepo dependency (e.g. `app-baseline-kit`)?**
+> Exclude it from `requirements.lock` with `[tool.uv.pip] no-emit-package` so a
+> frozen SHA in the lock cannot conflict with the unpinned `@main` URL when
+> Workflows `main` advances. See
+> [Monorepo Package Dependencies](ops/CONSUMER_REPO_MAINTENANCE.md#monorepo-package-dependencies-app-baseline-kit).
+
 ### Customization Checklist
 
 After copying a template:

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -276,10 +276,25 @@ reads `[tool.uv.pip]` from `pyproject.toml`, so the lock regen, the
 `dependency-refresh.yml` automation, and the lockfile-freshness check all honor
 it consistently with no extra wiring.
 
-Applied to `trip-planner` and `Counter_Risk`; apply the same block whenever a
-new repo adopts `app-baseline-kit` (or any future `packages/` member referenced
-by an unpinned `@main` URL). This is a per-repo `pyproject.toml`/`requirements.lock`
-change, not a synced template file.
+If the repo has a dependency-alignment test (`tests/test_dependency_version_alignment.py`,
+which asserts every `pyproject.toml` dependency is pinned in `requirements.lock`),
+make it read the same `no-emit-package` list and subtract those names from the
+expected set — otherwise it fails on the now-absent package. Drive it from the
+config, not a hardcoded name, so the two never drift:
+
+```python
+no_emit = {
+    n.split(" @ ")[0].split("[")[0].strip().lower()
+    for n in pyproject.get("tool", {}).get("uv", {}).get("pip", {}).get("no-emit-package", [])
+}
+declared -= no_emit
+```
+
+Applied to `trip-planner` and `Counter_Risk`; apply the same `pyproject.toml`,
+lock-regen, and alignment-test changes whenever a new repo adopts
+`app-baseline-kit` (or any future `packages/` member referenced by an unpinned
+`@main` URL). These are per-repo `pyproject.toml`/`requirements.lock`/test
+changes, not synced template files.
 
 ### Manual Sync Trigger
 

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -227,6 +227,60 @@ exist, but continues syncing the canonical pins from Workflows. The
 `maint-auto-update-pypi-versions.yml` workflow owns opening source bump PRs for
 freshness updates.
 
+### Monorepo Package Dependencies (`app-baseline-kit`)
+
+Shared packages that live in this repo under `packages/` (currently
+`app-baseline-kit`, which ships the `baseline_kit` import) are consumed by
+other repos via an **unpinned** git URL in `pyproject.toml`:
+
+```toml
+"app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+```
+
+That URL resolves to **Workflows `main` HEAD** at install time, which is the
+intended `@main` consumer default. The hazard is the compiled lockfile: by
+default `uv pip compile` freezes that dependency to whatever commit `main`
+pointed at when the lock was generated, e.g.
+
+```
+app-baseline-kit @ git+https://github.com/stranske/Workflows.git@<sha>#subdirectory=packages/app-baseline-kit
+```
+
+CI installs the lock **and** the editable project together
+(`uv pip install -r requirements.lock -e .[app,dev]`), so the same package is
+declared twice — pinned (lock) and unpinned (project). They agree only while
+`main` stays at `<sha>`. The next Workflows `main` advance makes the unpinned
+URL resolve to a different commit, and uv aborts the install:
+
+```
+Requirements contain conflicting URLs for package `app-baseline-kit`
+```
+
+This silently breaks every downstream consumer's CI on an unrelated Workflows
+merge (it broke trip-planner CI after the `py.typed` PR #2204). Refreshing the
+lock fixes it only until the next advance, so it is not a stable answer.
+
+**Convention: exclude monorepo `@main` packages from the lock.** In each
+consuming repo's `pyproject.toml`, add:
+
+```toml
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+```
+
+Then regenerate the lock with the repo's documented `uv pip compile` command.
+The dependency drops out of `requirements.lock` (every other, versioned package
+stays pinned), the editable project install resolves it from `@main`, and there
+is no frozen SHA to keep refreshed — the conflict class is gone permanently. uv
+reads `[tool.uv.pip]` from `pyproject.toml`, so the lock regen, the
+`dependency-refresh.yml` automation, and the lockfile-freshness check all honor
+it consistently with no extra wiring.
+
+Applied to `trip-planner` and `Counter_Risk`; apply the same block whenever a
+new repo adopts `app-baseline-kit` (or any future `packages/` member referenced
+by an unpinned `@main` URL). This is a per-repo `pyproject.toml`/`requirements.lock`
+change, not a synced template file.
+
 ### Manual Sync Trigger
 
 ```bash


### PR DESCRIPTION
## Document the stable fix for the app-baseline-kit lock/pin conflict

Consumers pull `packages/` members (`app-baseline-kit`) via an unpinned `@main` git URL, but `uv pip compile` freezes that to a commit SHA in `requirements.lock`. CI installs the lock + the editable project together, so the package is declared both pinned and unpinned; they agree only until Workflows `main` advances, then uv aborts with `conflicting URLs for package app-baseline-kit` — reddening downstream CI on an unrelated Workflows merge (this broke trip-planner after #2204).

## Change (docs only)

- `docs/ops/CONSUMER_REPO_MAINTENANCE.md`: new "Monorepo Package Dependencies (`app-baseline-kit`)" subsection — the failure mode and the convention: exclude such deps from the lock via `[tool.uv.pip] no-emit-package`. uv reads it from `pyproject.toml`, so lock regen, `dependency-refresh.yml`, and the freshness check all honor it.
- `docs/INTEGRATION_GUIDE.md`: pointer to the above near the `dependency-refresh.yml` row.

Applied in the consumer repos via their own PRs (trip-planner, Counter_Risk).