### PR TITLE
feat(baseline-kit): JSON/API response snapshot helper (api-snapshot modality)

### DIFF
--- a/packages/app-baseline-kit/README.md
+++ b/packages/app-baseline-kit/README.md
@@ -15,7 +15,8 @@ here:
 | `directional` | `evaluate_direction(direction, left, right)` — metamorphic comparisons. Works for both control-vs-variant (temporal) and entity-vs-entity (ordering) framings. |
 | `invariants` | `InvariantResult` + `assert_invariants` — error severity fails, warn severity reports. |
 | `manifest` | `CoverageManifest` — input-parameter → scenario coverage, typo/priority-gap detection, markdown report. |
-| `golden` | `check_metrics(num_regression, metrics)` — golden masters via pytest-regressions, float tolerance, `--force-regen` to re-bless. |
+| `golden` | `check_metrics(num_regression, metrics)` — golden masters of a **flat** scalar-metrics dict via pytest-regressions (`num_regression`, float tolerance, `--force-regen` to re-bless). |
+| `snapshot` | `check_snapshot(data_regression, payload)` — golden masters of **nested JSON** (API responses) via pytest-regressions `data_regression`. No numpy/pandas. Redacts volatile fields + deterministic ordering. See [api-snapshot modality](#api-snapshot-modality). |
 | `catalog` | `load_catalog(path)` — YAML scenario catalog loader. |
 
 ## Proven consumers
@@ -26,6 +27,65 @@ here:
 - **trip-planner** (`tests/baseline/`) — fixture-compute adapter over
   deterministic transport-option evaluation; golden masters per fixture,
   cross-option ordering checks, signal/cost invariants.
+
+## api-snapshot modality
+
+`golden.check_metrics` golden-masters a **flat** `dict[str, float|int]` and uses
+the `num_regression` fixture (which pulls in numpy/pandas). API responses are
+**nested** JSON, so `snapshot.check_snapshot` uses pytest-regressions'
+`data_regression` fixture instead — it snapshots arbitrary YAML-able data and
+needs **no** numpy/pandas, which keeps it cheap for lightweight services (e.g. a
+FastAPI app snapshotting `GET /managers`).
+
+```python
+from baseline_kit import check_snapshot, response_to_payload
+
+def test_list_managers(client, data_regression):     # client = FastAPI/Starlette TestClient
+    resp = client.get("/managers")
+    payload = response_to_payload(resp)               # {"status_code": ..., "json": <body>}
+    check_snapshot(
+        data_regression,
+        payload,
+        exclude=("id", "created_at", "json.meta.request_id"),
+        sort_key={"json.managers": lambda m: m["name"]},
+    )
+```
+
+Public API:
+
+- `normalize_response(payload, *, exclude=(), sort_key=None)` — return a
+  snapshot-stable copy (redaction + deterministic ordering); call it directly to
+  inspect/assert structure without writing a golden.
+- `check_snapshot(data_regression, payload, *, exclude=(), sort_key=None, basename=None)`
+  — normalize `payload` then `data_regression.check(...)`. Re-bless with
+  `--force-regen`.
+- `response_to_payload(response)` — duck-typed adapter for any object with
+  `.json()` + `.status_code` (Starlette/FastAPI `TestClient`, `httpx.Response`);
+  returns `{"status_code": ..., "json": <body>}`. No fastapi/httpx dependency.
+
+### Normalization
+
+Real responses carry non-deterministic fields (autoincrement ids, timestamps,
+UUIDs) and order-unstable record lists. `normalize_response` (applied by
+`check_snapshot`) handles both, in order: **redact** → **sort_key reorder** →
+**recursive key sort**. The input is never mutated; `tuple` is coerced to `list`.
+
+**`exclude` path syntax.** Each entry is a string path; matched nodes are
+dropped:
+
+| Form | Example | Matches |
+|---|---|---|
+| Bare key (no `.`) | `"id"`, `"created_at"` | that key at **any depth** |
+| Dotted path | `"meta.request_id"` | that exact location, **anchored at the root** |
+| Wildcard `*` | `"items.*.updated_at"` | `updated_at` in every element of the top-level `items` list |
+| Wildcard `*` | `"data.*"` | every direct child of `data` |
+
+`*` consumes exactly one level (a list index or a dict key).
+
+**List ordering.** Lists keep their input order by default. For order-unstable
+record lists, pass `sort_key={<path-to-the-list>: <key-fn>}` (path uses the same
+syntax, pointing at the list) — the helper sorts that list by the key function
+before snapshotting. Alternatively, pre-sort in the app/adapter.
 
 ## Install
 

--- a/packages/app-baseline-kit/baseline_kit/__init__.py
+++ b/packages/app-baseline-kit/baseline_kit/__init__.py
@@ -23,6 +23,7 @@ from .directional import DIRECTIONS, evaluate_direction
 from .golden import DEFAULT_TOLERANCE, check_metrics
 from .invariants import InvariantResult, assert_invariants, split_results
 from .manifest import CoverageManifest
+from .snapshot import check_snapshot, normalize_response, response_to_payload
 
 __all__ = [
     "load_catalog",
@@ -34,4 +35,7 @@ __all__ = [
     "assert_invariants",
     "split_results",
     "CoverageManifest",
+    "check_snapshot",
+    "normalize_response",
+    "response_to_payload",
 ]

--- a/packages/app-baseline-kit/baseline_kit/snapshot.py
+++ b/packages/app-baseline-kit/baseline_kit/snapshot.py
@@ -1,0 +1,226 @@
+"""JSON/API response snapshot glue over pytest-regressions ("api-snapshot").
+
+The ``golden`` module golden-masters a *flat* dict of scalar metrics via the
+``num_regression`` fixture (which pulls in numpy/pandas). API responses are
+instead *nested* JSON -- dicts, lists, strings, mixed scalars -- so this module
+uses pytest-regressions' ``data_regression`` fixture, which snapshots arbitrary
+YAML-able data and needs **no** numpy/pandas. That keeps it ideal for
+lightweight services (e.g. a FastAPI app snapshotting ``GET /managers``).
+
+The contract mirrors the rest of the kit: the app hands over a JSON-able payload
+(typically a parsed response body), and the helper produces a stable golden
+snapshot. "Stable" is the hard part for real responses, so normalization does
+two things before the payload reaches disk:
+
+  * **Redaction** -- volatile fields (autoincrement ids, timestamps, UUIDs)
+    named by ``exclude`` are removed recursively, so they never spuriously diff.
+  * **Determinism** -- dict keys are sorted recursively, and lists may be sorted
+    via an optional ``sort_key`` so order-unstable record lists snapshot stably.
+
+Re-bless an intended change with ``--force-regen`` (a pytest-regressions flag).
+
+Exclude path syntax
+-------------------
+``exclude`` is an iterable of string paths. Each path is matched against the
+payload tree; matched nodes are dropped. Segments are split on ``.`` and a
+segment may be the wildcard ``*``:
+
+  * A **bare key** (no ``.``) such as ``"id"`` or ``"created_at"`` matches that
+    key wherever it appears, at *any* depth. This is the common case: drop every
+    ``id``/``updated_at`` in the tree regardless of nesting.
+  * A **dotted path** such as ``"meta.request_id"`` is anchored at the root and
+    matches only that exact location.
+  * ``*`` matches one level of any list index or any dict key. So
+    ``"items.*.updated_at"`` drops ``updated_at`` from every element of the
+    top-level ``items`` list, and ``"data.*"`` drops every direct child of
+    ``data``. ``*`` only ever consumes a single level.
+
+Redaction is applied first, then ``sort_key`` reordering, then recursive key
+sorting -- so sort keys may reference fields that survive redaction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+JSONValue = Any  # a JSON-able value: dict | list | str | int | float | bool | None
+
+# A sort_key maps a path (same syntax as exclude, but pointing at a *list*) to a
+# callable producing an order-stable sort key for that list's elements.
+SortKeys = Mapping[str, Callable[[Any], Any]]
+
+
+def _split(path: str) -> list[str]:
+    """Split a dotted path into its segments."""
+    return path.split(".")
+
+
+def _match_paths(exclude: Iterable[str]) -> tuple[list[list[str]], frozenset[str]]:
+    """Partition exclude paths into anchored dotted paths and bare-key names.
+
+    Returns ``(anchored, bare)`` where ``anchored`` is the list of multi-segment
+    (and wildcard) paths matched from the root, and ``bare`` is the set of
+    single-segment plain keys matched at any depth.
+    """
+    anchored: list[list[str]] = []
+    bare: set[str] = set()
+    for raw in exclude:
+        segs = _split(raw)
+        if len(segs) == 1 and segs[0] != "*":
+            bare.add(segs[0])
+        else:
+            anchored.append(segs)
+    return anchored, frozenset(bare)
+
+
+def _seg_matches(seg: str, key: str) -> bool:
+    """Return True if path segment ``seg`` matches dict/list key token ``key``."""
+    return seg == "*" or seg == key
+
+
+def _redact(node: JSONValue, anchored: list[list[str]], bare: frozenset[str]) -> JSONValue:
+    """Recursively drop nodes matched by ``bare`` keys or ``anchored`` paths.
+
+    ``anchored`` paths are consumed one segment per level of descent; a path is
+    "active" at the current node if its first segment matches the token leading
+    here. Bare keys are matched against dict keys at every depth.
+    """
+    if isinstance(node, Mapping):
+        out: dict[str, JSONValue] = {}
+        for key, value in node.items():
+            # Bare-key redaction: drop this key anywhere it appears.
+            if key in bare:
+                continue
+            # Anchored redaction: an anchored path whose first segment matches
+            # this key and that is fully consumed (length 1) drops the node;
+            # otherwise its tail is carried into the recursion.
+            child_anchored: list[list[str]] = []
+            dropped = False
+            for path in anchored:
+                if _seg_matches(path[0], key):
+                    if len(path) == 1:
+                        dropped = True
+                        break
+                    child_anchored.append(path[1:])
+            if dropped:
+                continue
+            out[key] = _redact(value, child_anchored, bare)
+        return out
+    if isinstance(node, (list, tuple)):
+        out_list: list[JSONValue] = []
+        for index, value in enumerate(node):
+            token = str(index)
+            child_anchored = []
+            dropped = False
+            for path in anchored:
+                if _seg_matches(path[0], token):
+                    if len(path) == 1:
+                        dropped = True
+                        break
+                    child_anchored.append(path[1:])
+            if dropped:
+                continue
+            out_list.append(_redact(value, child_anchored, bare))
+        return out_list
+    return node
+
+
+def _apply_sort_keys(
+    node: JSONValue, sort_keys: list[tuple[list[str], Callable[[Any], Any]]]
+) -> JSONValue:
+    """Recursively reorder lists whose anchored path has a registered sort_key.
+
+    A sort_key whose path is consumed down to an empty tail ``[]`` at a list
+    node sorts that list; non-empty tails are carried into the recursion.
+    """
+    if isinstance(node, Mapping):
+        out: dict[str, JSONValue] = {}
+        for key, value in node.items():
+            child = [(p[1:], fn) for p, fn in sort_keys if p and _seg_matches(p[0], key)]
+            out[key] = _apply_sort_keys(value, child)
+        return out
+    if isinstance(node, list):
+        # A sort_key registered at exactly this list's path has an empty tail.
+        here = [fn for p, fn in sort_keys if not p]
+        descended = []
+        for index, value in enumerate(node):
+            token = str(index)
+            child = [(p[1:], fn) for p, fn in sort_keys if p and _seg_matches(p[0], token)]
+            descended.append(_apply_sort_keys(value, child))
+        if here:
+            descended = sorted(descended, key=here[0])
+        return descended
+    return node
+
+
+def _sort_keys_recursive(node: JSONValue) -> JSONValue:
+    """Recursively sort dict keys so serialized output is order-independent."""
+    if isinstance(node, Mapping):
+        return {k: _sort_keys_recursive(node[k]) for k in sorted(node, key=str)}
+    if isinstance(node, list):
+        return [_sort_keys_recursive(v) for v in node]
+    return node
+
+
+def normalize_response(
+    payload: JSONValue,
+    *,
+    exclude: Iterable[str] = (),
+    sort_key: SortKeys | None = None,
+) -> JSONValue:
+    """Return a normalized, snapshot-stable copy of a JSON-able ``payload``.
+
+    Normalization, in order: redact fields named by ``exclude`` (see module
+    docstring for the path syntax), reorder any lists named in ``sort_key``, then
+    recursively sort all dict keys. The input is not mutated. ``tuple`` is
+    coerced to ``list`` so YAML serialization is stable. Scalars and ``None`` pass
+    through unchanged.
+    """
+    anchored, bare = _match_paths(exclude)
+    redacted = _redact(payload, anchored, bare)
+    if sort_key:
+        prepared = [(_split(path), fn) for path, fn in sort_key.items()]
+        redacted = _apply_sort_keys(redacted, prepared)
+    return _sort_keys_recursive(redacted)
+
+
+def check_snapshot(
+    data_regression,
+    payload: JSONValue,
+    *,
+    exclude: Iterable[str] = (),
+    sort_key: SortKeys | None = None,
+    basename: str | None = None,
+) -> None:
+    """Golden-master a nested JSON ``payload`` via the data_regression fixture.
+
+    ``payload`` is normalized (redaction + deterministic ordering -- see
+    :func:`normalize_response`) and handed to ``data_regression.check``. Pass
+    ``basename`` to control the snapshot filename when a single test produces
+    several snapshots. Re-bless an intended change with ``--force-regen``.
+    """
+    normalized = normalize_response(payload, exclude=exclude, sort_key=sort_key)
+    if basename is None:
+        data_regression.check(normalized)
+    else:
+        data_regression.check(normalized, basename=basename)
+
+
+def response_to_payload(response: Any) -> dict[str, JSONValue]:
+    """Adapt a TestClient/httpx-style response to a snapshot-able payload.
+
+    Duck-typed (no fastapi/httpx dependency): ``response`` only needs a callable
+    ``.json()`` and a ``.status_code`` attribute, as provided by Starlette's /
+    FastAPI's ``TestClient`` and by ``httpx.Response``. Returns
+    ``{"status_code": ..., "json": <parsed body>}`` so the snapshot also pins the
+    HTTP status alongside the body.
+    """
+    return {"status_code": response.status_code, "json": response.json()}
+
+
+__all__ = [
+    "normalize_response",
+    "check_snapshot",
+    "response_to_payload",
+]

--- a/packages/app-baseline-kit/pyproject.toml
+++ b/packages/app-baseline-kit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "app-baseline-kit"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared harness for scenario-driven wiring/sensibility/regression baselines across apps."
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/app-baseline-kit/tests/test_snapshot.py
+++ b/packages/app-baseline-kit/tests/test_snapshot.py
@@ -1,0 +1,158 @@
+"""Tests for baseline_kit.snapshot (api-snapshot modality)."""
+
+from __future__ import annotations
+
+from baseline_kit import check_snapshot, normalize_response, response_to_payload
+
+
+def test_bare_key_redaction_at_any_depth():
+    payload = {
+        "id": 1,
+        "name": "alpha",
+        "owner": {"id": 99, "email": "a@b.c"},
+        "items": [{"id": 7, "v": 1}, {"id": 8, "v": 2}],
+    }
+    out = normalize_response(payload, exclude=("id",))
+    assert "id" not in out
+    assert "id" not in out["owner"]
+    assert all("id" not in item for item in out["items"])
+    # non-excluded fields survive
+    assert out["name"] == "alpha"
+    assert out["owner"]["email"] == "a@b.c"
+    assert [i["v"] for i in out["items"]] == [1, 2]
+
+
+def test_dotted_path_is_anchored_at_root():
+    payload = {
+        "request_id": "top-level-keep-if-not-excluded",
+        "meta": {"request_id": "drop-me"},
+        "nested": {"meta": {"request_id": "survives-anchored"}},
+    }
+    out = normalize_response(payload, exclude=("meta.request_id",))
+    # anchored path only removes meta.request_id at the root
+    assert "request_id" not in out["meta"]
+    assert out["request_id"] == "top-level-keep-if-not-excluded"
+    assert out["nested"]["meta"]["request_id"] == "survives-anchored"
+
+
+def test_wildcard_path_redacts_each_list_element():
+    payload = {
+        "items": [
+            {"name": "a", "updated_at": "2020-01-01"},
+            {"name": "b", "updated_at": "2020-02-02"},
+        ]
+    }
+    out = normalize_response(payload, exclude=("items.*.updated_at",))
+    assert all("updated_at" not in item for item in out["items"])
+    assert [i["name"] for i in out["items"]] == ["a", "b"]
+
+
+def test_wildcard_drops_all_direct_children():
+    payload = {"data": {"a": 1, "b": 2}, "keep": "yes"}
+    out = normalize_response(payload, exclude=("data.*",))
+    assert out["data"] == {}
+    assert out["keep"] == "yes"
+
+
+def test_key_sorting_is_deterministic():
+    a = normalize_response({"b": 1, "a": 2, "c": {"z": 1, "y": 2}})
+    b = normalize_response({"c": {"y": 2, "z": 1}, "a": 2, "b": 1})
+    assert list(a.keys()) == ["a", "b", "c"]
+    assert list(a["c"].keys()) == ["y", "z"]
+    assert a == b
+
+
+def test_list_order_is_preserved_without_sort_key():
+    payload = {"xs": [3, 1, 2]}
+    out = normalize_response(payload)
+    assert out["xs"] == [3, 1, 2]
+
+
+def test_sort_key_reorders_record_list():
+    payload = {
+        "managers": [
+            {"name": "Charlie", "id": 3},
+            {"name": "Alice", "id": 1},
+            {"name": "Bob", "id": 2},
+        ]
+    }
+    out = normalize_response(payload, sort_key={"managers": lambda m: m["name"]})
+    assert [m["name"] for m in out["managers"]] == ["Alice", "Bob", "Charlie"]
+
+
+def test_sort_key_runs_before_redaction_target_is_fine():
+    # sort by a field, then redact a different (volatile) field
+    payload = {
+        "rows": [
+            {"key": "b", "ts": "2020-02-02"},
+            {"key": "a", "ts": "2020-01-01"},
+        ]
+    }
+    out = normalize_response(payload, exclude=("rows.*.ts",), sort_key={"rows": lambda r: r["key"]})
+    assert [r["key"] for r in out["rows"]] == ["a", "b"]
+    assert all("ts" not in r for r in out["rows"])
+
+
+def test_tuple_is_coerced_to_list():
+    out = normalize_response({"xs": (1, 2, 3)})
+    assert out["xs"] == [1, 2, 3]
+    assert isinstance(out["xs"], list)
+
+
+def test_input_is_not_mutated():
+    payload = {"id": 1, "name": "x"}
+    normalize_response(payload, exclude=("id",))
+    assert payload == {"id": 1, "name": "x"}
+
+
+def test_top_level_list_payload():
+    payload = [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]
+    out = normalize_response(payload, exclude=("id",))
+    assert out == [{"v": "a"}, {"v": "b"}]
+
+
+def test_scalar_and_none_pass_through():
+    assert normalize_response(None) is None
+    assert normalize_response(42) == 42
+    assert normalize_response("x") == "x"
+
+
+class _FakeResponse:
+    """Duck-typed stand-in for a TestClient/httpx response."""
+
+    def __init__(self, status_code, body):
+        self.status_code = status_code
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def test_response_to_payload_duck_typed():
+    resp = _FakeResponse(200, {"managers": [{"id": 1, "name": "Alice"}]})
+    payload = response_to_payload(resp)
+    assert payload == {
+        "status_code": 200,
+        "json": {"managers": [{"id": 1, "name": "Alice"}]},
+    }
+
+
+def test_check_snapshot_round_trip(data_regression):
+    # Mirrors a FastAPI GET /managers response with volatile fields redacted.
+    resp = _FakeResponse(
+        200,
+        {
+            "managers": [
+                {"id": 7, "name": "Bravo", "created_at": "2026-05-31T00:00:00Z"},
+                {"id": 3, "name": "Alpha", "created_at": "2026-05-30T00:00:00Z"},
+            ],
+            "meta": {"request_id": "abc-123", "count": 2},
+        },
+    )
+    payload = response_to_payload(resp)
+    check_snapshot(
+        data_regression,
+        payload,
+        exclude=("id", "created_at", "json.meta.request_id"),
+        sort_key={"json.managers": lambda m: m["name"]},
+    )

--- a/packages/app-baseline-kit/tests/test_snapshot/test_check_snapshot_round_trip.yml
+++ b/packages/app-baseline-kit/tests/test_snapshot/test_check_snapshot_round_trip.yml
@@ -1,0 +1,7 @@
+json:
+  managers:
+  - name: Alpha
+  - name: Bravo
+  meta:
+    count: 2
+status_code: 200


### PR DESCRIPTION
## What

Adds an **API/JSON response-snapshot helper** to `packages/app-baseline-kit/`, unblocking the **api-snapshot** testing modality. The next consumer is **Manager-Database** (a FastAPI app), which will snapshot `GET /managers`-style JSON responses against a seeded DB.

`golden.check_metrics` only handles a *flat* `dict[str, float|int]` via the `num_regression` fixture (numpy/pandas). API responses are *nested* JSON, so this uses pytest-regressions' **`data_regression`** fixture instead — arbitrary YAML-able data, **no numpy/pandas** — keeping it cheap for lightweight services.

## New public API (`baseline_kit/snapshot.py`, exported from `__init__`)

- `normalize_response(payload, *, exclude=(), sort_key=None)` — return a snapshot-stable copy of a JSON-able payload (redaction + deterministic ordering); call directly to inspect/assert structure.
- `check_snapshot(data_regression, payload, *, exclude=(), sort_key=None, basename=None)` — normalize then `data_regression.check(...)`; re-bless with `--force-regen`.
- `response_to_payload(response)` — duck-typed adapter for any object with `.json()` + `.status_code` (Starlette/FastAPI `TestClient`, `httpx.Response`) → `{"status_code": ..., "json": <body>}`. No fastapi/httpx dependency.

## Normalization (order: redact → sort_key reorder → recursive key sort)

Input never mutated; `tuple` coerced to `list`.

**`exclude` path syntax** (matched nodes are dropped):

| Form | Example | Matches |
|---|---|---|
| Bare key (no `.`) | `"id"`, `"created_at"` | that key at **any depth** |
| Dotted path | `"meta.request_id"` | that exact location, **anchored at root** |
| Wildcard `*` | `"items.*.updated_at"` | `updated_at` in every element of top-level `items` |
| Wildcard `*` | `"data.*"` | every direct child of `data` |

`*` consumes exactly one level (list index or dict key).

**List ordering:** preserved by default; pass `sort_key={<path-to-list>: <key-fn>}` to sort an order-unstable record list before snapshotting (or pre-sort in the adapter).

## Design decisions to confirm

- **Bare key = match at any depth; dotted path = anchored at root.** A bare `"id"`/`"created_at"` redacts that field wherever it nests (the common timestamp/autoincrement case); a dotted path like `"meta.request_id"` only removes that exact root-anchored location. Flagging in case you'd prefer all paths anchored.
- **Lists keep input order unless `sort_key` is given.** Kept simple/correct; sort is opt-in per-path rather than guessing a key.

## Files
- **Added:** `baseline_kit/snapshot.py`, `tests/test_snapshot.py`, `tests/test_snapshot/test_check_snapshot_round_trip.yml` (golden)
- **Changed:** `baseline_kit/__init__.py` (exports), `pyproject.toml` (0.1.0 → **0.2.0**), `README.md` (api-snapshot section + exclude syntax)

## Tests / lint
- `cd packages/app-baseline-kit && pip install -e . pytest-regressions && pytest -q` → **14 passed** (incl. a `data_regression` round-trip; covers bare/dotted/wildcard redaction, key sorting, list handling, sort_key reorder, no-mutation, top-level list, duck-typed adapter).
- `ruff check` + `ruff format --check` clean (root config: line-length 100, py312).

No new heavy deps (no numpy/pandas/fastapi/httpx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)