### PR TITLE
fix: address Collab Admin sync review blockers

### DIFF
--- a/scripts/langchain/task_decomposer.py
+++ b/scripts/langchain/task_decomposer.py
@@ -345,10 +345,11 @@ def _normalize_subtasks(
     audit still balances.
     """
     parts = _collect_cleaned_parts(sub_tasks)
+    task_parts = [part for part in parts if not is_elision_sentinel(part)]
     # Only expand the mechanical triple when the input was effectively a single
     # task; multiple parts already represent a decomposition and must not be
     # tripled again (that 3xN fan-out is what ballooned issues).
-    allow_triple = len(parts) == 1
+    allow_triple = len(task_parts) == 1
 
     normalized: list[str] = []
     for cleaned in parts:

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -150,15 +150,16 @@ def _validate_consumer(
 
     # Try each declared schema; the document conforms if it matches at least one
     # of the ingested schema shapes (e.g. an evidence-object/v1 object).
+    unknown = [
+        t for t in ingests if t not in INGEST_SCHEMA_FILES and t not in INGEST_CONVENTION_ONLY
+    ]
+    for tok in unknown:
+        report.fail(f"unknown ingest schema token '{tok}'", "ingests")
+
     schema_tokens = [t for t in ingests if t in INGEST_SCHEMA_FILES]
     if not schema_tokens:
         # Only convention-only ingests (e.g. identity-map-conventions): nothing
         # to schema-validate; presence of a declared ingest is enough.
-        unknown = [
-            t for t in ingests if t not in INGEST_SCHEMA_FILES and t not in INGEST_CONVENTION_ONLY
-        ]
-        for tok in unknown:
-            report.fail(f"unknown ingest schema token '{tok}'", "ingests")
         return report
 
     per_schema_errors: dict[str, list[str]] = {}
@@ -325,7 +326,11 @@ def main(argv: list[str] | None = None) -> int:
     if envelope is None:
         report = missing_envelope_report(registry, args.repo, args.run_json)
     else:
-        manifest = _load_json(args.manifest) if args.manifest else None
+        try:
+            manifest = _load_json(args.manifest) if args.manifest else None
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR: cannot load artifact manifest: {exc}", file=sys.stderr)
+            return 2
         report = validate_envelope(
             envelope=envelope,
             schema_dir=args.schema_dir,

--- a/tests/contracts/test_validate_run_contract.py
+++ b/tests/contracts/test_validate_run_contract.py
@@ -135,6 +135,39 @@ def test_cli_exit_codes(tmp_path) -> None:
     )
     assert rc == 0
 
+    # Bad/missing manifests are load errors, not traceback crashes.
+    rc = mod.main(
+        [
+            str(FIXTURES / "valid_run.json"),
+            "--manifest",
+            str(tmp_path / "missing-manifest.json"),
+            "--registry",
+            str(REGISTRY),
+            "--schema-dir",
+            str(SCHEMA_DIR),
+            "--repo",
+            PRODUCER_REPO,
+        ]
+    )
+    assert rc == 2
+
+    bad_manifest = tmp_path / "bad-manifest.json"
+    bad_manifest.write_text("{not json", encoding="utf-8")
+    rc = mod.main(
+        [
+            str(FIXTURES / "valid_run.json"),
+            "--manifest",
+            str(bad_manifest),
+            "--registry",
+            str(REGISTRY),
+            "--schema-dir",
+            str(SCHEMA_DIR),
+            "--repo",
+            PRODUCER_REPO,
+        ]
+    )
+    assert rc == 2
+
 
 def test_missing_envelope_skips_for_candidate_and_planned_and_absent(tmp_path) -> None:
     # A missing run.json must be an opt-in SKIP (exit 0) for a candidate
@@ -196,6 +229,41 @@ def test_missing_envelope_decision_by_status() -> None:
     # Absent repo -> skip.
     report = mod.missing_envelope_report({"participants": []}, "stranske/Y", run_json)
     assert report.skipped and report.conformant
+
+
+def test_consumer_mixed_unknown_ingest_token_fails() -> None:
+    """Unknown ingest tokens are invalid even when another declared token matches."""
+    mod = _import_validator()
+    evidence = {
+        "schema_version": "evidence-object/v1",
+        "evidence_id": "ev-1",
+        "fact_ref": "metric.alpha",
+        "source_id": "source-1",
+        "method": "computed",
+    }
+    registry = {
+        "participants": [
+            {
+                "repo": "stranske/Consumer",
+                "role": "consumer",
+                "status": "conformant",
+                "ingests": ["evidence-object/v1", "typo-object/v1"],
+            }
+        ]
+    }
+
+    report = mod.validate_envelope(
+        envelope=evidence,
+        schema_dir=SCHEMA_DIR,
+        registry=registry,
+        repo="stranske/Consumer",
+        manifest=None,
+    )
+
+    assert not report.conformant
+    assert any(
+        "unknown ingest schema token 'typo-object/v1'" == v.message for v in report.violations
+    )
 
 
 def test_registry_shape_meta() -> None:

--- a/tests/contracts/test_validate_run_contract.py
+++ b/tests/contracts/test_validate_run_contract.py
@@ -262,7 +262,7 @@ def test_consumer_mixed_unknown_ingest_token_fails() -> None:
 
     assert not report.conformant
     assert any(
-        "unknown ingest schema token 'typo-object/v1'" == v.message for v in report.violations
+        v.message == "unknown ingest schema token 'typo-object/v1'" for v in report.violations
     )
 
 

--- a/tests/scripts/test_task_decomposer.py
+++ b/tests/scripts/test_task_decomposer.py
@@ -843,6 +843,21 @@ def test_normalize_subtasks_single_large_task_still_expands_to_triple() -> None:
     assert any(t.lower().startswith("validate focused slice for:") for t in result)
 
 
+def test_normalize_subtasks_ignores_elision_sentinel_when_allowing_triple() -> None:
+    """A carried elision sentinel must not make one real large task look multi-part."""
+    result = task_decomposer.normalize_subtasks(
+        [
+            "Implement end-to-end constraint validation across the entire system",
+            task_decomposer.elision_sentinel(4, kind="sub-tasks"),
+        ],
+        max_subtasks=5,
+    )
+    assert any(t.lower().startswith("define scope for:") for t in result)
+    assert any(t.lower().startswith("implement focused slice for:") for t in result)
+    assert any(t.lower().startswith("validate focused slice for:") for t in result)
+    assert any(task_decomposer.is_elision_sentinel(t) for t in result)
+
+
 def test_normalize_subtasks_is_idempotent_on_capped_output() -> None:
     """Re-normalizing capped output is stable and preserves the sentinel verbatim."""
     parts = [


### PR DESCRIPTION
## Summary
- keep carried elision sentinels from making a single large task skip the intended scope/implement/validate expansion
- fail unknown consumer ingest tokens even when another declared ingest schema matches
- return structured CLI load-error exit code 2 for missing/invalid artifact manifests

## Validation
- uv run black scripts/langchain/task_decomposer.py scripts/validate_run_contract.py tests/scripts/test_task_decomposer.py tests/contracts/test_validate_run_contract.py
- uv run pytest tests/scripts/test_task_decomposer.py tests/contracts/test_validate_run_contract.py
- scripts/sync_templates.sh
- scripts/validate_template_completeness.py

Addresses active source-review feedback from stranske/Collab-Admin#784 and tracker stranske/Workflows#1836.