### PR TITLE
fix: use canonical setup checklist maintenance link

### DIFF
--- a/docs/templates/SETUP_CHECKLIST.md
+++ b/docs/templates/SETUP_CHECKLIST.md
@@ -8,7 +8,7 @@ configuration** and will fail silently if any element is missing.
 > before keepalive started functioning correctly. The lessons learned are encoded
 > in this checklist.
 
-> **See also**: [Consumer Repo Maintenance Guide](../ops/CONSUMER_REPO_MAINTENANCE.md)
+> **See also**: [Consumer Repo Maintenance Guide](https://github.com/stranske/Workflows/blob/main/docs/ops/CONSUMER_REPO_MAINTENANCE.md)
 > for debugging issues across multiple repos.
 
 ---

--- a/templates/consumer-repo/docs/SETUP_CHECKLIST.md
+++ b/templates/consumer-repo/docs/SETUP_CHECKLIST.md
@@ -8,7 +8,7 @@ configuration** and will fail silently if any element is missing.
 > before keepalive started functioning correctly. The lessons learned are encoded
 > in this checklist.
 
-> **See also**: [Consumer Repo Maintenance Guide](../ops/CONSUMER_REPO_MAINTENANCE.md)
+> **See also**: [Consumer Repo Maintenance Guide](https://github.com/stranske/Workflows/blob/main/docs/ops/CONSUMER_REPO_MAINTENANCE.md)
 > for debugging issues across multiple repos.
 
 ---


### PR DESCRIPTION
## Summary
- replace the consumer setup checklist's unsynced relative maintenance-guide link with the canonical Workflows URL
- update both the docs template copy and the consumer template copy so future sync PRs do not break consumer docs-link tests

## Validation
- scripts/validate_template_completeness.py
- rg for the stale ../ops/CONSUMER_REPO_MAINTENANCE.md checklist link returned no matches
- git diff --check