### PR TITLE
fix: unblock sync template gate failures

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -44,7 +44,10 @@ jobs:
       cache: ${{ steps.python_ci_toggles.outputs.cache || 'true' }}
       pytest_markers: >-
         ${{ steps.python_ci_toggles.outputs.pytest_markers || 'not quarantine and not slow' }}
-      workflow_changed: ${{ steps.classify.outputs.is-workflow-change || steps.diff.outputs.workflow_changed || 'false' }}
+      workflow_changed: >-
+        ${{ steps.classify.outputs.is-workflow-change
+        || steps.diff.outputs.workflow_changed
+        || 'false' }}
       is_docs_only: ${{ steps.classify.outputs.is-docs-only || 'false' }}
       is_python_code: ${{ steps.classify.outputs.is-python-code || 'true' }}
       is_workflow_change: ${{ steps.classify.outputs.is-workflow-change || 'false' }}
@@ -198,15 +201,34 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Detect optional script test suites
+        id: script_tests
+        run: |
+          set -euo pipefail
+          if [ -d .github/scripts/__tests__ ]; then
+            echo "node_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "node_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -d tests/workflows/github_scripts ]; then
+            echo "python_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python_tests=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/setup-node@v6
+        if: ${{ steps.script_tests.outputs.node_tests == 'true' }}
         with:
           node-version: '20'
       - run: node --test .github/scripts/__tests__/*.test.js
+        if: ${{ steps.script_tests.outputs.node_tests == 'true' }}
       - uses: actions/setup-python@v6
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
         with:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip pytest requests
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
       - run: pytest tests/workflows/github_scripts
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
 
   issue-consistency:
     name: issue consistency
@@ -229,15 +251,22 @@ jobs:
           git fetch --no-tags upstream \
             "refs/heads/${base_ref}:refs/remotes/upstream/${base_ref}"
       - uses: actions/setup-python@v6
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') != '' }}
         with:
           python-version: '3.12'
       - name: Check issue number consistency
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') != '' }}
         run: python scripts/check_issue_consistency.py
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_REF: ${{ github.base_ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BASE_REMOTE: upstream
+      - name: Skip issue consistency check
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') == '' }}
+        run: >-
+          echo "scripts/check_issue_consistency.py not present;
+          skipping Workflows-specific issue consistency check."
 
   docker-smoke:
     name: docker smoke

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -177,8 +177,9 @@ def _detect_local_project_modules() -> set[str]:
             # Check for packages (directories with __init__.py)
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)
-            # Check for standalone .py modules (but not in root .)
-            elif source_dir != Path(".") and item.suffix == ".py":
+            # Check for standalone .py modules, including root-level modules
+            # such as adapter.py in small consumer repos.
+            elif item.suffix == ".py":
                 detected.add(item.stem)
 
     return detected

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -278,6 +278,7 @@ def missing_envelope_report(registry: dict[str, Any], repo: str, run_json: Path)
     report = Report(repo=repo, role=entry.get("role", "") if entry else "")
     is_active_participant = entry is not None and entry.get("status") in EMITTING_STATUSES
     if is_active_participant:
+        assert entry is not None
         report.fail(
             f"{repo} is an active backplane participant "
             f"(role={entry.get('role')!r}, status={entry.get('status')!r}) "

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -209,15 +209,34 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Detect optional script test suites
+        id: script_tests
+        run: |
+          set -euo pipefail
+          if [ -d .github/scripts/__tests__ ]; then
+            echo "node_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "node_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -d tests/workflows/github_scripts ]; then
+            echo "python_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python_tests=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: ${{ steps.script_tests.outputs.node_tests == 'true' }}
         with:
           node-version: '20'
       - run: node --test .github/scripts/__tests__/*.test.js
+        if: ${{ steps.script_tests.outputs.node_tests == 'true' }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
         with:
           python-version: '3.12'
       - run: python -m pip install --upgrade pip pytest requests
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
       - run: pytest tests/workflows/github_scripts
+        if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
 
   issue-consistency:
     name: issue consistency
@@ -240,15 +259,22 @@ jobs:
           git fetch --no-tags upstream \
             "refs/heads/${base_ref}:refs/remotes/upstream/${base_ref}"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') != '' }}
         with:
           python-version: '3.12'
       - name: Check issue number consistency
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') != '' }}
         run: python scripts/check_issue_consistency.py
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_REF: ${{ github.base_ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BASE_REMOTE: upstream
+      - name: Skip issue consistency check
+        if: ${{ hashFiles('scripts/check_issue_consistency.py') == '' }}
+        run: >-
+          echo "scripts/check_issue_consistency.py not present;
+          skipping Workflows-specific issue consistency check."
 
   docker-smoke:
     name: docker smoke

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -177,8 +177,9 @@ def _detect_local_project_modules() -> set[str]:
             # Check for packages (directories with __init__.py)
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)
-            # Check for standalone .py modules (but not in root .)
-            elif source_dir != Path(".") and item.suffix == ".py":
+            # Check for standalone .py modules, including root-level modules
+            # such as adapter.py in small consumer repos.
+            elif item.suffix == ".py":
                 detected.add(item.stem)
 
     return detected

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -39,7 +39,7 @@ def test_detect_local_project_modules_finds_packages_and_modules(
     assert "tool" in detected
     assert "pkg" in detected
     assert "rootpkg" in detected
-    assert "root_module" not in detected
+    assert "root_module" in detected
 
 
 def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make Gate script-test and issue-consistency jobs skip cleanly when consumer repos lack Workflows-only helper files
- treat root-level consumer modules as first-party in sync_test_dependencies
- narrow validate_run_contract active-participant typing for mypy

## Validation
- python scripts/validate_workflow_yaml.py .github/workflows/pr-00-gate.yml templates/consumer-repo/.github/workflows/pr-00-gate.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py scripts/validate_run_contract.py
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/contracts/test_validate_run_contract.py tests/workflows/test_workflow_autofix_guard.py -q
- git diff --check
- scripts/sync_templates.sh