### PR TITLE
fix: drop placeholder checklist rows

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -877,12 +877,18 @@ def _strip_checkbox(line: str, list_match: re.Match[str] | None = None) -> str:
 
 
 def _is_placeholder_checklist_text(text: str) -> bool:
-    normalized = text.strip().strip("_").strip()
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
     return normalized in {
         "",
         "---",
         "Not provided.",
-    } or normalized.startswith("Filed from ")
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )
 
 
 def _parse_checklist(lines: list[str]) -> list[str]:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -876,6 +876,15 @@ def _strip_checkbox(line: str, list_match: re.Match[str] | None = None) -> str:
     return content
 
 
+def _is_placeholder_checklist_text(text: str) -> bool:
+    normalized = text.strip().strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or normalized.startswith("Filed from ")
+
+
 def _parse_checklist(lines: list[str]) -> list[str]:
     """Extract checklist items from lines, handling both checkbox and plain list formats."""
     items: list[str] = []
@@ -887,7 +896,7 @@ def _parse_checklist(lines: list[str]) -> list[str]:
         checkbox_match = CHECKBOX_REGEX.match(stripped)
         if checkbox_match:
             value = checkbox_match.group(2).strip()
-            if value and len(value) > 3:
+            if value and len(value) > 3 and not _is_placeholder_checklist_text(value):
                 items.append(value)
             continue
         # Then try list item (with optional checkbox inside)
@@ -895,7 +904,7 @@ def _parse_checklist(lines: list[str]) -> list[str]:
         if list_match:
             # Pass the match to avoid re-matching in _strip_checkbox
             value = _strip_checkbox(line, list_match)
-            if value and len(value) > 3:
+            if value and len(value) > 3 and not _is_placeholder_checklist_text(value):
                 items.append(value)
     return items
 

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -241,6 +241,15 @@ def _normalize_non_action_lines(lines: list[str]) -> list[str]:
     return cleaned
 
 
+def _is_placeholder_checklist_text(text: str) -> bool:
+    normalized = text.strip().strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or normalized.startswith("Filed from ")
+
+
 def _normalize_checklist_lines(lines: list[str]) -> list[str]:
     cleaned: list[str] = []
     in_fence = False
@@ -262,12 +271,15 @@ def _normalize_checklist_lines(lines: list[str]) -> list[str]:
             if checkbox:
                 mark = "x" if checkbox.group(1).lower() == "x" else " "
                 text = checkbox.group(2).strip()
-                if text:
+                if text and not _is_placeholder_checklist_text(text):
                     cleaned.append(f"{indent}- [{mark}] {text}")
                 continue
-            cleaned.append(f"{indent}- [ ] {remainder.strip()}")
+            text = remainder.strip()
+            if not _is_placeholder_checklist_text(text):
+                cleaned.append(f"{indent}- [ ] {text}")
         else:
-            cleaned.append(f"- [ ] {stripped}")
+            if not _is_placeholder_checklist_text(stripped):
+                cleaned.append(f"- [ ] {stripped}")
     return cleaned
 
 

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -242,12 +242,18 @@ def _normalize_non_action_lines(lines: list[str]) -> list[str]:
 
 
 def _is_placeholder_checklist_text(text: str) -> bool:
-    normalized = text.strip().strip("_").strip()
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
     return normalized in {
         "",
         "---",
         "Not provided.",
-    } or normalized.startswith("Filed from ")
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )
 
 
 def _normalize_checklist_lines(lines: list[str]) -> list[str]:

--- a/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
+++ b/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
@@ -290,6 +290,21 @@ def _truncate_task_to_budget(task: str, budget: int) -> str:
     return best or suffix.strip()
 
 
+def _is_placeholder_checklist_text(text: str) -> bool:
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )
+
+
 @dataclass
 class VerificationData:
     """Data extracted from verification comments."""
@@ -502,14 +517,22 @@ def extract_original_issue_data(
     checkbox_pattern = re.compile(r"^\s*[-*+]\s*\[([ xX])\]\s*(.+)$", re.MULTILINE)
     for match in checkbox_pattern.finditer(task_section):
         task_text = match.group(2).strip()
-        if task_text and len(task_text) > 3:  # Skip tiny fragments
+        if (
+            task_text
+            and len(task_text) > 3
+            and not _is_placeholder_checklist_text(task_text)
+        ):  # Skip tiny fragments
             data.tasks.append(task_text)
 
     # Extract acceptance criteria
     ac_section = sections.get("acceptance criteria", sections.get("acceptance", ""))
     for match in checkbox_pattern.finditer(ac_section):
         criterion = match.group(2).strip()
-        if criterion and len(criterion) > 3:
+        if (
+            criterion
+            and len(criterion) > 3
+            and not _is_placeholder_checklist_text(criterion)
+        ):
             data.acceptance_criteria.append(criterion)
 
     return data

--- a/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
+++ b/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
@@ -518,9 +518,7 @@ def extract_original_issue_data(
     for match in checkbox_pattern.finditer(task_section):
         task_text = match.group(2).strip()
         if (
-            task_text
-            and len(task_text) > 3
-            and not _is_placeholder_checklist_text(task_text)
+            task_text and len(task_text) > 3 and not _is_placeholder_checklist_text(task_text)
         ):  # Skip tiny fragments
             data.tasks.append(task_text)
 
@@ -528,11 +526,7 @@ def extract_original_issue_data(
     ac_section = sections.get("acceptance criteria", sections.get("acceptance", ""))
     for match in checkbox_pattern.finditer(ac_section):
         criterion = match.group(2).strip()
-        if (
-            criterion
-            and len(criterion) > 3
-            and not _is_placeholder_checklist_text(criterion)
-        ):
+        if criterion and len(criterion) > 3 and not _is_placeholder_checklist_text(criterion):
             data.acceptance_criteria.append(criterion)
 
     return data

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -183,6 +183,21 @@ def _normalize_non_action_lines(lines: list[str]) -> list[str]:
     return cleaned
 
 
+def _is_placeholder_checklist_text(text: str) -> bool:
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )
+
+
 def _normalize_checklist_lines(lines: list[str]) -> list[str]:
     cleaned: list[str] = []
     in_fence = False
@@ -204,12 +219,15 @@ def _normalize_checklist_lines(lines: list[str]) -> list[str]:
             if checkbox:
                 mark = "x" if checkbox.group(1).lower() == "x" else " "
                 text = checkbox.group(2).strip()
-                if text:
+                if text and not _is_placeholder_checklist_text(text):
                     cleaned.append(f"{indent}- [{mark}] {text}")
                 continue
-            cleaned.append(f"{indent}- [ ] {remainder.strip()}")
+            text = remainder.strip()
+            if not _is_placeholder_checklist_text(text):
+                cleaned.append(f"{indent}- [ ] {text}")
         else:
-            cleaned.append(f"- [ ] {stripped}")
+            if not _is_placeholder_checklist_text(stripped):
+                cleaned.append(f"- [ ] {stripped}")
     return cleaned
 
 

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -121,11 +121,15 @@ def test_normalize_checklist_lines_drops_placeholder_checkboxes() -> None:
         "- [ ] _Filed from the 2026-05-29 design-vs-implementation + blueprint review (upgraded issue set)._",
         "- [ ] _Not provided._",
         "- [ ] Add focused regression test",
+        "- [ ] Filed from intake form preserves source metadata",
     ]
 
     normalized = issue_formatter._normalize_checklist_lines(lines)
 
-    assert normalized == ["- [ ] Add focused regression test"]
+    assert normalized == [
+        "- [ ] Add focused regression test",
+        "- [ ] Filed from intake form preserves source metadata",
+    ]
 
 
 def test_format_issue_fallback_preserves_raw_issue() -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -115,6 +115,19 @@ def test_format_issue_fallback_uses_placeholders() -> None:
     assert acceptance == "- [ ] _Not provided._"
 
 
+def test_normalize_checklist_lines_drops_placeholder_checkboxes() -> None:
+    lines = [
+        "- [ ] ---",
+        "- [ ] _Filed from the 2026-05-29 design-vs-implementation + blueprint review (upgraded issue set)._",
+        "- [ ] _Not provided._",
+        "- [ ] Add focused regression test",
+    ]
+
+    normalized = issue_formatter._normalize_checklist_lines(lines)
+
+    assert normalized == ["- [ ] Add focused regression test"]
+
+
 def test_format_issue_fallback_preserves_raw_issue() -> None:
     raw = "Raw issue text\n\n- bullet"
     result = issue_formatter.format_issue_body(raw, use_llm=False)

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -102,9 +102,13 @@ def test_parse_checklist_drops_placeholder_checkboxes() -> None:
         "- [ ] _Filed from the 2026-05-29 design-vs-implementation + blueprint review (upgraded issue set)._",
         "- [ ] _Not provided._",
         "- [ ] Add focused regression test",
+        "- [ ] Filed from intake form preserves source metadata",
     ]
 
-    assert followup_issue_generator._parse_checklist(lines) == ["Add focused regression test"]
+    assert followup_issue_generator._parse_checklist(lines) == [
+        "Add focused regression test",
+        "Filed from intake form preserves source metadata",
+    ]
 
 
 def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -97,6 +97,16 @@ def test_budget_followup_tasks_omits_task_when_suffix_exceeds_budget(
     assert selected == []
 
 
+def test_parse_checklist_drops_placeholder_checkboxes() -> None:
+    lines = [
+        "- [ ] _Filed from the 2026-05-29 design-vs-implementation + blueprint review (upgraded issue set)._",
+        "- [ ] _Not provided._",
+        "- [ ] Add focused regression test",
+    ]
+
+    assert followup_issue_generator._parse_checklist(lines) == ["Add focused regression test"]
+
+
 def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:
     original_issue = OriginalIssueData(
         title="Mixed verifier follow-up",


### PR DESCRIPTION
## Summary
- drop placeholder checklist rows such as `- [ ] ---`, `_Not provided._`, and `_Filed from ..._` in Workflows-owned LangChain helpers
- add focused Workflows regression coverage matching the failing consumer sync tests

## Validation
- python -m pytest tests/scripts/test_issue_formatter.py tests/test_followup_issue_generator.py tests/contracts/test_validate_run_contract.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check