### PR TITLE
fix: centralize checklist placeholder handling

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -504,6 +504,9 @@ scripts:
   - source: scripts/langchain/verifier_config.py
     description: "Shared verifier prompt budgets, schema-repair policy, and terminal artifact validation"
 
+  - source: scripts/langchain/checklist_utils.py
+    description: "Shared checklist parsing helpers for issue and follow-up generation"
+
   - source: scripts/langchain/issue_formatter.py
     description: "Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format"
 

--- a/scripts/langchain/checklist_utils.py
+++ b/scripts/langchain/checklist_utils.py
@@ -1,0 +1,20 @@
+"""Shared helpers for checklist parsing and normalization."""
+
+from __future__ import annotations
+
+
+def is_placeholder_checklist_text(text: str) -> bool:
+    """Return true for standard placeholder checklist text."""
+
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -33,9 +33,13 @@ from pathlib import Path
 from typing import Any
 
 from scripts.langchain import verdict_policy
-from scripts.langchain.checklist_utils import is_placeholder_checklist_text
 from scripts.langchain.issue_pr_context import estimate_tokens
 from scripts.langchain.verifier_config import EVAL_FOLLOW_UP_BUDGET_TOKENS
+
+try:
+    from scripts.langchain.checklist_utils import is_placeholder_checklist_text
+except ImportError:  # pragma: no cover - fallback for direct invocation
+    from checklist_utils import is_placeholder_checklist_text
 
 try:
     from scripts.langchain.injection_guard import check_prompt_injection

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.langchain import verdict_policy
+from scripts.langchain.checklist_utils import is_placeholder_checklist_text
 from scripts.langchain.issue_pr_context import estimate_tokens
 from scripts.langchain.verifier_config import EVAL_FOLLOW_UP_BUDGET_TOKENS
 
@@ -876,21 +877,6 @@ def _strip_checkbox(line: str, list_match: re.Match[str] | None = None) -> str:
     return content
 
 
-def _is_placeholder_checklist_text(text: str) -> bool:
-    stripped = text.strip()
-    normalized = stripped.strip("_").strip()
-    return normalized in {
-        "",
-        "---",
-        "Not provided.",
-    } or (
-        stripped.startswith("_")
-        and stripped.endswith("_")
-        and normalized.startswith("Filed from ")
-        and " review" in normalized
-    )
-
-
 def _parse_checklist(lines: list[str]) -> list[str]:
     """Extract checklist items from lines, handling both checkbox and plain list formats."""
     items: list[str] = []
@@ -902,7 +888,7 @@ def _parse_checklist(lines: list[str]) -> list[str]:
         checkbox_match = CHECKBOX_REGEX.match(stripped)
         if checkbox_match:
             value = checkbox_match.group(2).strip()
-            if value and len(value) > 3 and not _is_placeholder_checklist_text(value):
+            if value and len(value) > 3 and not is_placeholder_checklist_text(value):
                 items.append(value)
             continue
         # Then try list item (with optional checkbox inside)
@@ -910,7 +896,7 @@ def _parse_checklist(lines: list[str]) -> list[str]:
         if list_match:
             # Pass the match to avoid re-matching in _strip_checkbox
             value = _strip_checkbox(line, list_match)
-            if value and len(value) > 3 and not _is_placeholder_checklist_text(value):
+            if value and len(value) > 3 and not is_placeholder_checklist_text(value):
                 items.append(value)
     return items
 
@@ -1638,6 +1624,8 @@ def _generate_without_llm(
         original_issue,
         verification_data,
     )
+    if not acceptance_criteria:
+        acceptance_criteria = [_fallback_followup_acceptance_criterion(pr_number)]
 
     # Build body
     body_parts = [
@@ -1990,6 +1978,13 @@ def _select_followup_acceptance_criteria(
     if filtered:
         return filtered[:limit]
     return criteria[:limit]
+
+
+def _fallback_followup_acceptance_criterion(pr_number: int) -> str:
+    return (
+        f"Verification concerns from PR #{pr_number} are addressed and follow-up "
+        "verification passes."
+    )
 
 
 def main() -> int:

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.langchain.checklist_utils import is_placeholder_checklist_text
     from scripts.langchain.injection_guard import check_prompt_injection
     from scripts.langchain.issue_pr_context import (
         ContextOptions,
@@ -28,6 +29,7 @@ try:
     )
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ImportError:  # pragma: no cover - fallback for direct invocation
+    from checklist_utils import is_placeholder_checklist_text
     from injection_guard import check_prompt_injection
     from issue_pr_context import (
         ContextOptions,
@@ -241,21 +243,6 @@ def _normalize_non_action_lines(lines: list[str]) -> list[str]:
     return cleaned
 
 
-def _is_placeholder_checklist_text(text: str) -> bool:
-    stripped = text.strip()
-    normalized = stripped.strip("_").strip()
-    return normalized in {
-        "",
-        "---",
-        "Not provided.",
-    } or (
-        stripped.startswith("_")
-        and stripped.endswith("_")
-        and normalized.startswith("Filed from ")
-        and " review" in normalized
-    )
-
-
 def _normalize_checklist_lines(lines: list[str]) -> list[str]:
     cleaned: list[str] = []
     in_fence = False
@@ -277,14 +264,14 @@ def _normalize_checklist_lines(lines: list[str]) -> list[str]:
             if checkbox:
                 mark = "x" if checkbox.group(1).lower() == "x" else " "
                 text = checkbox.group(2).strip()
-                if text and not _is_placeholder_checklist_text(text):
+                if text and not is_placeholder_checklist_text(text):
                     cleaned.append(f"{indent}- [{mark}] {text}")
                 continue
             text = remainder.strip()
-            if not _is_placeholder_checklist_text(text):
+            if not is_placeholder_checklist_text(text):
                 cleaned.append(f"{indent}- [ ] {text}")
         else:
-            if not _is_placeholder_checklist_text(stripped):
+            if not is_placeholder_checklist_text(stripped):
                 cleaned.append(f"- [ ] {stripped}")
     return cleaned
 

--- a/templates/consumer-repo/scripts/langchain/checklist_utils.py
+++ b/templates/consumer-repo/scripts/langchain/checklist_utils.py
@@ -1,0 +1,20 @@
+"""Shared helpers for checklist parsing and normalization."""
+
+from __future__ import annotations
+
+
+def is_placeholder_checklist_text(text: str) -> bool:
+    """Return true for standard placeholder checklist text."""
+
+    stripped = text.strip()
+    normalized = stripped.strip("_").strip()
+    return normalized in {
+        "",
+        "---",
+        "Not provided.",
+    } or (
+        stripped.startswith("_")
+        and stripped.endswith("_")
+        and normalized.startswith("Filed from ")
+        and " review" in normalized
+    )

--- a/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
+++ b/templates/consumer-repo/scripts/langchain/followup_issue_generator.py
@@ -32,6 +32,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+try:
+    from scripts.langchain.checklist_utils import is_placeholder_checklist_text
+except ImportError:  # pragma: no cover - fallback for direct invocation
+    from checklist_utils import is_placeholder_checklist_text
+
 DEFAULT_TOKEN_BUDGET = 4000
 EVAL_FOLLOW_UP_BUDGET_TOKENS = DEFAULT_TOKEN_BUDGET
 TOKEN_CHARS = 4
@@ -290,21 +295,6 @@ def _truncate_task_to_budget(task: str, budget: int) -> str:
     return best or suffix.strip()
 
 
-def _is_placeholder_checklist_text(text: str) -> bool:
-    stripped = text.strip()
-    normalized = stripped.strip("_").strip()
-    return normalized in {
-        "",
-        "---",
-        "Not provided.",
-    } or (
-        stripped.startswith("_")
-        and stripped.endswith("_")
-        and normalized.startswith("Filed from ")
-        and " review" in normalized
-    )
-
-
 @dataclass
 class VerificationData:
     """Data extracted from verification comments."""
@@ -518,7 +508,7 @@ def extract_original_issue_data(
     for match in checkbox_pattern.finditer(task_section):
         task_text = match.group(2).strip()
         if (
-            task_text and len(task_text) > 3 and not _is_placeholder_checklist_text(task_text)
+            task_text and len(task_text) > 3 and not is_placeholder_checklist_text(task_text)
         ):  # Skip tiny fragments
             data.tasks.append(task_text)
 
@@ -526,7 +516,7 @@ def extract_original_issue_data(
     ac_section = sections.get("acceptance criteria", sections.get("acceptance", ""))
     for match in checkbox_pattern.finditer(ac_section):
         criterion = match.group(2).strip()
-        if criterion and len(criterion) > 3 and not _is_placeholder_checklist_text(criterion):
+        if criterion and len(criterion) > 3 and not is_placeholder_checklist_text(criterion):
             data.acceptance_criteria.append(criterion)
 
     return data
@@ -828,6 +818,8 @@ def _generate_without_llm(
 
     # Use original unmet acceptance criteria
     acceptance_criteria = original_issue.acceptance_criteria[:10]
+    if not acceptance_criteria:
+        acceptance_criteria = [_fallback_followup_acceptance_criterion(pr_number)]
 
     # Build body
     body_parts = [
@@ -914,6 +906,13 @@ def _generate_without_llm(
         title=title,
         body="\n".join(body_parts),
         labels=["follow-up", "agents:optimize"],
+    )
+
+
+def _fallback_followup_acceptance_criterion(pr_number: int) -> str:
+    return (
+        f"Verification concerns from PR #{pr_number} are addressed and follow-up "
+        "verification passes."
     )
 
 

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -18,10 +18,12 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.langchain.checklist_utils import is_placeholder_checklist_text
     from scripts.langchain.injection_guard import check_prompt_injection
     from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ImportError:  # pragma: no cover - fallback for direct invocation
+    from checklist_utils import is_placeholder_checklist_text
     from injection_guard import check_prompt_injection
     from issue_pr_context import ContextOptions, build_issue_context
     from trace_utils import TraceInfo, invoke_with_trace
@@ -183,21 +185,6 @@ def _normalize_non_action_lines(lines: list[str]) -> list[str]:
     return cleaned
 
 
-def _is_placeholder_checklist_text(text: str) -> bool:
-    stripped = text.strip()
-    normalized = stripped.strip("_").strip()
-    return normalized in {
-        "",
-        "---",
-        "Not provided.",
-    } or (
-        stripped.startswith("_")
-        and stripped.endswith("_")
-        and normalized.startswith("Filed from ")
-        and " review" in normalized
-    )
-
-
 def _normalize_checklist_lines(lines: list[str]) -> list[str]:
     cleaned: list[str] = []
     in_fence = False
@@ -219,14 +206,14 @@ def _normalize_checklist_lines(lines: list[str]) -> list[str]:
             if checkbox:
                 mark = "x" if checkbox.group(1).lower() == "x" else " "
                 text = checkbox.group(2).strip()
-                if text and not _is_placeholder_checklist_text(text):
+                if text and not is_placeholder_checklist_text(text):
                     cleaned.append(f"{indent}- [{mark}] {text}")
                 continue
             text = remainder.strip()
-            if not _is_placeholder_checklist_text(text):
+            if not is_placeholder_checklist_text(text):
                 cleaned.append(f"{indent}- [ ] {text}")
         else:
-            if not _is_placeholder_checklist_text(stripped):
+            if not is_placeholder_checklist_text(stripped):
                 cleaned.append(f"- [ ] {stripped}")
     return cleaned
 

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -111,6 +111,37 @@ def test_parse_checklist_drops_placeholder_checkboxes() -> None:
     ]
 
 
+def test_generate_without_llm_adds_fallback_acceptance_when_placeholders_filter_out() -> None:
+    original_issue = extract_original_issue_data("""
+## Why
+Verifier follow-up needed.
+
+## Tasks
+- [ ] Fix the reported issue
+
+## Acceptance Criteria
+- [ ] _Not provided._
+""")
+    verification_data = VerificationData(
+        provider_verdicts={"openai": {"verdict": "CONCERNS", "confidence": 80}},
+        concerns=["Missing regression coverage"],
+    )
+
+    followup = generate_followup_issue(
+        verification_data=verification_data,
+        original_issue=original_issue,
+        pr_number=321,
+        use_llm=False,
+    )
+
+    assert original_issue.acceptance_criteria == []
+    assert "- [ ] _Not provided._" not in followup.body
+    assert (
+        "- [ ] Verification concerns from PR #321 are addressed and follow-up "
+        "verification passes."
+    ) in followup.body
+
+
 def test_select_followup_acceptance_criteria_keeps_workflow_items_for_workflow_feedback() -> None:
     original_issue = OriginalIssueData(
         title="Mixed verifier follow-up",


### PR DESCRIPTION
## Summary
- centralize placeholder checklist detection in a shared LangChain helper
- keep source and consumer-template issue/follow-up scripts aligned
- add a no-LLM fallback acceptance criterion when placeholders filter out all original criteria

## Validation
- python -m pytest tests/scripts/test_issue_formatter.py tests/test_followup_issue_generator.py -q
- python -m py_compile scripts/langchain/checklist_utils.py scripts/langchain/issue_formatter.py scripts/langchain/followup_issue_generator.py templates/consumer-repo/scripts/langchain/checklist_utils.py templates/consumer-repo/scripts/langchain/issue_formatter.py templates/consumer-repo/scripts/langchain/followup_issue_generator.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh && python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py && git diff --check