### PR TITLE
fix: ignore test helper modules in dependency sync

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -182,6 +182,15 @@ def _detect_local_project_modules() -> set[str]:
             elif item.suffix == ".py":
                 detected.add(item.stem)
 
+    tests_dir = Path("tests")
+    if tests_dir.is_dir():
+        for item in tests_dir.rglob("*.py"):
+            if any(part.startswith(".") or part == "__pycache__" for part in item.parts):
+                continue
+            if item.name.startswith("test_") or item.name in {"__init__.py", "conftest.py"}:
+                continue
+            detected.add(item.stem)
+
     return detected
 
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -182,6 +182,15 @@ def _detect_local_project_modules() -> set[str]:
             elif item.suffix == ".py":
                 detected.add(item.stem)
 
+    tests_dir = Path("tests")
+    if tests_dir.is_dir():
+        for item in tests_dir.rglob("*.py"):
+            if any(part.startswith(".") or part == "__pycache__" for part in item.parts):
+                continue
+            if item.name.startswith("test_") or item.name in {"__init__.py", "conftest.py"}:
+                continue
+            detected.add(item.stem)
+
     return detected
 
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -218,6 +218,36 @@ def test_find_missing_dependencies_ignores_local_and_mapped_modules(
     assert std.find_missing_dependencies() == {"pandas"}
 
 
+def test_find_missing_dependencies_ignores_test_helper_modules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[project.optional-dependencies]",
+                "dev = [",
+                '  "requests",',
+                "]",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    helper_dir = tmp_path / "tests" / "baseline"
+    helper_dir.mkdir(parents=True)
+    (helper_dir / "adapter.py").write_text("value = 1\n", encoding="utf-8")
+    (helper_dir / "test_adapter.py").write_text(
+        "import adapter\nimport requests\nimport pandas\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std.find_missing_dependencies() == {"pandas"}
+
+
 def test_find_missing_dependencies_ignores_reviewed_stdlib_and_maps_jwt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat non-test Python helper modules under tests/** as first-party in scripts/sync_test_dependencies.py.
- Mirror the change into the consumer template copy.
- Add coverage for imports like tests/baseline/adapter.py so sync PRs do not require fake adapter dependencies.

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- git diff --check

Campaign context: unblocks stranske/Inv-Man-Intake#505 after the Workflows#2220 replacement sync wave.