### PR TITLE
fix: refine test helper dependency detection

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -184,12 +184,16 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
-        for item in tests_dir.rglob("*.py"):
-            if any(part.startswith(".") or part == "__pycache__" for part in item.parts):
+        for item in tests_dir.iterdir():
+            if item.name.startswith(".") or item.name == "__pycache__":
                 continue
-            if item.name.startswith("test_") or item.name in {"__init__.py", "conftest.py"}:
-                continue
-            detected.add(item.stem)
+            if item.is_dir() and (item / "__init__.py").exists():
+                detected.add(item.name)
+            elif item.suffix == ".py":
+                if item.name == "conftest.py":
+                    detected.add("conftest")
+                elif not item.name.startswith("test_") and item.name != "__init__.py":
+                    detected.add(item.stem)
 
     return detected
 
@@ -290,7 +294,7 @@ def extract_imports_from_file(file_path: Path) -> set[str]:
             for alias in node.names:
                 module = alias.name.split(".")[0]
                 imports.add(module)
-        elif isinstance(node, ast.ImportFrom) and node.module:
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             module = node.module.split(".")[0]
             imports.add(module)
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -184,12 +184,16 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
-        for item in tests_dir.rglob("*.py"):
-            if any(part.startswith(".") or part == "__pycache__" for part in item.parts):
+        for item in tests_dir.iterdir():
+            if item.name.startswith(".") or item.name == "__pycache__":
                 continue
-            if item.name.startswith("test_") or item.name in {"__init__.py", "conftest.py"}:
-                continue
-            detected.add(item.stem)
+            if item.is_dir() and (item / "__init__.py").exists():
+                detected.add(item.name)
+            elif item.suffix == ".py":
+                if item.name == "conftest.py":
+                    detected.add("conftest")
+                elif not item.name.startswith("test_") and item.name != "__init__.py":
+                    detected.add(item.stem)
 
     return detected
 
@@ -290,7 +294,7 @@ def extract_imports_from_file(file_path: Path) -> set[str]:
             for alias in node.names:
                 module = alias.name.split(".")[0]
                 imports.add(module)
-        elif isinstance(node, ast.ImportFrom) and node.module:
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             module = node.module.split(".")[0]
             imports.add(module)
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -42,6 +42,28 @@ def test_detect_local_project_modules_finds_packages_and_modules(
     assert "root_module" in detected
 
 
+def test_detect_local_project_modules_finds_top_level_test_helpers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "conftest.py").write_text("FIXTURE = object()\n", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tests_dir / "test_helpers.py").write_text("import pandas\n", encoding="utf-8")
+    (tests_dir / "support").mkdir()
+    (tests_dir / "support" / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "baseline").mkdir()
+    (tests_dir / "baseline" / "adapter.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    detected = std._detect_local_project_modules()
+
+    assert {"conftest", "helpers", "support"}.issubset(detected)
+    assert "test_helpers" not in detected
+    assert "adapter" not in detected
+
+
 def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(
@@ -61,6 +83,25 @@ def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> N
     imports = std.extract_imports_from_file(sample)
 
     assert imports == {"os", "requests", "yaml", "pkg"}
+
+
+def test_extract_imports_from_file_ignores_relative_import_modules(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "\n".join(
+            [
+                "from .adapter import Adapter",
+                "from ..conftest import fixture",
+                "from requests import Session",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    imports = std.extract_imports_from_file(sample)
+
+    assert imports == {"requests"}
 
 
 def test_extract_imports_from_file_handles_parse_errors(tmp_path: Path) -> None:
@@ -237,8 +278,9 @@ def test_find_missing_dependencies_ignores_test_helper_modules(
     helper_dir = tmp_path / "tests" / "baseline"
     helper_dir.mkdir(parents=True)
     (helper_dir / "adapter.py").write_text("value = 1\n", encoding="utf-8")
+    (helper_dir / "conftest.py").write_text("fixture_value = 1\n", encoding="utf-8")
     (helper_dir / "test_adapter.py").write_text(
-        "import adapter\nimport requests\nimport pandas\n",
+        "from .adapter import value\nfrom .conftest import fixture_value\nimport requests\nimport pandas\n",
         encoding="utf-8",
     )
 
@@ -246,6 +288,36 @@ def test_find_missing_dependencies_ignores_test_helper_modules(
     monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
 
     assert std.find_missing_dependencies() == {"pandas"}
+
+
+def test_find_missing_dependencies_keeps_nested_helper_stems_available_for_packages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[project.optional-dependencies]",
+                "dev = [",
+                '  "requests",',
+                "]",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    helper_dir = tmp_path / "tests" / "baseline"
+    helper_dir.mkdir(parents=True)
+    (helper_dir / "adapter.py").write_text("value = 1\n", encoding="utf-8")
+    (helper_dir / "test_adapter.py").write_text(
+        "import adapter\nimport requests\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std.find_missing_dependencies() == {"adapter"}
 
 
 def test_find_missing_dependencies_ignores_reviewed_stdlib_and_maps_jwt(


### PR DESCRIPTION
## Summary
- ignore relative import targets when collecting third-party imports
- detect top-level test helper modules/packages and conftest without recursively adding nested helper stems
- mirror the fix into the consumer template copy and add focused regression tests

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- git diff --check

Related to sync/dependabot cleanup campaign.