### PR TITLE
fix: avoid packaged test submodule masking

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -184,8 +184,13 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
+        tests_is_package = (tests_dir / "__init__.py").exists()
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
+                continue
+            if tests_is_package:
+                if item.name == "conftest.py":
+                    detected.add("conftest")
                 continue
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -184,8 +184,13 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
+        tests_is_package = (tests_dir / "__init__.py").exists()
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
+                continue
+            if tests_is_package:
+                if item.name == "conftest.py":
+                    detected.add("conftest")
                 continue
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -64,6 +64,26 @@ def test_detect_local_project_modules_finds_top_level_test_helpers(
     assert "adapter" not in detected
 
 
+def test_detect_local_project_modules_does_not_mask_packaged_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "conftest.py").write_text("FIXTURE = object()\n", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tests_dir / "api").mkdir()
+    (tests_dir / "api" / "__init__.py").write_text("", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    detected = std._detect_local_project_modules()
+
+    assert "conftest" in detected
+    assert "helpers" not in detected
+    assert "api" not in detected
+
+
 def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(


### PR DESCRIPTION
## Summary
- skip adding bare top-level `tests/*` helper/package names when `tests` itself is a package
- keep `conftest` ignored as a local test helper
- mirror the source fix into the consumer template copy

## Validation
- `python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`
- `git diff --check`