### PR TITLE
fix: refine packaged test module detection

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -192,7 +192,7 @@ def _detect_local_project_modules() -> set[str]:
             if tests_is_package:
                 if item.name == "conftest.py":
                     detected.add("conftest")
-                elif item.is_dir() and (item / "__init__.py").exists():
+                elif tests_on_pythonpath and item.is_dir() and (item / "__init__.py").exists():
                     detected.add(item.name)
                 elif (
                     tests_on_pythonpath

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -196,8 +196,7 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.name)
                 elif (
                     tests_on_pythonpath
-                    and
-                    item.suffix == ".py"
+                    and item.suffix == ".py"
                     and not item.name.startswith("test_")
                     and item.name != "__init__.py"
                 ):

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -185,13 +185,18 @@ def _detect_local_project_modules() -> set[str]:
     tests_dir = Path("tests")
     if tests_dir.is_dir():
         tests_is_package = (tests_dir / "__init__.py").exists()
+        tests_on_pythonpath = _tests_dir_on_pythonpath()
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
                 continue
             if tests_is_package:
                 if item.name == "conftest.py":
                     detected.add("conftest")
+                elif item.is_dir() and (item / "__init__.py").exists():
+                    detected.add(item.name)
                 elif (
+                    tests_on_pythonpath
+                    and
                     item.suffix == ".py"
                     and not item.name.startswith("test_")
                     and item.name != "__init__.py"
@@ -207,6 +212,31 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.stem)
 
     return detected
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    if not PYPROJECT_FILE.exists():
+        return False
+    try:
+        with PYPROJECT_FILE.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    pytest_options = (
+        data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+        if isinstance(data, dict)
+        else {}
+    )
+    pythonpath = pytest_options.get("pythonpath", [])
+    if isinstance(pythonpath, str):
+        entries = pythonpath.split()
+    elif isinstance(pythonpath, list):
+        entries = [str(entry) for entry in pythonpath]
+    else:
+        entries = []
+
+    return any(entry.strip().rstrip("/").removeprefix("./") == "tests" for entry in entries)
 
 
 def _read_local_modules() -> set[str]:

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -192,7 +192,7 @@ def _detect_local_project_modules() -> set[str]:
             if tests_is_package:
                 if item.name == "conftest.py":
                     detected.add("conftest")
-                elif item.is_dir() and (item / "__init__.py").exists():
+                elif tests_on_pythonpath and item.is_dir() and (item / "__init__.py").exists():
                     detected.add(item.name)
                 elif (
                     tests_on_pythonpath

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -196,8 +196,7 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.name)
                 elif (
                     tests_on_pythonpath
-                    and
-                    item.suffix == ".py"
+                    and item.suffix == ".py"
                     and not item.name.startswith("test_")
                     and item.name != "__init__.py"
                 ):

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -185,13 +185,18 @@ def _detect_local_project_modules() -> set[str]:
     tests_dir = Path("tests")
     if tests_dir.is_dir():
         tests_is_package = (tests_dir / "__init__.py").exists()
+        tests_on_pythonpath = _tests_dir_on_pythonpath()
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
                 continue
             if tests_is_package:
                 if item.name == "conftest.py":
                     detected.add("conftest")
+                elif item.is_dir() and (item / "__init__.py").exists():
+                    detected.add(item.name)
                 elif (
+                    tests_on_pythonpath
+                    and
                     item.suffix == ".py"
                     and not item.name.startswith("test_")
                     and item.name != "__init__.py"
@@ -207,6 +212,31 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.stem)
 
     return detected
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    if not PYPROJECT_FILE.exists():
+        return False
+    try:
+        with PYPROJECT_FILE.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    pytest_options = (
+        data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+        if isinstance(data, dict)
+        else {}
+    )
+    pythonpath = pytest_options.get("pythonpath", [])
+    if isinstance(pythonpath, str):
+        entries = pythonpath.split()
+    elif isinstance(pythonpath, list):
+        entries = [str(entry) for entry in pythonpath]
+    else:
+        entries = []
+
+    return any(entry.strip().rstrip("/").removeprefix("./") == "tests" for entry in entries)
 
 
 def _read_local_modules() -> set[str]:

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -80,7 +80,7 @@ def test_detect_local_project_modules_handles_packaged_tests_without_pythonpath(
     detected = std._detect_local_project_modules()
 
     assert "conftest" in detected
-    assert "api" in detected
+    assert "api" not in detected
     assert "helpers" not in detected
 
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -64,7 +64,7 @@ def test_detect_local_project_modules_finds_top_level_test_helpers(
     assert "adapter" not in detected
 
 
-def test_detect_local_project_modules_does_not_mask_packaged_tests(
+def test_detect_local_project_modules_handles_packaged_tests_without_pythonpath(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     tests_dir = tmp_path / "tests"
@@ -80,8 +80,38 @@ def test_detect_local_project_modules_does_not_mask_packaged_tests(
     detected = std._detect_local_project_modules()
 
     assert "conftest" in detected
-    assert "helpers" in detected
-    assert "api" not in detected
+    assert "api" in detected
+    assert "helpers" not in detected
+
+
+def test_detect_local_project_modules_keeps_packaged_test_helpers_on_pythonpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[tool.pytest.ini_options]",
+                'pythonpath = ["tests"]',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "conftest.py").write_text("FIXTURE = object()\n", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tests_dir / "api").mkdir()
+    (tests_dir / "api" / "__init__.py").write_text("", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    detected = std._detect_local_project_modules()
+
+    assert {"api", "conftest", "helpers"}.issubset(detected)
 
 
 def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> None:
@@ -347,6 +377,9 @@ def test_find_missing_dependencies_ignores_packaged_top_level_test_helpers(
     pyproject.write_text(
         "\n".join(
             [
+                "[tool.pytest.ini_options]",
+                'pythonpath = ["tests"]',
+                "",
                 "[project.optional-dependencies]",
                 "dev = [",
                 '  "requests",',


### PR DESCRIPTION
## Summary
- detect packaged helper directories under packaged tests before skipping deeper package scanning
- only treat top-level helper modules under packaged tests as first-party when pytest explicitly puts `tests` on `pythonpath`
- mirror the consumer template script and add focused regression coverage

## Validation
- `python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`
- `git diff --check`