### PR TITLE
fix: read pytest pythonpath configs

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -33,10 +33,15 @@ else:
     TOMLKIT_ERROR = None
 
 PYPROJECT_FILE = Path("pyproject.toml")
-PYTEST_TOML_FILE = Path("pytest.toml")
+PYTEST_TOML_FILES = (
+    Path("pytest.toml"),
+    Path(".pytest.toml"),
+)
 PYTEST_INI_CONFIGS = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
+)
+PYTEST_FALLBACK_INI_CONFIGS = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )
@@ -274,11 +279,13 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
         return False
+    if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
+        return True
     pytest_options = pytest_config.get("ini_options")
-    if not isinstance(pytest_options, dict):
-        return False
+    if isinstance(pytest_options, dict):
+        return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
 
-    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+    return False
 
 
 def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
@@ -300,9 +307,10 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
 
 
 def _tests_dir_on_pythonpath() -> bool:
-    pytest_toml = _resolve_config_path(PYTEST_TOML_FILE)
-    if pytest_toml.exists():
-        return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
+    for config_file in PYTEST_TOML_FILES:
+        pytest_toml = _resolve_config_path(config_file)
+        if pytest_toml.exists():
+            return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
 
     for config_file, section_names in PYTEST_INI_CONFIGS:
         resolved_config = _resolve_config_path(config_file)
@@ -312,6 +320,11 @@ def _tests_dir_on_pythonpath() -> bool:
     pyproject = _resolve_config_path(PYPROJECT_FILE)
     if pyproject.exists():
         return _tests_dir_on_pyproject_pythonpath(pyproject)
+
+    for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
     return False
 
 

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import configparser
 import re
 import sys
 import tomllib
@@ -32,6 +33,13 @@ else:
     TOMLKIT_ERROR = None
 
 PYPROJECT_FILE = Path("pyproject.toml")
+PYTEST_TOML_FILE = Path("pytest.toml")
+PYTEST_INI_CONFIGS = (
+    (Path("pytest.ini"), ("pytest",)),
+    (Path(".pytest.ini"), ("pytest",)),
+    (Path("tox.ini"), ("pytest",)),
+    (Path("setup.cfg"), ("tool:pytest", "pytest")),
+)
 DEV_EXTRA = "dev"
 
 # Stdlib modules that don't need to be installed. Prefer Python's runtime
@@ -185,7 +193,7 @@ def _detect_local_project_modules() -> set[str]:
     tests_dir = Path("tests")
     if tests_dir.is_dir():
         tests_is_package = (tests_dir / "__init__.py").exists()
-        tests_on_pythonpath = _tests_dir_on_pythonpath()
+        tests_on_pythonpath = _tests_dir_on_pythonpath() if tests_is_package else False
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
                 continue
@@ -213,21 +221,7 @@ def _detect_local_project_modules() -> set[str]:
     return detected
 
 
-def _tests_dir_on_pythonpath() -> bool:
-    if not PYPROJECT_FILE.exists():
-        return False
-    try:
-        with PYPROJECT_FILE.open("rb") as fh:
-            data = tomllib.load(fh)
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-
-    pytest_options = (
-        data.get("tool", {}).get("pytest", {}).get("ini_options", {})
-        if isinstance(data, dict)
-        else {}
-    )
-    pythonpath = pytest_options.get("pythonpath", [])
+def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
         entries = pythonpath.split()
     elif isinstance(pythonpath, list):
@@ -235,7 +229,90 @@ def _tests_dir_on_pythonpath() -> bool:
     else:
         entries = []
 
-    return any(entry.strip().rstrip("/").removeprefix("./") == "tests" for entry in entries)
+    return any(
+        entry.strip().strip('"').strip("'").rstrip("/").removeprefix("./") == "tests"
+        for entry in entries
+    )
+
+
+def _config_root() -> Path:
+    return PYPROJECT_FILE.parent if PYPROJECT_FILE.is_absolute() else Path(".")
+
+
+def _resolve_config_path(path: Path) -> Path:
+    return path if path.is_absolute() else _config_root() / path
+
+
+def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    pytest_options = data.get("pytest")
+    if not isinstance(pytest_options, dict):
+        return False
+
+    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return False
+    pytest_config = tool.get("pytest")
+    if not isinstance(pytest_config, dict):
+        return False
+    pytest_options = pytest_config.get("ini_options")
+    if not isinstance(pytest_options, dict):
+        return False
+
+    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+
+def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
+    config = configparser.ConfigParser()
+    try:
+        read_files = config.read(config_file, encoding="utf-8")
+    except (configparser.Error, OSError, UnicodeDecodeError):
+        return False
+    if not read_files:
+        return False
+
+    for section_name in section_names:
+        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
+            config.get(section_name, "pythonpath")
+        ):
+            return True
+
+    return False
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    pytest_toml = _resolve_config_path(PYTEST_TOML_FILE)
+    if pytest_toml.exists():
+        return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
+
+    for config_file, section_names in PYTEST_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+
+    pyproject = _resolve_config_path(PYPROJECT_FILE)
+    if pyproject.exists():
+        return _tests_dir_on_pyproject_pythonpath(pyproject)
+    return False
 
 
 def _read_local_modules() -> set[str]:

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -33,10 +33,15 @@ else:
     TOMLKIT_ERROR = None
 
 PYPROJECT_FILE = Path("pyproject.toml")
-PYTEST_TOML_FILE = Path("pytest.toml")
+PYTEST_TOML_FILES = (
+    Path("pytest.toml"),
+    Path(".pytest.toml"),
+)
 PYTEST_INI_CONFIGS = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
+)
+PYTEST_FALLBACK_INI_CONFIGS = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )
@@ -274,11 +279,13 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
         return False
+    if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
+        return True
     pytest_options = pytest_config.get("ini_options")
-    if not isinstance(pytest_options, dict):
-        return False
+    if isinstance(pytest_options, dict):
+        return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
 
-    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+    return False
 
 
 def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
@@ -300,9 +307,10 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
 
 
 def _tests_dir_on_pythonpath() -> bool:
-    pytest_toml = _resolve_config_path(PYTEST_TOML_FILE)
-    if pytest_toml.exists():
-        return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
+    for config_file in PYTEST_TOML_FILES:
+        pytest_toml = _resolve_config_path(config_file)
+        if pytest_toml.exists():
+            return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
 
     for config_file, section_names in PYTEST_INI_CONFIGS:
         resolved_config = _resolve_config_path(config_file)
@@ -312,6 +320,11 @@ def _tests_dir_on_pythonpath() -> bool:
     pyproject = _resolve_config_path(PYPROJECT_FILE)
     if pyproject.exists():
         return _tests_dir_on_pyproject_pythonpath(pyproject)
+
+    for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
     return False
 
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import configparser
 import re
 import sys
 import tomllib
@@ -32,6 +33,13 @@ else:
     TOMLKIT_ERROR = None
 
 PYPROJECT_FILE = Path("pyproject.toml")
+PYTEST_TOML_FILE = Path("pytest.toml")
+PYTEST_INI_CONFIGS = (
+    (Path("pytest.ini"), ("pytest",)),
+    (Path(".pytest.ini"), ("pytest",)),
+    (Path("tox.ini"), ("pytest",)),
+    (Path("setup.cfg"), ("tool:pytest", "pytest")),
+)
 DEV_EXTRA = "dev"
 
 # Stdlib modules that don't need to be installed. Prefer Python's runtime
@@ -185,7 +193,7 @@ def _detect_local_project_modules() -> set[str]:
     tests_dir = Path("tests")
     if tests_dir.is_dir():
         tests_is_package = (tests_dir / "__init__.py").exists()
-        tests_on_pythonpath = _tests_dir_on_pythonpath()
+        tests_on_pythonpath = _tests_dir_on_pythonpath() if tests_is_package else False
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
                 continue
@@ -213,21 +221,7 @@ def _detect_local_project_modules() -> set[str]:
     return detected
 
 
-def _tests_dir_on_pythonpath() -> bool:
-    if not PYPROJECT_FILE.exists():
-        return False
-    try:
-        with PYPROJECT_FILE.open("rb") as fh:
-            data = tomllib.load(fh)
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-
-    pytest_options = (
-        data.get("tool", {}).get("pytest", {}).get("ini_options", {})
-        if isinstance(data, dict)
-        else {}
-    )
-    pythonpath = pytest_options.get("pythonpath", [])
+def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
         entries = pythonpath.split()
     elif isinstance(pythonpath, list):
@@ -235,7 +229,90 @@ def _tests_dir_on_pythonpath() -> bool:
     else:
         entries = []
 
-    return any(entry.strip().rstrip("/").removeprefix("./") == "tests" for entry in entries)
+    return any(
+        entry.strip().strip('"').strip("'").rstrip("/").removeprefix("./") == "tests"
+        for entry in entries
+    )
+
+
+def _config_root() -> Path:
+    return PYPROJECT_FILE.parent if PYPROJECT_FILE.is_absolute() else Path(".")
+
+
+def _resolve_config_path(path: Path) -> Path:
+    return path if path.is_absolute() else _config_root() / path
+
+
+def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    pytest_options = data.get("pytest")
+    if not isinstance(pytest_options, dict):
+        return False
+
+    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+    try:
+        with config_file.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return False
+    pytest_config = tool.get("pytest")
+    if not isinstance(pytest_config, dict):
+        return False
+    pytest_options = pytest_config.get("ini_options")
+    if not isinstance(pytest_options, dict):
+        return False
+
+    return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
+
+
+def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
+    config = configparser.ConfigParser()
+    try:
+        read_files = config.read(config_file, encoding="utf-8")
+    except (configparser.Error, OSError, UnicodeDecodeError):
+        return False
+    if not read_files:
+        return False
+
+    for section_name in section_names:
+        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
+            config.get(section_name, "pythonpath")
+        ):
+            return True
+
+    return False
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    pytest_toml = _resolve_config_path(PYTEST_TOML_FILE)
+    if pytest_toml.exists():
+        return _tests_dir_on_pytest_toml_pythonpath(pytest_toml)
+
+    for config_file, section_names in PYTEST_INI_CONFIGS:
+        resolved_config = _resolve_config_path(config_file)
+        if resolved_config.exists():
+            return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+
+    pyproject = _resolve_config_path(PYPROJECT_FILE)
+    if pyproject.exists():
+        return _tests_dir_on_pyproject_pythonpath(pyproject)
+    return False
 
 
 def _read_local_modules() -> set[str]:

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -121,6 +121,7 @@ def test_detect_local_project_modules_keeps_packaged_test_helpers_on_pythonpath(
         (".pytest.ini", "[pytest]"),
         ("tox.ini", "[pytest]"),
         ("setup.cfg", "[tool:pytest]"),
+        ("setup.cfg", "[pytest]"),
     ],
 )
 def test_detect_local_project_modules_reads_ini_pythonpath_for_packaged_tests(
@@ -151,10 +152,11 @@ def test_detect_local_project_modules_reads_ini_pythonpath_for_packaged_tests(
     assert "helpers" in detected
 
 
+@pytest.mark.parametrize("config_name", ["pytest.toml", ".pytest.toml"])
 def test_detect_local_project_modules_reads_pytest_toml_pythonpath_for_packaged_tests(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_name: str
 ) -> None:
-    (tmp_path / "pytest.toml").write_text(
+    (tmp_path / config_name).write_text(
         "\n".join(
             [
                 "[pytest]",
@@ -171,6 +173,33 @@ def test_detect_local_project_modules_reads_pytest_toml_pythonpath_for_packaged_
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    detected = std._detect_local_project_modules()
+
+    assert "helpers" in detected
+
+
+def test_detect_local_project_modules_reads_native_pyproject_pythonpath_for_packaged_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "\n".join(
+            [
+                "[tool.pytest]",
+                'pythonpath = ["tests"]',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
 
     detected = std._detect_local_project_modules()
 
@@ -194,6 +223,28 @@ def test_tests_dir_on_pythonpath_uses_first_existing_pytest_config(
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    assert std._tests_dir_on_pythonpath() is False
+
+
+def test_tests_dir_on_pythonpath_uses_pyproject_before_tox_ini(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.pytest.ini_options]\naddopts = '-q'\n", encoding="utf-8")
+    (tmp_path / "tox.ini").write_text(
+        "\n".join(
+            [
+                "[pytest]",
+                "pythonpath = tests",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
 
     assert std._tests_dir_on_pythonpath() is False
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -114,6 +114,124 @@ def test_detect_local_project_modules_keeps_packaged_test_helpers_on_pythonpath(
     assert {"api", "conftest", "helpers"}.issubset(detected)
 
 
+@pytest.mark.parametrize(
+    "config_name, section",
+    [
+        ("pytest.ini", "[pytest]"),
+        (".pytest.ini", "[pytest]"),
+        ("tox.ini", "[pytest]"),
+        ("setup.cfg", "[tool:pytest]"),
+    ],
+)
+def test_detect_local_project_modules_reads_ini_pythonpath_for_packaged_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_name: str, section: str
+) -> None:
+    (tmp_path / config_name).write_text(
+        "\n".join(
+            [
+                section,
+                "pythonpath =",
+                "    src",
+                "    tests",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    detected = std._detect_local_project_modules()
+
+    assert "helpers" in detected
+
+
+def test_detect_local_project_modules_reads_pytest_toml_pythonpath_for_packaged_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pytest.toml").write_text(
+        "\n".join(
+            [
+                "[pytest]",
+                'pythonpath = ["src", "tests"]',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    detected = std._detect_local_project_modules()
+
+    assert "helpers" in detected
+
+
+def test_tests_dir_on_pythonpath_uses_first_existing_pytest_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pytest.ini").write_text("[pytest]\naddopts = -q\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[tool.pytest.ini_options]",
+                'pythonpath = ["tests"]',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    assert std._tests_dir_on_pythonpath() is False
+
+
+@pytest.mark.parametrize(
+    "pyproject_contents",
+    [
+        '[tool]\npytest = "not-a-table"\n',
+        '[tool.pytest]\nini_options = "not-a-table"\n',
+    ],
+)
+def test_tests_dir_on_pythonpath_ignores_non_table_pyproject_shapes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pyproject_contents: str
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(pyproject_contents, encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is False
+
+
+def test_detect_local_project_modules_skips_pythonpath_read_for_unpackaged_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "helpers.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "_tests_dir_on_pythonpath", lambda: pytest.fail("unexpected read"))
+
+    detected = std._detect_local_project_modules()
+
+    assert "helpers" in detected
+
+
 def test_extract_imports_from_file_parses_top_level_imports(tmp_path: Path) -> None:
     sample = tmp_path / "sample.py"
     sample.write_text(


### PR DESCRIPTION
## Summary
- read pytest pythonpath from pytest.toml, pytest.ini, .pytest.ini, tox.ini, setup.cfg, and pyproject.toml
- avoid crashing on non-table pyproject pytest config shapes
- only inspect pythonpath config when packaged tests need it
- mirror the consumer template copy and add focused regression coverage

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py
- python -m black --check --target-version py312 --line-length 100 scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py tests/scripts/test_sync_test_dependencies.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Campaign: sync/dependabot cleanup.