### PR TITLE
fix: harden pytest config discovery

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -264,7 +264,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
     return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
 
 
-def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -272,13 +272,13 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
         return False
 
     if not isinstance(data, dict):
-        return False
+        return None
     tool = data.get("tool")
     if not isinstance(tool, dict):
-        return False
+        return None
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
-        return False
+        return False if "pytest" in tool else None
     if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
         return True
     pytest_options = pytest_config.get("ini_options")
@@ -289,7 +289,7 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     try:
         read_files = config.read(config_file, encoding="utf-8")
     except (configparser.Error, OSError, UnicodeDecodeError):
@@ -298,9 +298,13 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
         return False
 
     for section_name in section_names:
-        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
-            config.get(section_name, "pythonpath")
-        ):
+        if not config.has_option(section_name, "pythonpath"):
+            continue
+        try:
+            pythonpath = config.get(section_name, "pythonpath", raw=True)
+        except configparser.Error:
+            return False
+        if _pythonpath_has_tests(pythonpath):
             return True
 
     return False
@@ -319,7 +323,9 @@ def _tests_dir_on_pythonpath() -> bool:
 
     pyproject = _resolve_config_path(PYPROJECT_FILE)
     if pyproject.exists():
-        return _tests_dir_on_pyproject_pythonpath(pyproject)
+        pyproject_result = _tests_dir_on_pyproject_pythonpath(pyproject)
+        if pyproject_result is not None:
+            return pyproject_result
 
     for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
         resolved_config = _resolve_config_path(config_file)

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -264,7 +264,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
     return _pythonpath_has_tests(pytest_options.get("pythonpath", []))
 
 
-def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
+def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -272,13 +272,13 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
         return False
 
     if not isinstance(data, dict):
-        return False
+        return None
     tool = data.get("tool")
     if not isinstance(tool, dict):
-        return False
+        return None
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
-        return False
+        return False if "pytest" in tool else None
     if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
         return True
     pytest_options = pytest_config.get("ini_options")
@@ -289,7 +289,7 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ...]) -> bool:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     try:
         read_files = config.read(config_file, encoding="utf-8")
     except (configparser.Error, OSError, UnicodeDecodeError):
@@ -298,9 +298,13 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
         return False
 
     for section_name in section_names:
-        if config.has_option(section_name, "pythonpath") and _pythonpath_has_tests(
-            config.get(section_name, "pythonpath")
-        ):
+        if not config.has_option(section_name, "pythonpath"):
+            continue
+        try:
+            pythonpath = config.get(section_name, "pythonpath", raw=True)
+        except configparser.Error:
+            return False
+        if _pythonpath_has_tests(pythonpath):
             return True
 
     return False
@@ -319,7 +323,9 @@ def _tests_dir_on_pythonpath() -> bool:
 
     pyproject = _resolve_config_path(PYPROJECT_FILE)
     if pyproject.exists():
-        return _tests_dir_on_pyproject_pythonpath(pyproject)
+        pyproject_result = _tests_dir_on_pyproject_pythonpath(pyproject)
+        if pyproject_result is not None:
+            return pyproject_result
 
     for config_file, section_names in PYTEST_FALLBACK_INI_CONFIGS:
         resolved_config = _resolve_config_path(config_file)

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -249,6 +249,33 @@ def test_tests_dir_on_pythonpath_uses_pyproject_before_tox_ini(
     assert std._tests_dir_on_pythonpath() is False
 
 
+def test_tests_dir_on_pythonpath_falls_back_when_pyproject_has_no_pytest_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'sample'\n", encoding="utf-8")
+    (tmp_path / "tox.ini").write_text("[pytest]\npythonpath = tests\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is True
+
+
+def test_tests_dir_on_pythonpath_reads_ini_values_without_interpolation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pytest.ini").write_text(
+        "[pytest]\npythonpath = tests %(missing_value)s\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
+
+    assert std._tests_dir_on_pythonpath() is True
+
+
 @pytest.mark.parametrize(
     "pyproject_contents",
     [


### PR DESCRIPTION
## Summary
- read pytest INI pythonpath values without interpolation so literal %(...) tokens cannot crash dependency sync
- let pyproject.toml without pytest config fall through to tox.ini/setup.cfg fallback discovery
- mirror the consumer template copy and add regression coverage

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m black --check --target-version py312 --line-length 100 scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py tests/scripts/test_sync_test_dependencies.py
- git diff --check