### PR TITLE
fix: harden synced dependency tooling

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -265,11 +265,12 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
+    """Return None when pyproject has no usable pytest config and fallback files should be checked."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
     except (OSError, tomllib.TOMLDecodeError):
-        return False
+        return None
 
     if not isinstance(data, dict):
         return None

--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -265,11 +265,12 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
+    """Return None when pyproject has no usable pytest config and fallback files should be checked."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
     except (OSError, tomllib.TOMLDecodeError):
-        return False
+        return None
 
     if not isinstance(data, dict):
         return None

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -262,6 +262,19 @@ def test_tests_dir_on_pythonpath_falls_back_when_pyproject_has_no_pytest_config(
     assert std._tests_dir_on_pythonpath() is True
 
 
+def test_tests_dir_on_pythonpath_falls_back_when_pyproject_is_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.pytest.ini_options\npythonpath = ['src']\n", encoding="utf-8")
+    (tmp_path / "tox.ini").write_text("[pytest]\npythonpath = tests\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is True
+
+
 def test_tests_dir_on_pythonpath_reads_ini_values_without_interpolation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- make `sync_test_dependencies.py` fall back to other pytest config files when `pyproject.toml` is unreadable or invalid
- document the helper tri-state return contract and add a regression test
- bump the consumer template `anthropics/claude-code-action` SHA to the Dependabot-proposed v1.0.134 commit

## Validation
- `python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q`
- `python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml`
- `python -m black --check --line-length 100 scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py tests/scripts/test_sync_test_dependencies.py`
- `git diff --check`

Related campaign: sync/dependabot cleanup.