### PR TITLE
fix: harden pytest config pythonpath detection

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -12,6 +12,7 @@ import argparse
 import ast
 import configparser
 import re
+import shlex
 import sys
 import tomllib
 from pathlib import Path
@@ -228,11 +229,12 @@ def _detect_local_project_modules() -> set[str]:
 
 def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
-        entries = re.split(r"[\s,]+", pythonpath)
+        try:
+            entries = shlex.split(pythonpath, posix=False)
+        except ValueError:
+            entries = pythonpath.split()
     elif isinstance(pythonpath, list):
-        entries = [
-            candidate for entry in pythonpath for candidate in re.split(r"[\s,]+", str(entry))
-        ]
+        entries = [str(entry) for entry in pythonpath]
     else:
         entries = []
 

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -228,14 +228,17 @@ def _detect_local_project_modules() -> set[str]:
 
 def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
-        entries = pythonpath.split()
+        entries = re.split(r"[\s,]+", pythonpath)
     elif isinstance(pythonpath, list):
-        entries = [str(entry) for entry in pythonpath]
+        entries = [
+            candidate for entry in pythonpath for candidate in re.split(r"[\s,]+", str(entry))
+        ]
     else:
         entries = []
 
     return any(
-        entry.strip().strip('"').strip("'").rstrip("/").removeprefix("./") == "tests"
+        entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/").removeprefix("./")
+        == "tests"
         for entry in entries
     )
 
@@ -265,7 +268,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
-    """Return None when pyproject has no usable pytest config and fallback files should be checked."""
+    """Return None when pyproject has no readable, usable pytest config."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -279,7 +282,7 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
         return None
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
-        return False if "pytest" in tool else None
+        return None
     if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
         return True
     pytest_options = pytest_config.get("ini_options")
@@ -323,7 +326,8 @@ def _tests_dir_on_pythonpath() -> bool:
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
 
     pyproject = _resolve_config_path(PYPROJECT_FILE)
-    if pyproject.exists():
+    pyproject_exists = pyproject.exists()
+    if pyproject_exists:
         pyproject_result = _tests_dir_on_pyproject_pythonpath(pyproject)
         if pyproject_result is not None:
             return pyproject_result
@@ -332,6 +336,9 @@ def _tests_dir_on_pythonpath() -> bool:
         resolved_config = _resolve_config_path(config_file)
         if resolved_config.exists():
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+
+    if pyproject_exists:
+        return False
     return False
 
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -12,6 +12,7 @@ import argparse
 import ast
 import configparser
 import re
+import shlex
 import sys
 import tomllib
 from pathlib import Path
@@ -228,11 +229,12 @@ def _detect_local_project_modules() -> set[str]:
 
 def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
-        entries = re.split(r"[\s,]+", pythonpath)
+        try:
+            entries = shlex.split(pythonpath, posix=False)
+        except ValueError:
+            entries = pythonpath.split()
     elif isinstance(pythonpath, list):
-        entries = [
-            candidate for entry in pythonpath for candidate in re.split(r"[\s,]+", str(entry))
-        ]
+        entries = [str(entry) for entry in pythonpath]
     else:
         entries = []
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -228,14 +228,17 @@ def _detect_local_project_modules() -> set[str]:
 
 def _pythonpath_has_tests(pythonpath: Any) -> bool:
     if isinstance(pythonpath, str):
-        entries = pythonpath.split()
+        entries = re.split(r"[\s,]+", pythonpath)
     elif isinstance(pythonpath, list):
-        entries = [str(entry) for entry in pythonpath]
+        entries = [
+            candidate for entry in pythonpath for candidate in re.split(r"[\s,]+", str(entry))
+        ]
     else:
         entries = []
 
     return any(
-        entry.strip().strip('"').strip("'").rstrip("/").removeprefix("./") == "tests"
+        entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/").removeprefix("./")
+        == "tests"
         for entry in entries
     )
 
@@ -265,7 +268,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
-    """Return None when pyproject has no usable pytest config and fallback files should be checked."""
+    """Return None when pyproject has no readable, usable pytest config."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -279,7 +282,7 @@ def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
         return None
     pytest_config = tool.get("pytest")
     if not isinstance(pytest_config, dict):
-        return False if "pytest" in tool else None
+        return None
     if _pythonpath_has_tests(pytest_config.get("pythonpath", [])):
         return True
     pytest_options = pytest_config.get("ini_options")
@@ -323,7 +326,8 @@ def _tests_dir_on_pythonpath() -> bool:
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
 
     pyproject = _resolve_config_path(PYPROJECT_FILE)
-    if pyproject.exists():
+    pyproject_exists = pyproject.exists()
+    if pyproject_exists:
         pyproject_result = _tests_dir_on_pyproject_pythonpath(pyproject)
         if pyproject_result is not None:
             return pyproject_result
@@ -332,6 +336,9 @@ def _tests_dir_on_pythonpath() -> bool:
         resolved_config = _resolve_config_path(config_file)
         if resolved_config.exists():
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
+
+    if pyproject_exists:
+        return False
     return False
 
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -262,12 +262,49 @@ def test_tests_dir_on_pythonpath_falls_back_when_pyproject_has_no_pytest_config(
     assert std._tests_dir_on_pythonpath() is True
 
 
+def test_tests_dir_on_pythonpath_falls_back_when_pyproject_pytest_is_not_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[tool]\npytest = "not-a-table"\n', encoding="utf-8")
+    (tmp_path / "tox.ini").write_text("[pytest]\npythonpath = tests\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is True
+
+
 def test_tests_dir_on_pythonpath_falls_back_when_pyproject_is_invalid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[tool.pytest.ini_options\npythonpath = ['src']\n", encoding="utf-8")
     (tmp_path / "tox.ini").write_text("[pytest]\npythonpath = tests\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is True
+
+
+@pytest.mark.parametrize("pythonpath", ["src,tests", ".\\tests", ["src,tests"], ["tests\\"]])
+def test_tests_dir_on_pythonpath_accepts_common_path_spellings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pythonpath: object
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    if isinstance(pythonpath, list):
+        value = ", ".join(f'"{entry.replace(chr(92), chr(92) * 2)}"' for entry in pythonpath)
+        pyproject.write_text(
+            f"[tool.pytest]\npythonpath = [{value}]\n",
+            encoding="utf-8",
+        )
+    else:
+        escaped_pythonpath = str(pythonpath).replace("\\", "\\\\")
+        pyproject.write_text(
+            f'[tool.pytest]\npythonpath = "{escaped_pythonpath}"\n',
+            encoding="utf-8",
+        )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -288,7 +288,7 @@ def test_tests_dir_on_pythonpath_falls_back_when_pyproject_is_invalid(
     assert std._tests_dir_on_pythonpath() is True
 
 
-@pytest.mark.parametrize("pythonpath", ["src,tests", ".\\tests", ["src,tests"], ["tests\\"]])
+@pytest.mark.parametrize("pythonpath", ["src tests", ".\\tests", ["tests\\"]])
 def test_tests_dir_on_pythonpath_accepts_common_path_spellings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pythonpath: object
 ) -> None:
@@ -310,6 +310,29 @@ def test_tests_dir_on_pythonpath_accepts_common_path_spellings(
     monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
 
     assert std._tests_dir_on_pythonpath() is True
+
+
+@pytest.mark.parametrize("pythonpath", ["src,tests", ["src,tests"]])
+def test_tests_dir_on_pythonpath_does_not_split_comma_separated_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pythonpath: object
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    if isinstance(pythonpath, list):
+        value = ", ".join(f'"{entry}"' for entry in pythonpath)
+        pyproject.write_text(
+            f"[tool.pytest]\npythonpath = [{value}]\n",
+            encoding="utf-8",
+        )
+    else:
+        pyproject.write_text(
+            f'[tool.pytest]\npythonpath = "{pythonpath}"\n',
+            encoding="utf-8",
+        )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(std, "PYPROJECT_FILE", pyproject)
+
+    assert std._tests_dir_on_pythonpath() is False
 
 
 def test_tests_dir_on_pythonpath_reads_ini_values_without_interpolation(


### PR DESCRIPTION
## Summary
- normalize pytest pythonpath values for comma-separated and Windows-style tests paths
- let malformed/non-table pyproject pytest config fall back to other pytest config files
- mirror the synced consumer script and add focused regression coverage

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- python -m black --check --line-length 100 --target-version py312 scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py tests/scripts/test_sync_test_dependencies.py
- git diff --check