### PR TITLE
fix: resolve pythonpath review debt

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -238,11 +238,14 @@ def _pythonpath_has_tests(pythonpath: Any) -> bool:
     else:
         entries = []
 
-    return any(
-        entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/").removeprefix("./")
-        == "tests"
-        for entry in entries
-    )
+    return any(_pythonpath_entry_is_tests_dir(entry) for entry in entries)
+
+
+def _pythonpath_entry_is_tests_dir(entry: str) -> bool:
+    normalized = entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized == "tests" or normalized.endswith("/tests")
 
 
 def _config_root() -> Path:
@@ -270,7 +273,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
-    """Return None when pyproject has no readable, usable pytest config."""
+    """Return None when pyproject has no usable pytest table or cannot be read."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -309,7 +312,7 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
         try:
             pythonpath = config.get(section_name, "pythonpath", raw=True)
         except configparser.Error:
-            return False
+            continue
         if _pythonpath_has_tests(pythonpath):
             return True
 
@@ -339,8 +342,6 @@ def _tests_dir_on_pythonpath() -> bool:
         if resolved_config.exists():
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
 
-    if pyproject_exists:
-        return False
     return False
 
 

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -238,11 +238,14 @@ def _pythonpath_has_tests(pythonpath: Any) -> bool:
     else:
         entries = []
 
-    return any(
-        entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/").removeprefix("./")
-        == "tests"
-        for entry in entries
-    )
+    return any(_pythonpath_entry_is_tests_dir(entry) for entry in entries)
+
+
+def _pythonpath_entry_is_tests_dir(entry: str) -> bool:
+    normalized = entry.strip().strip('"').strip("'").replace("\\", "/").rstrip("/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized == "tests" or normalized.endswith("/tests")
 
 
 def _config_root() -> Path:
@@ -270,7 +273,7 @@ def _tests_dir_on_pytest_toml_pythonpath(config_file: Path) -> bool:
 
 
 def _tests_dir_on_pyproject_pythonpath(config_file: Path) -> bool | None:
-    """Return None when pyproject has no readable, usable pytest config."""
+    """Return None when pyproject has no usable pytest table or cannot be read."""
     try:
         with config_file.open("rb") as fh:
             data = tomllib.load(fh)
@@ -309,7 +312,7 @@ def _tests_dir_on_ini_pythonpath(config_file: Path, section_names: tuple[str, ..
         try:
             pythonpath = config.get(section_name, "pythonpath", raw=True)
         except configparser.Error:
-            return False
+            continue
         if _pythonpath_has_tests(pythonpath):
             return True
 
@@ -339,8 +342,6 @@ def _tests_dir_on_pythonpath() -> bool:
         if resolved_config.exists():
             return _tests_dir_on_ini_pythonpath(resolved_config, section_names)
 
-    if pyproject_exists:
-        return False
     return False
 
 

--- a/tests/scripts/test_sync_test_dependencies.py
+++ b/tests/scripts/test_sync_test_dependencies.py
@@ -288,7 +288,17 @@ def test_tests_dir_on_pythonpath_falls_back_when_pyproject_is_invalid(
     assert std._tests_dir_on_pythonpath() is True
 
 
-@pytest.mark.parametrize("pythonpath", ["src tests", ".\\tests", ["tests\\"]])
+@pytest.mark.parametrize(
+    "pythonpath",
+    [
+        "src tests",
+        ".\\tests",
+        '"./tests"',
+        'src "./tests"',
+        '"C:\\path with spaces\\tests"',
+        ["tests\\"],
+    ],
+)
 def test_tests_dir_on_pythonpath_accepts_common_path_spellings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pythonpath: object
 ) -> None:
@@ -300,7 +310,7 @@ def test_tests_dir_on_pythonpath_accepts_common_path_spellings(
             encoding="utf-8",
         )
     else:
-        escaped_pythonpath = str(pythonpath).replace("\\", "\\\\")
+        escaped_pythonpath = str(pythonpath).replace("\\", "\\\\").replace('"', '\\"')
         pyproject.write_text(
             f'[tool.pytest]\npythonpath = "{escaped_pythonpath}"\n',
             encoding="utf-8",
@@ -347,6 +357,30 @@ def test_tests_dir_on_pythonpath_reads_ini_values_without_interpolation(
     monkeypatch.setattr(std, "PYPROJECT_FILE", tmp_path / "pyproject.toml")
 
     assert std._tests_dir_on_pythonpath() is True
+
+
+def test_tests_dir_on_ini_pythonpath_checks_next_section_after_read_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class ConfigWithBrokenFirstSection:
+        def read(self, config_file: Path, encoding: str) -> list[str]:
+            return [str(config_file)]
+
+        def has_option(self, section_name: str, option_name: str) -> bool:
+            return section_name in {"tool:pytest", "pytest"} and option_name == "pythonpath"
+
+        def get(self, section_name: str, option_name: str, raw: bool) -> str:
+            if section_name == "tool:pytest":
+                raise std.configparser.Error("bad section")
+            return "tests"
+
+    monkeypatch.setattr(
+        std.configparser,
+        "ConfigParser",
+        lambda interpolation=None: ConfigWithBrokenFirstSection(),
+    )
+
+    assert std._tests_dir_on_ini_pythonpath(tmp_path / "pytest.ini", ("tool:pytest", "pytest"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- normalize pytest pythonpath entries through a helper that accepts quoted, relative, and absolute paths ending in tests
- continue checking later INI sections when one section raises a configparser read error
- mirror the source helper into the consumer template and add focused regression tests

## Validation
- python -m pytest tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q
- python -m py_compile scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- python -m black --check --line-length 100 --target-version py312 scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py tests/scripts/test_sync_test_dependencies.py
- git diff --check