### PR TITLE
ci: bump pinned checkout action

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -50,7 +50,7 @@ jobs:
       should_run: ${{ steps.eligibility.outputs.should-run }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -71,7 +71,7 @@ jobs:
       proceed: ${{ steps.eligibility.outputs.should-run }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -155,7 +155,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
 
@@ -198,7 +198,7 @@ jobs:
 
       - name: Checkout Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
           repository: stranske/Workflows

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -62,7 +62,7 @@ jobs:
       workflow_app_auth_mode: ${{ steps.workflow-app-creds.outputs.workflow_app_auth_mode }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/.github/workflows/agents-moderate-connector.yml
+++ b/.github/workflows/agents-moderate-connector.yml
@@ -28,7 +28,7 @@ jobs:
       moderated: ${{ steps.evaluate.outputs.delete || 'false' }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           token: ${{ steps.select-token.outputs.token }}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -37,7 +37,7 @@ jobs:
       dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -167,7 +167,7 @@ jobs:
           echo "dry_run=${{ inputs.dry_run }}" >>"$GITHUB_OUTPUT"
 
       - name: Checkout repo (for retry helpers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ env.GH_DISPATCH_TOKEN }}
           fetch-depth: 1
@@ -198,7 +198,7 @@ jobs:
             core.setOutput('ref', data.default_branch);
 
       - name: Checkout (for retry helpers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
@@ -307,7 +307,7 @@ jobs:
 
       - name: Checkout default branch
         if: ${{ steps.pick.outputs.issue != '' && steps.mode.outputs.dry_run != 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.pick.outputs.base }}
           token: ${{ env.GH_DISPATCH_TOKEN }}

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -290,7 +290,7 @@ jobs:
               .write();
 
       - name: Checkout repo (for retry helpers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ env.GH_BELT_TOKEN }}
           fetch-depth: 1
@@ -321,7 +321,7 @@ jobs:
             core.setOutput('ref', data.default_branch);
 
       - name: Checkout Workflows scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
@@ -584,7 +584,7 @@ jobs:
 
       - name: Checkout branch
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.ctx.outputs.branch }}
           token: ${{ env.GH_BELT_TOKEN }}
@@ -592,7 +592,7 @@ jobs:
 
       - name: Checkout belt tooling
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}

--- a/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -184,7 +184,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Checkout retry helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -72,7 +72,7 @@ jobs:
       should_run: ${{ steps.eligibility.outputs.should-run || 'false' }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js
@@ -313,7 +313,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           token: ${{ secrets.SERVICE_BOT_PAT || github.token }}

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -81,7 +81,7 @@ jobs:
       fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
@@ -381,7 +381,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
@@ -483,7 +483,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout runner library
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             scripts/runner_lib
@@ -544,7 +544,7 @@ jobs:
     environment: agent-standard
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
@@ -843,7 +843,7 @@ jobs:
       dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout (for security gate + agent registry)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -1279,7 +1279,7 @@ jobs:
     environment: agent-standard
     steps:
       - name: Checkout (for retry helpers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js
@@ -1349,7 +1349,7 @@ jobs:
     environment: agent-standard
     steps:
       - name: Checkout (for retry helpers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.eligibility.outputs.should-run == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         if: steps.eligibility.outputs.should-run == 'true'

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -71,7 +71,7 @@ jobs:
       proceed: ${{ steps.eligibility.outputs.should-run }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -155,7 +155,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
 
@@ -198,7 +198,7 @@ jobs:
 
       - name: Checkout Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
           repository: stranske/Workflows

--- a/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
@@ -28,7 +28,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout workflow helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |

--- a/templates/consumer-repo/.github/workflows/agents-capability-check.yml
+++ b/templates/consumer-repo/.github/workflows/agents-capability-check.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-decompose.yml
+++ b/templates/consumer-repo/.github/workflows/agents-decompose.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-dedup.yml
+++ b/templates/consumer-repo/.github/workflows/agents-dedup.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -67,7 +67,7 @@ jobs:
         if: >-
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request_target'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout-cone-mode: false
@@ -137,7 +137,7 @@ jobs:
         if: >-
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -117,11 +117,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout Workflows repository for scripts
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           path: workflows-scripts

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout keepalive scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/scripts

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -86,7 +86,7 @@ jobs:
       fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout retry helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -329,7 +329,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout state fingerprint helper
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: scripts/state_fingerprint.py
           sparse-checkout-cone-mode: false

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-merged.outputs.merged == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: stranske/Workflows
           token: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -27,7 +27,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
 
           token: ${{ steps.app_token.outputs.token || github.token }}

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -67,7 +67,7 @@ jobs:
       dispatch_reason: ${{ steps.runner_dispatch.outputs.reason }}
     steps:
       - name: Checkout eligibility action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: >-
             ${{ github.event.pull_request.base.sha ||
@@ -91,7 +91,7 @@ jobs:
 
       - name: Checkout for API helpers
         if: steps.eligibility.outputs.should-run == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -517,7 +517,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout runner library
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             scripts/runner_lib

--- a/templates/consumer-repo/.github/workflows/backplane-conformance.yml
+++ b/templates/consumer-repo/.github/workflows/backplane-conformance.yml
@@ -25,7 +25,7 @@ jobs:
       run_json: artifacts/reference/run.json
       manifest: artifacts/reference/manifest.json
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'

--- a/templates/consumer-repo/.github/workflows/dependabot-automerge.yml
+++ b/templates/consumer-repo/.github/workflows/dependabot-automerge.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get PR metadata
         id: metadata

--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
       reason: ${{ steps.resolve.outputs.reason }}
     steps:
       - name: Checkout (for API wrappers)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -113,7 +113,7 @@ jobs:
       workflow_unchanged: ${{ steps.workflow-integrity.outputs.workflow_unchanged }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -181,7 +181,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
 
       - name: Checkout retry helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
@@ -117,7 +117,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Locate latest Gate workflow run
         id: discover

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -77,7 +77,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout workflow helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
 
           token: ${{ steps.app_token.outputs.token || github.token }}
@@ -205,7 +205,7 @@ jobs:
     if: ${{ needs.detect.outputs.doc_only != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -245,7 +245,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -307,7 +307,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token || github.token }}
@@ -370,7 +370,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout workflow helpers
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
 
           token: ${{ steps.app_token.outputs.token || github.token }}

--- a/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
+++ b/templates/consumer-repo/.github/workflows/reusable-pr-context.yml
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout (for scripts)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
             .github/scripts

--- a/tests/scripts/test_check_workflow_action_pins.py
+++ b/tests/scripts/test_check_workflow_action_pins.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from scripts import check_workflow_action_pins
 
-PINNED_CHECKOUT = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+PINNED_CHECKOUT = "df4cb1c069e1874edd31b4311f1884172cec0e10"
 PINNED_GITHUB_SCRIPT = "3a2844b7e9c422d3c10d287c895573f7108da1b3"
 
 
@@ -16,7 +16,7 @@ on: push
 jobs:
   test:
     steps:
-      - uses: actions/checkout@{PINNED_CHECKOUT} # v6
+      - uses: actions/checkout@{PINNED_CHECKOUT} # v6.0.3
       - name: Script
         uses: actions/github-script@{PINNED_GITHUB_SCRIPT} # v9
 """,
@@ -104,7 +104,7 @@ on: push
 jobs:
   test:
     steps:
-      - uses: actions/checkout@{PINNED_CHECKOUT} # v6
+      - uses: actions/checkout@{PINNED_CHECKOUT} # v6.0.3
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- bump pinned actions/checkout SHA from v6.0.2 to v6.0.3 in Workflows-owned agent/autofix entry points
- update the workflow action pin test fixture to the new checkout SHA/comment

## Validation
- python -m pytest tests/scripts/test_check_workflow_action_pins.py -q
- python scripts/check_workflow_action_pins.py .github/workflows/agents-verify-to-new-pr.yml templates/consumer-repo/.github/workflows
- python scripts/validate_workflow_yaml.py .github/workflows/agents-70-orchestrator.yml .github/workflows/agents-auto-label.yml .github/workflows/agents-auto-pilot.yml .github/workflows/agents-bot-comment-handler.yml .github/workflows/agents-guard.yml .github/workflows/agents-moderate-connector.yml .github/workflows/agents-verify-to-new-pr.yml .github/workflows/autofix.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Campaign: sync-dependabot cleanup; source fix for Template Dependabot PR stranske/Template#768.