### PR TITLE
Issue #2228: sync api client for PR verifier

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -492,6 +492,9 @@ scripts:
     description: "Scans agent belt for available tools"
 
   # LangChain scripts for agent workflows
+  - source: scripts/api_client.py
+    description: "Shared GitHub API client used by synced Python automation scripts"
+
   # Issue optimization (Phase 1) - agents-issue-optimizer.yml
   - source: scripts/langchain/issue_optimizer.py
     description: "Issue optimizer - analyzes issues and suggests improvements"

--- a/scripts/check_api_wrapper_guard.py
+++ b/scripts/check_api_wrapper_guard.py
@@ -25,6 +25,7 @@ SKIP_FILES = {
     ROOT / "scripts" / "check_api_wrapper_guard.py",
     ROOT / "scripts" / "check_consumer_sync_drift.py",
     ROOT / "scripts" / "api_client.py",
+    ROOT / "templates" / "consumer-repo" / "scripts" / "api_client.py",
     ROOT / "tools" / "enforce_gate_branch_protection.py",
     ROOT / ".github" / "workflows" / "maint-80-langsmith-metrics-dashboard.yml",
     # Health/diagnostic workflows that intentionally test raw API auth

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_TIMEOUT = 30
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_BACKOFF = 1.0
+RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _should_retry(status_code: int, detail: Any) -> bool:
+    if status_code in RETRY_STATUS_CODES:
+        return True
+    if status_code == 403:
+        message = ""
+        if isinstance(detail, dict):
+            message = str(detail.get("message") or "")
+        else:
+            message = str(detail or "")
+        if "rate limit" in message.lower():
+            return True
+    return False
+
+
+def _sleep_with_backoff(backoff: float, attempt: int) -> None:
+    if backoff <= 0:
+        return
+    delay = backoff * (2 ** (attempt - 1))
+    time.sleep(delay)
+
+
+def _request_json(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, Any] | None,
+    *,
+    max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+    backoff: float = DEFAULT_RETRY_BACKOFF,
+) -> Any:
+    response = _request_response(
+        method,
+        url,
+        token,
+        payload,
+        max_attempts=max_attempts,
+        backoff=backoff,
+    )
+    if response.status_code == 204:
+        return None
+    return response.json()
+
+
+def _request_response(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, Any] | None,
+    *,
+    max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+    backoff: float = DEFAULT_RETRY_BACKOFF,
+) -> requests.Response:
+    attempts = max(1, max_attempts)
+    for attempt in range(1, attempts + 1):
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json=payload,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            if attempt >= attempts:
+                raise RuntimeError("GitHub API request failed.") from exc
+            _sleep_with_backoff(backoff, attempt)
+            continue
+
+        if response.status_code >= 400:
+            try:
+                detail = response.json()
+            except ValueError:
+                detail = response.text
+            if _should_retry(response.status_code, detail) and attempt < attempts:
+                _sleep_with_backoff(backoff, attempt)
+                continue
+            raise RuntimeError(f"GitHub API error {response.status_code}: {detail}")
+
+        return response
+
+    raise RuntimeError("GitHub API request failed after retries.")
+
+
+def _retry_kwargs(
+    retry_attempts: int | None,
+    retry_backoff: float | None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if retry_attempts is not None:
+        kwargs["max_attempts"] = retry_attempts
+    if retry_backoff is not None:
+        kwargs["backoff"] = retry_backoff
+    return kwargs
+
+
+def _build_url(base_url: str, params: dict[str, Any] | None) -> str:
+    if not params:
+        return base_url
+    return f"{base_url}?{urlencode(params)}"
+
+
+def fetch_issue(
+    repo: str,
+    issue_number: int,
+    token: str,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+):
+    url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}"
+    data = _request_json(
+        "GET",
+        url,
+        token,
+        payload=None,
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    if not isinstance(data, dict):
+        raise RuntimeError("GitHub API did not return a JSON object for the issue.")
+    from scripts.duplicate_detection import parse_source_issue
+
+    return parse_source_issue(data)
+
+
+def fetch_issues(
+    repo: str,
+    token: str,
+    *,
+    labels: list[str] | None,
+    page: int,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+    per_page: int = 100,
+) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"state": "open", "page": page, "per_page": per_page}
+    if labels:
+        params["labels"] = ",".join(labels)
+    url = _build_url(f"{GITHUB_API}/repos/{repo}/issues", params)
+    data = _request_json(
+        "GET",
+        url,
+        token,
+        payload=None,
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    if not isinstance(data, list):
+        raise RuntimeError("GitHub API did not return a JSON array for issues.")
+    return data
+
+
+def fetch_issue_comments(
+    repo: str,
+    issue_number: int,
+    token: str,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+) -> list[dict[str, Any]]:
+    url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}/comments?per_page=100"
+    data = _request_json(
+        "GET",
+        url,
+        token,
+        payload=None,
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    if not isinstance(data, list):
+        raise RuntimeError("GitHub API did not return a JSON array for issue comments.")
+    return data
+
+
+def create_issue(
+    repo: str,
+    token: str,
+    title: str,
+    body: str | None,
+    labels: list[str] | None,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+) -> dict[str, Any]:
+    url = f"{GITHUB_API}/repos/{repo}/issues"
+    from scripts.duplicate_detection import build_issue_payload
+
+    payload = build_issue_payload(title, body, labels)
+    data = _request_json(
+        "POST",
+        url,
+        token,
+        payload=payload,
+        **_retry_kwargs(retry_attempts, retry_backoff),
+    )
+    if not isinstance(data, dict):
+        raise RuntimeError("GitHub API did not return a JSON object for the issue.")
+    return data
+
+
+def fetch_oauth_scopes(
+    token: str,
+    *,
+    retry_attempts: int | None = None,
+    retry_backoff: float | None = None,
+) -> str | None:
+    try:
+        response = _request_response(
+            "GET",
+            GITHUB_API,
+            token,
+            payload=None,
+            **_retry_kwargs(retry_attempts, retry_backoff),
+        )
+    except RuntimeError:
+        return None
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    return headers.get("X-OAuth-Scopes")

--- a/tests/scripts/test_pr_verifier_sync_manifest.py
+++ b/tests/scripts/test_pr_verifier_sync_manifest.py
@@ -1,0 +1,36 @@
+"""Regression coverage for synced pr_verifier dependencies."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / ".github" / "sync-manifest.yml"
+PR_VERIFIER = ROOT / "scripts" / "langchain" / "pr_verifier.py"
+
+
+def _manifest_sources() -> set[str]:
+    sources: set[str] = set()
+    for line in MANIFEST.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- source: "):
+            sources.add(stripped.removeprefix("- source: ").strip())
+    return sources
+
+
+def test_pr_verifier_imports_api_client_from_synced_manifest() -> None:
+    tree = ast.parse(PR_VERIFIER.read_text(encoding="utf-8"))
+
+    imports_api_client = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "scripts"
+        and any(alias.name == "api_client" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+
+    assert imports_api_client, "pr_verifier.py should continue importing scripts.api_client"
+
+    sources = _manifest_sources()
+    assert "scripts/langchain/pr_verifier.py" in sources
+    assert "scripts/api_client.py" in sources

--- a/tests/scripts/test_pr_verifier_sync_manifest.py
+++ b/tests/scripts/test_pr_verifier_sync_manifest.py
@@ -40,6 +40,4 @@ def test_pr_verifier_imports_api_client_from_synced_manifest() -> None:
 
 def test_pr_verifier_api_client_is_available_in_consumer_template() -> None:
     assert TEMPLATE_API_CLIENT.exists()
-    assert TEMPLATE_API_CLIENT.read_text(encoding="utf-8") == API_CLIENT.read_text(
-        encoding="utf-8"
-    )
+    assert TEMPLATE_API_CLIENT.read_text(encoding="utf-8") == API_CLIENT.read_text(encoding="utf-8")

--- a/tests/scripts/test_pr_verifier_sync_manifest.py
+++ b/tests/scripts/test_pr_verifier_sync_manifest.py
@@ -8,6 +8,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 MANIFEST = ROOT / ".github" / "sync-manifest.yml"
 PR_VERIFIER = ROOT / "scripts" / "langchain" / "pr_verifier.py"
+API_CLIENT = ROOT / "scripts" / "api_client.py"
+TEMPLATE_API_CLIENT = ROOT / "templates" / "consumer-repo" / "scripts" / "api_client.py"
 
 
 def _manifest_sources() -> set[str]:
@@ -34,3 +36,10 @@ def test_pr_verifier_imports_api_client_from_synced_manifest() -> None:
     sources = _manifest_sources()
     assert "scripts/langchain/pr_verifier.py" in sources
     assert "scripts/api_client.py" in sources
+
+
+def test_pr_verifier_api_client_is_available_in_consumer_template() -> None:
+    assert TEMPLATE_API_CLIENT.exists()
+    assert TEMPLATE_API_CLIENT.read_text(encoding="utf-8") == API_CLIENT.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2228 -->
> **Source:** Issue #2228

Closes #2228

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**This fix belongs in `stranske/Workflows`, not this consumer repo.** `scripts/langchain/pr_verifier.py:26` does `from scripts import api_client`, but no `api_client` module exists in the repo, so `import scripts.langchain.pr_verifier` raises `ImportError` at load and the `api_client.create_issue(...)` call site ([pr_verifier.py:681](scripts/langchain/pr_verifier.py:681)) is unreachable. `scripts/langchain/*` is synced from Workflows (`Workflows/.github/sync-manifest.yml:546`), so `api_client.py` was likely never synced to consumers. **Current** break (import fails). A locally-authored `api_client.py` would diverge from / be overwritten by the synced infra.

#### Tasks
- [ ] (Upstream, in `stranske/Workflows`) ensure `api_client` is present and synced for `scripts/langchain/pr_verifier.py:26` (add to `.github/sync-manifest.yml`, or change the import to the correct module).
- [ ] (Consumer) add `tests/test_langchain_imports_smoke.py` that attempts `import scripts.langchain.pr_verifier` (and the other `scripts/langchain/*` modules).
- [ ] (Consumer) after the upstream fix syncs, confirm the smoke test passes.

#### Acceptance criteria
- [ ] `tests/test_langchain_imports_smoke.py` exists and runs via `python -m pytest tests/test_langchain_imports_smoke.py -q`.
- [ ] **Observable gate (documents the current break):** TODAY, `python -c "import scripts.langchain.pr_verifier"` raises `ImportError` for `api_client` (capture in PR). After the upstream `api_client` sync, the same import succeeds and the smoke test passes.
- [ ] No local `scripts/api_client.py` is added in this repo (confirm absent).

<!-- auto-status-summary:end -->