### PR TITLE
fix: bump Codex CLI for gpt-5.5 runs

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -55,7 +55,7 @@ on:
       codex_cli_version:
         description: 'Pinned @openai/codex CLI version to install.'
         required: false
-        default: '0.101.0'
+        default: '0.125.0'
         type: string
       codex_model:
         description: 'Codex model ID to pass to codex exec.'

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -215,6 +215,7 @@ def test_reusable_codex_run_prefers_gpt_55_with_non_codex_fallback() -> None:
     run_step = _find_step_by_name(workflow, "Run Codex")
 
     assert inputs["codex_model"]["default"] == "gpt-5.5"
+    assert inputs["codex_cli_version"]["default"] == "0.125.0"
     assert resolve_step.get("id") == "codex_model"
     assert resolve_step["env"]["DEFAULT_CODEX_MODEL"] == "gpt-5.5"
     assert resolve_step["env"]["FALLBACK_CODEX_MODELS"] == "gpt-5.4"


### PR DESCRIPTION
## Summary
- bump reusable Codex runner default @openai/codex from 0.101.0 to 0.125.0
- assert the gpt-5.5 model default and CLI default stay aligned in workflow tests

## Root cause
After #2239, PR stranske/trip-planner#1339 did use gpt-5.5, but the runner still installed @openai/codex 0.101.0. The failed artifact contains:

```
The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.
```

## Verification
- uv run pytest tests/workflows/test_workflow_llm_installs.py tests/workflows/test_verifier_terminal_disposition.py -q
- git diff --check