### PR TITLE
style: format Codex CLI compatibility test

### DIFF
--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -258,9 +258,7 @@ def test_reusable_codex_run_model_cli_compatibility_contract() -> None:
 
     installed_cli = _parse_version_tuple(inputs["codex_cli_version"]["default"])
     candidates = _codex_run_model_candidates(resolve_step)
-    unreviewed_models = [
-        model for model in candidates if model not in MIN_CODEX_CLI_BY_RUN_MODEL
-    ]
+    unreviewed_models = [model for model in candidates if model not in MIN_CODEX_CLI_BY_RUN_MODEL]
     assert not unreviewed_models, (
         "Reusable Codex run model candidates need an explicit reviewed minimum CLI mapping: "
         + ", ".join(unreviewed_models)


### PR DESCRIPTION
## Summary
- apply Black formatting to the Codex model/CLI compatibility test added in #2241

## Why
#2241 merged, but post-merge CI reported that tests/workflows/test_workflow_llm_installs.py needed Black formatting.

## Validation
- uv run pytest tests/workflows/test_workflow_llm_installs.py -q
- uv run black --check --line-length 100 tests/workflows/test_workflow_llm_installs.py
- git diff --check