### PR TITLE
fix: resolve synced review debt

### DIFF
--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -68,15 +68,19 @@ def _request_response(
     attempts = max(1, max_attempts)
     for attempt in range(1, attempts + 1):
         try:
-            response = requests.request(
-                method,
-                url,
-                headers={
+            request_kwargs: dict[str, Any] = {
+                "headers": {
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
                 },
-                json=payload,
-                timeout=DEFAULT_TIMEOUT,
+                "timeout": DEFAULT_TIMEOUT,
+            }
+            if payload is not None:
+                request_kwargs["json"] = payload
+            response = requests.request(
+                method,
+                url,
+                **request_kwargs,
             )
         except requests.RequestException as exc:
             if attempt >= attempts:

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -68,15 +68,19 @@ def _request_response(
     attempts = max(1, max_attempts)
     for attempt in range(1, attempts + 1):
         try:
-            response = requests.request(
-                method,
-                url,
-                headers={
+            request_kwargs: dict[str, Any] = {
+                "headers": {
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
                 },
-                json=payload,
-                timeout=DEFAULT_TIMEOUT,
+                "timeout": DEFAULT_TIMEOUT,
+            }
+            if payload is not None:
+                request_kwargs["json"] = payload
+            response = requests.request(
+                method,
+                url,
+                **request_kwargs,
             )
         except requests.RequestException as exc:
             if attempt >= attempts:

--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -83,7 +83,7 @@ class EmbeddingProvider(ABC):
     cost_tier: int = 1
     latency_tier: int = 1
     priority: int = 0
-    capabilities: set[str] = set()
+    capabilities: frozenset[str] = frozenset()
 
     @property
     def default_model(self) -> str:
@@ -132,7 +132,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
     cost_tier = 2
     latency_tier = 2
     priority = 10
-    capabilities = {"embeddings"}
+    capabilities = frozenset({"embeddings"})
 
     @property
     def default_model(self) -> str:
@@ -191,7 +191,7 @@ class LocalFallbackEmbeddingProvider(EmbeddingProvider):
     cost_tier = 0
     latency_tier = 1
     priority = 0
-    capabilities = {"embeddings", "local"}
+    capabilities = frozenset({"embeddings", "local"})
 
     @property
     def default_model(self) -> str:
@@ -231,7 +231,7 @@ def _tokenize(text: str) -> list[str]:
 
 
 def _hash_token(token: str) -> int:
-    digest = hashlib.md5(token.encode("utf-8")).digest()
+    digest = hashlib.sha256(token.encode("utf-8")).digest()
     return int.from_bytes(digest[:8], "little")
 
 

--- a/tests/scripts/test_issue_dedup_smoke.py
+++ b/tests/scripts/test_issue_dedup_smoke.py
@@ -235,6 +235,32 @@ def test_request_json_returns_payload(monkeypatch) -> None:
     assert api_client._request_json("GET", "http://example", "token", None) == {"ok": True}
 
 
+def test_request_json_omits_json_argument_without_payload(monkeypatch) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_request(method, url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResponse(200, json_data={"ok": True})
+
+    monkeypatch.setattr(api_client.requests, "request", _fake_request)
+
+    assert api_client._request_json("GET", "http://example", "token", None) == {"ok": True}
+    assert "json" not in captured_kwargs
+
+
+def test_request_json_includes_json_argument_with_payload(monkeypatch) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_request(method, url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResponse(200, json_data={"ok": True})
+
+    monkeypatch.setattr(api_client.requests, "request", _fake_request)
+
+    assert api_client._request_json("POST", "http://example", "token", {"x": 1}) == {"ok": True}
+    assert captured_kwargs["json"] == {"x": 1}
+
+
 def test_request_json_retries_on_server_error(monkeypatch) -> None:
     responses = [
         DummyResponse(500, json_data={"message": "oops"}),

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 import types
 
@@ -46,6 +47,18 @@ def test_registry_selects_fallback_without_credentials(monkeypatch):
     assert selection is not None
     assert selection.provider.provider_id == "fallback"
     assert selection.provider.is_fallback() is True
+
+
+def test_provider_capabilities_are_immutable_and_fallback_hash_uses_sha256():
+    assert embedding_provider.EmbeddingProvider.capabilities == frozenset()
+    assert embedding_provider.OpenAIEmbeddingProvider.capabilities == frozenset({"embeddings"})
+    assert embedding_provider.LocalFallbackEmbeddingProvider.capabilities == frozenset(
+        {"embeddings", "local"}
+    )
+
+    digest = hashlib.sha256(b"example").digest()
+    expected = int.from_bytes(digest[:8], "little")
+    assert embedding_provider._hash_token("example") == expected
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -83,7 +83,7 @@ class EmbeddingProvider(ABC):
     cost_tier: int = 1
     latency_tier: int = 1
     priority: int = 0
-    capabilities: set[str] = set()
+    capabilities: frozenset[str] = frozenset()
 
     @property
     def default_model(self) -> str:
@@ -132,7 +132,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
     cost_tier = 2
     latency_tier = 2
     priority = 10
-    capabilities = {"embeddings"}
+    capabilities = frozenset({"embeddings"})
 
     @property
     def default_model(self) -> str:
@@ -191,7 +191,7 @@ class LocalFallbackEmbeddingProvider(EmbeddingProvider):
     cost_tier = 0
     latency_tier = 1
     priority = 0
-    capabilities = {"embeddings", "local"}
+    capabilities = frozenset({"embeddings", "local"})
 
     @property
     def default_model(self) -> str:
@@ -231,7 +231,7 @@ def _tokenize(text: str) -> list[str]:
 
 
 def _hash_token(token: str) -> int:
-    digest = hashlib.md5(token.encode("utf-8")).digest()
+    digest = hashlib.sha256(token.encode("utf-8")).digest()
     return int.from_bytes(digest[:8], "little")
 
 


### PR DESCRIPTION
## Summary

- Make synced embedding provider capability constants immutable with `frozenset`.
- Switch deterministic fallback token hashing from MD5 to SHA-256.
- Avoid passing `json=None` through the synced GitHub API request helper.

## Validation

- `python -m pytest tests/tools/test_embedding_provider.py tests/scripts/test_issue_dedup_smoke.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`
- `python -m black --check --line-length 100 scripts/api_client.py templates/consumer-repo/scripts/api_client.py tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py tests/scripts/test_issue_dedup_smoke.py`
- `python -m py_compile scripts/api_client.py templates/consumer-repo/scripts/api_client.py tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py`
- `git diff --check`

## Campaign

Addresses active non-outdated bot review debt observed on the current sync wave for `Travel-Plan-Permission#1164` and `trip-planner#1347`.
