### PR TITLE
ci: bump Claude Code action pin

### DIFF
--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Summary

- Bump the consumer-template `anthropics/claude-code-action` pin to the Dependabot-proposed `v1.0.140` SHA.
- Keep the update in Workflows source so synced consumers receive the shared workflow change consistently.

## Validation

- `python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python scripts/check_workflow_action_pins.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml`
- `git diff --check`

## Campaign

Supersedes the overlapping consumer Dependabot PRs that only update `.github/workflows/maint-76-claude-code-review.yml`.
