### PR TITLE
fix: resolve synced API client review debt

### DIFF
--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -126,9 +127,10 @@ def fetch_issue(
     issue_number: int,
     token: str,
     *,
+    parser: Callable[[dict[str, Any]], Any] | None = None,
     retry_attempts: int | None = None,
     retry_backoff: float | None = None,
-):
+) -> Any:
     url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}"
     data = _request_json(
         "GET",
@@ -139,9 +141,9 @@ def fetch_issue(
     )
     if not isinstance(data, dict):
         raise RuntimeError("GitHub API did not return a JSON object for the issue.")
-    from scripts.duplicate_detection import parse_source_issue
-
-    return parse_source_issue(data)
+    if parser is not None:
+        return parser(data)
+    return data
 
 
 def fetch_issues(
@@ -202,9 +204,11 @@ def create_issue(
     retry_backoff: float | None = None,
 ) -> dict[str, Any]:
     url = f"{GITHUB_API}/repos/{repo}/issues"
-    from scripts.duplicate_detection import build_issue_payload
-
-    payload = build_issue_payload(title, body, labels)
+    payload: dict[str, Any] = {"title": title}
+    if body is not None:
+        payload["body"] = body
+    if labels:
+        payload["labels"] = labels
     data = _request_json(
         "POST",
         url,

--- a/scripts/cli_handler.py
+++ b/scripts/cli_handler.py
@@ -19,6 +19,7 @@ from scripts.duplicate_detection import (
     format_source_confirmation,
     format_source_issue_line,
     matches_expected_duplicate,
+    parse_source_issue,
 )
 
 
@@ -372,6 +373,7 @@ def main(argv: list[str]) -> int:
             args.repo,
             args.source_issue,
             token,
+            parser=parse_source_issue,
             retry_attempts=args.retry_attempts,
             retry_backoff=args.retry_backoff,
         )

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -126,9 +127,10 @@ def fetch_issue(
     issue_number: int,
     token: str,
     *,
+    parser: Callable[[dict[str, Any]], Any] | None = None,
     retry_attempts: int | None = None,
     retry_backoff: float | None = None,
-):
+) -> Any:
     url = f"{GITHUB_API}/repos/{repo}/issues/{issue_number}"
     data = _request_json(
         "GET",
@@ -139,9 +141,9 @@ def fetch_issue(
     )
     if not isinstance(data, dict):
         raise RuntimeError("GitHub API did not return a JSON object for the issue.")
-    from scripts.duplicate_detection import parse_source_issue
-
-    return parse_source_issue(data)
+    if parser is not None:
+        return parser(data)
+    return data
 
 
 def fetch_issues(
@@ -202,9 +204,11 @@ def create_issue(
     retry_backoff: float | None = None,
 ) -> dict[str, Any]:
     url = f"{GITHUB_API}/repos/{repo}/issues"
-    from scripts.duplicate_detection import build_issue_payload
-
-    payload = build_issue_payload(title, body, labels)
+    payload: dict[str, Any] = {"title": title}
+    if body is not None:
+        payload["body"] = body
+    if labels:
+        payload["labels"] = labels
     data = _request_json(
         "POST",
         url,

--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -169,7 +169,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
-            client = OpenAIEmbeddings(model=resolved_model, api_key=os.environ["OPENAI_API_KEY"])
+            client = OpenAIEmbeddings(
+                model=resolved_model,
+                openai_api_key=os.environ["OPENAI_API_KEY"],
+            )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors
             raise RuntimeError("OpenAI embeddings request failed.") from exc

--- a/tests/scripts/test_issue_dedup_smoke.py
+++ b/tests/scripts/test_issue_dedup_smoke.py
@@ -261,6 +261,68 @@ def test_request_json_includes_json_argument_with_payload(monkeypatch) -> None:
     assert captured_kwargs["json"] == {"x": 1}
 
 
+def test_fetch_issue_returns_raw_issue_json_without_parser(monkeypatch) -> None:
+    def _fake_request(method, url, **kwargs):
+        return DummyResponse(
+            200,
+            json_data={
+                "number": 42,
+                "title": "Source",
+                "body": "Details",
+                "html_url": "http://example/42",
+            },
+        )
+
+    monkeypatch.setattr(api_client.requests, "request", _fake_request)
+
+    assert api_client.fetch_issue("owner/repo", 42, "token") == {
+        "number": 42,
+        "title": "Source",
+        "body": "Details",
+        "html_url": "http://example/42",
+    }
+
+
+def test_fetch_issue_applies_optional_parser(monkeypatch) -> None:
+    def _fake_request(method, url, **kwargs):
+        return DummyResponse(200, json_data={"number": 42, "title": "Source"})
+
+    monkeypatch.setattr(api_client.requests, "request", _fake_request)
+
+    assert (
+        api_client.fetch_issue(
+            "owner/repo",
+            42,
+            "token",
+            parser=lambda data: f"#{data['number']} {data['title']}",
+        )
+        == "#42 Source"
+    )
+
+
+def test_create_issue_builds_payload_without_duplicate_detection_import(monkeypatch) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_request(method, url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResponse(200, json_data={"html_url": "http://example/created"})
+
+    monkeypatch.setattr(api_client.requests, "request", _fake_request)
+
+    assert api_client.create_issue(
+        "owner/repo",
+        "token",
+        "Title",
+        "Body",
+        ["triage"],
+    ) == {"html_url": "http://example/created"}
+    assert captured_kwargs["json"] == {
+        "title": "Title",
+        "body": "Body",
+        "labels": ["triage"],
+    }
+
+
 def test_request_json_retries_on_server_error(monkeypatch) -> None:
     responses = [
         DummyResponse(500, json_data={"message": "oops"}),

--- a/tests/scripts/test_semantic_matcher.py
+++ b/tests/scripts/test_semantic_matcher.py
@@ -6,10 +6,10 @@ from tools.embedding_provider import FALLBACK_DIMENSIONS, LocalFallbackEmbedding
 
 
 class StubEmbeddings:
-    def __init__(self, model, base_url=None, api_key=None):
+    def __init__(self, model, base_url=None, api_key=None, openai_api_key=None):
         self.model = model
         self.base_url = base_url
-        self.api_key = api_key
+        self.api_key = api_key or openai_api_key
 
     def embed_documents(self, texts):
         return [[float(len(text))] for text in texts]

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -5,8 +5,22 @@ import types
 from tools import embedding_provider
 
 
+class StubEmbeddings:
+    def __init__(self, model, openai_api_key=None):
+        self.model = model
+        self.openai_api_key = openai_api_key
+
+    def embed_documents(self, texts):
+        return [[float(len(text))] for text in texts]
+
+
 def _install_stub_langchain(monkeypatch):
     monkeypatch.setitem(sys.modules, "langchain_openai", types.SimpleNamespace())
+
+
+def _install_stub_openai_embeddings(monkeypatch):
+    module = types.SimpleNamespace(OpenAIEmbeddings=StubEmbeddings)
+    monkeypatch.setitem(sys.modules, "langchain_openai", module)
 
 
 def test_registry_selects_openai_with_credentials(monkeypatch):
@@ -59,6 +73,18 @@ def test_provider_capabilities_are_immutable_and_fallback_hash_uses_sha256():
     digest = hashlib.sha256(b"example").digest()
     expected = int.from_bytes(digest[:8], "little")
     assert embedding_provider._hash_token("example") == expected
+
+
+def test_openai_provider_passes_openai_api_key(monkeypatch):
+    _install_stub_openai_embeddings(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+
+    provider = embedding_provider.OpenAIEmbeddingProvider()
+    response = provider.embed(["alpha"])
+
+    assert response.vectors == [[5.0]]
+    assert response.metadata.provider == "openai"
+    assert response.metadata.dimensions == 1
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -169,7 +169,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
-            client = OpenAIEmbeddings(model=resolved_model, api_key=os.environ["OPENAI_API_KEY"])
+            client = OpenAIEmbeddings(
+                model=resolved_model,
+                openai_api_key=os.environ["OPENAI_API_KEY"],
+            )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors
             raise RuntimeError("OpenAI embeddings request failed.") from exc


### PR DESCRIPTION
## Summary
- make synced api_client fetch/create helpers self-contained, with an optional parser hook for Workflows duplicate-detection callers
- pass OpenAI credentials to LangChain embeddings via openai_api_key
- mirror consumer template copies and add focused regressions

## Validation
- python -m pytest tests/tools/test_embedding_provider.py tests/scripts/test_semantic_matcher.py tests/scripts/test_issue_dedup_smoke.py -q
- python -m black --check --line-length 100 --target-version py312 scripts/api_client.py templates/consumer-repo/scripts/api_client.py scripts/cli_handler.py tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py tests/scripts/test_semantic_matcher.py tests/scripts/test_issue_dedup_smoke.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m py_compile scripts/api_client.py templates/consumer-repo/scripts/api_client.py scripts/cli_handler.py tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py
- git diff --check