### PR TITLE
ci: bump Claude Code action pin

### DIFF
--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
+        uses: anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -105,6 +105,7 @@ class EmbeddingProvider(ABC):
 
     def supports_model(self, model: str | None) -> bool:
         """Return True if the provider can serve the requested model."""
+        del model
         return True
 
     def supports_capabilities(self, required: set[str]) -> bool:

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -105,6 +105,7 @@ class EmbeddingProvider(ABC):
 
     def supports_model(self, model: str | None) -> bool:
         """Return True if the provider can serve the requested model."""
+        del model
         return True
 
     def supports_capabilities(self, required: set[str]) -> bool:


### PR DESCRIPTION
## Summary
- Bump the consumer template Claude Code review action pin to the Dependabot-requested v1.0.141 commit.
- Keep the change centralized in Workflows so consumer Dependabot PRs touching the synced workflow can be superseded by template sync.

## Validation
- python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
- python scripts/check_workflow_action_pins.py templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check