### PR TITLE
fix: simplify embedding provider model support

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -103,9 +103,8 @@ class EmbeddingProvider(ABC):
         """Return True if this provider is a non-LLM fallback."""
         return False
 
-    def supports_model(self, model: str | None) -> bool:
+    def supports_model(self, model: str | None) -> bool:  # noqa: ARG002
         """Return True if the provider can serve the requested model."""
-        del model
         return True
 
     def supports_capabilities(self, required: set[str]) -> bool:

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -75,6 +75,12 @@ def test_provider_capabilities_are_immutable_and_fallback_hash_uses_sha256():
     assert embedding_provider._hash_token("example") == expected
 
 
+def test_base_provider_supports_model_accepts_keyword_argument():
+    provider = embedding_provider.LocalFallbackEmbeddingProvider()
+
+    assert provider.supports_model(model="custom-embedding-model") is True
+
+
 def test_openai_provider_passes_openai_api_key(monkeypatch):
     _install_stub_openai_embeddings(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "token")

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -103,9 +103,8 @@ class EmbeddingProvider(ABC):
         """Return True if this provider is a non-LLM fallback."""
         return False
 
-    def supports_model(self, model: str | None) -> bool:
+    def supports_model(self, model: str | None) -> bool:  # noqa: ARG002
         """Return True if the provider can serve the requested model."""
-        del model
         return True
 
     def supports_capabilities(self, required: set[str]) -> bool:


### PR DESCRIPTION
## Summary
- remove the `del model` statement from the base embedding provider `supports_model()` implementation
- keep the public `model=` keyword name with a targeted Ruff `ARG002` suppression
- mirror the consumer template copy and add a regression for keyword-call compatibility

## Validation
- `python -m pytest tests/tools/test_embedding_provider.py -q`
- `python -m ruff check --select ARG002 tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`
- `git diff --check`

Campaign: sync/dependabot cleanup; source fix for active sync PR review threads in `tools/embedding_provider.py`.