### PR TITLE
fix: pass OpenAI embeddings api key correctly

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -171,7 +171,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                openai_api_key=os.environ["OPENAI_API_KEY"],
+                api_key=os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -6,9 +6,9 @@ from tools import embedding_provider
 
 
 class StubEmbeddings:
-    def __init__(self, model, openai_api_key=None):
+    def __init__(self, model, api_key=None):
         self.model = model
-        self.openai_api_key = openai_api_key
+        self.api_key = api_key
 
     def embed_documents(self, texts):
         return [[float(len(text))] for text in texts]
@@ -81,7 +81,7 @@ def test_base_provider_supports_model_accepts_keyword_argument():
     assert provider.supports_model(model="custom-embedding-model") is True
 
 
-def test_openai_provider_passes_openai_api_key(monkeypatch):
+def test_openai_provider_passes_api_key(monkeypatch):
     _install_stub_openai_embeddings(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "token")
 

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -171,7 +171,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                openai_api_key=os.environ["OPENAI_API_KEY"],
+                api_key=os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors


### PR DESCRIPTION
## Summary
- Pass OPENAI_API_KEY to langchain_openai.OpenAIEmbeddings using the current api_key keyword
- Mirror the fix into the consumer template embedding provider
- Update the regression stub so the test fails on the obsolete openai_api_key keyword

## Validation
- python -m pytest tests/tools/test_embedding_provider.py -q
- python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python -m black --check --line-length 100 --target-version py312 tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- git diff --check

Related to active sync/dependabot cleanup campaign.