### PR TITLE
fix: resolve synced typecheck and gate summary failures

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -663,6 +663,7 @@ jobs:
           GATE_ARTIFACTS_ROOT: ${{ github.workspace }}/gate_artifacts
 
       - name: Compose PR summary comment
+        if: always()
         id: compose_comment
         run: |
           python <<'PY'
@@ -674,7 +675,10 @@ jobs:
           head_sha = os.environ.get('HEAD_SHA', '').strip()
 
           if not body:
-              raise SystemExit('Summary body missing; aborting comment composition.')
+              body = (
+                  '## Automated Status Summary\n\n'
+                  '_Gate summary details were unavailable for this run._'
+              )
 
           head_token = head_sha[:12] if head_sha else ''
           parts = []
@@ -877,6 +881,10 @@ jobs:
             const { upsertAnchoredComment } = require('./.github/scripts/comment-dedupe.js');
 
             const commentPath = path.resolve('gate-summary.md');
+            if (!fs.existsSync(commentPath)) {
+              core.warning('gate-summary.md was not created; skipping summary comment update.');
+              return;
+            }
             const body = fs.readFileSync(commentPath, 'utf8');
             await upsertAnchoredComment({
               github,

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 GITHUB_API = "https://api.github.com"
 DEFAULT_TIMEOUT = 30

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -33,16 +33,17 @@ except ImportError as exc:  # pragma: no cover - exercised via CLI messaging.
 else:
     TOMLKIT_ERROR = None
 
+PytestIniConfig = tuple[Path, tuple[str, ...]]
 PYPROJECT_FILE = Path("pyproject.toml")
 PYTEST_TOML_FILES = (
     Path("pytest.toml"),
     Path(".pytest.toml"),
 )
-PYTEST_INI_CONFIGS = (
+PYTEST_INI_CONFIGS: tuple[PytestIniConfig, ...] = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
 )
-PYTEST_FALLBACK_INI_CONFIGS = (
+PYTEST_FALLBACK_INI_CONFIGS: tuple[PytestIniConfig, ...] = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -670,6 +670,7 @@ jobs:
           GATE_ARTIFACTS_ROOT: ${{ github.workspace }}/gate_artifacts
 
       - name: Compose PR summary comment
+        if: always()
         id: compose_comment
         run: |
           python <<'PY'
@@ -681,7 +682,10 @@ jobs:
           head_sha = os.environ.get('HEAD_SHA', '').strip()
 
           if not body:
-              raise SystemExit('Summary body missing; aborting comment composition.')
+              body = (
+                  '## Automated Status Summary\n\n'
+                  '_Gate summary details were unavailable for this run._'
+              )
 
           head_token = head_sha[:12] if head_sha else ''
           parts = []
@@ -884,6 +888,10 @@ jobs:
             const { upsertAnchoredComment } = require('./.github/scripts/comment-dedupe.js');
 
             const commentPath = path.resolve('gate-summary.md');
+            if (!fs.existsSync(commentPath)) {
+              core.warning('gate-summary.md was not created; skipping summary comment update.');
+              return;
+            }
             const body = fs.readFileSync(commentPath, 'utf8');
             await upsertAnchoredComment({
               github,

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 GITHUB_API = "https://api.github.com"
 DEFAULT_TIMEOUT = 30

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -33,16 +33,17 @@ except ImportError as exc:  # pragma: no cover - exercised via CLI messaging.
 else:
     TOMLKIT_ERROR = None
 
+PytestIniConfig = tuple[Path, tuple[str, ...]]
 PYPROJECT_FILE = Path("pyproject.toml")
 PYTEST_TOML_FILES = (
     Path("pytest.toml"),
     Path(".pytest.toml"),
 )
-PYTEST_INI_CONFIGS = (
+PYTEST_INI_CONFIGS: tuple[PytestIniConfig, ...] = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
 )
-PYTEST_FALLBACK_INI_CONFIGS = (
+PYTEST_FALLBACK_INI_CONFIGS: tuple[PytestIniConfig, ...] = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )

--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -17,6 +17,7 @@ Selection semantics:
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 import math
 import os
@@ -171,7 +172,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=os.environ["OPENAI_API_KEY"],
+                api_key=lambda: os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors
@@ -256,12 +257,14 @@ class EmbeddingProviderRegistry:
         """Register a provider instance."""
         self._providers.append(provider)
 
-    def list(self) -> list[EmbeddingProvider]:
+    def list(self) -> builtins.list[EmbeddingProvider]:
         """Return a copy of registered providers."""
         return list(self._providers)
 
-    def _eligible_providers(self, criteria: EmbeddingSelectionCriteria) -> list[EmbeddingProvider]:
-        candidates: list[EmbeddingProvider] = []
+    def _eligible_providers(
+        self, criteria: EmbeddingSelectionCriteria
+    ) -> builtins.list[EmbeddingProvider]:
+        candidates: builtins.list[EmbeddingProvider] = []
         for provider in self._providers:
             provider_id = provider.provider_id
             if criteria.provider_allowlist and provider_id not in criteria.provider_allowlist:

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -6,9 +6,12 @@ from tools import embedding_provider
 
 
 class StubEmbeddings:
+    last_instance = None
+
     def __init__(self, model, api_key=None):
         self.model = model
         self.api_key = api_key
+        StubEmbeddings.last_instance = self
 
     def embed_documents(self, texts):
         return [[float(len(text))] for text in texts]
@@ -91,6 +94,8 @@ def test_openai_provider_passes_api_key(monkeypatch):
     assert response.vectors == [[5.0]]
     assert response.metadata.provider == "openai"
     assert response.metadata.dimensions == 1
+    assert callable(StubEmbeddings.last_instance.api_key)
+    assert StubEmbeddings.last_instance.api_key() == "token"
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -17,6 +17,7 @@ Selection semantics:
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 import math
 import os
@@ -171,7 +172,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=os.environ["OPENAI_API_KEY"],
+                api_key=lambda: os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors
@@ -256,12 +257,14 @@ class EmbeddingProviderRegistry:
         """Register a provider instance."""
         self._providers.append(provider)
 
-    def list(self) -> list[EmbeddingProvider]:
+    def list(self) -> builtins.list[EmbeddingProvider]:
         """Return a copy of registered providers."""
         return list(self._providers)
 
-    def _eligible_providers(self, criteria: EmbeddingSelectionCriteria) -> list[EmbeddingProvider]:
-        candidates: list[EmbeddingProvider] = []
+    def _eligible_providers(
+        self, criteria: EmbeddingSelectionCriteria
+    ) -> builtins.list[EmbeddingProvider]:
+        candidates: builtins.list[EmbeddingProvider] = []
         for provider in self._providers:
             provider_id = provider.provider_id
             if criteria.provider_allowlist and provider_id not in criteria.provider_allowlist:


### PR DESCRIPTION
## Summary
- Fix synced embedding provider typing by passing the OpenAI API key as a callable and avoiding the registry list method annotation collision.
- Fix synced helper mypy noise for pytest INI config tuples and intentionally untyped requests imports.
- Make Gate summary comment creation resilient when summary body generation does not produce gate-summary.md.

## Validation
- python -m pytest tests/tools/test_embedding_provider.py tests/scripts/test_sync_test_dependencies.py tests/scripts/test_issue_dedup_smoke.py -q
- python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py scripts/api_client.py templates/consumer-repo/scripts/api_client.py tests/tools/test_embedding_provider.py
- python -m black --check --line-length 100 --target-version py312 tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py scripts/api_client.py templates/consumer-repo/scripts/api_client.py tests/tools/test_embedding_provider.py
- python -m mypy --config-file /dev/null --disable-error-code import-not-found tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py scripts/api_client.py templates/consumer-repo/scripts/api_client.py
- python scripts/validate_workflow_yaml.py .github/workflows/pr-00-gate.yml templates/consumer-repo/.github/workflows/pr-00-gate.yml
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- scripts/sync_templates.sh
- git diff --check