### PR TITLE
fix: pass OpenAI embeddings api key as string

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -172,7 +172,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=lambda: os.environ["OPENAI_API_KEY"],
+                api_key=os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -94,8 +94,7 @@ def test_openai_provider_passes_api_key(monkeypatch):
     assert response.vectors == [[5.0]]
     assert response.metadata.provider == "openai"
     assert response.metadata.dimensions == 1
-    assert callable(StubEmbeddings.last_instance.api_key)
-    assert StubEmbeddings.last_instance.api_key() == "token"
+    assert StubEmbeddings.last_instance.api_key == "token"
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -172,7 +172,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=lambda: os.environ["OPENAI_API_KEY"],
+                api_key=os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors


### PR DESCRIPTION
## Summary
- pass the resolved OpenAI API key string into `OpenAIEmbeddings` instead of a callable
- mirror the fix in the consumer template copy
- tighten the embedding provider regression test

## Validation
- `python -m pytest tests/tools/test_embedding_provider.py -q`
- `python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `scripts/sync_templates.sh`
- `git diff --check`