### PR TITLE
fix: resolve synced script type hygiene

### DIFF
--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+import importlib
 import time
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol, cast
 from urllib.parse import urlencode
-
-import requests  # type: ignore[import-untyped]
 
 GITHUB_API = "https://api.github.com"
 DEFAULT_TIMEOUT = 30
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF = 1.0
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class _Response(Protocol):
+    status_code: int
+    text: str
+
+    def json(self) -> Any: ...
+
+
+class _RequestsModule(Protocol):
+    RequestException: type[Exception]
+
+    def request(self, method: str, url: str, **kwargs: Any) -> _Response: ...
+
+
+requests = cast(_RequestsModule, importlib.import_module("requests"))
 
 
 def _should_retry(status_code: int, detail: Any) -> bool:
@@ -65,7 +80,7 @@ def _request_response(
     *,
     max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
     backoff: float = DEFAULT_RETRY_BACKOFF,
-) -> requests.Response:
+) -> _Response:
     attempts = max(1, max_attempts)
     for attempt in range(1, attempts + 1):
         try:
@@ -238,6 +253,7 @@ def fetch_oauth_scopes(
     except RuntimeError:
         return None
     headers = getattr(response, "headers", None)
-    if not headers:
+    if not isinstance(headers, Mapping):
         return None
-    return headers.get("X-OAuth-Scopes")
+    scopes = headers.get("X-OAuth-Scopes")
+    return str(scopes) if scopes is not None else None

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -33,7 +33,7 @@ except ImportError as exc:  # pragma: no cover - exercised via CLI messaging.
 else:
     TOMLKIT_ERROR = None
 
-PytestIniConfig = tuple[Path, tuple[str, ...]]
+type PytestIniConfig = tuple[Path, tuple[str, ...]]
 PYPROJECT_FILE = Path("pyproject.toml")
 PYTEST_TOML_FILES = (
     Path("pytest.toml"),

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+import importlib
 import time
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol, cast
 from urllib.parse import urlencode
-
-import requests  # type: ignore[import-untyped]
 
 GITHUB_API = "https://api.github.com"
 DEFAULT_TIMEOUT = 30
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF = 1.0
 RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class _Response(Protocol):
+    status_code: int
+    text: str
+
+    def json(self) -> Any: ...
+
+
+class _RequestsModule(Protocol):
+    RequestException: type[Exception]
+
+    def request(self, method: str, url: str, **kwargs: Any) -> _Response: ...
+
+
+requests = cast(_RequestsModule, importlib.import_module("requests"))
 
 
 def _should_retry(status_code: int, detail: Any) -> bool:
@@ -65,7 +80,7 @@ def _request_response(
     *,
     max_attempts: int = DEFAULT_RETRY_ATTEMPTS,
     backoff: float = DEFAULT_RETRY_BACKOFF,
-) -> requests.Response:
+) -> _Response:
     attempts = max(1, max_attempts)
     for attempt in range(1, attempts + 1):
         try:
@@ -238,6 +253,7 @@ def fetch_oauth_scopes(
     except RuntimeError:
         return None
     headers = getattr(response, "headers", None)
-    if not headers:
+    if not isinstance(headers, Mapping):
         return None
-    return headers.get("X-OAuth-Scopes")
+    scopes = headers.get("X-OAuth-Scopes")
+    return str(scopes) if scopes is not None else None

--- a/templates/consumer-repo/scripts/sync_test_dependencies.py
+++ b/templates/consumer-repo/scripts/sync_test_dependencies.py
@@ -33,7 +33,7 @@ except ImportError as exc:  # pragma: no cover - exercised via CLI messaging.
 else:
     TOMLKIT_ERROR = None
 
-PytestIniConfig = tuple[Path, tuple[str, ...]]
+type PytestIniConfig = tuple[Path, tuple[str, ...]]
 PYPROJECT_FILE = Path("pyproject.toml")
 PYTEST_TOML_FILES = (
     Path("pytest.toml"),


### PR DESCRIPTION
## Summary
- replace the synced `PytestIniConfig` assignment with a Python 3.12 type alias statement
- remove the `requests` import-untyped suppression from the synced API client by using a narrow local protocol around the runtime module
- mirror both changes into `templates/consumer-repo/`

## Validation
- `python -m py_compile scripts/api_client.py templates/consumer-repo/scripts/api_client.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py`
- `python -m pytest tests/scripts/test_issue_dedup_smoke.py tests/scripts/test_sync_test_dependencies.py tests/scripts/test_sync_test_dependencies_mapping.py -q`
- `python scripts/validate_template_sync.py && python scripts/validate_template_completeness.py && scripts/sync_templates.sh && git diff --check`
- `python -m ruff check scripts/api_client.py templates/consumer-repo/scripts/api_client.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py`
- `python -m mypy --python-version 3.12 --strict --ignore-missing-imports scripts/api_client.py templates/consumer-repo/scripts/api_client.py scripts/sync_test_dependencies.py templates/consumer-repo/scripts/sync_test_dependencies.py`

Campaign note: resolves active bot review debt observed on `stranske/learning-management-system#274`; wait for this PR to merge, then dispatch Maint 68 to replace the blocked sync PR.
