### PR TITLE
fix: pass OpenAI embeddings api key as SecretStr

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -168,7 +168,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             from langchain_openai import OpenAIEmbeddings
             from pydantic import SecretStr
         except ImportError as exc:
-            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
+            raise RuntimeError(
+                "langchain_openai and pydantic are required for OpenAI embeddings."
+            ) from exc
 
         try:
             api_key = SecretStr(os.environ["OPENAI_API_KEY"])

--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -166,13 +166,15 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("OpenAI embeddings requested without OPENAI_API_KEY configured.")
         try:
             from langchain_openai import OpenAIEmbeddings
+            from pydantic import SecretStr
         except ImportError as exc:
             raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
+            api_key = SecretStr(os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=os.environ["OPENAI_API_KEY"],
+                api_key=api_key,
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -97,6 +97,21 @@ def test_openai_provider_passes_api_key(monkeypatch):
     assert StubEmbeddings.last_instance.api_key.get_secret_value() == "token"
 
 
+def test_openai_provider_names_required_imports(monkeypatch):
+    _install_stub_openai_embeddings(monkeypatch)
+    monkeypatch.setitem(sys.modules, "pydantic", None)
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+
+    provider = embedding_provider.OpenAIEmbeddingProvider()
+
+    try:
+        provider.embed(["alpha"])
+    except RuntimeError as exc:
+        assert "langchain_openai and pydantic are required" in str(exc)
+    else:
+        raise AssertionError("expected missing pydantic to raise RuntimeError")
+
+
 def test_registry_selection_is_deterministic(monkeypatch):
     _install_stub_langchain(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "token")

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -94,7 +94,7 @@ def test_openai_provider_passes_api_key(monkeypatch):
     assert response.vectors == [[5.0]]
     assert response.metadata.provider == "openai"
     assert response.metadata.dimensions == 1
-    assert StubEmbeddings.last_instance.api_key == "token"
+    assert StubEmbeddings.last_instance.api_key.get_secret_value() == "token"
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -168,7 +168,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             from langchain_openai import OpenAIEmbeddings
             from pydantic import SecretStr
         except ImportError as exc:
-            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
+            raise RuntimeError(
+                "langchain_openai and pydantic are required for OpenAI embeddings."
+            ) from exc
 
         try:
             api_key = SecretStr(os.environ["OPENAI_API_KEY"])

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -166,13 +166,15 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("OpenAI embeddings requested without OPENAI_API_KEY configured.")
         try:
             from langchain_openai import OpenAIEmbeddings
+            from pydantic import SecretStr
         except ImportError as exc:
             raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
+            api_key = SecretStr(os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=os.environ["OPENAI_API_KEY"],
+                api_key=api_key,
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors


### PR DESCRIPTION
## Summary
- Wrap the OpenAI embeddings API key in pydantic SecretStr before constructing OpenAIEmbeddings
- Mirror the fix into the consumer template copy
- Update the focused embedding provider regression test

## Validation
- python -m pytest tests/tools/test_embedding_provider.py -q
- python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m py_compile tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py
- scripts/sync_templates.sh
- git diff --check
- python -m black --check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python -m mypy --config-file pyproject.toml tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py