### PR TITLE
fix: keep OpenAI embedding api key runtime-compatible

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -25,6 +25,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 FALLBACK_DIMENSIONS = 256
@@ -166,14 +167,11 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("OpenAI embeddings requested without OPENAI_API_KEY configured.")
         try:
             from langchain_openai import OpenAIEmbeddings
-            from pydantic import SecretStr
         except ImportError as exc:
-            raise RuntimeError(
-                "langchain_openai and pydantic are required for OpenAI embeddings."
-            ) from exc
+            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
-            api_key = SecretStr(os.environ["OPENAI_API_KEY"])
+            api_key = cast(Any, os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
                 api_key=api_key,

--- a/tests/tools/test_embedding_provider.py
+++ b/tests/tools/test_embedding_provider.py
@@ -94,22 +94,7 @@ def test_openai_provider_passes_api_key(monkeypatch):
     assert response.vectors == [[5.0]]
     assert response.metadata.provider == "openai"
     assert response.metadata.dimensions == 1
-    assert StubEmbeddings.last_instance.api_key.get_secret_value() == "token"
-
-
-def test_openai_provider_names_required_imports(monkeypatch):
-    _install_stub_openai_embeddings(monkeypatch)
-    monkeypatch.setitem(sys.modules, "pydantic", None)
-    monkeypatch.setenv("OPENAI_API_KEY", "token")
-
-    provider = embedding_provider.OpenAIEmbeddingProvider()
-
-    try:
-        provider.embed(["alpha"])
-    except RuntimeError as exc:
-        assert "langchain_openai and pydantic are required" in str(exc)
-    else:
-        raise AssertionError("expected missing pydantic to raise RuntimeError")
+    assert StubEmbeddings.last_instance.api_key == "token"
 
 
 def test_registry_selection_is_deterministic(monkeypatch):

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -25,6 +25,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 FALLBACK_DIMENSIONS = 256
@@ -166,14 +167,11 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             raise RuntimeError("OpenAI embeddings requested without OPENAI_API_KEY configured.")
         try:
             from langchain_openai import OpenAIEmbeddings
-            from pydantic import SecretStr
         except ImportError as exc:
-            raise RuntimeError(
-                "langchain_openai and pydantic are required for OpenAI embeddings."
-            ) from exc
+            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
 
         try:
-            api_key = SecretStr(os.environ["OPENAI_API_KEY"])
+            api_key = cast(Any, os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
                 api_key=api_key,


### PR DESCRIPTION
## Summary
- pass OpenAI embedding API keys as plain strings at runtime for optional SDK compatibility
- keep newer langchain_openai type stubs quiet with a narrow cast
- remove the pydantic-only regression expectation from the focused tests

## Validation
- python -m pytest tests/tools/test_embedding_provider.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python -m mypy tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- python -m black --check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py
- scripts/sync_templates.sh
- git diff --check