### PR TITLE
fix: keep OpenAI embedding key typed

### DIFF
--- a/templates/consumer-repo/tools/embedding_provider.py
+++ b/templates/consumer-repo/tools/embedding_provider.py
@@ -25,7 +25,6 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, cast
 
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 FALLBACK_DIMENSIONS = 256
@@ -168,13 +167,15 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             from langchain_openai import OpenAIEmbeddings
         except ImportError as exc:
-            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
+            raise RuntimeError(
+                "langchain_openai and its dependencies are required for OpenAI embeddings."
+            ) from exc
 
         try:
-            api_key = cast(Any, os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=api_key,
+                # Keep a plain str for runtime compatibility across supported langchain_openai versions.
+                api_key=os.environ["OPENAI_API_KEY"],  # type: ignore[arg-type]
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors

--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -25,7 +25,6 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, cast
 
 DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 FALLBACK_DIMENSIONS = 256
@@ -168,13 +167,15 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             from langchain_openai import OpenAIEmbeddings
         except ImportError as exc:
-            raise RuntimeError("langchain_openai is required for OpenAI embeddings.") from exc
+            raise RuntimeError(
+                "langchain_openai and its dependencies are required for OpenAI embeddings."
+            ) from exc
 
         try:
-            api_key = cast(Any, os.environ["OPENAI_API_KEY"])
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=api_key,
+                # Keep a plain str for runtime compatibility across supported langchain_openai versions.
+                api_key=os.environ["OPENAI_API_KEY"],  # type: ignore[arg-type]
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors


### PR DESCRIPTION
## Summary\n- remove the redundant Any/cast escape hatch around OPENAI_API_KEY\n- keep passing a plain string at runtime for langchain_openai compatibility\n- broaden the import error message for missing transitive dependencies\n- mirror the source change into the consumer template copy\n\n## Validation\n- python -m pytest tests/tools/test_embedding_provider.py -q\n- python -m ruff check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py\n- python scripts/validate_template_sync.py\n- python scripts/validate_template_completeness.py\n- python -m black --check tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py tests/tools/test_embedding_provider.py\n- python -m mypy tools/embedding_provider.py templates/consumer-repo/tools/embedding_provider.py\n- scripts/sync_templates.sh\n- git diff --check