### PR TITLE
security: env-pass agent-generated issue title/body in agents-80 (script-injection fix)

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -481,6 +481,13 @@ jobs:
       - name: Create issue
         if: steps.check-merged.outputs.merged == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        # Security: pass agent/LLM-generated title and body via the environment, never
+        # interpolated into the script body. A value containing a quote or newline could
+        # otherwise break out of the JS string literal and execute with the workflow token
+        # on the pull_request_target path (script injection).
+        env:
+          ISSUE_TITLE: ${{ steps.generate.outputs.issue_title || steps.fallback.outputs.issue_title }}
+          ISSUE_BODY: ${{ steps.generate.outputs.issue_body || steps.fallback.outputs.issue_body }}
         with:
           script: |
             const fs = require('fs');
@@ -489,12 +496,8 @@ jobs:
               ? require(retryHelperPath)
               : { withRetry: (fn) => fn() };
 
-            const issueTitle = (
-              '${{ steps.generate.outputs.issue_title || steps.fallback.outputs.issue_title }}'
-            );
-            const issueBody = (
-              '${{ steps.generate.outputs.issue_body || steps.fallback.outputs.issue_body }}'
-            );
+            const issueTitle = process.env.ISSUE_TITLE || '';
+            const issueBody = process.env.ISSUE_BODY || '';
 
             if (!issueTitle || !issueBody) {
               core.setFailed('Failed to generate issue content');


### PR DESCRIPTION
## Why

The `verify_to_issue` → **Create issue** step in `templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml` interpolated the agent/LLM-generated `issue_title` and `issue_body` **directly into the `actions/github-script` JS source** as single-quoted string literals (previously lines 492-497):

```js
const issueTitle = ( '${{ steps.generate.outputs.issue_title || steps.fallback.outputs.issue_title }}' );
const issueBody  = ( '${{ steps.generate.outputs.issue_body  || steps.fallback.outputs.issue_body  }}' );
```

The body is produced by `scripts/langchain/followup_issue_generator.py` (or the fallback, which reads PR title + verification text), i.e. content influenced by PR/issue input. This job runs on the **`pull_request_target`** trigger, so it executes with the base-repo token. A title/body containing a single quote (or `');…//`/newline) breaks out of the JS string literal and executes arbitrary JS with that token. This file is synced to all 9 consumer repos via `maint-68`, so the exposure is fleet-wide.

## What changed

Standard GitHub-recommended mitigation: pass the two values through `env:` and read `process.env` in the script, so they are **data, not code**. No behavioral change for normal content.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(F))"` → OK.
- Grep for `'${{` / `"${{` interpolated into a JS literal in this file → none remain.
- The remaining `${{ }}` uses in the file are YAML-level `with:`/`env:` value bindings (safe), not script-body interpolation.

## Follow-up (not in this PR)

Optional defense-in-depth: add a fork-author guard on the `pull_request_target` path. Kept out of this PR to keep the security fix minimal and behavior-preserving; can be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)