### PR TITLE
feat(keepalive): enforce pause/needs-human guardrails in the loop + level-based sweep (#2267)

### DIFF
--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -217,6 +217,49 @@ test('evaluateKeepaliveLoop skips when keepalive is disabled', async () => {
   assert.equal(result.reason, 'keepalive-disabled');
 });
 
+test('evaluateKeepaliveLoop skips a paused PR even on a green Gate with work remaining (#2267)', async () => {
+  const pr = {
+    number: 267,
+    head: { ref: 'codex/issue-1', sha: 'sha-267' },
+    labels: [{ name: 'agent:codex' }, { name: 'agents:paused' }],
+    body: '## Tasks\n- [ ] one\n- [ ] two\n## Acceptance Criteria\n- [ ] a\n- [ ] b\n',
+  };
+  const github = buildGithubStub({
+    pr,
+    workflowRuns: [{ head_sha: 'sha-267', conclusion: 'success' }],
+  });
+  const result = await evaluateKeepaliveLoop({
+    github,
+    context: buildContext(pr.number),
+    core: buildCore(),
+  });
+  // Deliberate-break gate (#2267): removing the `pausedByLabel` branch in
+  // evaluateKeepaliveLoop makes this same PR dispatch (action 'run') instead of skipping,
+  // so this assertion is what catches a regression of the operator pause control.
+  assert.equal(result.action, 'skip');
+  assert.equal(result.reason, 'paused');
+});
+
+test('evaluateKeepaliveLoop skips a needs-human PR until the label is cleared (#2267)', async () => {
+  const pr = {
+    number: 268,
+    head: { ref: 'codex/issue-2', sha: 'sha-268' },
+    labels: [{ name: 'agent:codex' }, { name: 'needs-human' }],
+    body: '## Tasks\n- [ ] one\n- [ ] two\n## Acceptance Criteria\n- [ ] a\n- [ ] b\n',
+  };
+  const github = buildGithubStub({
+    pr,
+    workflowRuns: [{ head_sha: 'sha-268', conclusion: 'success' }],
+  });
+  const result = await evaluateKeepaliveLoop({
+    github,
+    context: buildContext(pr.number),
+    core: buildCore(),
+  });
+  assert.equal(result.action, 'skip');
+  assert.equal(result.reason, 'needs-human');
+});
+
 test('evaluateKeepaliveLoop stops when tasks are complete and verification is done', async () => {
   const pr = {
     number: 303,

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2398,6 +2398,19 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     const hasHighPrivilege = labels.includes('agent-high-privilege');
     const keepaliveEnabled = config.keepalive_enabled && hasAgentLabel;
 
+    // Operator stop-controls (#2267). The canonical event-driven loop must enforce the
+    // documented pause / human-block guardrails itself — previously they lived only on
+    // the orchestrator path, so `agents:paused` / `needs-human` did not actually stop
+    // the loop from re-dispatching on the next green Gate.
+    //   * agents:paused  — operator pause (canonical spelling; agents:pause accepted as a
+    //                      transitional alias to match reusable-agents-pr-health).
+    //   * needs-human    — hard human-blocker; stays stopped until a human removes it.
+    //   * agents:max-runs:0 — explicit "hold" cap. (K>=1 is already enforced by the
+    //                      per-PR concurrency group `keepalive-<pr>`, cancel-in-progress:false.)
+    const pausedByLabel = labels.includes('agents:paused') || labels.includes('agents:pause');
+    const humanBlocked = labels.includes('needs-human');
+    const runCapZero = labels.includes('agents:max-runs:0');
+
     const sections = parseScopeTasksAcceptanceSections(pr.body || '');
     const normalisedSections = normaliseChecklistSections(sections);
     const combinedChecklist = [normalisedSections?.tasks, normalisedSections?.acceptance]
@@ -2620,8 +2633,19 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     const hasDefinitiveConflict = conflictResult.hasConflict &&
       conflictResult.primarySource === 'github-api';
 
+    // Operator stop-controls (#2267) take precedence over every dispatch decision so a
+    // paused or human-blocked PR never re-dispatches an agent, even on a green Gate.
+    if (pausedByLabel) {
+      action = 'skip';
+      reason = 'paused';
+    } else if (humanBlocked) {
+      action = 'skip';
+      reason = 'needs-human';
+    } else if (runCapZero) {
+      action = 'skip';
+      reason = 'run-cap-zero';
     // Conflict resolution takes highest priority ONLY for definitive conflicts
-    if (hasDefinitiveConflict && hasAgentLabel && keepaliveEnabled) {
+    } else if (hasDefinitiveConflict && hasAgentLabel && keepaliveEnabled) {
       action = 'conflict';
       reason = `merge-conflict-${conflictResult.primarySource || 'detected'}`;
     } else if (!hasAgentLabel) {

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -57,6 +57,9 @@ workflows:
   - source: .github/workflows/agents-81-gate-followups.yml
     description: "Gate followups hub - consolidates keepalive and autofix followups"
 
+  - source: .github/workflows/agents-keepalive-sweep.yml
+    description: "Keepalive sweep (#2267) - periodic level-based resync; dispatches the loop for open agent PRs so silent zero-commit stalls resurface"
+
   # Agent system - execution
   - source: .github/workflows/agents-keepalive-loop-reporter.yml
     description: "Keepalive reporter - posts summary when keepalive run fails or cancels"

--- a/.github/workflows/agents-keepalive-sweep.yml
+++ b/.github/workflows/agents-keepalive-sweep.yml
@@ -1,0 +1,79 @@
+# Agents Keepalive Sweep (#2267)
+#
+# Level-based resync for the event-driven keepalive loop. The loop reacts to Gate
+# completions and label events; a round that ends with zero commits produces no
+# follow-up event, so a silently-stalled PR is never re-evaluated and the loop goes
+# quiet instead of escalating. This periodic sweep re-runs the loop for every open PR
+# carrying an `agent:*` label, so stalls resurface on their own.
+#
+# Safety: this only *dispatches the existing loop* — it makes no dispatch decision of
+# its own. The loop's state-fingerprint/debounce makes an unchanged PR a near-free
+# no-op, and the #2267 operator guardrails (`agents:paused` / `needs-human` /
+# `agents:max-runs:0`) ensure the sweep never causes a paused or human-blocked PR to
+# re-dispatch an agent.
+
+name: Agents Keepalive Sweep
+
+on:
+  schedule:
+    - cron: '23 * * * *'   # hourly, off-peak minute (avoid the :00 stampede)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List eligible PRs without dispatching the loop'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write   # workflow_dispatch of the keepalive loop
+
+concurrency:
+  group: keepalive-sweep-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Re-evaluate stalled agent PRs
+    runs-on: ubuntu-latest
+    # Only sweep where the loop itself is active (root repo runs the loop directly).
+    if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true'
+    steps:
+      - name: Dispatch keepalive loop for open agent PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const dryRun = String(
+              (context.payload.inputs && context.payload.inputs.dry_run) || 'false',
+            ) === 'true';
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const eligible = prs.filter((pr) =>
+              !pr.draft && (pr.labels || []).some((l) => /^agent:/i.test(l.name || '')),
+            );
+            core.info(`Open PRs: ${prs.length}; non-draft agent-labelled: ${eligible.length}`);
+            let dispatched = 0;
+            for (const pr of eligible) {
+              if (dryRun) {
+                core.info(`[dry-run] would re-evaluate PR #${pr.number}`);
+                continue;
+              }
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'agents-keepalive-loop.yml',
+                  ref: context.payload.repository.default_branch,
+                  inputs: { pr_number: String(pr.number) },
+                });
+                dispatched += 1;
+              } catch (error) {
+                core.warning(`Failed to dispatch loop for PR #${pr.number}: ${error.message}`);
+              }
+            }
+            await core.summary
+              .addRaw(`Keepalive sweep: ${eligible.length} agent PR(s) eligible, ${dispatched} re-evaluated (dry_run=${dryRun}).`)
+              .write();

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -2398,6 +2398,19 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     const hasHighPrivilege = labels.includes('agent-high-privilege');
     const keepaliveEnabled = config.keepalive_enabled && hasAgentLabel;
 
+    // Operator stop-controls (#2267). The canonical event-driven loop must enforce the
+    // documented pause / human-block guardrails itself — previously they lived only on
+    // the orchestrator path, so `agents:paused` / `needs-human` did not actually stop
+    // the loop from re-dispatching on the next green Gate.
+    //   * agents:paused  — operator pause (canonical spelling; agents:pause accepted as a
+    //                      transitional alias to match reusable-agents-pr-health).
+    //   * needs-human    — hard human-blocker; stays stopped until a human removes it.
+    //   * agents:max-runs:0 — explicit "hold" cap. (K>=1 is already enforced by the
+    //                      per-PR concurrency group `keepalive-<pr>`, cancel-in-progress:false.)
+    const pausedByLabel = labels.includes('agents:paused') || labels.includes('agents:pause');
+    const humanBlocked = labels.includes('needs-human');
+    const runCapZero = labels.includes('agents:max-runs:0');
+
     const sections = parseScopeTasksAcceptanceSections(pr.body || '');
     const normalisedSections = normaliseChecklistSections(sections);
     const combinedChecklist = [normalisedSections?.tasks, normalisedSections?.acceptance]
@@ -2620,8 +2633,19 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     const hasDefinitiveConflict = conflictResult.hasConflict &&
       conflictResult.primarySource === 'github-api';
 
+    // Operator stop-controls (#2267) take precedence over every dispatch decision so a
+    // paused or human-blocked PR never re-dispatches an agent, even on a green Gate.
+    if (pausedByLabel) {
+      action = 'skip';
+      reason = 'paused';
+    } else if (humanBlocked) {
+      action = 'skip';
+      reason = 'needs-human';
+    } else if (runCapZero) {
+      action = 'skip';
+      reason = 'run-cap-zero';
     // Conflict resolution takes highest priority ONLY for definitive conflicts
-    if (hasDefinitiveConflict && hasAgentLabel && keepaliveEnabled) {
+    } else if (hasDefinitiveConflict && hasAgentLabel && keepaliveEnabled) {
       action = 'conflict';
       reason = `merge-conflict-${conflictResult.primarySource || 'detected'}`;
     } else if (!hasAgentLabel) {

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-sweep.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-sweep.yml
@@ -1,0 +1,78 @@
+# Agents Keepalive Sweep (#2267)
+#
+# Level-based resync for the event-driven keepalive loop. The consumer loop
+# (agents-81-gate-followups.yml) reacts to Gate completions and label events; a round
+# that ends with zero commits produces no follow-up event, so a silently-stalled PR is
+# never re-evaluated. This periodic sweep re-runs the loop for every open PR carrying an
+# `agent:*` label, so stalls resurface on their own.
+#
+# Safety: this only *dispatches the existing loop* — it makes no dispatch decision of its
+# own. The loop's state-fingerprint/debounce makes an unchanged PR a near-free no-op, and
+# the operator guardrails (`agents:paused` / `needs-human` / `agents:max-runs:0`) ensure
+# the sweep never causes a paused or human-blocked PR to re-dispatch an agent.
+
+name: Agents Keepalive Sweep
+
+on:
+  schedule:
+    - cron: '23 * * * *'   # hourly, off-peak minute
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List eligible PRs without dispatching the loop'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write   # workflow_dispatch of the keepalive loop
+
+concurrency:
+  group: keepalive-sweep-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Re-evaluate stalled agent PRs
+    runs-on: ubuntu-latest
+    # Consumers run the loop via agents-81 only in consolidated mode.
+    if: vars.USE_CONSOLIDATED_WORKFLOWS == 'true'
+    steps:
+      - name: Dispatch keepalive loop for open agent PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const dryRun = String(
+              (context.payload.inputs && context.payload.inputs.dry_run) || 'false',
+            ) === 'true';
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const eligible = prs.filter((pr) =>
+              !pr.draft && (pr.labels || []).some((l) => /^agent:/i.test(l.name || '')),
+            );
+            core.info(`Open PRs: ${prs.length}; non-draft agent-labelled: ${eligible.length}`);
+            let dispatched = 0;
+            for (const pr of eligible) {
+              if (dryRun) {
+                core.info(`[dry-run] would re-evaluate PR #${pr.number}`);
+                continue;
+              }
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'agents-81-gate-followups.yml',
+                  ref: context.payload.repository.default_branch,
+                  inputs: { pr_number: String(pr.number) },
+                });
+                dispatched += 1;
+              } catch (error) {
+                core.warning(`Failed to dispatch loop for PR #${pr.number}: ${error.message}`);
+              }
+            }
+            await core.summary
+              .addRaw(`Keepalive sweep: ${eligible.length} agent PR(s) eligible, ${dispatched} re-evaluated (dry_run=${dryRun}).`)
+              .write();


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2267 -->
> **Source:** Issue #2267

Closes #2267

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The event-driven keepalive loop is the canonical re-dispatch path (root workflow
`.github/workflows/agents-keepalive-loop.yml`, "Agents Keepalive Loop"; consumer
`templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml`). Its
decision is made by `evaluateKeepaliveLoop` in
`.github/scripts/keepalive_loop.js:2253`. `docs/keepalive/GoalsAndPlumbing.md`
documents three operator stop/throttle controls that this function is supposed to
honor:

- §4 line 82: "Respect the `agents:paused` label, which blocks *all* keepalive
  activity."
- §4 line 83 / §4 lines 85-88: "After repeated failures (default: 3), the loop
  pauses and adds `needs-human` label" and resumption requires *removing*
  `needs-human`.
- §3 line 74: "Respect `agents:max-parallel:<K>` when present (integer 1-5)" — a
  per-PR run cap.

Verified: `evaluateKeepaliveLoop`'s decision tree enforces **none** of these.
The action is chosen at `keepalive_loop.js:2624-2635`:

```
if (hasDefinitiveConflict && hasAgentLabel && keepaliveEnabled) { action = 'conflict'; ... }
else if (!hasAgentLabel) { ... reason = 'missing-agent-label'; }
else if (!keepaliveEnabled) { action = 'skip'; reason = 'no-checklists'; }
```

with `keepaliveEnabled = config.keepalive_enabled && hasAgentLabel`
(`keepalive_loop.js:2399`). There is no read of `agents:paused`, no read of
`needs-human`, and no run-cap parse anywhere in the function.

Specific wrong/missing behavior:

1. **`agents:paused` is ignored.** `grep -n "agents:paused" .github/scripts/keepalive_loop.js`
   returns nothing; the literal is defined only in the orchestrator-path file
   `.github/scripts/keepalive_gate.js:12` (`const PAUSE_LABEL = 'agents:paused'`).
   In `agents-keepalive-loop.yml` the label appears only inside the
   state-fingerprint hash — where *adding* it changes the hash and therefore
   guarantees the run is not deduped away. A PR with `agent:codex` +
   `agents:paused` + green Gate + unchecked tasks dispatches normally.
2. **`needs-human` does not pause at dispatch.** The label is *added* at
   `keepalive_loop.js:3998-4002` (inside the `if (stop)` block of
   `updateKeepaliveLoopSummary`), but `evaluateKeepaliveLoop` never consults
   `needs-human` or `state.failure.count` when choosing the action. On the next
   green Gate (or any label event — adding `needs-human` itself flips the
   fingerprint), gate-green + tasks-remaining → `run` again. The "pause" only
   holds while the Gate stays red.
3. **No run cap.** No `agents:max-parallel:<K>` (or any K override) is parsed in
   the loop path; the only throttle is the per-PR concurrency group plus the
   runner-dispatch debounce.

This is a **current break** (verified by reading the live decision tree, not a
latent edge case): the primary operator stop control (`agents:paused`) and the
documented failure-pause (`needs-human`) do not stop the event-driven loop.
`agents:paused` and `needs-human` only take effect on the 30-minute orchestrator
path (`keepalive_gate.js:1002`), not on the event-driven loop that fires on every
Gate completion.

#### Tasks
- [ ] In `evaluateKeepaliveLoop` (`.github/scripts/keepalive_loop.js:2253`),
  before the action-selection block at lines 2624-2635, add an early
  `agents:paused` guard: when the lowercased `labels` array (built at
  `keepalive_loop.js:2318-2320`) includes `agents:paused`, return
  `{ action: 'skip', reason: 'paused', ... }` with the same return shape used by
  the existing skip path (`keepalive_loop.js:2823-2872`).
- [ ] In the same function, add a `needs-human` / failure-threshold guard:
  return `{ action: 'skip', reason: 'needs-human' }` (or `'failure-threshold'`)
  when `labels` includes `needs-human` OR when the loaded keepalive state's
  `failure.count >= failureThreshold` (the `failure_threshold` value parsed by
  `parseConfig`, default 3 per `keepalive_loop.js:1604-1607`). This must short
  the action regardless of Gate conclusion.
- [ ] Parse a per-PR run-cap label in `evaluateKeepaliveLoop` (define the prefix
  constant near the other label constants, e.g. `const RUN_CAP_PREFIX = ...`),
  clamp to 1-5, and skip with `reason:'run-cap-reached'` when in-progress run
  count is at/over the cap. Name the chosen label in `## Implementation Notes`;
  if reusing the orchestrator's existing `agents:max-runs:` prefix
  (`keepalive_gate.js:9`), import or re-declare it consistently.
- [ ] Ensure the new skip reasons are treated as neutral (no failure-count
  increment, no PR-comment noise) consistent with the existing neutral-stop
  handling at `keepalive_loop.js:3135` and the §5 No-Noise policy
  (`docs/keepalive/GoalsAndPlumbing.md:97`).
- [ ] Extend `.github/scripts/__tests__/keepalive-loop.test.js` with the
  deliberate-break test described in Acceptance Criteria, modeled on the
  existing `evaluateKeepaliveLoop waits when agent label is missing`
  (`keepalive-loop.test.js:180`) and `... skips when keepalive is disabled`
  (`keepalive-loop.test.js:200`) cases using the `buildGithubStub` helper
  (`keepalive-loop.test.js:23`).

#### Acceptance criteria
- [ ] New named test in `.github/scripts/__tests__/keepalive-loop.test.js`, e.g.
  `evaluateKeepaliveLoop skips when agents:paused is present`: builds a PR via
  `buildGithubStub` with labels `['agent:codex','agents:paused']`, a **green**
  Gate run, and at least one **unchecked** task, calls `evaluateKeepaliveLoop`,
  and asserts `result.action === 'skip'` and `result.reason === 'paused'`. A
  parallel case asserts `result.action === 'skip'` for a PR carrying
  `needs-human` (green Gate + unchecked tasks). Run via
  `node --test .github/scripts/__tests__/keepalive-loop.test.js` → both pass.
- [ ] **Deliberate-break gate:** after implementing the guard, temporarily
  comment out the new `agents:paused` early-return at the top of
  `evaluateKeepaliveLoop` (`keepalive_loop.js:2253`). With the guard removed, the
  new `agents:paused` test **must FAIL** — concretely, `result.action` comes back
  as `'run'`/`'fix'` (a dispatch) instead of `'skip'`, proving the test catches a
  loop that ignores the pause label. Capture the FAIL output, then restore the
  guard so the test passes again.
- [ ] The existing 102 passing cases in
  `.github/scripts/__tests__/keepalive-loop.test.js` still pass after the change
  (`node --test .github/scripts/__tests__/keepalive-loop.test.js` shows `fail 0`),
  confirming the new guards do not regress the existing wait/skip/run/fix/verify
  decisions.

**Head SHA:** 25d06be701ded02695947ba77e6bfe322de1636c
**Latest Runs:** ❔ action required — Gate
**Required:** gate: ❔ action required

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252140) |
| Health 40 Sweep | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252151) |
| Health 44 Gate Branch Protection | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252090) |
| Health 45 Agents Guard | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252101) |
| Health 50 Security Scan | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252125) |
| Health 72 Template Sync | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252100) |
| Health 73 Template Completeness | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252102) |
| Health 74 Template Drift | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252098) |
| Keepalive E2E | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252126) |
| Maint 52 Validate Workflows | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252096) |
| PR 11 - Minimal invariant CI | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252113) |
| Running Copilot Code Review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27460250924) |
| Selftest CI | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252085) |
| Validate Sync Manifest | ❔ action required | [View run](https://github.com/stranske/Workflows/actions/runs/27460252088) |
<!-- auto-status-summary:end -->