### PR TITLE
Fix IndentationError in reusable-codex-run reference-pack heredoc (#2263)

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -509,9 +509,9 @@ jobs:
               print(f"Cloning {repo}@{ref} for pack '{name}'...")
               if os.path.exists(clone_dir):
                   shutil.rmtree(clone_dir)
-                if token:
+              if token:
                   clone_url = f"https://x-access-token:{token}@github.com/{repo}.git"
-                else:
+              else:
                   clone_url = f"https://github.com/{repo}.git"
 
               # Detect whether ref is a full 40-char commit SHA.

--- a/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
+++ b/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
@@ -1,0 +1,67 @@
+"""Static guard: the reference-pack Python heredoc embedded in the reusable
+agent-run workflows is valid, compilable Python.
+
+Background — why this test exists
+=================================
+Issue #2263: ``.github/workflows/reusable-codex-run.yml`` carried an
+``IndentationError`` in the "Validate and materialize reference packs" step.
+Inside the ``python3 <<'REFPACK_EOF'`` heredoc the ``if token:`` / ``else:``
+block was indented at 16 spaces — a level matching no enclosing block (the
+loop body is at 14 spaces, the inner ``if`` body at 18). Python raised
+``IndentationError: unindent does not match any outer indentation level``.
+
+The step has no step-level ``if:`` and only short-circuits (via a shell guard)
+when ``.github/reference_packs.json`` is absent. Any repo that ships that file
+(PAEM does today) ran the broken heredoc and failed the step hard, before the
+"Assemble prompt" step — so every Codex keepalive/fix/conflict/verify run in
+that repo aborted, while the correctly-indented Claude sibling succeeded.
+
+Ordinary CI never compiled the heredoc body (it lives as text inside a YAML
+``run:`` block), so the break was invisible until runtime. This test closes
+that gap: it extracts the ``REFPACK_EOF`` heredoc body from both reusable run
+workflows and asserts it compiles.
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REUSABLE_RUN_WORKFLOWS = [
+    ".github/workflows/reusable-codex-run.yml",
+    ".github/workflows/reusable-claude-run.yml",
+]
+
+# Matches `python3 <<'REFPACK_EOF'` or `python3 << 'REFPACK_EOF'` and captures
+# the heredoc body up to the closing marker.
+_HEREDOC = re.compile(
+    r"python3 ?<< ?'REFPACK_EOF'\n(.*?)\n\s*REFPACK_EOF",
+    re.S,
+)
+
+
+@pytest.mark.parametrize("workflow_rel", REUSABLE_RUN_WORKFLOWS)
+def test_refpack_heredoc_compiles(workflow_rel: str) -> None:
+    path = ROOT / workflow_rel
+    assert path.exists(), f"missing workflow file: {workflow_rel}"
+
+    src = path.read_text()
+    match = _HEREDOC.search(src)
+    assert match is not None, (
+        f"{workflow_rel}: could not locate the python3 <<'REFPACK_EOF' "
+        "reference-pack heredoc"
+    )
+
+    body = textwrap.dedent(match.group(1))
+    try:
+        compile(body, f"<{workflow_rel}:REFPACK_EOF>", "exec")
+    except SyntaxError as exc:  # IndentationError is a SyntaxError subclass
+        pytest.fail(
+            f"{workflow_rel}: reference-pack heredoc does not compile: "
+            f"{type(exc).__name__}: {exc}"
+        )

--- a/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
+++ b/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
@@ -53,8 +53,7 @@ def test_refpack_heredoc_compiles(workflow_rel: str) -> None:
     src = path.read_text()
     match = _HEREDOC.search(src)
     assert match is not None, (
-        f"{workflow_rel}: could not locate the python3 <<'REFPACK_EOF' "
-        "reference-pack heredoc"
+        f"{workflow_rel}: could not locate the python3 <<'REFPACK_EOF' " "reference-pack heredoc"
     )
 
     body = textwrap.dedent(match.group(1))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2263 -->
> **Source:** Issue #2263

Closes #2263

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`.github/workflows/reusable-codex-run.yml` has a Python `IndentationError` in the
"Validate and materialize reference packs" step (step `id: reference_packs`,
`reusable-codex-run.yml:476`). Inside the `python3 <<'REFPACK_EOF'` heredoc
(opens at `reusable-codex-run.yml:494`), the `if token:` / `else:` block is
mis-indented:

- `reusable-codex-run.yml:510` `if os.path.exists(clone_dir):` is at 14 spaces (correct loop-body level).
- `reusable-codex-run.yml:511` `shutil.rmtree(clone_dir)` is at 18 spaces (correctly nested under the `if os.path.exists`).
- `reusable-codex-run.yml:512` `if token:` and `:514` `else:` are at **16 spaces** — a level that matches **no** enclosing block (the `for plan in ...` body is 14 spaces, the inner `if` body is 18). Python raises `IndentationError: unindent does not match any outer indentation level`.

Verified by extracting the heredoc body and running `python -m py_compile` →
it fails with that exact error at the `if token:` line. The correct, working
shape is the Claude sibling at `reusable-claude-run.yml:487` (`if token:`) and
`:489` (`else:`), both at 14 spaces; that file's heredoc (marker `REFPACK_EOF`,
`reusable-claude-run.yml:469-547`) compiles cleanly.

The step has **no step-level `if:`** (it runs on every codex-run invocation) and
its `run:` block starts with `set -euo pipefail` (`reusable-codex-run.yml:481`).
A shell guard at `reusable-codex-run.yml:482` (`if [ ! -f ".github/reference_packs.json" ]; then ... exit 0; fi`)
short-circuits the step only when `.github/reference_packs.json` is **absent**.
When that file is present, execution reaches the broken heredoc and the step
fails hard, before the "Assemble prompt" step.

This is a **current break**, not latent fragility, for any repo that ships
`.github/reference_packs.json`. `Portable-Alpha-Extension-Model/.github/reference_packs.json`
exists today (785 bytes, the only fleet repo with the file). Consumers call this
workflow `@main` (`templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml:425`
and `:1242`), and seven root workflows call it too (`agents-keepalive-loop.yml`,
`agents-autofix-loop.yml`, `reusable-bot-comment-handler.yml`,
`reusable-agents-pr-health.yml`, `health-codex-auth-check.yml`,
`maint-72-fix-pr-body-conflicts.yml`, `health-keepalive-e2e.yml`). Net effect: in
PAEM every Codex keepalive / fix / conflict / verify run fails at reference-pack
materialization, while the Claude lane (correct indentation) succeeds — silently
skewing delegation/effectiveness data toward Claude in the one repo that uses the
feature.

#### Tasks
- [ ] In `.github/workflows/reusable-codex-run.yml`, re-indent `if token:`
  (line 512) and `else:` (line 514) from 16 spaces to **14 spaces** (loop-body
  level), and align their body lines (`:513`, `:515`) to 18 spaces, so the block
  is a sibling of the `if os.path.exists(clone_dir):` at line 510 — matching
  `reusable-claude-run.yml:487-490`.
- [ ] Extract the `reference_packs` heredoc body (between `python3 <<'REFPACK_EOF'`
  at `:494` and `REFPACK_EOF`) and confirm `python -m py_compile` succeeds on it
  (see Implementation Notes for the exact extraction command).
- [ ] Diff the corrected `reusable-codex-run.yml` heredoc against the
  `reusable-claude-run.yml` heredoc (`:469-547`) and confirm the `if token:`/`else:`
  indentation now matches the Claude variant exactly.
- [ ] Confirm no other line in the `reference_packs` heredoc changed (the PR diff
  for this file is whitespace-only on lines 512-515).

#### Acceptance criteria
- [ ] **Deliberate-state gate (compile must flip FAIL→PASS):** extracting the
  `reference_packs` heredoc body from `reusable-codex-run.yml` and running
  `python -m py_compile <extracted.py>` **fails** on the unmodified file with
  `IndentationError: unindent does not match any outer indentation level` at the
  `if token:` line, and **passes** after the re-indent. Capture both outputs in
  the PR. (To prove the gate is falsifiable: re-introducing the 16-space
  indentation must reproduce the failure.)
- [ ] The corrected `if token:`/`else:` block in `reusable-codex-run.yml` is
  byte-for-byte indentation-identical to `reusable-claude-run.yml:487-490`
  (verified by diff in the PR).
- [ ] `python -m yaml` / a YAML lint of `reusable-codex-run.yml` still parses
  (the heredoc edit did not break the surrounding YAML), e.g.
  `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/reusable-codex-run.yml'))"`
  exits 0.

<!-- auto-status-summary:end -->