### PR TITLE
Fix health-40 aggregate heredoc gate (#2264)

### DIFF
--- a/.github/workflows/health-40-repo-selfcheck.yml
+++ b/.github/workflows/health-40-repo-selfcheck.yml
@@ -494,10 +494,10 @@ jobs:
               lines.append('| --- | --- | --- |')
               for check in checks:
                   title = check.get('title', 'Unknown')
-                status_key = check.get('status', 'info')
-                status = status_labels.get(status_key, status_key)
-                detail_raw = check.get('detail') or ''
-                detail = str(detail_raw).replace('\n', '<br>').replace('|', '\\|')
+                  status_key = check.get('status', 'info')
+                  status = status_labels.get(status_key, status_key)
+                  detail_raw = check.get('detail') or ''
+                  detail = str(detail_raw).replace('\n', '<br>').replace('|', '\\|')
                   lines.append(f'| {title} | {status} | {detail} |')
 
           if privileged_skipped:
@@ -662,7 +662,7 @@ jobs:
               *fix_items,
           ])
 
-            comment_body = '\n'.join(block for block in comment_sections if block is not None)
+          comment_body = '\n'.join(block for block in comment_sections if block is not None)
 
           issue_sections = [
               '# Repository self-check findings',
@@ -709,6 +709,7 @@ jobs:
               has_warnings = 'true' if findings and not error_findings else 'false'
               handle.write(f"has_errors={has_errors}\n")
               handle.write(f"has_warnings={has_warnings}\n")
+              handle.write("checks_ran=true\n")
               handle.write(f"privileged_mode={privileged_mode}\n")
               handle.write('issue_body<<ISSUE\n')
               handle.write(issue_body)
@@ -948,6 +949,7 @@ jobs:
       - name: Close failure tracker issue
         if: >-
           ${{
+            steps.aggregate.outputs.checks_ran == 'true' &&
             steps.aggregate.outputs.has_errors != 'true' &&
             steps.aggregate.outputs.has_warnings != 'true'
           }}

--- a/tests/workflows/test_health40_repo_selfcheck_aggregate.py
+++ b/tests/workflows/test_health40_repo_selfcheck_aggregate.py
@@ -13,10 +13,10 @@ WORKFLOW = ROOT / ".github/workflows/health-40-repo-selfcheck.yml"
 def _extract_aggregate_heredoc() -> str:
     text = WORKFLOW.read_text(encoding="utf-8")
     match = re.search(
-        r"      - name: Aggregate & Summarize\n"
-        r".*?^          python - <<'PY'\n"
+        r"^\s*-\s+name:\s+Aggregate & Summarize\n"
+        r".*?^\s*python\s+-\s+<<'PY'\n"
         r"(?P<body>.*?)"
-        r"^          PY\n",
+        r"^\s*PY\n",
         text,
         flags=re.MULTILINE | re.DOTALL,
     )
@@ -38,10 +38,11 @@ def test_close_tracker_gate_requires_positive_checks_ran_signal() -> None:
 
     assert 'handle.write("checks_ran=true\\n")' in text
     assert re.search(
-        r"- name: Close failure tracker issue\n"
-        r".*?steps\.aggregate\.outputs\.checks_ran == 'true' &&\n"
-        r"\s+steps\.aggregate\.outputs\.has_errors != 'true' &&\n"
-        r"\s+steps\.aggregate\.outputs\.has_warnings != 'true'",
+        r"-\s+name:\s+Close failure tracker issue\b"
+        r"(?s:.*?)"
+        r"steps\.aggregate\.outputs\.checks_ran\s*==\s*'true'\s*&&\s*"
+        r"steps\.aggregate\.outputs\.has_errors\s*!=\s*'true'\s*&&\s*"
+        r"steps\.aggregate\.outputs\.has_warnings\s*!=\s*'true'",
         text,
         flags=re.DOTALL,
     )

--- a/tests/workflows/test_health40_repo_selfcheck_aggregate.py
+++ b/tests/workflows/test_health40_repo_selfcheck_aggregate.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import py_compile
+import re
+import tempfile
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/health-40-repo-selfcheck.yml"
+
+
+def _extract_aggregate_heredoc() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        r"      - name: Aggregate & Summarize\n"
+        r".*?^          python - <<'PY'\n"
+        r"(?P<body>.*?)"
+        r"^          PY\n",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match, "Aggregate & Summarize Python heredoc not found"
+    return textwrap.dedent(match.group("body"))
+
+
+def test_aggregate_python_heredoc_compiles() -> None:
+    body = _extract_aggregate_heredoc()
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", encoding="utf-8") as handle:
+        handle.write(body)
+        handle.flush()
+        py_compile.compile(handle.name, doraise=True)
+
+
+def test_close_tracker_gate_requires_positive_checks_ran_signal() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'handle.write("checks_ran=true\\n")' in text
+    assert re.search(
+        r"- name: Close failure tracker issue\n"
+        r".*?steps\.aggregate\.outputs\.checks_ran == 'true' &&\n"
+        r"\s+steps\.aggregate\.outputs\.has_errors != 'true' &&\n"
+        r"\s+steps\.aggregate\.outputs\.has_warnings != 'true'",
+        text,
+        flags=re.DOTALL,
+    )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,9 @@
+# Workloop State
+
+## 2026-06-13T08:23Z - closer (codex) review-fix pushed for #2288
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2288](https://github.com/stranske/Workflows/pull/2288), source issue `#2264`, branch `codex/issue-2264-health40-aggregate-heredoc`.
+- **Blocker:** two unresolved Copilot review threads in `tests/workflows/test_health40_repo_selfcheck_aggregate.py` flagged indentation/layout-sensitive regex assertions.
+- **Action:** relaxed the aggregate heredoc extraction and close-gate assertion regexes to tolerate YAML indentation and line wrapping while preserving the required contract checks.
+- **Validation:** `python -m pytest tests/workflows/test_health40_repo_selfcheck_aggregate.py -q -rA` passed (`2 passed`); `python -m py_compile tests/workflows/test_health40_repo_selfcheck_aggregate.py` passed.
+- **Next action:** wait for fresh PR checks and review-thread state after push; if checks are green and review threads are resolved, merge and apply the appropriate verifier handling for source issue `#2264`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2264 -->
> **Source:** Issue #2264

Closes #2264

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The "Aggregate & Summarize" step of `.github/workflows/health-40-repo-selfcheck.yml`
(step `id: aggregate`, `health-40-repo-selfcheck.yml:405`) contains a Python
heredoc (`python - <<'PY'`, opens at `:422`, closes at the `PY` marker on `:717`)
with **two** `IndentationError`s:

1. `health-40-repo-selfcheck.yml:497` — `status_key = check.get('status', 'info')`
   is at **16 spaces**, but it sits inside the `for check in checks:` loop opened
   at `:495` whose body (`:496` `title = check.get('title', 'Unknown')`) is at
   18 spaces. 16 < 18 with no matching outer level → `IndentationError: unindent
   does not match any outer indentation level`.
2. `health-40-repo-selfcheck.yml:665` — `comment_body = '\n'.join(...)` is at
   **12 spaces**, immediately after a block that dedents to 10 spaces (`:663`
   `])`, `:667` `issue_sections = [` at 10). A line at 12 there is an unexpected
   indent.

Verified by extracting the heredoc body (`:423`–`:716`) and running
`python -m py_compile` → it fails with `IndentationError`. The step's `run:` uses
the default GitHub Actions shell (`bash -e`), the step has **no**
`continue-on-error`, and the crash happens at Python parse time — before
`:704` ever opens `$GITHUB_OUTPUT`. So the step **fails on every run** and writes
**none** of its outputs (`comment_body`, `has_errors`, `has_warnings`,
`issue_body`, `privileged_mode`, defined at `:705`–`:715`).

This is a **current break**: the `repo-health` job fails on its weekly schedule
(`cron: '20 6 * * 1'`, `:4-5`) and on every `workflow_dispatch`, and the
downstream summary/issue-body/comment steps that depend on the missing outputs
are starved.

**Latent state-destruction risk in the close path (NOT currently reachable, but
load-bearing to fix):** the "Close failure tracker issue" step
(`health-40-repo-selfcheck.yml:948`) fires when
`steps.aggregate.outputs.has_errors != 'true' && ...has_warnings != 'true'`
(`:951-952`) and, on match, closes the issue titled
`[health] repository self-check failed` with `state: 'closed'`,
`state_reason: 'completed'` (`:988-993`). This `!= 'true'` predicate treats
**absent/empty output as "all clear"** — a no-signal-equals-success design.
Today the destructive close does **not** trigger off this crash, because the
Close step uses a **bare `if:`** (no `success()`/`always()`/`failure()`
function), so GitHub Actions prepends an implicit `success()`; once the Aggregate
step fails, `success()` is false and the Close step is **skipped** (the
`if: always()` step at `:720` does not reset this). The fragility is real and
one edit away from becoming destructive: any future change that makes the
Aggregate step *succeed while still emitting empty outputs* (e.g. wrapping the
heredoc in a `try/except`, adding `continue-on-error: true`, or an early
non-crashing return) would satisfy `!= 'true'` for both and auto-close a
legitimately-open tracker issue. We fix the crash (current break) **and** harden
the close gate to require a positive success signal (latent fragility) so the
two failure modes can never compose into silent issue deletion.

#### Tasks
- [ ] In `.github/workflows/health-40-repo-selfcheck.yml`, re-indent
  `status_key = check.get('status', 'info')` (line 497) and the following sibling
  lines `:498`–`:500` from 16 spaces to **18 spaces** so they are inside the
  `for check in checks:` body (loop at `:495`, body level set by `:496` at 18sp).
- [ ] Re-indent `comment_body = '\n'.join(...)` (line 665) from 12 spaces to
  **10 spaces** so it aligns with the surrounding statements (`:663` `])` at 10,
  `:667` `issue_sections = [` at 10).
- [ ] In the same heredoc's output-writing block (`:704`–`:715`), add a positive
  signal `handle.write("checks_ran=true\n")` so a successful Aggregate run emits
  `checks_ran=true` and a crashed run emits nothing.
- [ ] Change the "Close failure tracker issue" `if:` (`:949-953`) to require the
  positive signal, e.g. `steps.aggregate.outputs.checks_ran == 'true' &&
  steps.aggregate.outputs.has_errors != 'true' && steps.aggregate.outputs.has_warnings != 'true'`,
  so an empty/absent `checks_ran` (the crash case) can never reach the
  `github.rest.issues.update({ state: 'closed' })` call at `:988-993`.
- [ ] Perform the deliberate-state verification in Acceptance Criteria (extract
  heredoc → py_compile FAIL→PASS), capturing both outputs in the PR.

#### Acceptance criteria
- [ ] **Deliberate-state gate (compile must flip FAIL→PASS):** extracting the
  `aggregate` heredoc body (lines 423–716) from `health-40-repo-selfcheck.yml`
  and running `python -m py_compile <extracted.py>` **fails** with
  `IndentationError` on the unmodified file and **passes** after both re-indents.
  Capture both outputs in the PR. (Falsifiability: re-introducing either the
  16-space `status_key` or the 12-space `comment_body` must reproduce a compile
  failure.)
- [ ] The close-gate hardening is demonstrated by a documented dry-run/trace:
  with `checks_ran` **absent** (simulating the crashed-Aggregate case), the
  rendered `if:` expression
  `checks_ran == 'true' && has_errors != 'true' && has_warnings != 'true'`
  evaluates to **false** (so the close path is not taken). Show the evaluated
  condition (e.g. a `gh workflow run health-40-repo-selfcheck.yml` run where the
  "Close failure tracker issue" step is reported as skipped, or a documented
  expression-evaluation in the PR) — the close step must NOT run when
  `checks_ran` is empty.
- [ ] A clean run (no findings) still closes the tracker: with
  `checks_ran=true`, `has_errors=false`, `has_warnings=false`, the close
  condition evaluates true (documented in the PR), preserving the intended
  close-on-recovery behavior.

<!-- auto-status-summary:end -->