### PR TITLE
Fix auto-pilot verify_step github-script parse error + undefined vars (#2265)

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -2190,9 +2190,8 @@ jobs:
               env: process.env,
               task: 'auto-pilot-verify',
               capabilities: ['issues:write', 'pulls:read']
-              }));
-              const prefix = `Dispatched belt dispatcher (agent: ${agentKey}) for issue`;
-              core.info(`${prefix} #${issueNumber}`);
+            });
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
 
             // Find the merged PR for this issue
             // Look for PRs with the meta marker or explicit closing reference

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -2190,9 +2190,8 @@ jobs:
               env: process.env,
               task: 'auto-pilot-verify',
               capabilities: ['issues:write', 'pulls:read']
-              }));
-              const prefix = `Dispatched belt dispatcher (agent: ${agentKey}) for issue`;
-              core.info(`${prefix} #${issueNumber}`);
+            });
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
 
             // Find the merged PR for this issue
             // Look for PRs with the meta marker or explicit closing reference

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -34,6 +34,15 @@ def _workflow_on_section(data: dict) -> dict:
     return data.get("on") or data.get(True) or {}
 
 
+def _workflow_step_by_id(path: Path, step_id: str) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    for job in (data.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if step.get("id") == step_id:
+                return step
+    raise AssertionError(f"{path} must define step id {step_id!r}")
+
+
 def test_agents_orchestrator_inputs_and_uses():
     # The orchestrator is now split: dispatcher calls init and main reusable workflows
     dispatcher = WORKFLOWS_DIR / "agents-70-orchestrator.yml"
@@ -148,6 +157,25 @@ def test_auto_pilot_dispatches_pr_event_hub_pr_meta_only():
         assert "inputsByWorkflow" in text
         assert "'agents-80-pr-event-hub.yml': {" in text
         assert "handler: 'pr-meta'" in text
+
+
+def test_auto_pilot_verify_step_parses_in_source_and_template():
+    workflow_paths = [
+        WORKFLOWS_DIR / "agents-auto-pilot.yml",
+        Path("templates/consumer-repo/.github/workflows/agents-auto-pilot.yml"),
+    ]
+
+    for workflow_path in workflow_paths:
+        step = _workflow_step_by_id(workflow_path, "verify_step")
+        script = (step.get("with") or {}).get("script") or ""
+
+        assert "capabilities: ['issues:write', 'pulls:read']\n}));" not in script
+        assert (
+            "capabilities: ['issues:write', 'pulls:read']\n});\n"
+            "const issueNumber = Number(process.env.ISSUE_NUMBER);"
+        ) in script
+        assert "agentKey" not in script
+        assert "Dispatched belt dispatcher" not in script
 
 
 def test_orchestrator_bootstrap_label_delegates_fallback():

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,14 @@
 # Workloop State
 
+## 2026-06-13T09:13Z - closer (codex) review-fix pushed for #2289
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2289](https://github.com/stranske/Workflows/pull/2289), source issue `#2265`, branch `claude/issue-2265-autopilot-verify-paren`.
+- **Blocker:** two unresolved review threads required mirroring the `verify_step` github-script parse/runtime repair from `.github/workflows/agents-auto-pilot.yml` into the consumer template at `templates/consumer-repo/.github/workflows/agents-auto-pilot.yml`.
+- **Action:** pushed rebased commit `ae57662b` to the PR branch. The template verify step now closes `createTokenAwareRetry({...})` with `});`, binds `issueNumber` from `process.env.ISSUE_NUMBER`, and removes the stale `agentKey` belt-dispatcher log. Added `test_auto_pilot_verify_step_parses_in_source_and_template` to guard the source/template pair.
+- **Validation:** `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q -rA` passed (`62 passed`); `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; AsyncFunction parse checks passed for both source and template verify-step script bodies.
+- **Review state:** resolved review threads `PRRT_kwDOQprj9M6JUFOW` and `PRRT_kwDOQprj9M6JUFRf`; posted evidence comment https://github.com/stranske/Workflows/pull/2289#issuecomment-4698092479.
+- **Next action:** wait for fresh CI on head `ae57662b` to finish. Final snapshot: PR non-draft, `MERGEABLE`, `mergeStateStatus=UNSTABLE`; review threads resolved; checks still in progress (`Gate` python ci/ledger validation, `enforce`, `CodeQL`). If they settle green, merge #2289; Workflows convention means no verifier label unless a repo-specific verifier target is explicitly intended.
+
 ## 2026-06-13T08:23Z - closer (codex) review-fix pushed for #2288
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2288](https://github.com/stranske/Workflows/pull/2288), source issue `#2264`, branch `codex/issue-2264-health40-aggregate-heredoc`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2265 -->
> **Source:** Issue #2265

Closes #2265

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The "Execute step - Verify" step of `.github/workflows/agents-auto-pilot.yml`
(step `id: verify_step`, `agents-auto-pilot.yml:2178`, gated
`if: steps.next.outputs.next_step == 'verify'`) runs an
`actions/github-script@v9` body (`agents-auto-pilot.yml:2181`, `script:` block
starts at `:2185`) that does not parse:

- `agents-auto-pilot.yml:2187` opens `const { withRetry } = await createTokenAwareRetry({`
  with a single `(` and a single `{`.
- `agents-auto-pilot.yml:2193` closes that call with `}));` — `}` closes the
  object literal, then there are **two** `)`. Only one `(` was opened, so the
  second `)` is an unmatched/extra paren → `SyntaxError: Unexpected token ')'`.
- `agents-auto-pilot.yml:2194-2195` then reference `${agentKey}` and
  `#${issueNumber}` (in a "Dispatched belt dispatcher" log line that looks
  copy-pasted from a belt-dispatcher step). Neither symbol is declared anywhere
  in this script body: a scan of the verify_step body (`:2186` through the next
  step at `:2278`) finds **no** `const/let/var agentKey`, no `const/let/var
  issueNumber`, and no `issueNumber =` assignment. Only `env.ISSUE_NUMBER` is set
  (`:2183`); the script never binds `issueNumber` from it. So even with the paren
  fixed, these two lines are `ReferenceError`s.

Because `@actions/github-script` compiles the `script:` body with the
`AsyncFunction` constructor before invoking it, the unmatched paren is a hard
parse error: the body never runs. Verified by extracting the `verify_step` body
and compiling it the way github-script does — `new AsyncFunction(...args, body)`
throws `SyntaxError: Unexpected token ')'`; an async-wrapped `node --check`
reports the same at the `}));` line.

This is a **current break**: the post-merge verify step
(`next_step == 'verify'`) fails on **every** auto-pilot verify run. This is the
syntax-level root cause of "post-merge verification is unreachable" in the
auto-pilot path — the step throws at parse time before any verification logic
(PR lookup, acceptance check) executes. (Confirmed against `origin/main`: the
file is byte-identical to `origin/main`, so the break is live, not an artifact of
an un-pulled fix.)

#### Tasks
- [x] In `.github/workflows/agents-auto-pilot.yml`, fix the unmatched paren at
  line 2193: change `}));` to `});` so it correctly closes the single
  `createTokenAwareRetry({ ... })` call opened at `:2187`.
- [x] Resolve `:2194-2195`: either delete the stray
  `const prefix = \`Dispatched belt dispatcher (agent: ${agentKey}) ...\`` /
  `core.info(\`${prefix} #${issueNumber}\`)` lines (they reference a belt
  dispatcher this verify step never invokes), or define both symbols —
  `const issueNumber = Number(process.env.ISSUE_NUMBER)` (env wired at `:2183`)
  and a real `agentKey` source — so no undefined reference remains.
- [x] Confirm every remaining use of `issueNumber` in the verify body
  (`:2221`, `:2222`, `:2223`, `:2231`, `:2240`, `:2246`, `:2258`) has a binding in
  scope after the change (if you delete the env-derived binding plan, ensure
  these later uses are also satisfied; the PR lookup block relies on `issueNumber`).
- [x] Run the parse gate in Acceptance Criteria against the extracted body and
  capture FAIL→PASS in the PR.

#### Acceptance criteria
- [x] **Deliberate-state gate (parse must flip FAIL→PASS):** extract the
  `verify_step` `script:` body (from `:2186` to the next step at `:2278`) and
  compile it the way github-script does:

  ```bash
  node -e '
    const fs=require("fs");
    const body=fs.readFileSync("/tmp/verify_body.js","utf8");
    const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor;
    try{ new AsyncFunction("github","context","core","exec","glob","io","fetch","require",body);
         console.log("PARSE OK"); }
    catch(e){ console.log("PARSE FAIL:", e.message); process.exit(1); }'
  ```

- [x] On the unmodified file this prints `PARSE FAIL: Unexpected token ')'`; after the
  fix it prints `PARSE OK`. Capture both in the PR. (Falsifiability: restoring the
  extra `)` reproduces `Unexpected token ')'`.)
- [x] A static scan of the corrected `verify_step` body finds **no** undefined
  reference to `agentKey` and `issueNumber` is bound before first use — e.g.
  `grep -nE 'agentKey' <extracted body>` returns no hits (lines deleted) OR an
  explicit `const agentKey =` / `const issueNumber =` is present; documented in
  the PR.
- [ ] Live-verification gate: trigger an auto-pilot run that reaches the verify
  branch (`gh workflow run agents-auto-pilot.yml` with inputs that drive
  `next_step == 'verify'`, or re-run on an issue whose linked PR is already
  merged) and confirm the "Execute step - Verify" step **completes** (no
  `SyntaxError`/`ReferenceError` in the step log) instead of failing at parse
  time. Capture the step log in the PR.

<!-- auto-status-summary:end -->
