### PR TITLE
Measure Workflows coverage across scripts, tools, and src (#2266)

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -181,7 +181,7 @@ jobs:
       typecheck: ${{ needs.detect.outputs.typecheck == 'true' }}
       run-mypy: ${{ needs.detect.outputs.typecheck == 'true' }}
       coverage: ${{ needs.detect.outputs.coverage == 'true' }}
-      # Measure scripts/, tools/, and src/ via pyproject coverage source; keep threshold informational.
+      # Keep coverage threshold informational; reusable Python CI owns source selection.
       coverage-min: ''
       cache: ${{ needs.detect.outputs.cache == 'true' }}
       enable-soft-gate: ${{ needs.detect.outputs.coverage == 'true' }}

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -181,7 +181,7 @@ jobs:
       typecheck: ${{ needs.detect.outputs.typecheck == 'true' }}
       run-mypy: ${{ needs.detect.outputs.typecheck == 'true' }}
       coverage: ${{ needs.detect.outputs.coverage == 'true' }}
-      # Workflows repo has scripts/, not src/ - disable coverage minimum
+      # Measure scripts/, tools/, and src/ via pyproject coverage source; keep threshold informational.
       coverage-min: ''
       cache: ${{ needs.detect.outputs.cache == 'true' }}
       enable-soft-gate: ${{ needs.detect.outputs.coverage == 'true' }}

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1876,13 +1876,9 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/${{ inputs['working-directory'] || '.' }}
         run: |
           set -euo pipefail
-          coverage_target="src"
-          if [ ! -d "$coverage_target" ]; then
-            coverage_target="."
-          fi
           args=("--junitxml=pytest-junit.xml")
           if [ "${COVERAGE_ENABLED}" = "true" ]; then
-            args+=("--cov=${coverage_target}")
+            args+=("--cov=." "--cov-config=pyproject.toml")
             args+=("--cov-report=xml:coverage.xml")
             args+=("--cov-report=term-missing")
             args+=("--cov-report=json:coverage.json")

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1878,7 +1878,7 @@ jobs:
           set -euo pipefail
           args=("--junitxml=pytest-junit.xml")
           if [ "${COVERAGE_ENABLED}" = "true" ]; then
-            args+=("--cov=." "--cov-config=pyproject.toml")
+            args+=("--cov" "--cov-config=pyproject.toml")
             args+=("--cov-report=xml:coverage.xml")
             args+=("--cov-report=term-missing")
             args+=("--cov-report=json:coverage.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 parallel = true
+source = ["scripts", "tools", "src"]
 omit = [
     "*/tests/*",
     "*/test_*.py",

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -189,7 +189,7 @@ jobs:
       typecheck: ${{ needs.detect.outputs.typecheck == 'true' }}
       run-mypy: ${{ needs.detect.outputs.typecheck == 'true' }}
       coverage: ${{ needs.detect.outputs.coverage == 'true' }}
-      # Workflows repo has scripts/, not src/ - disable coverage minimum
+      # Keep coverage threshold informational; reusable Python CI owns source selection.
       coverage-min: ''
       cache: ${{ needs.detect.outputs.cache == 'true' }}
       enable-soft-gate: ${{ needs.detect.outputs.coverage == 'true' }}

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -9,6 +9,13 @@
 - **Review state:** resolved review threads `PRRT_kwDOQprj9M6JUFOW` and `PRRT_kwDOQprj9M6JUFRf`; posted evidence comment https://github.com/stranske/Workflows/pull/2289#issuecomment-4698092479.
 - **Next action:** wait for fresh CI on head `ae57662b` to finish. Final snapshot: PR non-draft, `MERGEABLE`, `mergeStateStatus=UNSTABLE`; review threads resolved; checks still in progress (`Gate` python ci/ledger validation, `enforce`, `CodeQL`). If they settle green, merge #2289; Workflows convention means no verifier label unless a repo-specific verifier target is explicitly intended.
 
+## 2026-06-13T09:03Z - opener (codex) opened #2290 for issue #2266
+
+- **Selected opener lane:** issue [#2266](https://github.com/stranske/Workflows/issues/2266), branch `codex/issue-2266-coverage-source`, PR [#2290](https://github.com/stranske/Workflows/pull/2290).
+- **Implementation:** added `source = ["scripts", "tools", "src"]` to `[tool.coverage.run]`, changed reusable Python CI coverage from the `src` heuristic to `--cov=. --cov-config=pyproject.toml`, and corrected the stale Gate coverage-min comment.
+- **Validation:** pre-fix `uv run --extra dev ... --cov=src` on `tests/scripts/test_langsmith_fleet_conformance.py` passed with `scripts-prefixed: 0` and `tools-prefixed: 0`; post-fix `--cov=. --cov-config=pyproject.toml` passed with `scripts-prefixed: 126` and `tools-prefixed: 16`. TOML/YAML parse check passed for all touched files.
+- **Next action:** wait for Gate/keepalive on #2290; keepalive owns any CI or bot-review iteration.
+
 ## 2026-06-13T08:23Z - closer (codex) review-fix pushed for #2288
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2288](https://github.com/stranske/Workflows/pull/2288), source issue `#2264`, branch `codex/issue-2264-health40-aggregate-heredoc`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,14 @@
 # Workloop State
 
+## 2026-06-13T09:29Z - closer (codex) review-fix pushed for #2290
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2290](https://github.com/stranske/Workflows/pull/2290), source issue `#2266`, branch `codex/issue-2266-coverage-source`.
+- **Blocker:** four unresolved review threads correctly flagged that `--cov=.` overrides `[tool.coverage.run].source`, the Gate coverage comment overclaimed pyproject ownership, and the consumer template gate comment still carried stale `scripts/, not src/` wording.
+- **Action:** changed reusable Python CI to pass bare `--cov` with `--cov-config=pyproject.toml`, updated the in-repo Gate comment to avoid overclaiming source selection, and mirrored the comment into `templates/consumer-repo/.github/workflows/pr-00-gate.yml`.
+- **Validation:** `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; `python -m pytest tests/workflows/test_workflow_agents_consolidation.py -q -rA` passed (`62 passed`); YAML/TOML parse smoke passed and confirmed `--cov=.` is absent.
+- **Review/post-push state:** pushed head `7c204049` to `codex/issue-2266-coverage-source`, posted evidence comment https://github.com/stranske/Workflows/pull/2290#issuecomment-4698126188, and resolved all four review threads (`PRRT_kwDOQprj9M6JUHtH`, `PRRT_kwDOQprj9M6JUH6z`, `PRRT_kwDOQprj9M6JUH64`, `PRRT_kwDOQprj9M6JUH7B`).
+- **Next action:** wait for fresh CI on head `7c204049`; final snapshot was non-draft, `MERGEABLE`, `mergeStateStatus=UNSTABLE`, with checks in progress/pending.
+
 ## 2026-06-13T09:13Z - closer (codex) review-fix pushed for #2289
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2289](https://github.com/stranske/Workflows/pull/2289), source issue `#2265`, branch `claude/issue-2265-autopilot-verify-paren`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2266 -->
> **Source:** Issue #2266

Closes #2266

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
CI Python coverage in this repo measures only the 279-line `src/` stub package
and silently omits the `scripts/` and `tools/` packages where the production
code actually lives.

- `.github/workflows/reusable-10-ci-python.yml:1879` sets `coverage_target="src"`
  and falls back to `.` **only if `src/` is absent** (`:1880-1882`
  `if [ ! -d "$coverage_target" ]; then coverage_target="."`). The pytest
  invocation then uses `--cov=${coverage_target}` (`:1885`).
- `src/` **exists**, so `--cov=src` is always chosen. Verified contents: 4
  modules totaling **279 lines** — `src/aggregator.py` (99), `src/cli_parser.py`
  (86), `src/ndjson_parser.py` (41), `src/percentile_calculator.py` (53), plus an
  empty `src/__init__.py`. (The `src/trend_analysis/` tree under it is autofix
  test fixtures, explicitly omitted via `pyproject.toml:201`
  `"src/trend_analysis/*"`.)
- The real code lives outside `src/`: `scripts/` is a package
  (`scripts/__init__.py` present) with **101 `*.py` files / ~34,683 lines**, and
  `tools/` is a package (`tools/__init__.py` present) with **17 files / ~6,945
  lines** — together **~41.6k lines** that the tests exercise (tests import via
  `from scripts.` / `from tools.`, 160+ occurrences across `tests/`).
- `pyproject.toml` `[tool.coverage.run]` (`:191-202`) has `branch`, `parallel`,
  and `omit`, but **no `source =` directive**, so nothing redirects measurement
  away from the `--cov=src` target.

Verified empirically: running a scripts-importing test under `--cov=src`
produces a `coverage.xml` whose only `<package>` is `name="."` and whose `<class
filename=...>` entries are just the src stub files (`aggregator.py`,
`cli_parser.py`, ...) — **zero** `scripts/`-prefixed files. So every coverage
report, the soft-gate (`enable-soft-gate`, `pr-00-gate.yml:187`), and any
coverage delta is computed against the 279-line stub and is meaningless for the
~41.6k lines of real code.

The hard coverage minimum is **already** disabled with a now-false rationale:
`pr-00-gate.yml:184` reads `# Workflows repo has scripts/, not src/ - disable
coverage minimum`, followed by `coverage-min: ''` (`:185`). That comment is
**stale/false** — `src/` exists and is exactly what silently becomes the cov
target. What is corrupted is the soft-gate / coverage-report / delta pipeline
derived from the src-only `coverage.xml`.

This is a **current break** (every coverage artifact CI produces today is
measured against the wrong package set), with the practical severity of latent
fragility because the *hard* gate is already off — a real regression in
`scripts/` or `tools/` would never dent the coverage number.

#### Tasks
- [ ] In `pyproject.toml` `[tool.coverage.run]` (lines 191-202), add
  `source = ["scripts", "tools", "src"]` (keep the existing `branch`, `parallel`,
  and `omit` keys unchanged).
- [ ] In `.github/workflows/reusable-10-ci-python.yml` (lines 1879-1885), replace
  the `coverage_target="src"` / fallback heuristic with
  `args+=("--cov=." "--cov-config=pyproject.toml")` (keeping the existing
  `--cov-report=xml:coverage.xml`, `--cov-report=term-missing`, and
  `--cov-report=json:coverage.json` flags) so `coverage.xml` carries
  `scripts/`-prefixed filenames.
- [ ] Update the stale comment at `.github/workflows/pr-00-gate.yml:184`
  (`# Workflows repo has scripts/, not src/ - disable coverage minimum`) to state
  that `src/` exists and coverage is now measured across `scripts`/`tools`/`src`
  via the `[tool.coverage.run] source` directive.
- [ ] Run the coverage-XML check in Acceptance Criteria locally and confirm
  `scripts/`-prefixed `filename=` entries now appear (and did not before),
  capturing both counts in the PR.

#### Acceptance criteria
- [ ] **Deliberate-state gate (coverage.xml must flip absent→present):** running a
  scripts-importing test with coverage and counting `scripts/`-prefixed files:
  `grep -c 'filename="scripts/' coverage.xml` returns **0** under the current
  `--cov=src` behavior and a **non-zero** count after the fix
  (`--cov=. --cov-config=pyproject.toml` with `source=[...]`). Capture both
  counts in the PR. (Falsifiability: reverting to `--cov=src` returns the count
  to 0.)
- [ ] The same coverage run also includes `tools/`-prefixed files
  (`grep -c 'filename="tools/' coverage.xml` is non-zero after the fix),
  confirming both production packages are measured, not just `scripts/`.
- [ ] `pr-00-gate.yml:184` no longer claims "has scripts/, not src/"; the comment
  reflects the new `source`-based measurement (verified by reading the line in
  the PR diff).

<!-- auto-status-summary:end -->