### PR TITLE
fix(keepalive): make agent:auto delegation able to detect stalls and switch (#2268)

### DIFF
--- a/.github/scripts/__tests__/agent-delegation-policy.test.js
+++ b/.github/scripts/__tests__/agent-delegation-policy.test.js
@@ -118,7 +118,11 @@ test('calculateEffectiveness returns effective=true when tasks completed', () =>
   assert.ok(result.summary.includes('2 tasks'));
 });
 
-test('calculateEffectiveness returns effective=true when gate passed', () => {
+// Semantics intentionally changed for #2268: a commit-less green Gate is NOT
+// progress. A normal `run` dispatch only happens on a green Gate, so a stuck
+// agent records gate:'pass' every round; counting that as effective made the
+// stall detector unable to fire. gatePassed is still reported for visibility.
+test('calculateEffectiveness does NOT count a commit-less gate pass as effective', () => {
   const history = [
     { iteration: 16, commits: 0, tasks: 0, gate: 'fail' },
     { iteration: 17, commits: 0, tasks: 0, gate: 'pass' },
@@ -127,7 +131,7 @@ test('calculateEffectiveness returns effective=true when gate passed', () => {
 
   const result = calculateEffectiveness({ history, lookbackRounds: 3 });
 
-  assert.equal(result.effective, true);
+  assert.equal(result.effective, false);
   assert.equal(result.gatePassed, true);
   assert.ok(result.summary.includes('gate passed'));
 });
@@ -160,6 +164,23 @@ test('detectStall returns isStalled=true when threshold exceeded', () => {
   assert.equal(result.isStalled, true);
   assert.equal(result.consecutiveRounds, 3);
   assert.ok(result.reason.includes('3 rounds, no progress'));
+});
+
+// #2268 deliberate-break gate: a 3-round zero-commit green-gate history MUST
+// produce isStalled=true. Restoring the old `|| round.gate === 'pass'` progress
+// test in detectStall makes this case come back isStalled=false (the green gates
+// reset the counter), proving this test catches the gate-pass-as-progress poison.
+test('detectStall fires after 3 zero-commit green-gate rounds', () => {
+  const history = [
+    { iteration: 16, commits: 0, tasks: 0, gate: 'pass' },
+    { iteration: 17, commits: 0, tasks: 0, gate: 'pass' },
+    { iteration: 18, commits: 0, tasks: 0, gate: 'pass' },
+  ];
+
+  const result = detectStall({ history, threshold: 3 });
+
+  assert.equal(result.isStalled, true);
+  assert.equal(result.consecutiveRounds, 3);
 });
 
 test('detectStall returns isStalled=false when progress in last round', () => {

--- a/.github/scripts/agent_delegation_policy.js
+++ b/.github/scripts/agent_delegation_policy.js
@@ -216,11 +216,15 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
   const tasks = recentRounds.reduce((sum, round) => sum + (round.tasks || 0), 0);
   const gatePassed = recentRounds.some((round) => round.gate === 'pass');
 
-  // Agent is effective if any of these conditions met:
-  // - Made at least 1 commit in lookback window
-  // - Completed at least 1 task in lookback window
-  // - Gate passed in lookback window
-  const effective = commits >= 1 || tasks >= 1 || gatePassed;
+  // Agent is effective only when it produced real forward motion:
+  // - Made at least 1 commit in lookback window, OR
+  // - Completed at least 1 task in lookback window.
+  // A green Gate with zero commits and zero tasks is NOT progress: a normal
+  // `run` dispatch only happens on a green Gate (Activation Guardrail §2), so a
+  // genuinely stuck agent records `gate: 'pass'` every round. Counting that as
+  // effective made the stall detector unable to ever fire (#2268). `gatePassed`
+  // is still returned/reported below, just not treated as progress.
+  const effective = commits >= 1 || tasks >= 1;
 
   const summary = [
     commits > 0 ? `${commits} commits` : null,
@@ -263,10 +267,13 @@ function detectStall({ history = [], threshold = 3, core }) {
   let consecutiveNoProgress = 0;
   for (let i = history.length - 1; i >= 0; i--) {
     const round = history[i];
+    // Progress = real forward motion only. A commit-less green Gate must NOT
+    // reset the consecutive-no-progress counter, otherwise a stuck agent that
+    // keeps a green Gate while making zero commits never trips the stall
+    // threshold and `agent:auto` delegation can never switch (#2268).
     const hasProgress =
       (round.commits || 0) > 0 ||
-      (round.tasks || 0) > 0 ||
-      round.gate === 'pass';
+      (round.tasks || 0) > 0;
 
     if (hasProgress) {
       break; // Found progress, stop counting

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2385,7 +2385,23 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     if (hasAgentLabel) {
       try {
         const { resolveAgentRoutingFromLabels } = require('./agent_registry.js');
-        const routing = resolveAgentRoutingFromLabels(routingLabelCandidates.length ? routingLabelCandidates : pr.labels);
+        // agent:auto overrides a co-present concrete agent label (#2268). The
+        // capacity-stuck runbook says to ADD agent:auto alongside the existing
+        // agent:<X>; without this filter, resolveAgentRoutingFromLabels throws on
+        // the auto+concrete combination, the catch below disables keepalive, and
+        // the runbook silently does the opposite of its intent. Dropping the
+        // concrete label here lets auto win and routing stay enabled; the current
+        // agent is tracked in delegation state, not via the label.
+        const candidateLabels = routingLabelCandidates.length ? routingLabelCandidates : pr.labels;
+        const hasAutoLabel = candidateLabels.some(
+          (label) => normalise((typeof label === 'object' ? label.name : label) || '').toLowerCase() === 'agent:auto',
+        );
+        const routingLabels = hasAutoLabel
+          ? candidateLabels.filter(
+            (label) => normalise((typeof label === 'object' ? label.name : label) || '').toLowerCase() === 'agent:auto',
+          )
+          : candidateLabels;
+        const routing = resolveAgentRoutingFromLabels(routingLabels);
         agentType = routing.agentKey;
         agentRoutingMode = routing.mode;
       } catch (error) {
@@ -3849,8 +3865,11 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         ? previousState.effectiveness_history
         : [];
 
-      // Build effectiveness entry for this round (only when agent ran)
-      const effectivenessEntry = action === 'run' ? {
+      // Build effectiveness entry for this round. Record `run`, `fix`, and
+      // `conflict` rounds: a stuck agent burns fix/conflict rounds without
+      // commits too, and excluding them hid those stalled rounds from
+      // effectiveness_history so the stall detector under-counted (#2268).
+      const effectivenessEntry = ['run', 'fix', 'conflict'].includes(action) ? {
         iteration: nextIteration,
         agent: agentType,
         commits: agentCommitSha ? 1 : 0,

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -57,6 +57,9 @@ jobs:
       has_agent_label: ${{ steps.evaluate.outputs.has_agent_label }}
       has_high_privilege: ${{ steps.evaluate.outputs.has_high_privilege }}
       agent_type: ${{ steps.evaluate.outputs.agent_type }}
+      agent_routing_mode: ${{ steps.evaluate.outputs.agent_routing_mode }}
+      delegation_reason: ${{ steps.evaluate.outputs.delegation_reason }}
+      delegation_should_switch: ${{ steps.evaluate.outputs.delegation_should_switch }}
       # task_appendix is delivered via artifact upload (keepalive-task-appendix-<pr>)
       # to avoid GitHub's secret scanner censoring the job output.
       trace: ${{ steps.evaluate.outputs.trace }}
@@ -1289,6 +1292,9 @@ jobs:
               keepalive_enabled: '${{ needs.evaluate.outputs.keepalive_enabled }}',
               autofix_enabled: '${{ needs.evaluate.outputs.autofix_enabled }}',
               agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              agent_routing_mode: '${{ needs.evaluate.outputs.agent_routing_mode }}',
+              delegation_reason: '${{ needs.evaluate.outputs.delegation_reason }}',
+              delegation_should_switch: '${{ needs.evaluate.outputs.delegation_should_switch }}',
               trace: '${{ needs.evaluate.outputs.trace }}',
               // Agent run result - check which agent ran
               run_result: runResult,

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -130,11 +130,11 @@ This document describes all labels that trigger automated workflows or affect CI
 **Effect:**
 1. Delegates routing to the auto-delegation policy in `.github/scripts/agent_delegation_policy.js`
 2. The policy switches between Codex and Claude based on stall/effectiveness signals
-3. Used to recover from capacity-stuck PRs by replacing the concrete `agent:<name>` label with `agent:auto`; the registry rejects `agent:auto` when it is co-present with a concrete agent label
+3. Used to recover from capacity-stuck PRs: **add** `agent:auto` to the PR (alongside the existing `agent:<name>` label); keepalive will override the concrete label and route through auto-delegation
 4. Selects a runner through the delegation policy without mutating labels; if no current agent is recorded, the policy chooses the default available agent or the first available alternative
 
 **Prerequisites:**
-- Do not combine `agent:auto` with `agent:codex`, `agent:claude`, or another concrete routing label; exactly one routing mode must be present
+- When `agent:auto` is present, any co-present concrete `agent:<name>` label is silently ignored; `agent:auto` always wins
 - Existing delegation state improves switch decisions, but the initial-selection path can choose an agent without a concrete label
 
 **Lifecycle:** Applied manually or by orchestrator/closer when a PR is capacity-stuck. The delegation policy reads it on keepalive ticks and either keeps the current runner choice or switches the runner decision for that dispatch.

--- a/templates/consumer-repo/.github/scripts/agent_delegation_policy.js
+++ b/templates/consumer-repo/.github/scripts/agent_delegation_policy.js
@@ -216,11 +216,15 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
   const tasks = recentRounds.reduce((sum, round) => sum + (round.tasks || 0), 0);
   const gatePassed = recentRounds.some((round) => round.gate === 'pass');
 
-  // Agent is effective if any of these conditions met:
-  // - Made at least 1 commit in lookback window
-  // - Completed at least 1 task in lookback window
-  // - Gate passed in lookback window
-  const effective = commits >= 1 || tasks >= 1 || gatePassed;
+  // Agent is effective only when it produced real forward motion:
+  // - Made at least 1 commit in lookback window, OR
+  // - Completed at least 1 task in lookback window.
+  // A green Gate with zero commits and zero tasks is NOT progress: a normal
+  // `run` dispatch only happens on a green Gate (Activation Guardrail §2), so a
+  // genuinely stuck agent records `gate: 'pass'` every round. Counting that as
+  // effective made the stall detector unable to ever fire (#2268). `gatePassed`
+  // is still returned/reported below, just not treated as progress.
+  const effective = commits >= 1 || tasks >= 1;
 
   const summary = [
     commits > 0 ? `${commits} commits` : null,
@@ -263,10 +267,13 @@ function detectStall({ history = [], threshold = 3, core }) {
   let consecutiveNoProgress = 0;
   for (let i = history.length - 1; i >= 0; i--) {
     const round = history[i];
+    // Progress = real forward motion only. A commit-less green Gate must NOT
+    // reset the consecutive-no-progress counter, otherwise a stuck agent that
+    // keeps a green Gate while making zero commits never trips the stall
+    // threshold and `agent:auto` delegation can never switch (#2268).
     const hasProgress =
       (round.commits || 0) > 0 ||
-      (round.tasks || 0) > 0 ||
-      round.gate === 'pass';
+      (round.tasks || 0) > 0;
 
     if (hasProgress) {
       break; // Found progress, stop counting

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -2385,7 +2385,23 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     if (hasAgentLabel) {
       try {
         const { resolveAgentRoutingFromLabels } = require('./agent_registry.js');
-        const routing = resolveAgentRoutingFromLabels(routingLabelCandidates.length ? routingLabelCandidates : pr.labels);
+        // agent:auto overrides a co-present concrete agent label (#2268). The
+        // capacity-stuck runbook says to ADD agent:auto alongside the existing
+        // agent:<X>; without this filter, resolveAgentRoutingFromLabels throws on
+        // the auto+concrete combination, the catch below disables keepalive, and
+        // the runbook silently does the opposite of its intent. Dropping the
+        // concrete label here lets auto win and routing stay enabled; the current
+        // agent is tracked in delegation state, not via the label.
+        const candidateLabels = routingLabelCandidates.length ? routingLabelCandidates : pr.labels;
+        const hasAutoLabel = candidateLabels.some(
+          (label) => normalise((typeof label === 'object' ? label.name : label) || '').toLowerCase() === 'agent:auto',
+        );
+        const routingLabels = hasAutoLabel
+          ? candidateLabels.filter(
+            (label) => normalise((typeof label === 'object' ? label.name : label) || '').toLowerCase() === 'agent:auto',
+          )
+          : candidateLabels;
+        const routing = resolveAgentRoutingFromLabels(routingLabels);
         agentType = routing.agentKey;
         agentRoutingMode = routing.mode;
       } catch (error) {
@@ -3849,8 +3865,11 @@ async function updateKeepaliveLoopSummary({ github: rawGithub, context, core, in
         ? previousState.effectiveness_history
         : [];
 
-      // Build effectiveness entry for this round (only when agent ran)
-      const effectivenessEntry = action === 'run' ? {
+      // Build effectiveness entry for this round. Record `run`, `fix`, and
+      // `conflict` rounds: a stuck agent burns fix/conflict rounds without
+      // commits too, and excluding them hid those stalled rounds from
+      // effectiveness_history so the stall detector under-counted (#2268).
+      const effectivenessEntry = ['run', 'fix', 'conflict'].includes(action) ? {
         iteration: nextIteration,
         agent: agentType,
         commits: agentCommitSha ? 1 : 0,

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,13 @@
 # Workloop State
 
+## 2026-06-13T10:03Z - closer (codex) rebased #2292 conflict lane
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2292](https://github.com/stranske/Workflows/pull/2292), source issue `#2268`, branch `claude/issue-2268-auto-delegation`.
+- **Blocker:** GitHub reported `mergeable=CONFLICTING` / `mergeStateStatus=DIRTY` after `main` advanced through #2288, #2289, and #2290. Direct review-thread audit found 0 unresolved threads; current check snapshot had only passing/skipped checks, so the actionable blocker was the branch conflict.
+- **Action:** created automation worktree `/Users/teacher/.codex/automations/imi-merge-verify-closer/worktrees/workflows-2292-conflict-fix`, fetched/pruned remote state, rebased the PR branch onto `origin/main` (`8e5e3a51`), and resolved the sole conflict in `workloop-state.md` by preserving both the #2268 opener entry and the prior #2290 closer entry, newest first. Source files merged cleanly.
+- **Validation:** `node --test .github/scripts/__tests__/agent-delegation-policy.test.js` passed (`22 passed`); `node --test .github/scripts/__tests__/keepalive-loop.test.js` passed (`104 passed`); `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; `git diff --check` clean; `.github/workflows/agents-keepalive-loop.yml` parsed as YAML.
+- **Next action:** push the rebased branch with `--force-with-lease`, then wait for fresh PR checks. If checks settle green and the PR remains review-clear, merge and apply the intended verifier handling for source issue `#2268`.
+
 ## 2026-06-13T09:46Z - opener (claude_code) issue #2268 -> PR (agent:auto delegation)
 
 - **Selected lane:** `stranske/Workflows` issue [#2268](https://github.com/stranske/Workflows/issues/2268) (`P1: agent:auto delegation is structurally inert`), branch `claude/issue-2268-auto-delegation`, base `main`. Oldest unlinked P1 from the 2026-06-13 repo-review batch; cap was 2/5 (unlinked-liveness override).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,18 @@
 # Workloop State
 
+## 2026-06-13T09:46Z - opener (claude_code) issue #2268 -> PR (agent:auto delegation)
+
+- **Selected lane:** `stranske/Workflows` issue [#2268](https://github.com/stranske/Workflows/issues/2268) (`P1: agent:auto delegation is structurally inert`), branch `claude/issue-2268-auto-delegation`, base `main`. Oldest unlinked P1 from the 2026-06-13 repo-review batch; cap was 2/5 (unlinked-liveness override).
+- **Three coordinated fixes implemented:**
+  1. **Effectiveness signal** (`agent_delegation_policy.js`): a commit-less green Gate no longer counts as progress. `calculateEffectiveness` `effective = commits>=1 || tasks>=1` (dropped `|| gatePassed`; `gatePassed` still returned for reporting); `detectStall` progress test dropped `|| round.gate === 'pass'` so the consecutive-no-progress counter is not reset by green gates.
+  2. **Effectiveness-entry guard** (`keepalive_loop.js` ~3853): broadened from `action === 'run'` to `['run','fix','conflict']` so stuck fix/conflict rounds are recorded in `effectiveness_history`.
+  3. **Root output wiring** (`.github/workflows/agents-keepalive-loop.yml`): added `agent_routing_mode`, `delegation_reason`, `delegation_should_switch` to the `evaluate` job `outputs:` block and to the summary step `inputs` object, mirroring the consumer template's `agents-81-gate-followups.yml`.
+  4. **auto+concrete** (`keepalive_loop.js` ~2385): chose the CODE path — when `agent:auto` is present alongside a concrete `agent:<X>` label, filter to auto-only before `resolveAgentRoutingFromLabels` so auto wins and keepalive stays enabled. This makes the documented "add `agent:auto` alongside" capacity-stuck runbook work, so no CLAUDE.md/LABELS.md change was needed.
+- **Sync mirror:** `agent_delegation_policy.js` and `keepalive_loop.js` are sync-manifest mirrored root->consumer (kept byte-identical); copied both modified files into `templates/consumer-repo/.github/scripts/` to keep drift-check green. The test file and the root workflow are not synced.
+- **Tests:** added `detectStall fires after 3 zero-commit green-gate rounds` (asserts `isStalled===true`, `consecutiveRounds===3`) and changed the old `calculateEffectiveness returns effective=true when gate passed` to `...does NOT count a commit-less gate pass as effective` (now asserts `effective===false`, `gatePassed===true`). `node --test agent-delegation-policy.test.js` -> `pass 22 fail 0`; `keepalive-loop.test.js` -> `pass 104 fail 0`.
+- **Deliberate-break gate (acceptance criterion):** temporarily restored `|| round.gate === 'pass'` in `detectStall` -> new test FAILED with `isStalled` actual `false` / expected `true`; re-applied fix -> passes. JS `node -c` and YAML parse all OK; `git diff --check` clean.
+- **Next action:** ready-for-review PR opened with `agent:claude`, `agents:keepalive`, `autofix`; keepalive/Gate owns iteration.
+
 ## 2026-06-13T09:13Z - closer (codex) review-fix pushed for #2289
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2289](https://github.com/stranske/Workflows/pull/2289), source issue `#2265`, branch `claude/issue-2265-autopilot-verify-paren`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2268 -->
> **Source:** Issue #2268

Closes #2268

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`agent:auto` delegation is supposed to switch the active agent after a stall (the
"capacity-stuck recovery" runbook: add `agent:auto`, the policy switches to the
alternative agent after ~3 stalled rounds). Verified against the live tree, the
mechanism is structurally inert in three compounding ways, each a current break:

**1. A green Gate is recorded as "progress," and almost every normal dispatch
runs on a green Gate.** The per-round effectiveness entry is built in
`updateKeepaliveLoopSummary` at `.github/scripts/keepalive_loop.js:3829`:

```
const effectivenessEntry = action === 'run' ? {
  ...
  commits: agentCommitSha ? 1 : 0,                       // line 3832
  tasks: Math.max(0, tasksCompletedThisRound),
  gate: gateConclusion === 'success' ? 'pass' : 'fail',  // line 3834
  ...
} : null;
```

`gateConclusion` here is the conclusion of the **triggering** Gate run — and a
normal `run` dispatch only happens when the Gate is green (Activation Guardrail
§2, `docs/keepalive/GoalsAndPlumbing.md`). So `gate: 'pass'` is recorded on
essentially every zero-commit round. Then in
`.github/scripts/agent_delegation_policy.js`:

- `calculateEffectiveness` line 217 `const gatePassed = recentRounds.some(r => r.gate === 'pass')` and line 223 `const effective = commits >= 1 || tasks >= 1 || gatePassed` → a round with 0 commits and 0 tasks is still "effective" purely because the Gate was green.
- `detectStall` line 269 treats `round.gate === 'pass'` as progress and `break`s the consecutive-no-progress counter (lines 264-274) → the stall counter resets every green-gate round, so `isStalled` can never reach the threshold for a PR that keeps a green Gate while making no commits.

Net: a genuinely stuck agent (green Gate, no commits, no task completions, round
after round) is scored "effective" and never trips `detectStall`. The switch can
never fire.

**2. The ROOT workflow drops the delegation outputs, so effectiveness never
persists in stranske/Workflows.** `updateKeepaliveLoopSummary` only writes
`current_agent`/`effectiveness_history`/`delegation_log` when
`agentRoutingMode === 'auto'` (or a prior `current_agent` exists) —
`keepalive_loop.js:3818`, reading `inputs.agent_routing_mode` at
`keepalive_loop.js:2934`. The consumer template wires this through:
`templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml` job
outputs lines 72-74 and summary-step inputs lines 773-775. The **root**
`agents-keepalive-loop.yml` does NOT: `agent_routing_mode`, `delegation_reason`,
and `delegation_should_switch` are set as *step* outputs at lines 403-405, but
they are absent from the `evaluate` job's `outputs:` block (lines 42-75) and from
the summary step's `inputs` object (lines 1277-1307, the
`updateKeepaliveLoopSummary` call at line 1308). Consequence in stranske/Workflows
PRs: `inputs.agent_routing_mode` is always empty → `effectiveness_history` is
never written → `decideNextAgent` (`agent_delegation_policy.js:22`) always sees
empty history → perpetual `reason: 'initial-selection'`
(`agent_delegation_policy.js:79`); `detectStall` can never accumulate; the
documented switch never happens in this repo.

**3. `agent:auto` co-present with a concrete agent disables keepalive
entirely.** `resolveAgentRoutingFromLabels` in
`.github/scripts/agent_registry.js:175` throws when auto and an explicit agent
are both present:

```
if (hasAuto && explicitRequested.length > 0) {
  throw new Error(`Multiple agent labels present: auto, ${explicitRequested[0]}`);  // agent_registry.js:191-193
}
```

In `keepalive_loop.js:2387-2395` that throw is caught and sets
`hasAgentLabel = false`, which at `keepalive_loop.js:2399`
(`keepaliveEnabled = config.keepalive_enabled && hasAgentLabel`) makes
`keepaliveEnabled = false`. So a PR carrying `agent:codex` + `agent:auto` —
exactly the "add `agent:auto` alongside the existing label" capacity-stuck
runbook — produces `missing-agent-label` and keepalive is disabled, the opposite
of the intended effect. The runbook is broken.

These are **current breaks**, verified by reading the live decision/persistence
code, not latent edge cases.

#### Tasks
- [x] In `agent_delegation_policy.js`, change `detectStall` (line 253; the
  progress test at lines 266-269) and `calculateEffectiveness` (line 217 / line
  223) [ ] so a round counts as progress only when `commits >= 1` or `tasks >= 1` —
  a `gate === 'pass'` round with zero commits and zero tasks must NOT count as
  progress / must NOT reset the consecutive-no-progress counter.
- [x] In `keepalive_loop.js` `updateKeepaliveLoopSummary`, broaden the
  effectiveness-entry guard at line 3829 from `action === 'run'` to also include
  `'fix'` and `'conflict'` rounds, so stuck fix/conflict rounds are recorded in
  `effectiveness_history` (lines 3828-3840).
- [x] In `.github/workflows/agents-keepalive-loop.yml`, add `agent_routing_mode`,
  `delegation_reason`, and `delegation_should_switch` to the `evaluate` job's
  `outputs:` block (currently lines 42-75; the step already emits them at lines
  403-405), and add the same three keys to the summary step's `inputs` object
  (lines 1277-1307) before the `updateKeepaliveLoopSummary` call at line 1308 —
  mirroring `templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml`
  lines 72-74 and 773-775.
- [x] Resolve the auto+concrete conflict: either filter the concrete `agent:<X>`
  label before calling `resolveAgentRoutingFromLabels`
  (`keepalive_loop.js:2388`) so `agent:auto` overrides and keepalive stays
  enabled, OR update the runbook in `CLAUDE.md` ("Capacity-stuck recovery"
  section) and the matching label-combination row in `docs/LABELS.md` to say
  replace-not-add. Whichever path, the `agent:auto` + `agent:codex` combination
  must no longer silently yield `missing-agent-label` while the runbook still
  tells operators to create it.
- [x] Extend `.github/scripts/__tests__/agent-delegation-policy.test.js` with the
  deliberate-break test in Acceptance Criteria, modeled on the existing
  `detectStall returns isStalled=true when threshold exceeded`
  (`agent-delegation-policy.test.js:151`).

#### Acceptance criteria
- [ ] New named test in
  `.github/scripts/__tests__/agent-delegation-policy.test.js`, e.g.
  `detectStall fires after 3 zero-commit green-gate rounds`: builds
  `history = [{commits:0,tasks:0,gate:'pass'} x3]`, calls
  `detectStall({ history, threshold: 3 })`, and asserts `result.isStalled === true`
  and `result.consecutiveRounds === 3`. Run via
  `node --test .github/scripts/__tests__/agent-delegation-policy.test.js` → passes.
- [x] **Deliberate-break gate:** after the fix, temporarily revert the
  `detectStall` progress test in `agent_delegation_policy.js:266-269` to again
  include `|| round.gate === 'pass'`. With that line restored, the new test
  `detectStall fires after 3 zero-commit green-gate rounds` **must FAIL** —
  concretely `result.isStalled` comes back `false` (the green gates reset the
  counter), proving the test catches the gate-pass-as-progress poison. Capture
  the FAIL output, then re-apply the fix so the test passes.
- [x] The existing 21 passing cases in
  `.github/scripts/__tests__/agent-delegation-policy.test.js` still pass
  (`node --test ...` shows `fail 0`) — in particular
  `detectStall returns isStalled=true when threshold exceeded`
  (`agent-delegation-policy.test.js:151`), which uses `gate:'fail'` history and
  must remain green, and
  `calculateEffectiveness returns effective=true when gate passed`
  (`agent-delegation-policy.test.js:121`) — adjust that latter case if and only
  if the semantics intentionally change, and note the change in the PR.

<!-- auto-status-summary:end -->