### PR TITLE
fix(keepalive): honor dry-run for post-work mutations (#2269)

### DIFF
--- a/.github/scripts/__tests__/keepalive-post-work.test.js
+++ b/.github/scripts/__tests__/keepalive-post-work.test.js
@@ -281,7 +281,7 @@ test('runKeepalivePostWork removes sync label when head already advanced', async
   restore();
 });
 
-test('runKeepalivePostWork escalates and adds sync label when sync times out', async () => {
+test('runKeepalivePostWork performs no GitHub mutations in dry-run mode', async () => {
   const { core, outputs } = createCore();
   const stub = createStateManagerStub();
   const { runKeepalivePostWork, restore } = loadRunnerWithStateManager(stub.getManager);
@@ -300,9 +300,12 @@ test('runKeepalivePostWork escalates and adds sync label when sync times out', a
 
   assert.equal(outputs.action, 'escalate');
   assert.equal(outputs.status, 'needs_update');
-  assert.equal(github.calls.addLabels.length, 1);
-  assert.equal(github.calls.addLabels[0].labels[0], 'agents:sync-required');
-  assert.ok(github.calls.createComment[0].body.includes('Keepalive: manual action needed'));
+  assert.equal(github.calls.updateBranch.length, 0);
+  assert.equal(github.calls.createWorkflowDispatch.length, 0);
+  assert.equal(github.calls.addLabels.length, 0);
+  assert.equal(github.calls.removeLabel.length, 0);
+  assert.equal(github.calls.createComment.length, 0);
+  assert.equal(stub.saves.length, 0);
   restore();
 });
 

--- a/.github/scripts/keepalive_post_work.js
+++ b/.github/scripts/keepalive_post_work.js
@@ -412,10 +412,15 @@ async function dispatchFallbackWorkflow({
   idempotencyKey,
   roundTag = 'round=?',
   record,
+  statusMode = 'active',
 }) {
   if (!baseRef || !headRef || !headSha) {
     record('Fallback dispatch', `skipped: base/head/head_sha missing. ${roundTag}`);
     return { dispatched: false };
+  }
+  if (statusMode === 'dry-run') {
+    record('Fallback dispatch', `skipped: dry-run mode. ${roundTag}`);
+    return { dispatched: false, dryRun: true };
   }
   try {
     const inputs = {
@@ -730,6 +735,7 @@ async function attemptUpdateBranchViaApi({
   core,
   record,
   appendRound,
+  statusMode = 'active',
 }) {
   if (!Number.isFinite(prNumber) || prNumber <= 0 || !baselineHead) {
     record('Update-branch API', appendRound('skipped: missing PR context or baseline head.'));
@@ -738,6 +744,10 @@ async function attemptUpdateBranchViaApi({
   if (!github?.rest?.pulls?.updateBranch) {
     record('Update-branch API', appendRound('skipped: Octokit client lacks updateBranch support.'));
     return { attempted: false };
+  }
+  if (statusMode === 'dry-run') {
+    record('Update-branch API', appendRound('skipped: dry-run mode.'));
+    return { attempted: false, dryRun: true };
   }
 
   const requestPayload = {
@@ -847,6 +857,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   const appendRound = (message) => `${message} ${roundTag}`;
 
   const statusMode = parseBoolean(env.DRY_RUN, false) ? 'dry-run' : 'active';
+  const isDryRun = statusMode === 'dry-run';
   let syncStatus = 'needs_update';
   let statusHead = baselineHead || '';
   let statusBase = baseBranch || '';
@@ -1046,6 +1057,13 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   let stateCommentUrl = stateManager.commentUrl || '';
 
   const applyStateUpdate = async (updates, { forcePersist = false } = {}) => {
+    if (isDryRun) {
+      state = mergeStateShallow(state, updates);
+      commandState = state.command_dispatch && typeof state.command_dispatch === 'object' ? state.command_dispatch : {};
+      escalationRecord = state.escalation_comment && typeof state.escalation_comment === 'object' ? state.escalation_comment : {};
+      return { state: { ...state }, commentId: stateCommentId, commentUrl: stateCommentUrl, dryRun: true };
+    }
+
     if (!forcePersist && !stateCommentId) {
       state = mergeStateShallow(state, updates);
       commandState = state.command_dispatch && typeof state.command_dispatch === 'object' ? state.command_dispatch : {};
@@ -1066,7 +1084,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     const saved = await applyStateUpdate({}, { forcePersist: true });
     stateCommentId = saved.commentId || stateCommentId;
     stateCommentUrl = saved.commentUrl || stateCommentUrl;
-    record('State comment', appendRound(`initialised id=${stateCommentId || 0}`));
+    record('State comment', appendRound(isDryRun ? 'skipped initialisation: dry-run mode.' : `initialised id=${stateCommentId || 0}`));
   } else {
     record('State comment', appendRound(`reused id=${stateCommentId}`));
   }
@@ -1259,12 +1277,16 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   if (baselineHead && initialHead && baselineHead !== initialHead) {
     record('Head check', `Head already advanced to ${initialHead}; skipping sync gate.`);
     if (hasSyncLabel) {
-      try {
-        await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
-        record('Sync label', appendRound(`Removed ${syncLabel}.`));
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+      if (isDryRun) {
+        record('Sync label', appendRound(`Skipped removing ${syncLabel}: dry-run mode.`));
+      } else {
+        try {
+          await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
+          record('Sync label', appendRound(`Removed ${syncLabel}.`));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+        }
       }
     } else {
       record('Sync label', appendRound(`${syncLabel} not present.`));
@@ -1391,6 +1413,10 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
       record('Update-branch API', appendRound('skipped: baseline head missing.'));
       return { changed: false };
     }
+    if (isDryRun) {
+      record('Update-branch API', appendRound('skipped: dry-run mode.'));
+      return { changed: false, dryRun: true };
+    }
 
     try {
       const response = await github.rest.pulls.updateBranch({
@@ -1452,6 +1478,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
           headRepo: headRepoFullName,
           headIsFork,
           record,
+          statusMode,
         });
 
     if (!dispatchInfo.dispatched) {
@@ -1589,6 +1616,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
       core,
       record,
       appendRound,
+      statusMode,
     });
     if (apiResult?.attempted) {
       if (apiResult?.changed) {
@@ -1645,6 +1673,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
           headRepo: headRepoFullName,
           headIsFork,
           record,
+          statusMode,
         });
 
     if (dispatchInfo.dispatched && !state.fallback_dispatch?.dispatched) {
@@ -1723,15 +1752,19 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     await persistLastInstruction(finalHead || baselineHead || initialHead);
 
     if (hasSyncLabel) {
-      try {
-        await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
-        record('Sync label', `Removed ${syncLabel}.`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        record('Sync label', `Failed to remove ${syncLabel}: ${message}`);
+      if (isDryRun) {
+        record('Sync label', appendRound(`Skipped removing ${syncLabel}: dry-run mode.`));
+      } else {
+        try {
+          await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
+          record('Sync label', appendRound(`Removed ${syncLabel}.`));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+        }
       }
     } else {
-      record('Sync label', `${syncLabel} not present.`);
+      record('Sync label', appendRound(`${syncLabel} not present.`));
     }
     const elapsed = Date.now() - startTime;
     record('Result', appendRound(`mode=${mode || 'unknown'} sha=${finalHead || '(unknown)'} elapsed=${elapsed}ms`));
@@ -1762,12 +1795,16 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   });
 
   if (!hasSyncLabel) {
-    try {
-      await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [syncLabel] });
-      record('Sync label', appendRound(`Applied ${syncLabel}.`));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      record('Sync label', appendRound(`Failed to apply ${syncLabel}: ${message}`));
+    if (isDryRun) {
+      record('Sync label', appendRound(`Skipped applying ${syncLabel}: dry-run mode.`));
+    } else {
+      try {
+        await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [syncLabel] });
+        record('Sync label', appendRound(`Applied ${syncLabel}.`));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        record('Sync label', appendRound(`Failed to apply ${syncLabel}: ${message}`));
+      }
     }
   } else {
     record('Sync label', appendRound(`${syncLabel} already present.`));
@@ -1796,25 +1833,29 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     record('Escalation comment', appendRound('Reusing previous escalation comment.'));
   } else {
     const escalationMessage = `Keepalive: manual action needed — use update-branch/create-pr controls (click Update Branch or open Create PR) at: ${manualActionLink}`;
-    try {
-      const { data: escalationComment } = await github.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: prNumber,
-        body: escalationMessage,
-      });
-      updateSyncLink(escalationComment?.html_url || manualActionLink, { prefer: true });
-      await updateEscalationRecord({
-        comment_id: escalationComment?.id || '',
-        comment_url: escalationComment?.html_url || '',
-        idempotency_key: idempotencyKey,
-        recorded_at: new Date().toISOString(),
-        body: escalationMessage,
-      });
-      record('Escalation comment', appendRound('Posted escalation notice.'));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      record('Escalation comment', appendRound(`Failed to post escalation comment: ${message}`));
+    if (isDryRun) {
+      record('Escalation comment', appendRound('Skipped posting escalation notice: dry-run mode.'));
+    } else {
+      try {
+        const { data: escalationComment } = await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: escalationMessage,
+        });
+        updateSyncLink(escalationComment?.html_url || manualActionLink, { prefer: true });
+        await updateEscalationRecord({
+          comment_id: escalationComment?.id || '',
+          comment_url: escalationComment?.html_url || '',
+          idempotency_key: idempotencyKey,
+          recorded_at: new Date().toISOString(),
+          body: escalationMessage,
+        });
+        record('Escalation comment', appendRound('Posted escalation notice.'));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        record('Escalation comment', appendRound(`Failed to post escalation comment: ${message}`));
+      }
     }
   }
 

--- a/templates/consumer-repo/.github/scripts/keepalive_post_work.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_post_work.js
@@ -412,10 +412,15 @@ async function dispatchFallbackWorkflow({
   idempotencyKey,
   roundTag = 'round=?',
   record,
+  statusMode = 'active',
 }) {
   if (!baseRef || !headRef || !headSha) {
     record('Fallback dispatch', `skipped: base/head/head_sha missing. ${roundTag}`);
     return { dispatched: false };
+  }
+  if (statusMode === 'dry-run') {
+    record('Fallback dispatch', `skipped: dry-run mode. ${roundTag}`);
+    return { dispatched: false, dryRun: true };
   }
   try {
     const inputs = {
@@ -730,6 +735,7 @@ async function attemptUpdateBranchViaApi({
   core,
   record,
   appendRound,
+  statusMode = 'active',
 }) {
   if (!Number.isFinite(prNumber) || prNumber <= 0 || !baselineHead) {
     record('Update-branch API', appendRound('skipped: missing PR context or baseline head.'));
@@ -738,6 +744,10 @@ async function attemptUpdateBranchViaApi({
   if (!github?.rest?.pulls?.updateBranch) {
     record('Update-branch API', appendRound('skipped: Octokit client lacks updateBranch support.'));
     return { attempted: false };
+  }
+  if (statusMode === 'dry-run') {
+    record('Update-branch API', appendRound('skipped: dry-run mode.'));
+    return { attempted: false, dryRun: true };
   }
 
   const requestPayload = {
@@ -847,6 +857,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   const appendRound = (message) => `${message} ${roundTag}`;
 
   const statusMode = parseBoolean(env.DRY_RUN, false) ? 'dry-run' : 'active';
+  const isDryRun = statusMode === 'dry-run';
   let syncStatus = 'needs_update';
   let statusHead = baselineHead || '';
   let statusBase = baseBranch || '';
@@ -1046,6 +1057,13 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   let stateCommentUrl = stateManager.commentUrl || '';
 
   const applyStateUpdate = async (updates, { forcePersist = false } = {}) => {
+    if (isDryRun) {
+      state = mergeStateShallow(state, updates);
+      commandState = state.command_dispatch && typeof state.command_dispatch === 'object' ? state.command_dispatch : {};
+      escalationRecord = state.escalation_comment && typeof state.escalation_comment === 'object' ? state.escalation_comment : {};
+      return { state: { ...state }, commentId: stateCommentId, commentUrl: stateCommentUrl, dryRun: true };
+    }
+
     if (!forcePersist && !stateCommentId) {
       state = mergeStateShallow(state, updates);
       commandState = state.command_dispatch && typeof state.command_dispatch === 'object' ? state.command_dispatch : {};
@@ -1066,7 +1084,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     const saved = await applyStateUpdate({}, { forcePersist: true });
     stateCommentId = saved.commentId || stateCommentId;
     stateCommentUrl = saved.commentUrl || stateCommentUrl;
-    record('State comment', appendRound(`initialised id=${stateCommentId || 0}`));
+    record('State comment', appendRound(isDryRun ? 'skipped initialisation: dry-run mode.' : `initialised id=${stateCommentId || 0}`));
   } else {
     record('State comment', appendRound(`reused id=${stateCommentId}`));
   }
@@ -1259,12 +1277,16 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   if (baselineHead && initialHead && baselineHead !== initialHead) {
     record('Head check', `Head already advanced to ${initialHead}; skipping sync gate.`);
     if (hasSyncLabel) {
-      try {
-        await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
-        record('Sync label', appendRound(`Removed ${syncLabel}.`));
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+      if (isDryRun) {
+        record('Sync label', appendRound(`Skipped removing ${syncLabel}: dry-run mode.`));
+      } else {
+        try {
+          await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
+          record('Sync label', appendRound(`Removed ${syncLabel}.`));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+        }
       }
     } else {
       record('Sync label', appendRound(`${syncLabel} not present.`));
@@ -1391,6 +1413,10 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
       record('Update-branch API', appendRound('skipped: baseline head missing.'));
       return { changed: false };
     }
+    if (isDryRun) {
+      record('Update-branch API', appendRound('skipped: dry-run mode.'));
+      return { changed: false, dryRun: true };
+    }
 
     try {
       const response = await github.rest.pulls.updateBranch({
@@ -1452,6 +1478,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
           headRepo: headRepoFullName,
           headIsFork,
           record,
+          statusMode,
         });
 
     if (!dispatchInfo.dispatched) {
@@ -1589,6 +1616,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
       core,
       record,
       appendRound,
+      statusMode,
     });
     if (apiResult?.attempted) {
       if (apiResult?.changed) {
@@ -1645,6 +1673,7 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
           headRepo: headRepoFullName,
           headIsFork,
           record,
+          statusMode,
         });
 
     if (dispatchInfo.dispatched && !state.fallback_dispatch?.dispatched) {
@@ -1723,15 +1752,19 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     await persistLastInstruction(finalHead || baselineHead || initialHead);
 
     if (hasSyncLabel) {
-      try {
-        await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
-        record('Sync label', `Removed ${syncLabel}.`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        record('Sync label', `Failed to remove ${syncLabel}: ${message}`);
+      if (isDryRun) {
+        record('Sync label', appendRound(`Skipped removing ${syncLabel}: dry-run mode.`));
+      } else {
+        try {
+          await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: syncLabel });
+          record('Sync label', appendRound(`Removed ${syncLabel}.`));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          record('Sync label', appendRound(`Failed to remove ${syncLabel}: ${message}`));
+        }
       }
     } else {
-      record('Sync label', `${syncLabel} not present.`);
+      record('Sync label', appendRound(`${syncLabel} not present.`));
     }
     const elapsed = Date.now() - startTime;
     record('Result', appendRound(`mode=${mode || 'unknown'} sha=${finalHead || '(unknown)'} elapsed=${elapsed}ms`));
@@ -1762,12 +1795,16 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
   });
 
   if (!hasSyncLabel) {
-    try {
-      await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [syncLabel] });
-      record('Sync label', appendRound(`Applied ${syncLabel}.`));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      record('Sync label', appendRound(`Failed to apply ${syncLabel}: ${message}`));
+    if (isDryRun) {
+      record('Sync label', appendRound(`Skipped applying ${syncLabel}: dry-run mode.`));
+    } else {
+      try {
+        await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: [syncLabel] });
+        record('Sync label', appendRound(`Applied ${syncLabel}.`));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        record('Sync label', appendRound(`Failed to apply ${syncLabel}: ${message}`));
+      }
     }
   } else {
     record('Sync label', appendRound(`${syncLabel} already present.`));
@@ -1796,25 +1833,29 @@ async function runKeepalivePostWork({ core, github: rawGithub, context, env = pr
     record('Escalation comment', appendRound('Reusing previous escalation comment.'));
   } else {
     const escalationMessage = `Keepalive: manual action needed — use update-branch/create-pr controls (click Update Branch or open Create PR) at: ${manualActionLink}`;
-    try {
-      const { data: escalationComment } = await github.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: prNumber,
-        body: escalationMessage,
-      });
-      updateSyncLink(escalationComment?.html_url || manualActionLink, { prefer: true });
-      await updateEscalationRecord({
-        comment_id: escalationComment?.id || '',
-        comment_url: escalationComment?.html_url || '',
-        idempotency_key: idempotencyKey,
-        recorded_at: new Date().toISOString(),
-        body: escalationMessage,
-      });
-      record('Escalation comment', appendRound('Posted escalation notice.'));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      record('Escalation comment', appendRound(`Failed to post escalation comment: ${message}`));
+    if (isDryRun) {
+      record('Escalation comment', appendRound('Skipped posting escalation notice: dry-run mode.'));
+    } else {
+      try {
+        const { data: escalationComment } = await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: escalationMessage,
+        });
+        updateSyncLink(escalationComment?.html_url || manualActionLink, { prefer: true });
+        await updateEscalationRecord({
+          comment_id: escalationComment?.id || '',
+          comment_url: escalationComment?.html_url || '',
+          idempotency_key: idempotencyKey,
+          recorded_at: new Date().toISOString(),
+          body: escalationMessage,
+        });
+        record('Escalation comment', appendRound('Posted escalation notice.'));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        record('Escalation comment', appendRound(`Failed to post escalation comment: ${message}`));
+      }
     }
   }
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,13 @@
 # Workloop State
 
+## 2026-06-13T10:06Z - opener (codex) opened dry-run mutation guard lane for #2269
+
+- **Selected opener lane:** issue [#2269](https://github.com/stranske/Workflows/issues/2269), branch `codex/issue-2269-keepalive-dry-run`.
+- **Implementation:** guarded keepalive post-work dry-run mode so `updateBranch`, fallback workflow dispatch, sync-label add/remove, and escalation comments are skipped while read/poll/state-reporting paths still run. Mirrored the sync-managed script into `templates/consumer-repo/.github/scripts/keepalive_post_work.js`.
+- **Validation:** `node --test .github/scripts/__tests__/keepalive-post-work.test.js` passed (`5 pass, 0 fail`); `node -c` passed for source and template scripts; `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; `git diff --check` passed.
+- **Deliberate-break gate:** temporarily disabled the dry-run guard around sync-label `addLabels`; the new `performs no GitHub mutations in dry-run mode` test failed with `1 !== 0` at the add-label assertion, then the guard was restored and the suite passed.
+- **Next action:** push/open the ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI and bot-review iteration after PR creation.
+
 ## 2026-06-13T10:03Z - closer (codex) rebased #2292 conflict lane
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2292](https://github.com/stranske/Workflows/pull/2292), source issue `#2268`, branch `claude/issue-2268-auto-delegation`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,13 @@
 # Workloop State
 
+## 2026-06-13T10:24Z - closer (codex) review-fix pushed for #2293
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2293](https://github.com/stranske/Workflows/pull/2293), source issue `#2269`, branch `codex/issue-2269-keepalive-dry-run`.
+- **Blocker:** three unresolved review threads: one P2 correctly noted that dry-run still saved hidden keepalive-state comments via `applyStateUpdate`/`forcePersist`, and two Copilot threads noted inconsistent `Sync label` row formatting between dry-run and active paths.
+- **Action:** rebased onto `origin/main` after #2292 merged; resolved the `workloop-state.md` conflict by preserving both #2269 and #2292 entries. Added a dry-run guard to the shared state-save layer in root and consumer-template `keepalive_post_work.js`, leaving state in memory for outputs but skipping `stateManager.save(...)`; normalized active `Sync label` records to use `appendRound(...)`. Extended the dry-run test to assert `stub.saves.length === 0`.
+- **Validation:** `node --test .github/scripts/__tests__/keepalive-post-work.test.js` passed (`5 passed`); `node -c` passed for root and template scripts; `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync.
+- **Next action:** push with `--force-with-lease`, resolve the three review threads, and wait for fresh PR checks on the rebased head. If checks settle green and no new review threads appear, merge #2293 and apply verifier/source-issue sequencing for `#2269`.
+
 ## 2026-06-13T10:06Z - opener (codex) opened dry-run mutation guard lane for #2269
 
 - **Selected opener lane:** issue [#2269](https://github.com/stranske/Workflows/issues/2269), branch `codex/issue-2269-keepalive-dry-run`, PR [#2293](https://github.com/stranske/Workflows/pull/2293).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -2,11 +2,12 @@
 
 ## 2026-06-13T10:06Z - opener (codex) opened dry-run mutation guard lane for #2269
 
-- **Selected opener lane:** issue [#2269](https://github.com/stranske/Workflows/issues/2269), branch `codex/issue-2269-keepalive-dry-run`.
+- **Selected opener lane:** issue [#2269](https://github.com/stranske/Workflows/issues/2269), branch `codex/issue-2269-keepalive-dry-run`, PR [#2293](https://github.com/stranske/Workflows/pull/2293).
 - **Implementation:** guarded keepalive post-work dry-run mode so `updateBranch`, fallback workflow dispatch, sync-label add/remove, and escalation comments are skipped while read/poll/state-reporting paths still run. Mirrored the sync-managed script into `templates/consumer-repo/.github/scripts/keepalive_post_work.js`.
 - **Validation:** `node --test .github/scripts/__tests__/keepalive-post-work.test.js` passed (`5 pass, 0 fail`); `node -c` passed for source and template scripts; `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; `git diff --check` passed.
 - **Deliberate-break gate:** temporarily disabled the dry-run guard around sync-label `addLabels`; the new `performs no GitHub mutations in dry-run mode` test failed with `1 !== 0` at the add-label assertion, then the guard was restored and the suite passed.
-- **Next action:** push/open the ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI and bot-review iteration after PR creation.
+- **PR/dispatch state:** opened ready-for-review PR #2293 with `agent:codex`, `agents:keepalive`, and `autofix`; then added `agent:retry` and dispatched Workflows-native `agents-keepalive-loop.yml` (`27463791983`) after generic Gate Followups dispatch hit the known Workflows 404. Final cap-health classified #2293 as `draining` with an active Gate run and no non-drainable blocker.
+- **Next action:** wait for Gate/keepalive on #2293; keepalive owns CI and bot-review iteration.
 
 ## 2026-06-13T10:03Z - closer (codex) rebased #2292 conflict lane
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2269 -->
> **Source:** Issue #2269

Closes #2269

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`runKeepalivePostWork` in `.github/scripts/keepalive_post_work.js:795` is the
branch-sync remediation routine driven by the keepalive dispatch handler and the
orchestrator. It supports a `DRY_RUN` mode, set at
`.github/scripts/keepalive_post_work.js:849`:

```
const statusMode = parseBoolean(env.DRY_RUN, false) ? 'dry-run' : 'active';
```

Verified: `statusMode === 'dry-run'` is checked in exactly **one** place — the
`attemptCommand` helper at `keepalive_post_work.js:1328`:

```
if (statusMode === 'dry-run') {
  record(displayLabel, appendRound('skipped: dry-run mode.'));
  await persistEntry({ last_result: 'dry-run', status: 'skipped' });
  return { attempted: false, dryRun: true };
}
```

`attemptCommand` only fires repository_dispatch *comment commands*, and it is
reached at `keepalive_post_work.js:1621` and `:1625` — **after** the genuinely
mutating paths have already run. In dry-run, `runKeepalivePostWork` still performs
real side effects:

- **Real branch merge via API:** `attemptUpdateBranchViaApi` is called
  unconditionally at `keepalive_post_work.js:1580` (inside `if (!success)`). That
  function (defined at `keepalive_post_work.js:721`) calls
  `github.rest.pulls.updateBranch` at `keepalive_post_work.js:752` with no
  `statusMode` check — it actually merges the base branch into the PR head.
- **Real workflow dispatch:** `dispatchFallbackWorkflow`
  (`keepalive_post_work.js:397`) is called at `keepalive_post_work.js:1631` and
  calls `github.rest.actions.createWorkflowDispatch` at
  `keepalive_post_work.js:444` (dispatching `agents-keepalive-branch-sync.yml`)
  with no dry-run guard.
- **Real label writes:** the sync label is removed at
  `keepalive_post_work.js:1263` and `:1727`, and *added* at
  `keepalive_post_work.js:1766`
  (`github.rest.issues.addLabels({ ..., labels: [syncLabel] })`, default
  `agents:sync-required`) — none guarded by `statusMode`.
- **Real escalation comment:** `github.rest.issues.createComment` at
  `keepalive_post_work.js:1800` posts the "manual action needed" notice with no
  dry-run guard.

Callers genuinely pass `DRY_RUN`:
`.github/workflows/agents-keepalive-dispatch-handler.yml:191`
(`DRY_RUN: payload.dry_run || ''`) and
`.github/workflows/reusable-70-orchestrator-main.yml:2057`
(`DRY_RUN: ${{ inputs.dry_run || '' }}`).

The existing unit test makes the break undeniable:
`.github/scripts/__tests__/keepalive-post-work.test.js:284`
(`runKeepalivePostWork escalates and adds sync label when sync times out`) sets
`DRY_RUN: 'true'` (line 295) and then asserts `github.calls.addLabels.length === 1`
and `addLabels[0].labels[0] === 'agents:sync-required'` (lines 303-304) — i.e. the
suite currently *expects* a label write during a dry run.

This is a **current break**, not latent: a "dry run" performs real branch merges,
real workflow dispatches, and real label/comment writes. Only comment-command
dispatch is actually suppressed.

#### Tasks
- [ ] In `keepalive_post_work.js`, wrap the `attemptUpdateBranchViaApi` call at
  `:1580` (or add a guard inside the function at `:721`, before the
  `github.rest.pulls.updateBranch` call at `:752`) so it is skipped when
  `statusMode === 'dry-run'`, recording `appendRound('skipped: dry-run')` for the
  "Update-branch API" row.
- [ ] Gate the `dispatchFallbackWorkflow` call at `:1631` (or the
  `createWorkflowDispatch` at `:444`) behind `statusMode !== 'dry-run'`, with a
  "skipped: dry-run" record.
- [ ] Gate the sync-label mutations: `addLabels` at `:1766` and the
  `removeLabel` calls at `:1263` and `:1727`, each recording a "skipped: dry-run"
  row instead of calling the API.
- [ ] Gate the escalation `createComment` at `:1800` behind
  `statusMode !== 'dry-run'`, recording a "skipped: dry-run" row.
- [ ] Update the existing dry-run test
  `.github/scripts/__tests__/keepalive-post-work.test.js:284` (which currently
  asserts `addLabels.length === 1` at lines 303-304 under `DRY_RUN: 'true'`) to
  assert **zero** mutations, and add the dedicated deliberate-break test from
  Acceptance Criteria using the existing `createGithubStub` call counters
  (`keepalive-post-work.test.js:130-137`: `calls.updateBranch`,
  `calls.createWorkflowDispatch`, `calls.addLabels`).

#### Acceptance criteria
- [ ] New/updated named test in
  `.github/scripts/__tests__/keepalive-post-work.test.js`, e.g.
  `runKeepalivePostWork performs no GitHub mutations in dry-run mode`: drives
  `runKeepalivePostWork` with `env.DRY_RUN: 'true'` through the sync-timeout path
  (the scenario currently exercised at `keepalive-post-work.test.js:284`) and
  asserts all three call counters are empty:
  `github.calls.updateBranch.length === 0`,
  `github.calls.createWorkflowDispatch.length === 0`, and
  `github.calls.addLabels.length === 0`. Run via
  `node --test .github/scripts/__tests__/keepalive-post-work.test.js` → passes.
- [ ] **Deliberate-break gate:** after implementing the guards, temporarily
  remove the `statusMode !== 'dry-run'` guard around the sync-label `addLabels`
  call at `keepalive_post_work.js:1766`. With the guard removed, the new
  `... performs no GitHub mutations in dry-run mode` test **must FAIL** —
  concretely `github.calls.addLabels.length` comes back `1` (the
  `agents:sync-required` write fires during a dry run). Capture the FAIL output,
  then restore the guard so the test passes.
- [ ] The other passing cases in
  `.github/scripts/__tests__/keepalive-post-work.test.js` still pass
  (`node --test ...` shows `fail 0`) — in particular
  `runKeepalivePostWork removes sync label when head already advanced`
  (`keepalive-post-work.test.js:259`), which runs in active mode and must still
  observe the live `removeLabel` behavior, confirming the guards did not break
  the non-dry-run path.

<!-- auto-status-summary:end -->