### PR TITLE
fix(langsmith): stop zero-signal dashboard churn (#2273)

### DIFF
--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -375,14 +375,21 @@ jobs:
           EOF
 
           # Upsert a single pinned dashboard issue instead of minting a new
-          # no-data issue every schedule.
-          DASHBOARD_ISSUE=$(gh issue list \
+          # no-data issue every schedule. Capture the lookup separately so a
+          # transient API/list failure aborts the step instead of silently
+          # leaving DASHBOARD_ISSUE empty and falling through to the create
+          # branch, which would reintroduce the duplicate-issue churn this
+          # change exists to stop.
+          if ! DASHBOARD_ISSUE_JSON=$(gh issue list \
             --state open \
             --label "metrics" \
             --search "LangSmith Trace Coverage Dashboard in:title" \
-            --json number,title \
-            --jq '.[] | select(.title == "📊 LangSmith Trace Coverage Dashboard") | .number' | \
-            head -n 1)
+            --json number,title); then
+            echo "::error::Failed to list existing dashboard issues; aborting to avoid duplicate dashboard issue churn." >&2
+            exit 1
+          fi
+          DASHBOARD_ISSUE=$(printf '%s' "$DASHBOARD_ISSUE_JSON" \
+            | jq -r --arg title "$ISSUE_TITLE" 'map(select(.title == $title)) | .[0].number // empty')
 
           if [ -n "$DASHBOARD_ISSUE" ]; then
             gh issue edit "$DASHBOARD_ISSUE" \

--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -56,7 +56,9 @@ jobs:
           # Get workflow runs from metric-producing workflows.
           : > .metrics-tmp/run_ids.txt
           : > .metrics-tmp/workflow_errors.log
-          for WORKFLOW_PATH in agents-auto-pilot.yml reusable-agents-verifier.yml; do
+          # reusable-agents-verifier.yml is workflow_call-only; metrics runs
+          # accrue to the top-level verifier caller.
+          for WORKFLOW_PATH in agents-auto-pilot.yml agents-verifier.yml; do
             if ! gh api --method GET \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -319,7 +321,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 90
 
-      - name: Create dashboard issue
+      - name: Upsert dashboard issue
         if: >
           env.REPORT_AVAILABLE == 'true' &&
           (github.event_name == 'schedule' || inputs.create_issue == true)
@@ -335,6 +337,7 @@ jobs:
           END_DATE=$(date -u +%Y-%m-%d)
 
           # Create issue body
+          ISSUE_TITLE="📊 LangSmith Trace Coverage Dashboard"
           cat > .metrics-tmp/issue-body.md <<EOF
           # LangSmith Trace Coverage Report
 
@@ -366,16 +369,37 @@ jobs:
 
           ---
 
-          <sub>This report is generated automatically every Monday. To regenerate
+          <sub>This report is updated automatically every Monday. To regenerate
           manually, trigger the [LangSmith Metrics Dashboard workflow](
           ../actions/workflows/maint-80-langsmith-metrics-dashboard.yml).</sub>
           EOF
 
-          # Create issue
-          gh issue create \
-            --title "📊 LangSmith Trace Coverage Report - Week of $START_DATE" \
-            --body-file .metrics-tmp/issue-body.md \
-            --label "metrics,automated"
+          # Upsert a single pinned dashboard issue instead of minting a new
+          # no-data issue every schedule.
+          DASHBOARD_ISSUE=$(gh issue list \
+            --state open \
+            --label "metrics" \
+            --search "LangSmith Trace Coverage Dashboard in:title" \
+            --json number,title \
+            --jq '.[] | select(.title == "📊 LangSmith Trace Coverage Dashboard") | .number' | \
+            head -n 1)
+
+          if [ -n "$DASHBOARD_ISSUE" ]; then
+            gh issue edit "$DASHBOARD_ISSUE" \
+              --title "$ISSUE_TITLE" \
+              --body-file .metrics-tmp/issue-body.md \
+              --add-label "metrics" \
+              --add-label "automated"
+            echo "LANGSMITH_DASHBOARD_ISSUE=$DASHBOARD_ISSUE" >> "$GITHUB_ENV"
+            echo "Updated LangSmith dashboard issue #$DASHBOARD_ISSUE"
+          else
+            DASHBOARD_URL=$(gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body-file .metrics-tmp/issue-body.md \
+              --label "metrics,automated")
+            echo "LANGSMITH_DASHBOARD_ISSUE_URL=$DASHBOARD_URL" >> "$GITHUB_ENV"
+            echo "Created LangSmith dashboard issue $DASHBOARD_URL"
+          fi
 
       - name: Update dashboard file
         if: env.REPORT_AVAILABLE == 'true'
@@ -465,7 +489,7 @@ jobs:
             echo "  - Dashboard file: docs/dashboards/langsmith-metrics.md"
             if [ "${{ github.event_name }}" == "schedule" ] || \
                [ "${{ inputs.create_issue }}" == "true" ]; then
-              echo "  - Issue: Created with labels 'metrics,automated'"
+              echo "  - Issue: Upserted with labels 'metrics,automated'"
             fi
           else
             echo "⚠️ No metrics data available for the specified period"

--- a/config/langsmith_fleet_registry.json
+++ b/config/langsmith_fleet_registry.json
@@ -10,7 +10,7 @@
       "surface": "agent-automation",
       "operations": ["autopilot", "keepalive", "verifier", "dashboard-ingestion"],
       "artifact_name": "langsmith-fleet.ndjson",
-      "rollout_status": "contract-owner",
+      "rollout_status": "paused",
       "required_domain_fields": [
         "workflow",
         "agent",

--- a/docs/dashboards/README.md
+++ b/docs/dashboards/README.md
@@ -21,7 +21,7 @@ This directory contains automated dashboard reports for monitoring repository me
 #### Where to View
 
 1. **Dashboard file:** `docs/dashboards/langsmith-metrics.md` (updated weekly, committed to main)
-2. **Weekly issues:** Created automatically with labels `metrics,automated`
+2. **Dashboard issue:** A single open issue is updated with labels `metrics,automated`
 3. **Workflow artifacts:** Downloadable JSON + markdown reports (90-day retention)
 
 #### Manual Triggers
@@ -51,7 +51,7 @@ The dashboard aggregates two distinct data sources, fetched in this workflow:
 
 1. **Trace-coverage metrics** — artifacts from this repo's own completed runs,
    matched by name `autopilot-metrics-*` and `agents-verifier-metrics`
-   (`agents-auto-pilot.yml` and `reusable-agents-verifier.yml`), within the
+   (`agents-auto-pilot.yml` and `agents-verifier.yml`), within the
    `days_back` window. These feed `scripts/aggregate_metrics.py`.
 2. **LangSmith fleet artifacts** (`langsmith-fleet.ndjson`) — one per repo
    registered in `config/langsmith_fleet_registry.json`. The workflow attempts a
@@ -85,8 +85,8 @@ before treating a consumer-local validator as a design blocker.
 4. **Report** - Generates a markdown report combining the trace-coverage section
    and the fleet artifact status section (the report is published even when only
    the fleet section has content)
-5. **Publish** - Updates `docs/dashboards/langsmith-metrics.md`, creates the
-   weekly issue, and uploads artifacts (report + fleet status JSON/markdown)
+5. **Publish** - Updates `docs/dashboards/langsmith-metrics.md`, upserts the
+   dashboard issue, and uploads artifacts (report + fleet status JSON/markdown)
 
 ---
 

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -1,6 +1,8 @@
+import json
 from pathlib import Path
 
 WORKFLOW = Path(".github/workflows/maint-80-langsmith-metrics-dashboard.yml")
+FLEET_REGISTRY = Path("config/langsmith_fleet_registry.json")
 
 
 def test_fleet_artifact_lookup_does_not_mix_slurp_with_jq() -> None:
@@ -19,6 +21,35 @@ def test_dashboard_issue_uses_existing_labels() -> None:
     assert '--label "metrics,automated"' in source
     assert "metrics,langsmith,automated" not in source
     assert "labels 'metrics,automated'" in source
+
+
+def test_run_discovery_targets_workflows_with_runs() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+    discovery_line = next(
+        line for line in source.splitlines() if "for WORKFLOW_PATH in" in line
+    )
+
+    assert "agents-auto-pilot.yml" in discovery_line
+    assert "agents-verifier.yml" in discovery_line
+    assert "reusable-agents-verifier.yml" not in discovery_line
+
+
+def test_dashboard_issue_upserts_single_pinned_issue() -> None:
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'ISSUE_TITLE="📊 LangSmith Trace Coverage Dashboard"' in source
+    assert "gh issue list \\" in source
+    assert 'gh issue edit "$DASHBOARD_ISSUE"' in source
+    assert "LangSmith Trace Coverage Report - Week of $START_DATE" not in source
+
+
+def test_workflows_fleet_entry_is_paused_until_emitter_exists() -> None:
+    registry = json.loads(FLEET_REGISTRY.read_text(encoding="utf-8"))
+    workflows_entry = next(
+        entry for entry in registry["repos"] if entry["repo"] == "stranske/Workflows"
+    )
+
+    assert workflows_entry["rollout_status"] == "paused"
 
 
 def test_fleet_status_is_warning_only_and_appended_to_report() -> None:

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -25,9 +25,7 @@ def test_dashboard_issue_uses_existing_labels() -> None:
 
 def test_run_discovery_targets_workflows_with_runs() -> None:
     source = WORKFLOW.read_text(encoding="utf-8")
-    discovery_line = next(
-        line for line in source.splitlines() if "for WORKFLOW_PATH in" in line
-    )
+    discovery_line = next(line for line in source.splitlines() if "for WORKFLOW_PATH in" in line)
 
     assert "agents-auto-pilot.yml" in discovery_line
     assert "agents-verifier.yml" in discovery_line

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,13 @@
 # Workloop State
 
+## 2026-06-13T12:12Z - closer (codex) rebased #2295 after #2294 merge
+
+- **Selected complex lane:** `stranske/Workflows` PR [#2295](https://github.com/stranske/Workflows/pull/2295), source issue `#2273`, branch `codex/issue-2273-langsmith-zero-signal`.
+- **Blocker:** batch-safe merge of [#2294](https://github.com/stranske/Workflows/pull/2294) advanced `main`, and the attempted batch merge of #2295 then failed with GitHub `Pull Request has merge conflicts`.
+- **Action:** used disposable clone `/tmp/wf-2295-conflict.evQX0i`, rebased #2295 onto current `main` (`ec5fd586`), and resolved the state-only `workloop-state.md` conflicts by preserving the newer #2294 closer entries plus the #2273/#2295 opener entry. Source workflow/test files rebased without conflicts.
+- **Validation:** `python -m pytest tests/workflows/test_langsmith_metrics_dashboard.py -q -rA` passed (`7 passed`); `python scripts/validate_template_completeness.py` passed; `scripts/sync_templates.sh` reported all files already in sync; workflow YAML and registry JSON parse passed; `git diff --check` clean.
+- **Next action:** push the rebased branch with `--force-with-lease`; then wait for fresh Gate/review state. If checks settle green and review threads remain resolved, merge #2295, apply `verify:compare`, and keep issue #2273 open until durable verifier disposition.
+
 ## 2026-06-13T11:31Z - closer (codex) CI sync fix pushed for #2294
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2294](https://github.com/stranske/Workflows/pull/2294), source issue `#2271`, branch `claude/issue-2271-verifier-ci-gate`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -17,6 +17,16 @@
 - **Post-push state:** pushed code head `beb4818f`, posted evidence comment on #2294, resolved review threads `PRRT_kwDOQprj9M6JUfsP` and `PRRT_kwDOQprj9M6JUft7`, then pushed this state entry as final head `26267f30`. Final live snapshot after the state commit: review threads 0 unresolved; PR open/non-draft, `MERGEABLE`, `mergeStateStatus=UNSTABLE`; fresh checks are queued/in progress on `26267f30`. Non-key async wait override does not apply.
 - **Next action:** re-check #2294 after fresh checks settle on the latest head; if checks are green and review threads remain resolved, merge #2294, apply the intended `verify:compare` label, and sequence source issue `#2271` until durable verifier disposition.
 
+## 2026-06-13T11:04Z - opener (codex) issue #2273 LangSmith dashboard wiring
+
+- **Selected opener lane:** `stranske/Workflows` issue [#2273](https://github.com/stranske/Workflows/issues/2273), branch `codex/issue-2273-langsmith-zero-signal`, PR [#2295](https://github.com/stranske/Workflows/pull/2295).
+- **Cap/drain context:** raw opener cap was 2/5 after the drain sweep. PR #2287 remains scoped-blocked on the Selftest: Reusables zero-scenario design decision; PR #2294 was repaired from stale dispatch evidence to active-moving with fresh Gate/Agents Keepalive Loop runs after `agent:retry` was consumed.
+- **Implementation:** corrected LangSmith metrics discovery to query `agents-verifier.yml` instead of the `workflow_call`-only reusable verifier; changed dashboard issue publication from weekly issue creation to a single pinned dashboard issue upsert; marked the Workflows `agent-automation` LangSmith fleet registry row `paused` until an emitter exists; updated dashboard README wording.
+- **Validation:** `python -m pytest tests/workflows/test_langsmith_metrics_dashboard.py -v` passed (`7 passed`); YAML/JSON parse smoke passed; `git diff --check` passed; `python scripts/validate_template_completeness.py` passed; empty-record `scripts/langsmith_fleet.py` smoke confirmed the selected pause path preserves missing-row reporting while registry state is explicit.
+- **Deliberate-break gate:** temporarily changed the discovery loop back to `reusable-agents-verifier.yml`; `test_run_discovery_targets_workflows_with_runs` failed on the new assertion that the reusable workflow must not be in the discovery line; restored the fix and the full test file passed.
+- **Workspace note:** canonical Workflows `.git` metadata rejected new branch/worktree writes from Dropbox (`Operation not permitted`), so implementation used disposable clone `/tmp/wf-2273-codex.PmK4us` and will push `HEAD` to the registry branch.
+- **Next action:** push the branch, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`, then hand off to keepalive.
+
 ## 2026-06-13T10:24Z - closer (codex) review-fix pushed for #2293
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2293](https://github.com/stranske/Workflows/pull/2293), source issue `#2269`, branch `codex/issue-2269-keepalive-dry-run`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2273 -->
> **Source:** Issue #2273

Closes #2273

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The weekly LangSmith dashboard job produces zero actionable signal and mints a no-data issue every Monday. Two independent wiring defects, both verified against current `main`:

1. **Verifier `evaluation` metrics can never be discovered (wrong workflow queried).** `.github/workflows/maint-80-langsmith-metrics-dashboard.yml:59` discovers metric-producing runs with `for WORKFLOW_PATH in agents-auto-pilot.yml reusable-agents-verifier.yml; do` and lists `/repos/${{ github.repository }}/actions/workflows/$WORKFLOW_PATH/runs` (line 63). But `reusable-agents-verifier.yml:10-11` is `on: workflow_call` only — GitHub attributes called-workflow runs to the **caller**, which is `agents-verifier.yml:212` (`uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main`). The reusable file therefore has **zero runs of its own**, so the `agents-verifier-metrics` artifact uploaded at `reusable-agents-verifier.yml:1688` is never found. The committed dashboard confirms the symptom: `docs/dashboards/langsmith-metrics.md:11` reads "No autopilot/verifier trace metrics were found for this period."

2. **Fleet rollup is structurally all-"missing": no workflow uploads `langsmith-fleet.ndjson`.** Grepping `langsmith-fleet.ndjson` across `.github/workflows/` and `templates/consumer-repo/.github/workflows/` returns exactly one hit — the registry-default string at `maint-80-langsmith-metrics-dashboard.yml:169` (`entry.get("artifact_name", "langsmith-fleet.ndjson")`). No repo, including Workflows' own `agent-automation` surface (`config/langsmith_fleet_registry.json:6-21`), has an upload step. The committed dashboard shows 8/8 `missing` (`docs/dashboards/langsmith-metrics.md:16-31`: "Valid: 0 / Missing: 8").

3. **A no-data issue is minted weekly.** `maint-80-langsmith-metrics-dashboard.yml:322-330` creates a fresh `metrics,automated` issue whenever `env.REPORT_AVAILABLE == 'true'`, which is effectively always true: the setter at lines 284-289 sets it true when `METRICS_AVAILABLE == 'true'` **or** `fleet-status.md` exists, and fleet-status is always rendered. No step closes or supersedes the prior week's issue.

This is a **current break**, not latent fragility: the dashboard has shown zero coverage + 8/8 missing every cycle since wiring, and the weekly issue is standing opener/closer-lane and owner noise.

#### Tasks
- [ ] In `.github/workflows/maint-80-langsmith-metrics-dashboard.yml:59`, replace `reusable-agents-verifier.yml` in the `for WORKFLOW_PATH in ...` discovery loop with `agents-verifier.yml` (the caller verified at `agents-verifier.yml:212`); keep `agents-auto-pilot.yml`. Add a one-line comment stating the reusable is `workflow_call`-only and accrues no runs.
- [ ] Choose and implement ONE no-data-noise fix: (a) add a Workflows-side step that uploads a `langsmith-fleet.ndjson` artifact for the `agent-automation` surface so `config/langsmith_fleet_registry.json:10` stops reporting `missing`, OR (b) set `"rollout_status": "paused"` on the Workflows entry in `config/langsmith_fleet_registry.json:13` and change the "Create dashboard issue" step (`maint-80-langsmith-metrics-dashboard.yml:322`) to update a single pinned issue instead of creating a new `metrics,automated` issue each Monday.
- [ ] Extend `tests/workflows/test_langsmith_metrics_dashboard.py` with a new test (e.g. `test_run_discovery_targets_workflow_with_runs`) that reads the workflow source and asserts the discovery loop references `agents-verifier.yml` and does NOT reference `reusable-agents-verifier.yml` in the `for WORKFLOW_PATH` line.
- [ ] If the "pause" path is chosen, add an assertion to the same test file that the issue step no longer unconditionally creates a new issue every schedule (e.g. asserts a pinned-issue update marker / `--edit-last` style guard is present, mirroring the existing `test_dashboard_issue_uses_existing_labels` string-guard style at lines 16-22).
- [ ] Perform the deliberate-break verification in Acceptance Criteria, capture the FAIL output, then revert the break before requesting review.

#### Acceptance criteria
- [ ] `python -m pytest tests/workflows/test_langsmith_metrics_dashboard.py -v` collects and passes the new discovery-guard test (non-zero collected count for the named test), demonstrated by the run log, alongside the four existing tests.
- [ ] **Deliberate-break gate:** temporarily revert `maint-80-langsmith-metrics-dashboard.yml:59` to `for WORKFLOW_PATH in agents-auto-pilot.yml reusable-agents-verifier.yml; do`. With that change, the new test (`test_run_discovery_targets_workflow_with_runs`) **must FAIL** with its assertion that the loop must not reference `reusable-agents-verifier.yml`. Revert the line after capturing the failure; the test then passes.
- [ ] The committed dashboard's "missing" semantics are interpretable: either `docs/dashboards/langsmith-metrics.md` no longer shows `Missing: 8` for the Workflows `agent-automation` row after an upload step (live-verified by a `gh workflow run maint-80-langsmith-metrics-dashboard.yml` run whose published dashboard is captured in the PR), OR `config/langsmith_fleet_registry.json:13` shows `"rollout_status": "paused"` and a scheduled-equivalent run does not create a new `metrics,automated` issue (captured in the PR).

<!-- auto-status-summary:end -->