### PR TITLE
(#2272) priority tiering + single queue producer + materialization ledger

### DIFF
--- a/config/repo_review_automation.toml
+++ b/config/repo_review_automation.toml
@@ -65,26 +65,31 @@ output = "docs/reports/repo-review/round2/<owner>__<repo>/converged.json"
 if_failed = "round1=FAIL aborts that repo; round2=FAIL is surfaced in the summary but does not block other repos."
 
 [operational_notes.queue_builder]
-step = "3. Queue builder"
+step = "3. Queue-builder preview (does NOT write the artifact)"
 description = """
-Reads converged.json files and config/repo_review_feedback.json to produce
-the approved-issue-queue.json. Pure data assembly — no subprocess. Repos
-that deadlocked or were skipped are handled by the builder's per-repo
-decision routing. The cron does NOT auto-upload; the human reviews the
+Reads converged.json files and config/repo_review_feedback.json and computes a
+queue preview for the coordinator log only. Pure data assembly — no subprocess.
+As of #2272 the queue_builder is NOT a producer of approved-issue-queue.json:
+the final evaluator pass (step 4) is the SOLE writer of that artifact. This step
+previously wrote the file and the evaluator silently overwrote it with divergent
+approve/revise + meta-candidate + cycle-binding semantics, so what landed on disk
+depended on a race. The cron still does NOT auto-upload; the human reviews the
 packet and runs upload_repo_review_issues.py --apply.
 """
-output = "docs/reports/repo-review/approved-issue-queue.json"
-if_failed = "Non-fatal. Logged to stderr; cycle continues without a queue file."
+output = "none (preview counts logged to coordinator stdout)"
+if_failed = "Non-fatal. Logged to stderr; the evaluator still writes the queue in step 4."
 
 [operational_notes.final_evaluator]
-step = "4. Final evaluator pass"
+step = "4. Final evaluator pass (SOLE producer of approved-issue-queue.json)"
 description = """
-Second run of repo_review_evaluator.py to refresh the human-decision-packet.md
-and the per-repo decision briefs using the converged.json outputs. Skips the
-GitNexus preflight (maps already refreshed by round-1 runner).
+Second run of repo_review_evaluator.py. It refreshes the human-decision-packet.md
+and per-repo decision briefs from the converged.json outputs, and is the single
+producer of approved-issue-queue.json (evaluator.write_approved_issue_queue),
+applying the priority tiering and cycle-binding guards (#2272). Skips the GitNexus
+preflight (maps already refreshed by round-1 runner).
 """
-output = "docs/reports/repo-review/human-decision-packet.md"
-if_failed = "Logged to coordinator/final-evaluator.log. The packet from the prior step is still on disk."
+output = "docs/reports/repo-review/human-decision-packet.md, docs/reports/repo-review/approved-issue-queue.json (+ .md)"
+if_failed = "Logged to coordinator/final-evaluator.log. The packet/queue from the prior cycle remain on disk."
 
 [operational_notes.backlog_scan]
 step = "5. Backlog scan"

--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -110,7 +110,7 @@ Outputs are written to `docs/reports/repo-review/`:
 
 - `human-decision-packet.md`: one review queue across active repos.
 - `repo-review-summary.json`: machine-readable summary.
-- `approved-issue-queue.json`: machine-readable queue of approved, prioritized, agent-formatted issue bodies.
+- `approved-issue-queue.json`: machine-readable queue of approved, prioritized, agent-formatted issue bodies. Written by exactly one producer — the final evaluator pass (`repo_review_evaluator.write_approved_issue_queue`), which applies the priority-tiering and cycle-binding guards (#2272). The coordinator's step-3 queue-builder is a log-only preview and does **not** write this file.
 - `approved-issue-queue.md`: human-readable rendering of the approved issue queue, deeper-review items, and dropped candidates.
 - `repos/<owner>__<repo>/decision-brief.md`: human-facing progress, readiness, issue-set, and feedback brief.
 - `repos/<owner>__<repo>/review-execution.md`: automated evidence gathering and preliminary gap classification.

--- a/scripts/repo_review_coordinator.py
+++ b/scripts/repo_review_coordinator.py
@@ -576,10 +576,14 @@ def run(args: argparse.Namespace) -> int:
         )
         reports.append(report)
 
-    # 3. Build the approved-issue-queue.json from converged.json + feedback.
-    #    Pure data assembly, no subprocess; safe to run even if some repos
-    #    deadlocked (they're skipped by the queue builder's per-repo decision
-    #    routing). The cron does NOT auto-upload — that requires --apply on
+    # 3. Queue-builder preview only (#2272: single queue producer).
+    #    The approved-issue-queue.json has ONE producer: the final evaluator
+    #    pass in step 4 (evaluator.write_approved_issue_queue). queue_builder
+    #    used to write the artifact here and the evaluator silently overwrote it
+    #    with divergent approve/revise + meta + cycle-binding semantics, so the
+    #    file on disk depended on a race. The coordinator now only *computes* a
+    #    queue_builder preview for the log (counts), and must NOT write the
+    #    artifact. The cron still does NOT auto-upload — that requires --apply on
     #    the upload helper, which the human runs after reviewing the packet.
     feedback_path = workflows_steward_root / "config" / "repo_review_feedback.json"
     queue_out = output_dir / "approved-issue-queue.json"
@@ -593,18 +597,21 @@ def run(args: argparse.Namespace) -> int:
             from repo_review_queue_builder import build_queue  # type: ignore[no-redef]
         try:
             queue_data = build_queue(output_dir / "round2", feedback_path)
-            queue_out.write_text(json.dumps(queue_data, indent=2) + "\n", encoding="utf-8")
             n = len(queue_data["issues"])
-            print(f"[coordinator] queue-builder: wrote {n} issues → {queue_out.name}")
+            print(
+                f"[coordinator] queue-builder preview: {n} issue(s) "
+                f"(not written — evaluator step 4 is the sole writer of {queue_out.name})"
+            )
         except Exception as exc:  # pragma: no cover - never blocks the cycle
-            print(f"[coordinator] queue-builder FAILED (non-fatal): {exc}", file=sys.stderr)
+            print(f"[coordinator] queue-builder preview FAILED (non-fatal): {exc}", file=sys.stderr)
     else:
         print(
-            f"[coordinator] queue-builder: skipping — feedback file absent at {feedback_path}",
+            f"[coordinator] queue-builder preview: skipping — feedback file absent at {feedback_path}",
             file=sys.stderr,
         )
 
-    # 4. Final evaluator pass produces the human-decision-packet.md.
+    # 4. Final evaluator pass: refreshes human-decision-packet.md AND is the SOLE
+    #    producer of approved-issue-queue.json (evaluator.write_approved_issue_queue).
     print("[coordinator] running final evaluator pass to refresh packet")
     final_cmd = [
         sys.executable,

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -1794,6 +1794,7 @@ def _records_from_round2_candidates(
     converged: dict[str, Any],
     *,
     max_items: int | None,
+    meta_candidate: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     source_path = str(converged.get("__source_path", ""))
@@ -1825,6 +1826,11 @@ def _records_from_round2_candidates(
                 "round1_candidate": candidate,
                 "agent": agent,
                 "scope": scope,
+                # Bounded-autonomy tiering (#2272): mark the systemic meta-audit
+                # candidate so the queue producer can route it to deeper_review
+                # under a blanket approval. `meta_candidate is candidate` is an
+                # identity check against the object appended by the caller.
+                "is_meta": meta_candidate is not None and candidate is meta_candidate,
             }
         )
         if max_items is not None and len(records) >= max_items:
@@ -1850,9 +1856,12 @@ def issue_candidate_records(
     if isinstance(converged, dict):
         raw_candidates = list(converged.get("converged_candidates") or [])
         meta = converged.get("meta_candidate")
-        if isinstance(meta, dict):
-            raw_candidates.append(meta)
-        return _records_from_round2_candidates(raw_candidates, converged, max_items=max_items)
+        meta_obj = meta if isinstance(meta, dict) else None
+        if meta_obj is not None:
+            raw_candidates.append(meta_obj)
+        return _records_from_round2_candidates(
+            raw_candidates, converged, max_items=max_items, meta_candidate=meta_obj
+        )
 
     findings = state.get("round1_findings") or {}
     raw_candidates = findings.get("candidates") if isinstance(findings, dict) else None
@@ -2551,6 +2560,77 @@ def feedback_covers_converged(
     return fb >= cv
 
 
+def candidate_priority(candidate: dict[str, Any]) -> str:
+    """Normalized priority of a single candidate.
+
+    Round-1 and round-2 candidates carry their own ``priority`` on the source
+    dict stored under ``round1_candidate``; fall back to ``normal`` when absent.
+    """
+    source = candidate.get("round1_candidate")
+    if isinstance(source, dict):
+        return normalize_priority(source.get("priority"))
+    return normalize_priority(candidate.get("priority"))
+
+
+def candidate_is_deadlock_derived(candidate: dict[str, Any]) -> bool:
+    """True when a converged candidate carries deadlock provenance.
+
+    Round-2 deadlocks are normally surfaced to the human packet and never reach
+    the queue. But a human (via a hand-edited converged.json / resolution) or a
+    future synthesizer may promote a previously-deadlocked candidate into the
+    converged set; such a candidate must not auto-approve under a blanket
+    decision. We treat any of a small set of provenance markers on the source
+    candidate (or its ``origin`` block) as the deadlock-derived signal.
+    """
+    source = candidate.get("round1_candidate")
+    source = source if isinstance(source, dict) else candidate
+    for key in ("from_deadlock", "deadlock_derived", "deadlock_resolved", "resolved_from_deadlock"):
+        if bool(source.get(key)):
+            return True
+    origin = source.get("origin")
+    if isinstance(origin, dict):
+        for key in ("from_deadlock", "deadlock_derived", "deadlock_resolved"):
+            if bool(origin.get(key)):
+                return True
+    return False
+
+
+def high_stakes_tier(candidate: dict[str, Any]) -> str | None:
+    """Name the high-stakes tier of a candidate, or None if it is not high-stakes.
+
+    Bounded-autonomy tiering (#2272): even when feedback covers the converged
+    set, a blanket ``approve all`` must not unattended-approve these tiers. The
+    returned string is used in the deeper-review reason so the human sees which
+    tier held the candidate back. Order is most-to-least specific.
+    """
+    if candidate.get("is_meta"):
+        return "meta-audit"
+    if candidate_is_deadlock_derived(candidate):
+        return "deadlock-derived"
+    if candidate_priority(candidate) == "high":
+        return "high-priority"
+    return None
+
+
+def candidate_explicitly_named(
+    decision: dict[str, Any], candidate: dict[str, Any], candidates: list[dict[str, Any]]
+) -> bool:
+    """Was this candidate *individually* named by the human (not swept by "all")?
+
+    A high-stakes candidate still auto-approves when the human explicitly listed
+    its index in ``approved_candidates`` or matched it via
+    ``approved_title_patterns``. A blanket ``approved_candidates: "all"`` is NOT
+    an explicit naming and does not bypass the tiering gate.
+    """
+    index = int(candidate.get("candidate_index", 0))
+    if index in candidate_title_pattern_indexes(decision, "approved_title_patterns", candidates):
+        return True
+    approved = decision.get("approved_candidates", [])
+    if not isinstance(approved, list):
+        return False
+    return index in parse_candidate_indexes(approved)
+
+
 def build_approved_issue_queue(
     states: list[dict[str, Any]], feedback_config: dict[str, Any], generated_on: str
 ) -> dict[str, Any]:
@@ -2683,10 +2763,55 @@ def build_approved_issue_queue(
             warnings.append(
                 f"{state['repo']} approved missing candidate indexes: {', '.join(map(str, missing_indexes))}"
             )
+        auto_approve_high = bool(decision.get("auto_approve_high", False))
         for candidate in candidates:
             if candidate["candidate_index"] not in selected_indexes:
                 continue
             if candidate["candidate_index"] in dropped_indexes:
+                continue
+            # Bounded-autonomy priority tiering (#2272): even with feedback that
+            # covers the converged set, a blanket "approve all" must not
+            # unattended-approve high-stakes candidates — high-priority fixes,
+            # the systemic meta-audit, and deadlock-derived items. These route
+            # to deeper-review UNLESS the human named the candidate explicitly
+            # (approved_candidates index / approved_title_patterns) or the repo
+            # opted in with auto_approve_high: true. low/normal non-meta keep
+            # auto-approving.
+            tier = high_stakes_tier(candidate)
+            if (
+                tier is not None
+                and not auto_approve_high
+                and not candidate_explicitly_named(decision, candidate, candidates)
+            ):
+                warnings.append(
+                    f"{state['repo']} candidate {candidate['candidate_index']} "
+                    f"({tier}) was swept in by a blanket approval; routed to deeper-review "
+                    f"(high-stakes tiering guard)."
+                )
+                deeper_review.append(
+                    {
+                        "repo": state["repo"],
+                        "priority": priority,
+                        "decision": "deeper-review",
+                        "notes": (
+                            f"High-stakes candidate held back from unattended approval — tier "
+                            f"'{tier}'. A blanket 'approve all' does not auto-approve "
+                            f"{tier} candidates. To approve candidate "
+                            f"{candidate['candidate_index']} ({candidate['title']}), list its "
+                            f"index in approved_candidates, match it with an "
+                            f"approved_title_patterns entry, or set auto_approve_high: true for "
+                            f"this repo."
+                        ),
+                        "design_target": state["decision_brief"]["design_target"],
+                        "review_focus": state["decision_brief"]["review_focus"],
+                        "concerns": [
+                            *state["decision_brief"]["concerns"],
+                            f"Confirm the {tier} candidate {candidate['candidate_index']}: "
+                            f"{candidate['title']}",
+                        ],
+                        "gitnexus_map": state["gitnexus_map"],
+                    }
+                )
                 continue
             evidence_trace = review_evidence_trace_for_candidate(state, candidate)
             if evidence_trace is None:

--- a/scripts/repo_review_queue_builder.py
+++ b/scripts/repo_review_queue_builder.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
-"""Assemble approved-issue-queue.json from per-repo converged.json files
+"""Assemble an approved-issue-queue payload from per-repo converged.json files
 plus config/repo_review_feedback.json.
+
+NOTE (#2272): this module is NOT the producer of the weekly pipeline's
+``docs/reports/repo-review/approved-issue-queue.json``. The coordinator invokes
+``build_queue`` for a log-only preview (step 3) and the final evaluator pass
+(``repo_review_evaluator.write_approved_issue_queue``, step 4) is the SOLE writer
+of that artifact, applying the priority-tiering and cycle-binding guards. The
+standalone ``--out`` CLI here is a developer/debugging helper that writes
+wherever you point it; it does not feed the opener/uploader by itself.
 
 Honors per-repo feedback decisions:
 

--- a/scripts/upload_repo_review_issues.py
+++ b/scripts/upload_repo_review_issues.py
@@ -2,13 +2,17 @@
 """Create GitHub issues from the approved weekly repo-review queue.
 
 The script is intentionally explicit: dry-run is the default, and `--apply`
-is required before it writes to GitHub. Creation is idempotent against open
-issues with the exact same title in the target repo.
+is required before it writes to GitHub. Creation is idempotent: each created
+issue carries a stable per-item marker (`<!-- repo-review-item: <repo>#<hash> -->`)
+and dedup consults open AND recently-closed issues by that marker, then by exact
+title, then by token-Jaccard similarity — so re-running `--apply` after items
+were materialized-and-closed does not recreate them (#2272).
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import shlex
@@ -181,7 +185,62 @@ def validate_issue_queue(issues: list[dict[str, Any]]) -> None:
         raise ValueError(f"approved issue queue failed quality validation:\n- {joined}")
 
 
+ITEM_MARKER_RE = re.compile(r"<!--\s*repo-review-item:\s*(\S+?)\s*-->")
+
+
+def item_hash(repo: str, title: str) -> str:
+    """Stable short hash identifying a repo-review item by repo + candidate title.
+
+    Materialization ledger (#2272): the same approved candidate must hash to the
+    same value across re-runs and across cycles, so re-materialization can be
+    detected from the marker alone. Title is lowercased/whitespace-collapsed so
+    trivial formatting differences don't change the identity.
+    """
+    norm_title = re.sub(r"\s+", " ", str(title or "").strip().lower())
+    digest = hashlib.sha256(f"{repo}\x00{norm_title}".encode()).hexdigest()
+    return digest[:12]
+
+
+def item_marker(repo: str, title: str) -> str:
+    """The per-item HTML-comment marker embedded in created issue bodies."""
+    return f"<!-- repo-review-item: {repo}#{item_hash(repo, title)} -->"
+
+
+def body_has_item_marker(body: str, marker: str) -> bool:
+    """True when an existing issue body already carries this exact item marker."""
+    target = ITEM_MARKER_RE.search(marker)
+    target_id = target.group(1) if target else marker
+    return any(found.group(1) == target_id for found in ITEM_MARKER_RE.finditer(str(body or "")))
+
+
+def find_marker_duplicate(
+    issue: dict[str, Any], existing_issues: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Find an existing (open OR closed) issue already materialized for this item.
+
+    Consults the per-item marker (#2272) so a re-run after the issue was closed
+    finds it by identity even if the title was edited. Returns the matching
+    existing issue, or None.
+    """
+    marker = item_marker(str(issue.get("repo", "")), str(issue.get("title", "")))
+    for existing in existing_issues:
+        if body_has_item_marker(str(existing.get("body") or ""), marker):
+            return existing
+    return None
+
+
 def fetch_open_issues(repo: str, prefix: list[str]) -> list[dict[str, Any]]:
+    """Fetch issues to dedup against.
+
+    Materialization ledger (#2272): dedup must see recently-CLOSED issues, not
+    just open ones. The steady state within days of a weekly cycle is that every
+    approved item is already materialized AND closed; re-running ``--apply`` on a
+    queue that still lists those titles would otherwise recreate the whole batch
+    (the open-only blindness that produced duplicate storms). We therefore query
+    ``--state all`` and also pull each issue ``body`` so the per-item marker
+    (see ``item_marker``) can be matched exactly, independent of title drift.
+    The function name is retained for monkeypatch compatibility.
+    """
     result = run_command_with_retry(
         gh_command(
             prefix,
@@ -190,11 +249,11 @@ def fetch_open_issues(repo: str, prefix: list[str]) -> list[dict[str, Any]]:
             "--repo",
             repo,
             "--state",
-            "open",
+            "all",
             "--limit",
             "500",
             "--json",
-            "number,title,labels,url",
+            "number,title,labels,url,body,state",
         ),
         label=f"issue-list[{repo}]",
     )
@@ -325,21 +384,35 @@ def add_missing_labels(
     )
 
 
+def body_with_item_marker(repo: str, title: str, body: str) -> str:
+    """Return the issue body with the per-item marker appended (idempotent)."""
+    marker = item_marker(repo, title)
+    if body_has_item_marker(body, marker):
+        return body
+    return f"{body.rstrip()}\n\n{marker}\n"
+
+
 def create_issue(issue: dict[str, Any], prefix: list[str]) -> str:
     labels = [str(label) for label in issue.get("labels", [])]
+    repo = str(issue["repo"])
+    title = str(issue["title"])
     args = gh_command(
         prefix,
         "issue",
         "create",
         "--repo",
-        str(issue["repo"]),
+        repo,
         "--title",
-        str(issue["title"]),
+        title,
     )
     for label in labels:
         args.extend(["--label", label])
+    # Materialization ledger (#2272): stamp the body with a stable per-item
+    # marker so future runs can detect this item was already materialized,
+    # including after it is closed.
+    body = body_with_item_marker(repo, title, str(issue["body"]))
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md") as body_file:
-        body_file.write(str(issue["body"]))
+        body_file.write(body)
         body_file.flush()
         result = run_command_with_retry(
             [*args, "--body-file", body_file.name],
@@ -372,14 +445,22 @@ def upload_issues(
         by_repo.setdefault(repo, []).append(issue)
 
     for repo, repo_issues in sorted(by_repo.items()):
-        open_issues = fetch_open_issues(repo, prefix)
-        open_by_title = {item.get("title"): item for item in open_issues}
+        # `existing_issues` now includes recently-closed issues (#2272), so a
+        # re-run after items were materialized-and-closed does not recreate them.
+        existing_issues = fetch_open_issues(repo, prefix)
+        open_by_title = {item.get("title"): item for item in existing_issues}
         labels = sorted({label for issue in repo_issues for label in issue.get("labels", [])})
         if apply:
             ensure_labels(repo, labels, prefix)
         for issue in repo_issues:
             title = str(issue["title"])
-            existing = open_by_title.get(title) or find_semantic_duplicate(issue, open_issues)
+            # Dedup precedence: per-item marker (exact identity, open OR closed)
+            # > exact title > token-Jaccard semantic match.
+            existing = (
+                find_marker_duplicate(issue, existing_issues)
+                or open_by_title.get(title)
+                or find_semantic_duplicate(issue, existing_issues)
+            )
             if existing:
                 if apply:
                     add_missing_labels(
@@ -413,7 +494,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path("docs/reports/repo-review/approved-issue-queue.json"),
         help="Path to approved-issue-queue.json (default: the path the "
-        "coordinator's queue-builder writes)",
+        "final evaluator pass writes)",
     )
     parser.add_argument(
         "--gh-prefix",

--- a/tests/scripts/test_repo_review_evaluator.py
+++ b/tests/scripts/test_repo_review_evaluator.py
@@ -785,6 +785,148 @@ def test_round1_candidate_auto_generates_matching_evidence_trace(
     assert queue["deeper_review"] == []
 
 
+def _make_converged_candidate(
+    title: str, *, priority: str = "normal", scope: str = "fix"
+) -> dict[str, object]:
+    """A round-2 converged candidate carrying its own agent-ready body, the
+    structured fields the auto-trace needs, and a per-candidate priority."""
+    return {
+        "title": title,
+        "scope": scope,
+        "priority": priority,
+        "gap": "Specific design commitment unmet for this converged candidate.",
+        "current_state": "Today's code/tests do not prove the gap is closed.",
+        "required_change": "Add the targeted change described by this candidate.",
+        "design_refs": ["README.md", "docs/design.md"],
+        "implementation_refs": ["src/example.py"],
+        "test_refs": ["tests/test_example.py"],
+        "acceptance_criteria": ["Test fails before fix and passes after."],
+        "non_goals": ["Do not bundle unrelated cleanup."],
+        "tasks": ["First task", "Second task"],
+        "body": VALID_ISSUE_BODY,
+        "origin": {"source_agent": "codex", "round1_index": 1, "merged_from": None},
+    }
+
+
+def _tiering_state(tmp_path: Path) -> dict[str, object]:
+    """Repo state whose round-2 converged set carries a low, a normal, a high,
+    and a meta-audit candidate — the inputs for the high-stakes tiering gate."""
+    repo_dir = tmp_path / "Trend_Model_Project"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "README.md").write_text("# Trend\n", encoding="utf-8")
+    config = evaluator.RepoConfig(
+        repo="stranske/Trend_Model_Project",
+        local_path="Trend_Model_Project",
+        status="active",
+        cadence="weekly",
+        decision_anchor="trend model workflow",
+    )
+    converged = {
+        "schema_version": "v1",
+        "repo": "stranske/Trend_Model_Project",
+        "synthesized_at": "2026-04-20T09:00:00+00:00",
+        "converged_candidates": [
+            _make_converged_candidate("Add low-priority cleanup gate", priority="low"),
+            _make_converged_candidate("Add normal-priority smoke gate", priority="normal"),
+            _make_converged_candidate("Add high-priority release gate", priority="high"),
+        ],
+        "deadlocked_candidates": [],
+        "meta_candidate": _make_converged_candidate(
+            "Audit duplicate-dedup pattern across modules", priority="normal", scope="audit"
+        ),
+    }
+    return evaluator.collect_repo_state(
+        tmp_path,
+        config,
+        review_profile={
+            "progress_summary": "Trend has model surfaces and needs operational proof before release.",
+            "readiness_summary": "Trend needs deterministic smoke coverage before live confidence.",
+            "review_focus": ["Verify the release smoke path before upload."],
+            "concerns": ["Do not treat fallback-only tests as readiness."],
+        },
+        round2_converged=converged,
+        remote_progress={},
+    )
+
+
+def test_priority_tiering_routes_high_stakes_under_blanket_approval(tmp_path: Path) -> None:
+    """#2272 high-stakes tiering: under a fresh blanket 'approve all' (feedback
+    covers the converged set), low/normal candidates auto-approve, but a
+    high-priority candidate AND the meta-audit candidate route to deeper_review.
+
+    Deliberate-break gate: forcing ``high_stakes_tier`` to always return None
+    (i.e. deleting the tiering) makes the high-priority + meta candidates
+    auto-approve and the four-vs-two split assertions below fail.
+    """
+    state = _tiering_state(tmp_path)
+    # Feedback dated AFTER the converged synthesized_at, so feedback_covers_converged
+    # is True and the stale-feedback guard does NOT fire — only tiering can hold back.
+    feedback = {
+        "generated_on": "2026-05-01",
+        "defaults": {"approved_candidates": "all"},
+        "decisions": {
+            "stranske/Trend_Model_Project": {"decision": "approve", "priority": "normal"}
+        },
+    }
+
+    queue = evaluator.build_approved_issue_queue([state], feedback, "2026-05-01")
+
+    approved_titles = {item["title"] for item in queue["issues"]}
+    deeper_titles = " ".join(item["notes"] for item in queue["deeper_review"])
+    # low + normal auto-approve.
+    assert "Add low-priority cleanup gate" in approved_titles
+    assert "Add normal-priority smoke gate" in approved_titles
+    # high-priority + meta-audit are held back, NOT materialized.
+    assert "Add high-priority release gate" not in approved_titles
+    assert "Audit duplicate-dedup pattern across modules" not in approved_titles
+    assert len(queue["issues"]) == 2
+    # Two deeper_review entries naming their tiers.
+    assert "high-priority" in deeper_titles
+    assert "meta-audit" in deeper_titles
+    assert sum(1 for w in queue["warnings"] if "high-stakes tiering guard" in w) == 2
+
+
+def test_priority_tiering_respects_explicit_naming_and_opt_in(tmp_path: Path) -> None:
+    """The high-stakes gate yields to an explicit human decision: listing the
+    high-priority candidate's index in approved_candidates approves it, and the
+    repo-level auto_approve_high flag approves the whole high-stakes set."""
+    # (a) Explicitly naming the high-priority candidate index (3) approves it,
+    #     while the meta candidate (index 4) — not named — still routes deeper.
+    state = _tiering_state(tmp_path)
+    feedback_named = {
+        "generated_on": "2026-05-01",
+        "defaults": {"approved_candidates": "all"},
+        "decisions": {
+            "stranske/Trend_Model_Project": {
+                "decision": "approve",
+                "priority": "normal",
+                "approved_candidates": [1, 2, 3],
+            }
+        },
+    }
+    queue_named = evaluator.build_approved_issue_queue([state], feedback_named, "2026-05-01")
+    named_titles = {item["title"] for item in queue_named["issues"]}
+    assert "Add high-priority release gate" in named_titles
+    assert "Audit duplicate-dedup pattern across modules" not in named_titles
+
+    # (b) auto_approve_high opts the repo into unattended high-stakes approval:
+    #     all four candidates (incl. high + meta) materialize.
+    state_b = _tiering_state(tmp_path / "b")
+    feedback_optin = {
+        "generated_on": "2026-05-01",
+        "defaults": {"approved_candidates": "all"},
+        "decisions": {
+            "stranske/Trend_Model_Project": {
+                "decision": "approve",
+                "priority": "normal",
+                "auto_approve_high": True,
+            }
+        },
+    }
+    queue_optin = evaluator.build_approved_issue_queue([state_b], feedback_optin, "2026-05-01")
+    assert len(queue_optin["issues"]) == 4
+
+
 def test_round1_candidate_without_agent_ready_body_is_routed_to_revision(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_upload_repo_review_issues.py
+++ b/tests/scripts/test_upload_repo_review_issues.py
@@ -120,3 +120,95 @@ def test_upload_dry_run_skips_exact_title_duplicates(monkeypatch) -> None:
         }
     ]
     assert summary["would_create"] == [{"repo": "owner/repo", "title": "New issue"}]
+
+
+def test_fetch_open_issues_queries_state_all(monkeypatch) -> None:
+    """Materialization ledger (#2272): dedup must see closed issues. The list
+    query uses `--state all` (not `open`) and pulls `body` so the per-item
+    marker can be matched."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(args, *, label=""):
+        captured["args"] = args
+
+        class _R:
+            stdout = "[]"
+
+        return _R()
+
+    monkeypatch.setattr(uploader, "run_command_with_retry", fake_run)
+    uploader.fetch_open_issues("owner/repo", ["gh"])
+    args = captured["args"]
+    assert "--state" in args and args[args.index("--state") + 1] == "all"
+    json_fields = args[args.index("--json") + 1]
+    assert "body" in json_fields
+
+
+def test_upload_skips_recently_closed_item_by_marker(monkeypatch) -> None:
+    """#2272 deliberate-break gate: a queue item whose issue was already created
+    AND CLOSED must not be recreated. The closed issue carries the per-item
+    marker; dedup matches on it even though the closed issue's title was edited.
+
+    Break demonstration: reverting `fetch_open_issues` to `--state open` (so the
+    closed issue is invisible) OR dropping the `find_marker_duplicate` call from
+    `upload_issues` makes this item fall through to `would_create` and the
+    assertion below fails.
+    """
+    marker = uploader.item_marker("owner/repo", "Add a deterministic smoke gate")
+    closed_body = f"## Why\nAlready shipped last cycle.\n\n{marker}\n"
+
+    def fake_fetch(repo: str, prefix: list[str]):
+        return [
+            {
+                "number": 42,
+                "title": "Renamed after triage",  # title drifted; marker is stable
+                "state": "CLOSED",
+                "url": "https://github.test/owner/repo/issues/42",
+                "labels": [{"name": "repo-review-approved"}],
+                "body": closed_body,
+            }
+        ]
+
+    monkeypatch.setattr(uploader, "fetch_open_issues", fake_fetch)
+    issues = [issue("Add a deterministic smoke gate") | {"labels": ["repo-review-approved"]}]
+
+    summary = uploader.upload_issues(issues, prefix=["gh"], apply=False)
+
+    assert summary["would_create"] == []
+    assert summary["skipped_duplicates"] == [
+        {
+            "repo": "owner/repo",
+            "title": "Add a deterministic smoke gate",
+            "number": 42,
+            "url": "https://github.test/owner/repo/issues/42",
+        }
+    ]
+
+
+def test_create_issue_stamps_item_marker(monkeypatch) -> None:
+    """create_issue appends the per-item marker to the body it writes, so the
+    materialized issue is self-identifying on future dedup passes."""
+    written: dict[str, str] = {}
+
+    def fake_run(args, *, label=""):
+        body_path = args[args.index("--body-file") + 1]
+        written["body"] = Path(body_path).read_text(encoding="utf-8")
+
+        class _R:
+            stdout = "https://github.test/owner/repo/issues/7\n"
+
+        return _R()
+
+    monkeypatch.setattr(uploader, "run_command_with_retry", fake_run)
+    url = uploader.create_issue(
+        issue("Add a deterministic smoke gate") | {"labels": ["repo-review-approved"]},
+        ["gh"],
+    )
+    assert url == "https://github.test/owner/repo/issues/7"
+    expected_marker = uploader.item_marker("owner/repo", "Add a deterministic smoke gate")
+    assert expected_marker in written["body"]
+    # Idempotent: re-stamping a body that already has the marker does not duplicate it.
+    restamped = uploader.body_with_item_marker(
+        "owner/repo", "Add a deterministic smoke gate", written["body"]
+    )
+    assert restamped.count("repo-review-item:") == 1


### PR DESCRIPTION
Closes part of #2272. Builds the remaining bounded-autonomy layers on top of the merged cycle-binding core (PR #2285), grounded in audit findings FR-2, FR-3, P1-1, P1-3, P2-3.

## Layer 1 — Priority tiering (`scripts/repo_review_evaluator.py`, `build_approved_issue_queue`)
Even when `feedback_covers_converged()` is true, a blanket `"approve all"` no longer unattended-approves high-stakes candidates. These route to `deeper_review` with a tier-naming reason:
- candidate priority `high`,
- the meta-audit candidate (`meta_candidate`, marked via a new `is_meta` record flag),
- deadlock-derived candidates (provenance markers on the converged candidate / its `origin`).

They STILL auto-approve when the candidate is explicitly named in the decision's `approved_candidates` (index list) or `approved_title_patterns`, OR when the repo sets `auto_approve_high: true`. `low`/`normal` non-meta candidates keep auto-approving. Reuses existing `normalize_priority` + meta handling; repo-level `priority` (label) and per-candidate `priority` (tier) are kept distinct.

## Layer 2 — Single queue producer (`scripts/repo_review_coordinator.py`)
The final evaluator pass (`evaluator.write_approved_issue_queue`) is now the SOLE writer of `approved-issue-queue.json`. The coordinator step-3 `queue_builder` path is demoted to a log-only preview and no longer writes the artifact, ending the double-producer overwrite race (P1-1). The evaluator's `main()` writes the queue unconditionally, so the artifact is deterministic. Confirmed no other caller depends on `queue_builder` writing the file (only the coordinator preview + the queue_builder standalone `--out` CLI). Docs/config updated to attribute the artifact to the evaluator: `docs/ops/REPO_REVIEW_PROCESS.md`, `config/repo_review_automation.toml` (`queue_builder`/`final_evaluator` operational notes), and the `repo_review_queue_builder.py` module docstring.

## Layer 3 — Materialization ledger (`scripts/upload_repo_review_issues.py`)
- (a) Dedup now queries `--state all` (open + recently-closed) and pulls issue `body`, so re-running `--apply` after items were materialized-and-closed does not recreate them (P1-3).
- (b) Created issues carry a stable per-item marker `<!-- repo-review-item: <repo>#<hash> -->` derived from repo + candidate title (whitespace-collapsed, lowercased); dedup consults it (open + closed) first — even if the issue title later drifts. Marker stamping is idempotent.

## Verification
- `tests/scripts/test_repo_review_evaluator.py`: new tiering tests — a high-priority and a meta candidate under blanket `"all"` route to `deeper_review` while `low`/`normal` approve; explicit-naming and `auto_approve_high` bypass the gate.
- `tests/scripts/test_upload_repo_review_issues.py`: closed-issue/marker dedup — `--state all` query shape, a closed issue matched by marker (title drifted) is skipped, and `create_issue` stamps the marker.
- Full files green: evaluator + uploader + coordinator = **39 passed**. Broader repo-review suite: **125 passed**.
- `black --check --line-length 100` and `ruff check` clean on all 6 changed `.py` files; `config/repo_review_automation.toml` parses.

### Deliberate-break gates
- Layer 1: forcing `high_stakes_tier` to return `None` makes the high-priority + meta candidates auto-approve → `test_priority_tiering_routes_high_stakes_under_blanket_approval` fails → reverted.
- Layer 3: reverting `fetch_open_issues` to `--state open` and dropping the `find_marker_duplicate` call makes the closed item fall through to `would_create` → `test_upload_skips_recently_closed_item_by_marker` fails → reverted.

## Risk / scope
No workflow `.yml` changed (no registration needed). No github-script bodies touched. The deadlock-derived tier is forward-looking/defensive (the synthesizer does not currently promote deadlocks into the converged set), so it is a no-op on today's data but gates hand-edited/future converged sets. Layer 2 narrows the producer to one path already exercised by the evaluator's unit tests.

Recommend: merge if green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
