### PR TITLE
docs: add LOCAL_LANES.md lane contract + ignore workloop-state.md fleet-wide (#2280)

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -734,7 +734,7 @@ git_config:
 excluded:
 
   - path: .gitignore
-    reason: "Repo-specific ignore patterns"
+    reason: "Repo-specific ignore patterns; the managed Workflows status-file block is propagated by scripts/sync_status_file_ignores.py instead of generic sync targets"
   - path: README.md
     reason: "Repo-specific documentation"
   - path: config/coverage-baseline.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Start with the current docs instead of inferring behavior from old comments:
 - GitNexus is an optional local MCP/indexing layer for cross-repo search and impact checks. Read `docs/ops/GITNEXUS.md` before changing its setup.
 - Use GitNexus opportunistically for workflow/template drift, reusable workflow blast-radius checks, and Workflows-vs-consumer ownership questions when the MCP server is available and indexes are fresh.
 - Treat `.gitnexus/` and `~/.gitnexus/` as local derived cache. Do not commit indexes or make CI, remote workflows, or correctness depend on GitNexus output.
-- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is temporary automation state and must be ignored.
+- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is a load-bearing linked worktree for repo-review outputs; keep it ignored by GitNexus indexing, but arrange it as detached HEAD at `origin/main` so it does not lock the canonical clone's `main` branch. See `docs/ops/LOCAL_LANES.md`.
 - If GitNexus is unavailable or stale, continue with normal `rg`, git, and test-based repository exploration.
 
 ## Workflow PR Checklist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Start with the current docs instead of inferring behavior from old comments:
 - GitNexus is an optional local MCP/indexing layer for cross-repo search and impact checks. Read `docs/ops/GITNEXUS.md` before changing its setup.
 - Use GitNexus opportunistically for workflow/template drift, reusable workflow blast-radius checks, and Workflows-vs-consumer ownership questions when the MCP server is available and indexes are fresh.
 - Treat `.gitnexus/` and `~/.gitnexus/` as local derived cache. Do not commit indexes or make CI, remote workflows, or correctness depend on GitNexus output.
-- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is temporary automation state and must be ignored.
+- `Template` is part of the canonical GitNexus fleet because new repos are cloned from it. `Workflows-steward` is a load-bearing linked worktree for repo-review outputs; keep it ignored by GitNexus indexing, but arrange it as detached HEAD at `origin/main` so it does not lock the canonical clone's `main` branch. See `docs/ops/LOCAL_LANES.md`.
 - If GitNexus is unavailable or stale, continue with normal `rg`, git, and test-based repository exploration.
 
 ## Workflow PR Checklist

--- a/docs/ops/GITNEXUS.md
+++ b/docs/ops/GITNEXUS.md
@@ -20,8 +20,14 @@ The canonical GitNexus fleet is:
 - `Portable-Alpha-Extension-Model`
 - `Collab-Admin`
 
-`Workflows-steward` is temporary automation state and must be ignored by
-GitNexus. Do not add short-lived issue, PR, or review clones to the registry.
+`Workflows-steward` must be ignored by GitNexus for indexing, but it is **not**
+throwaway scratch: it is a linked git worktree of the canonical `Workflows`
+clone that holds the repo-review/steward outputs and is structurally
+load-bearing for the opener lane. To keep it from holding the canonical clone's
+`main` hostage, its canonical arrangement is a **detached `HEAD` at
+`origin/main`** (a detached HEAD takes no branch lock). See
+[`LOCAL_LANES.md`](LOCAL_LANES.md) for the full steward/lane-state contract. Do
+not add short-lived issue, PR, or review clones to the registry.
 
 ## Local Cache Policy
 

--- a/docs/ops/LOCAL_LANES.md
+++ b/docs/ops/LOCAL_LANES.md
@@ -1,0 +1,157 @@
+# Local Opener/Closer Lanes — State, Retention & Steward Contract
+
+This document is the **system-of-record contract** for the local opener/closer
+lane automation that drives issue→PR→merge→verify work across the supported
+`stranske/*` repos. `CLAUDE.md` requires that system behavior be grounded in an
+in-repo document; before this file existed, the lane state/retention/steward
+arrangement lived only in the local automation configs under `~/.codex` and in
+workspace-private memory, with no owning doc in the system-of-record repo.
+
+> **Editing scope.** The lane *implementation* — the automation TOMLs, the
+> `handoff.sh` helper, the rendered Claude prompt `.md` files, the worktree
+> reaper — lives under `~/.codex` and is **not** in this checkout. This document
+> is authoritative for the *contract* (what the arrangement is and why), but the
+> recommended changes to the out-of-repo implementation (moving `workloop-state.md`
+> out of repos, building/maintaining a worktree reaper) are recorded here as
+> **recommendations**, not implemented in this repository. The only files this
+> contract owns in-repo are this doc, the consumer-template `.gitignore` status
+> block, `.github/sync-manifest.yml`, `docs/ops/GITNEXUS.md`, and
+> `docs/ops/bin/gitnexus_fleet.sh`.
+
+Related docs: [`REPO_REVIEW_PROCESS.md`](REPO_REVIEW_PROCESS.md) (the weekly
+evaluator → approved-queue lifecycle the opener consumes) and
+[`GITNEXUS.md`](GITNEXUS.md) (the local code-intelligence layer and the
+`Workflows-steward` worktree note).
+
+## Lanes overview
+
+Two single-purpose lanes operate across the supported fleet:
+
+- **Opener** — *discover-and-create*. Reads the human-approved queue and live
+  fleet issues, then materializes the highest-priority unlinked implementation
+  issue as a new issue (when needed) plus a ready-for-review PR. Cap: **at most
+  5 active opener-owned PRs** across the whole fleet at any time. Round
+  outcomes: `new_issue` | `advance` | `no_op`.
+- **Closer** — *cleanup-merge-verify*. Drives existing PRs through
+  merge → verify → close → optional bounded follow-up. Round outcomes:
+  `merge` | `close` | `followup_only` | `no_op`.
+
+Each lane runs as both a Codex CLI automation and a Claude Code scheduled task;
+the two CLIs alternate via a shared baton sentinel (see below). The opener
+applies the matching concrete `agent:*` label (`agent:codex` / `agent:claude`)
+to the PR it opens — never to the source issue — so that the agent with live
+capacity claims the work and natural alternation is preserved.
+
+## State locations
+
+All durable lane state lives under `~/.codex`, outside any repo checkout:
+
+| State | Location | Purpose |
+| --- | --- | --- |
+| Baton sentinel | `~/.codex/handoff/lane-handoff.json` | Single cross-lane JSON: `baton` (round/chain), `active.*` (most-recent productive action — cross-lane, single-slot), `queue` pressures, `batch.last_sweep`, and `stop.scoped_blockers`. |
+| Handoff helper | `~/.codex/bin/handoff.sh` | Subcommands the lanes call: `write-event`, `set-key-pr`/`clear-key-pr`, `scope-blocker`/`clear-scoped-blocker`/`list-scoped-blockers`, `request-pause`/`approve-pause`/`reject-pause`. |
+| Pre/post-run relay | `~/.codex/bin/handoff-prerun.sh`, `~/.codex/bin/handoff-relay.sh`, `handoff-postrun.sh` | Lane mutex, structured resume block, and cross-agent dispatch on terminal events. |
+| Lane prompts (source) | `~/.codex/automations/<id>/automation.toml` | Codex TOML is the source of truth; `~/.codex/bin/render-claude-prompts.sh` re-renders the Claude `.md` variants under `~/.codex/handoff/prompts/`. |
+| Claude scheduled tasks | `~/.claude/scheduled-tasks/handoff-claude-opener/`, `…/handoff-claude-closer/` | The Claude-side scheduled entry points. |
+| Per-automation memory | `~/.codex/automations/<id>/memory.md` | Append-only round history (newest section prepended). See rotation policy below. |
+| Worktrees | `~/.codex/automations/pd-workloop-resume/worktrees/` and `~/.codex/worktrees/` | Persistent lane worktrees. Disposable clones go under `/tmp`. |
+| Per-repo run state | `<repo>/workloop-state.md` | Canonical per-repo lane state (repo, issue, branch, PR, blocker, next action). **Strategy below — should not be tracked.** |
+
+The two lanes (opener `pd-workloop-resume`, closer `imi-merge-verify-closer`)
+share the sentinel and hand off via the relay helper. The sentinel's `active.*`
+block is **cross-lane and single-slot**: it records the most recent productive
+action by either lane, not the full set of in-flight work. Because the opener
+cap is 5, the opener routinely has several PRs in flight that `active.*` cannot
+represent, so **opener discovery never gates on `active.*`** — it is
+informational only.
+
+## Worktree retention tiers
+
+Lane worktrees and disposable clones accumulate under `~/.codex` and `/tmp`. The
+intended lifecycle is a four-tier ladder, oldest-first:
+
+1. **live** — a worktree/clone for an in-progress materialization or recovery
+   lane. Never reaped while its branch has unpushed work.
+2. **reap-eligible** — work pushed and the PR opened/advanced; the local tree is
+   no longer needed. Eligible for archival once no process holds it.
+3. **compressed** — archived (e.g. tarred/aside) rather than deleted, so the
+   next round can recover context if needed. Archive, do not delete, stray
+   worktrees/clones.
+4. **deleted** — only after compression and a retention window; canonical repos
+   are **never** moved or deleted.
+
+Implementation note (out of repo): a worktree reaper is recommended to walk
+`~/.codex/**/worktrees` and `/tmp/wf-*`, demoting trees down the ladder by age
+and pushed-state. Until that exists, lanes archive rather than delete and run the
+code-workspace-hygiene audit when a checkout is created outside a canonical repo.
+
+## `workloop-state.md` strategy
+
+`workloop-state.md` is per-repo lane scratch state (current repo, issue, branch,
+PR, blocker, next action), updated at each push and before a round ends. It is a
+**lane artifact, not a repo deliverable.**
+
+**Recommendation: not tracked.** The file has historically been committed in
+some consumer repos — polluting PR diffs with lane-state churn and merge
+conflicts — with mixed per-branch ignore states across the fleet. The in-repo
+enabler delivered with this contract:
+
+- `workloop-state.md` is added to the managed status-file block in
+  [`templates/consumer-repo/.gitignore`](../../templates/consumer-repo/.gitignore)
+  (the `BEGIN/END WORKFLOWS STATUS FILES` region), so it is delivered to every
+  consumer repo by `scripts/sync_status_file_ignores.py` — the same mechanism
+  that ignores `keepalive_status.md`, `pr_body.md`, and the autofix status
+  files. (The whole consumer `.gitignore` is intentionally in the sync-manifest
+  `excluded:` list as "repo-specific"; the status-file script owns the managed
+  block, which is the correct propagation path for this entry.)
+
+Follow-ups (out of repo, owned by the local automations):
+
+- Stop committing `workloop-state.md` where it is already tracked. A fleet-wide
+  `git rm --cached workloop-state.md` is a **fleet operation, not an in-repo
+  change**, and is explicitly out of scope here; the gitignore entry above is the
+  enabler that makes new commits stop.
+- Consider moving lane state out of repos entirely to
+  `~/.codex/handoff/workloop/<repo>.md` so it never touches a checkout. This
+  removes the artifact from PR diffs at the source and is the recommended
+  end-state.
+
+## `Workflows-steward` arrangement
+
+`Workflows-steward` is a **linked git worktree of the canonical Dropbox
+`Workflows` clone** that holds the repo-review/steward outputs (the approved
+issue queue, the human-decision packet, the repo-review feedback config). The
+lane configs and `docs/ops/REPO_REVIEW_BODY_WRITER_PROMPT.md` hardcode steward
+paths as the source of approved-queue material, so it is **structurally
+load-bearing**, not disposable scratch.
+
+The historical framing ("temporary automation state, must be ignored") is
+misleading: it described GitNexus's *indexing* policy (GitNexus should not index
+the steward worktree — that remains true) but read as "the steward is
+throwaway." The real risk is the opposite. If the steward worktree has `main`
+checked out, the **canonical clone cannot `git checkout main`** — git refuses a
+branch already checked out in another worktree — so a "temporary" worktree ends
+up holding the default branch hostage.
+
+**Canonical arrangement: the `Workflows-steward` worktree should sit at a
+detached `HEAD` at `origin/main`.** A detached HEAD takes no branch lock, so the
+canonical clone keeps `main` free while the steward still tracks the latest
+reviewed tip. GitNexus continues to ignore the steward worktree for indexing —
+that part of the old note is correct and is preserved; only the "temporary /
+throwaway" framing is corrected (see [`GITNEXUS.md`](GITNEXUS.md) and
+`docs/ops/bin/gitnexus_fleet.sh`).
+
+## Memory-file rotation
+
+Each automation keeps an **append-only** `memory.md` under
+`~/.codex/automations/<id>/`. The contract:
+
+- Each round **prepends** a new `## <ISO timestamp>` section at the top; existing
+  entries are never modified or removed. The file is history — destructive
+  rewrites lose context the next round needs.
+- The pre-run helper emits only the **last few** entries in its structured
+  resume block (older history trimmed for output size); the full file remains on
+  disk.
+- Rotation, when needed, is by archiving the tail of the file (oldest sections)
+  to a dated sibling under the automation directory rather than truncating in
+  place — same archive-don't-delete principle as the worktree tiers above.

--- a/docs/ops/LOCAL_LANES.md
+++ b/docs/ops/LOCAL_LANES.md
@@ -50,7 +50,7 @@ All durable lane state lives under `~/.codex`, outside any repo checkout:
 | --- | --- | --- |
 | Baton sentinel | `~/.codex/handoff/lane-handoff.json` | Single cross-lane JSON: `baton` (round/chain), `active.*` (most-recent productive action — cross-lane, single-slot), `queue` pressures, `batch.last_sweep`, and `stop.scoped_blockers`. |
 | Handoff helper | `~/.codex/bin/handoff.sh` | Subcommands the lanes call: `write-event`, `set-key-pr`/`clear-key-pr`, `scope-blocker`/`clear-scoped-blocker`/`list-scoped-blockers`, `request-pause`/`approve-pause`/`reject-pause`. |
-| Pre/post-run relay | `~/.codex/bin/handoff-prerun.sh`, `~/.codex/bin/handoff-relay.sh`, `handoff-postrun.sh` | Lane mutex, structured resume block, and cross-agent dispatch on terminal events. |
+| Pre/post-run relay | `~/.codex/bin/handoff-prerun.sh`, `~/.codex/bin/handoff-relay.sh`, `~/.codex/bin/handoff-postrun.sh` | Lane mutex, structured resume block, and cross-agent dispatch on terminal events. |
 | Lane prompts (source) | `~/.codex/automations/<id>/automation.toml` | Codex TOML is the source of truth; `~/.codex/bin/render-claude-prompts.sh` re-renders the Claude `.md` variants under `~/.codex/handoff/prompts/`. |
 | Claude scheduled tasks | `~/.claude/scheduled-tasks/handoff-claude-opener/`, `…/handoff-claude-closer/` | The Claude-side scheduled entry points. |
 | Per-automation memory | `~/.codex/automations/<id>/memory.md` | Append-only round history (newest section prepended). See rotation policy below. |
@@ -104,6 +104,13 @@ enabler delivered with this contract:
   files. (The whole consumer `.gitignore` is intentionally in the sync-manifest
   `excluded:` list as "repo-specific"; the status-file script owns the managed
   block, which is the correct propagation path for this entry.)
+- The sync-manifest exclusion for `.gitignore` therefore remains intentional:
+  the generic consumer-template sync must not overwrite repo-local ignore
+  rules, while `scripts/sync_status_file_ignores.py --repo <owner/name>` checks
+  and reports the managed status block that consumers need. The fallback
+  canonical pattern list in that script also includes `workloop-state.md`, so
+  the propagation check remains valid even if the template block cannot be
+  loaded.
 
 Follow-ups (out of repo, owned by the local automations):
 
@@ -138,8 +145,8 @@ detached `HEAD` at `origin/main`.** A detached HEAD takes no branch lock, so the
 canonical clone keeps `main` free while the steward still tracks the latest
 reviewed tip. GitNexus continues to ignore the steward worktree for indexing —
 that part of the old note is correct and is preserved; only the "temporary /
-throwaway" framing is corrected (see [`GITNEXUS.md`](GITNEXUS.md) and
-`docs/ops/bin/gitnexus_fleet.sh`).
+throwaway" framing is corrected (see [`GITNEXUS.md`](GITNEXUS.md),
+`docs/ops/bin/gitnexus_fleet.sh`, `AGENTS.md`, and `CLAUDE.md`).
 
 ## Memory-file rotation
 

--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -127,6 +127,7 @@ Local changes are split by how they affect the review:
 - `Issues.txt` is a helper/queue file. Changes there are review inputs, not blockers.
 - Generated output such as `docs/reports/` is ephemeral and does not block review.
 - Other non-generated local changes are surfaced as review-blocking until they are understood, because they may change the implementation being evaluated.
+- `workloop-state.md` is local opener/closer lane scratch, not a review input or deliverable; it should not be tracked. See [`LOCAL_LANES.md`](LOCAL_LANES.md) for the lane state/retention/steward contract that the opener (which consumes this review's approved queue) operates under.
 
 Local `.gitnexus/` maps are review inputs, not blockers. The evaluator reads only `.gitnexus/meta.json` to report map freshness, indexed commit, and index size. It does not parse the binary local map. For deeper semantic review, especially repos marked `deeper-review`, use the GitNexus MCP query/context tools against the repo design target, review focus, and implementation paths surfaced in the packet. If a natural-language GitNexus query returns no processes, fall back to Cypher community/process listings before concluding the map has no useful signal.
 

--- a/docs/ops/bin/gitnexus_fleet.sh
+++ b/docs/ops/bin/gitnexus_fleet.sh
@@ -14,8 +14,9 @@ CODE_ROOT="${CODE_ROOT:-$(cd "${WORKFLOWS_ROOT}/.." && pwd)}"
 GITNEXUS_BIN="${GITNEXUS_BIN:-gitnexus}"
 GITNEXUS_GLOBAL_IGNORE="${GITNEXUS_GLOBAL_IGNORE:-${HOME}/.gitignore_global}"
 
-# Canonical repos only. Workflows-steward is a temporary automation worktree
-# and must not be registered in GitNexus.
+# Canonical repos only. Workflows-steward is a load-bearing linked worktree of
+# the canonical clone (detached HEAD at origin/main; see docs/ops/LOCAL_LANES.md)
+# and must not be registered in GitNexus for indexing.
 FLEET_REPOS=(
   "Workflows"
   "Template"
@@ -67,7 +68,8 @@ Environment:
                        Global excludes file. Default: ${GITNEXUS_GLOBAL_IGNORE}.
 
 Notes:
-  - This script intentionally ignores Workflows-steward.
+  - This script intentionally ignores Workflows-steward for indexing (it is a
+    load-bearing linked worktree, not throwaway; see docs/ops/LOCAL_LANES.md).
   - Initial indexing leaves embeddings off and skips AGENTS/CLAUDE rewrites.
   - Use --embeddings manually only after baseline indexing proves useful.
 USAGE

--- a/scripts/sync_status_file_ignores.py
+++ b/scripts/sync_status_file_ignores.py
@@ -61,6 +61,8 @@ FALLBACK_PATTERNS: list[str] = [
     ".autofix-venv/",
     # PR automation generated files (MEDIUM conflict risk)
     "pr_body.md",
+    # Local opener/closer lane state (MEDIUM conflict risk)
+    "workloop-state.md",
     # Test/coverage artifacts
     "coverage.xml",
     # Wrong package manager artifacts (defense-in-depth)

--- a/templates/consumer-repo/.gitignore
+++ b/templates/consumer-repo/.gitignore
@@ -179,6 +179,12 @@ archives/metrics/
 # PR automation generated files (MEDIUM conflict risk)
 pr_body.md
 
+# Local opener/closer lane state (MEDIUM conflict risk)
+# Per-repo lane scratch (repo/issue/branch/PR/blocker/next-action) written by
+# the local opener/closer lanes; a lane artifact, not a repo deliverable.
+# See stranske/Workflows docs/ops/LOCAL_LANES.md.
+workloop-state.md
+
 # Test/coverage artifacts
 coverage.xml
 

--- a/tests/docs/test_local_lanes_doc.py
+++ b/tests/docs/test_local_lanes_doc.py
@@ -1,0 +1,52 @@
+"""Guard the local opener/closer lane contract doc and its enablers (issue #2280).
+
+Covers the observable acceptance gates: the owning doc exists with its required
+sections, `workloop-state.md` is ignored fleet-wide via the consumer-template
+status block, and GITNEXUS.md links to the new contract doc.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_LANES = REPO_ROOT / "docs" / "ops" / "LOCAL_LANES.md"
+CONSUMER_GITIGNORE = REPO_ROOT / "templates" / "consumer-repo" / ".gitignore"
+GITNEXUS = REPO_ROOT / "docs" / "ops" / "GITNEXUS.md"
+
+# The four required section headings from the issue acceptance criteria.
+REQUIRED_HEADINGS = [
+    "state locations",
+    "retention tiers",
+    "workloop-state.md` strategy",
+    "Workflows-steward` arrangement",
+]
+
+
+def test_local_lanes_doc_exists_and_is_substantive() -> None:
+    assert LOCAL_LANES.exists(), "docs/ops/LOCAL_LANES.md must exist"
+    text = LOCAL_LANES.read_text(encoding="utf-8")
+    # Scaffold-only completion does not count: require real content.
+    assert len(text) > 1500, "LOCAL_LANES.md must be substantive, not a skeleton"
+
+
+def test_local_lanes_doc_has_all_required_sections() -> None:
+    text = LOCAL_LANES.read_text(encoding="utf-8").lower()
+    missing = [h for h in REQUIRED_HEADINGS if h.lower() not in text]
+    assert not missing, f"LOCAL_LANES.md missing required section(s): {missing}"
+
+
+def test_workloop_state_ignored_in_consumer_template_block() -> None:
+    text = CONSUMER_GITIGNORE.read_text(encoding="utf-8")
+    begin = text.index("# BEGIN WORKFLOWS STATUS FILES")
+    end = text.index("# END WORKFLOWS STATUS FILES")
+    block = text[begin:end]
+    assert "workloop-state.md" in block, (
+        "workloop-state.md must be inside the managed status-file block so "
+        "sync_status_file_ignores.py delivers it to consumer repos"
+    )
+
+
+def test_gitnexus_links_to_local_lanes() -> None:
+    text = GITNEXUS.read_text(encoding="utf-8")
+    assert "LOCAL_LANES.md" in text, "GITNEXUS.md must link to the lane contract doc"
+    # The misleading throwaway framing must be corrected.
+    assert "temporary automation state and must be ignored" not in text

--- a/tests/docs/test_local_lanes_doc.py
+++ b/tests/docs/test_local_lanes_doc.py
@@ -14,10 +14,10 @@ GITNEXUS = REPO_ROOT / "docs" / "ops" / "GITNEXUS.md"
 
 # The four required section headings from the issue acceptance criteria.
 REQUIRED_HEADINGS = [
-    "state locations",
-    "retention tiers",
-    "workloop-state.md` strategy",
-    "Workflows-steward` arrangement",
+    "## State locations",
+    "## Worktree retention tiers",
+    "## `workloop-state.md` strategy",
+    "## `Workflows-steward` arrangement",
 ]
 
 
@@ -36,6 +36,8 @@ def test_local_lanes_doc_has_all_required_sections() -> None:
 
 def test_workloop_state_ignored_in_consumer_template_block() -> None:
     text = CONSUMER_GITIGNORE.read_text(encoding="utf-8")
+    assert "# BEGIN WORKFLOWS STATUS FILES" in text
+    assert "# END WORKFLOWS STATUS FILES" in text
     begin = text.index("# BEGIN WORKFLOWS STATUS FILES")
     end = text.index("# END WORKFLOWS STATUS FILES")
     block = text[begin:end]
@@ -45,8 +47,23 @@ def test_workloop_state_ignored_in_consumer_template_block() -> None:
     )
 
 
+def test_status_ignore_sync_script_carries_workloop_state_pattern() -> None:
+    from scripts import sync_status_file_ignores
+
+    assert "workloop-state.md" in sync_status_file_ignores.CANONICAL_PATTERNS
+    assert "workloop-state.md" in sync_status_file_ignores.FALLBACK_PATTERNS
+
+
 def test_gitnexus_links_to_local_lanes() -> None:
     text = GITNEXUS.read_text(encoding="utf-8")
     assert "LOCAL_LANES.md" in text, "GITNEXUS.md must link to the lane contract doc"
     # The misleading throwaway framing must be corrected.
     assert "temporary automation state and must be ignored" not in text
+
+
+def test_agent_instructions_carry_steward_contract() -> None:
+    for path in (REPO_ROOT / "AGENTS.md", REPO_ROOT / "CLAUDE.md"):
+        text = path.read_text(encoding="utf-8")
+        assert "LOCAL_LANES.md" in text
+        assert "detached HEAD" in text
+        assert "temporary automation state and must be ignored" not in text


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2280 -->
> **Source:** Issue #2280

Closes #2280

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The opener/closer lane automation operates across all supported repos, but its state/retention/steward contract is **undocumented in the system-of-record repo** — the one place `CLAUDE.md` insists system behavior must be grounded. Three verified gaps, each a **latent correctness risk plus an undocumented-contract gap**, not a current runtime break:

1. **`Workflows-steward` is documented as disposable but is structurally load-bearing.** `docs/ops/GITNEXUS.md:23` states verbatim: "`Workflows-steward` is temporary automation state and must be ignored by" (the fleet tooling), and `docs/ops/bin/gitnexus_fleet.sh:17,70` repeat "temporary automation worktree … intentionally ignores Workflows-steward." Yet (per the audit) `Workflows-steward` is a *linked git worktree* of the canonical Dropbox Workflows clone holding `main` checked out — which means the canonical clone **cannot `git checkout main`** (git refuses a branch already checked out in another worktree), and the lane configs + `docs/ops/REPO_REVIEW_BODY_WRITER_PROMPT.md` hardcode steward paths as the source of the approved-issue-queue and repo-review templates. A "temporary" worktree that holds the default branch hostage is the opposite of disposable. Missing behavior: no in-repo doc states which steward arrangement is canonical (recommended: detached HEAD at `origin/main`, which takes no branch lock).

2. **`workloop-state.md` has no owning doc.** Verified `grep -rn workloop-state docs/ README.md` returns **only ephemeral report-output JSON** (`docs/reports/repo-review/repo-review-summary.json`, `…/repos/*/decision.json` — downstream artifacts that merely record the file's git status), and **no prose doc that defines the convention**. The convention lives solely in the local automation TOMLs and `~/.codex/bin/handoff.sh`. Per the audit, `workloop-state.md` is tracked-and-not-ignored in some consumer repos and has been merged into their `main` history (lane-state commits polluting PR diffs), with mixed per-branch ignore states across the fleet.

3. **No consumer-template gitignore entry for it.** Verified: `templates/consumer-repo/.gitignore` exists but contains no `workloop` entry (`grep -n workloop templates/consumer-repo/.gitignore` → no match), and `.github/sync-manifest.yml` does not mention `workloop` either. So nothing stops the file from being committed fleet-wide.

#### Tasks
- [ ] Create `docs/ops/LOCAL_LANES.md` with sections: (a) lane state locations under `~/.codex/automations/<id>/`; (b) worktree retention tiers; (c) the `workloop-state.md` strategy — recommend **not tracked**: add to consumer `.gitignore` via sync (this issue) and recommend moving lane state out of repos to `~/.codex/handoff/workloop/<repo>.md` (follow-up, owned by the local automations); (d) the `Workflows-steward` arrangement — recommend **detached HEAD at `origin/main`**; (e) memory-file rotation policy.
- [ ] Add a `workloop-state.md` line to `templates/consumer-repo/.gitignore` (verified today to contain no `workloop` entry).
- [ ] Register the `templates/consumer-repo/.gitignore` change in `.github/sync-manifest.yml` so the ignore entry is delivered to consumer repos (follow the existing sync-manifest entry pattern for consumer-template files).
- [ ] Correct `docs/ops/GITNEXUS.md:23` ("`Workflows-steward` is temporary automation state and must be ignored …") to state the canonical steward arrangement (detached HEAD at `origin/main`, which frees `main` for the canonical clone) and add a link to `docs/ops/LOCAL_LANES.md`; align the two comment lines in `docs/ops/bin/gitnexus_fleet.sh:17,70` to the same framing.
- [ ] Add an inbound link to `docs/ops/LOCAL_LANES.md` from `docs/ops/REPO_REVIEW_PROCESS.md` (or the docs index) so the new doc is discoverable.

#### Acceptance criteria
- [ ] **Owning-doc gate (observable):** `grep -rn workloop-state docs/` now returns at least one hit in `docs/ops/LOCAL_LANES.md` (the new owning doc), in addition to the pre-existing report-output JSON. Capture the grep output showing the `docs/ops/LOCAL_LANES.md` hit.
- [ ] **Gitignore gate (observable, deliberate-verify form):** `grep -n 'workloop-state.md' templates/consumer-repo/.gitignore` returns a line (it returned nothing before — capture the before/after). As a falsifiability check, confirm the entry is functional by running, in a scratch copy of the template dir, `touch workloop-state.md && git check-ignore workloop-state.md` → it prints `workloop-state.md` (ignored). Capture that output.
- [ ] `docs/ops/GITNEXUS.md` no longer describes `Workflows-steward` only as "temporary … must be ignored"; `grep -n 'LOCAL_LANES' docs/ops/GITNEXUS.md` returns a link to the new doc.
- [ ] `docs/ops/LOCAL_LANES.md` exists, is non-empty, and contains all four required section headings (state locations, retention tiers, `workloop-state.md` strategy, `Workflows-steward` arrangement) — confirmable via `grep -n` for each heading.

<!-- auto-status-summary:end -->