### PR TITLE
sync: deliver WIT agent hubs (#2281)

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -163,6 +163,8 @@ removals:
     description: "Remove deprecated orchestrator workflow from template consumers (replaced by agents-80-pr-event-hub.yml and agents-81-gate-followups.yml)"
   - target: .github/workflows/agents-orchestrator.yml
     description: "Remove deprecated legacy orchestrator workflow from template consumers (replaced by agents-80-pr-event-hub.yml and agents-81-gate-followups.yml)"
+  - target: .github/workflows/maint-sync-workflows.yml
+    description: "Remove stale consumer-local workflow syncer that can re-fetch retired agents-63/70 workflows after central manifest removals"
   - target: .github/workflows/agents-belt-dispatcher.yml
     description: "Remove retired belt dispatcher alias wrapper from template consumers (callers rewired to agents-71-codex-belt-dispatcher.yml)"
   - target: .github/workflows/agents-belt-worker.yml

--- a/.github/workflows/maint-69-sync-integration-repo.yml
+++ b/.github/workflows/maint-69-sync-integration-repo.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
     paths:
       - 'templates/integration-repo/**'
+      - 'templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml'
+      - 'templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml'
       - '.github/workflows/autofix-versions.env'
   workflow_dispatch:
     inputs:
@@ -41,6 +43,8 @@ jobs:
           path: workflows
           sparse-checkout: |
             templates/integration-repo
+            templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+            templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
             .github/workflows/autofix-versions.env
             .github/scripts/sync_tracker_state
           sparse-checkout-cone-mode: false
@@ -116,6 +120,18 @@ jobs:
             echo "✅ Updated notify-workflows.yml"
           fi
 
+          # Sync consumer-template PR/keepalive hubs required for WIT PR automation.
+          for workflow in agents-80-pr-event-hub.yml agents-81-gate-followups.yml; do
+            src="../workflows/templates/consumer-repo/.github/workflows/${workflow}"
+            if [ -f "${src}" ]; then
+              cp "${src}" ".github/workflows/${workflow}"
+              echo "✅ Updated ${workflow}"
+            else
+              echo "::error::Missing consumer-template workflow: ${src}"
+              exit 1
+            fi
+          done
+
           # Sync scripts directory (if exists in templates)
           if [ -d "../workflows/templates/integration-repo/scripts" ]; then
             mkdir -p scripts
@@ -181,6 +197,8 @@ jobs:
             -m "- ci.yml (with workflow reference)" \
             -m "- autofix-versions.env (version pins)" \
             -m "- notify-workflows.yml (bidirectional sync trigger)" \
+            -m "- agents-80-pr-event-hub.yml (consumer PR event hub)" \
+            -m "- agents-81-gate-followups.yml (consumer Gate followups hub)" \
             -m "- scripts/ (synced from templates)" \
             -m "- requirements.lock (regenerated with updated tool versions)" \
             -m "" \

--- a/tests/workflows/test_integration_repo_sync_hubs.py
+++ b/tests/workflows/test_integration_repo_sync_hubs.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SYNC_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "maint-69-sync-integration-repo.yml"
 SYNC_MANIFEST = REPO_ROOT / ".github" / "sync-manifest.yml"

--- a/tests/workflows/test_integration_repo_sync_hubs.py
+++ b/tests/workflows/test_integration_repo_sync_hubs.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "maint-69-sync-integration-repo.yml"
+SYNC_MANIFEST = REPO_ROOT / ".github" / "sync-manifest.yml"
+
+REQUIRED_HUBS = (
+    "agents-80-pr-event-hub.yml",
+    "agents-81-gate-followups.yml",
+)
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(SYNC_WORKFLOW.read_text(encoding="utf-8")) or {}
+
+
+def _step_run(workflow: dict, step_name: str) -> str:
+    steps = workflow["jobs"]["sync"]["steps"]
+    for step in steps:
+        if step.get("name") == step_name:
+            return str(step.get("run", ""))
+    raise AssertionError(f"Missing workflow step: {step_name}")
+
+
+def test_integration_repo_sync_delivers_consumer_agent_hubs_to_wit() -> None:
+    workflow = _workflow()
+    checkout = next(
+        step
+        for step in workflow["jobs"]["sync"]["steps"]
+        if step.get("name") == "Checkout Workflows repo"
+    )
+    sparse_checkout = str(checkout["with"]["sparse-checkout"])
+    apply_script = _step_run(workflow, "Apply template updates")
+    commit_script = _step_run(workflow, "Commit and push changes")
+
+    for hub in REQUIRED_HUBS:
+        source = f"templates/consumer-repo/.github/workflows/{hub}"
+
+        assert (REPO_ROOT / source).exists()
+        assert source in sparse_checkout
+        assert "../workflows/templates/consumer-repo/.github/workflows/${workflow}" in apply_script
+        assert hub in apply_script
+        assert 'cp "${src}" ".github/workflows/${workflow}"' in apply_script
+        assert hub in commit_script
+
+
+def test_sync_manifest_removes_stale_consumer_local_workflow_syncer() -> None:
+    manifest = yaml.safe_load(SYNC_MANIFEST.read_text(encoding="utf-8")) or {}
+    removal_targets = {
+        item.get("target") for item in manifest.get("removals", []) if isinstance(item, dict)
+    }
+
+    assert ".github/workflows/maint-sync-workflows.yml" in removal_targets

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,19 +1,22 @@
 # Workloop State
 
-## 2026-06-13T16:05Z - opener (codex) in progress: Workflows #2281
+## 2026-06-13T16:05Z - opener (codex) opened #2309 for issue #2281
 
 - Repo: stranske/Workflows
 - Issue: #2281
+- PR: #2309
 - Branch: codex/issue-2281-consumer-hygiene
-- Lane: opener materialization
+- Lane: opener materialization complete; keepalive owns next iteration
 - Scope: in-repo enabler only. Extend maint-69 WIT sync to deliver consumer-template agents-80/81 hubs and add maint-sync-workflows.yml to sync-manifest removals. Consumer-repo checkbox work remains tracked by #2281.
-- Validation so far:
+- PR state: open, non-draft, closes #2281, labels `agent:codex`, `agents:keepalive`, and `autofix`.
+- Validation:
   - pytest tests/workflows/test_integration_repo_sync_hubs.py -q -> 2 passed
   - deliberate-break gate: removing agents-81 from the maint-69 sparse checkout made test_integration_repo_sync_delivers_consumer_agent_hubs_to_wit fail on the missing delivered-set path; restored line and test passed
   - pytest tests/workflows/test_integration_repo_sync_hubs.py tests/workflows/test_consumer_sync_create_only_evidence.py tests/workflows/test_workflow_on_triggers_valid.py tests/workflows/test_workflow_naming.py -q -> 151 passed
   - python scripts/validate_template_completeness.py --strict --manifest .github/sync-manifest.yml --source sync-manifest -> pass
   - git diff --check -> pass
-- Next action: commit, push, open ready-for-review PR with agent:codex/agents:keepalive/autofix labels.
+- Handoff: `pr_opened` fired with `active.source_repo=stranske/Workflows`, `active.source_issue=2281`, `active.source_pr=2309`, `active.next_action=wait_for_keepalive`.
+- Next action: wait for Gate/keepalive on #2309; opener should move to the next eligible lane when cap allows.
 
 ## 2026-06-13T15:33Z - closer (codex) fixed #2305 Gate catalog regression
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,23 +1,5 @@
 # Workloop State
 
-## 2026-06-13T16:05Z - opener (codex) opened #2309 for issue #2281
-
-- Repo: stranske/Workflows
-- Issue: #2281
-- PR: #2309
-- Branch: codex/issue-2281-consumer-hygiene
-- Lane: opener materialization complete; keepalive owns next iteration
-- Scope: in-repo enabler only. Extend maint-69 WIT sync to deliver consumer-template agents-80/81 hubs and add maint-sync-workflows.yml to sync-manifest removals. Consumer-repo checkbox work remains tracked by #2281.
-- PR state: open, non-draft, closes #2281, labels `agent:codex`, `agents:keepalive`, and `autofix`.
-- Validation:
-  - pytest tests/workflows/test_integration_repo_sync_hubs.py -q -> 2 passed
-  - deliberate-break gate: removing agents-81 from the maint-69 sparse checkout made test_integration_repo_sync_delivers_consumer_agent_hubs_to_wit fail on the missing delivered-set path; restored line and test passed
-  - pytest tests/workflows/test_integration_repo_sync_hubs.py tests/workflows/test_consumer_sync_create_only_evidence.py tests/workflows/test_workflow_on_triggers_valid.py tests/workflows/test_workflow_naming.py -q -> 151 passed
-  - python scripts/validate_template_completeness.py --strict --manifest .github/sync-manifest.yml --source sync-manifest -> pass
-  - git diff --check -> pass
-- Handoff: `pr_opened` fired with `active.source_repo=stranske/Workflows`, `active.source_issue=2281`, `active.source_pr=2309`, `active.next_action=wait_for_keepalive`.
-- Next action: wait for Gate/keepalive on #2309; opener should move to the next eligible lane when cap allows.
-
 ## 2026-06-13T15:33Z - closer (codex) fixed #2305 Gate catalog regression
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2305](https://github.com/stranske/Workflows/pull/2305), source issue `#2279`, branch `codex/issue-2279-docs-remediation`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,20 @@
 # Workloop State
 
+## 2026-06-13T16:05Z - opener (codex) in progress: Workflows #2281
+
+- Repo: stranske/Workflows
+- Issue: #2281
+- Branch: codex/issue-2281-consumer-hygiene
+- Lane: opener materialization
+- Scope: in-repo enabler only. Extend maint-69 WIT sync to deliver consumer-template agents-80/81 hubs and add maint-sync-workflows.yml to sync-manifest removals. Consumer-repo checkbox work remains tracked by #2281.
+- Validation so far:
+  - pytest tests/workflows/test_integration_repo_sync_hubs.py -q -> 2 passed
+  - deliberate-break gate: removing agents-81 from the maint-69 sparse checkout made test_integration_repo_sync_delivers_consumer_agent_hubs_to_wit fail on the missing delivered-set path; restored line and test passed
+  - pytest tests/workflows/test_integration_repo_sync_hubs.py tests/workflows/test_consumer_sync_create_only_evidence.py tests/workflows/test_workflow_on_triggers_valid.py tests/workflows/test_workflow_naming.py -q -> 151 passed
+  - python scripts/validate_template_completeness.py --strict --manifest .github/sync-manifest.yml --source sync-manifest -> pass
+  - git diff --check -> pass
+- Next action: commit, push, open ready-for-review PR with agent:codex/agents:keepalive/autofix labels.
+
 ## 2026-06-13T15:33Z - closer (codex) fixed #2305 Gate catalog regression
 
 - **Selected complex lane:** `stranske/Workflows` PR [#2305](https://github.com/stranske/Workflows/pull/2305), source issue `#2279`, branch `codex/issue-2279-docs-remediation`.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2281 -->
> **Source:** Issue #2281

Closes #2281

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The consumer-integration audit found four hygiene defects across the fleet. **Most fixes land in CONSUMER repos whose `ci.yml` and `config/` files are `sync_mode: create_only`** — so the central sync in this repo will never push them — which is exactly why this is a **tracker issue** in `stranske/Workflows`: it enumerates the per-repo fixes (as checkboxes) and the **one in-repo enabler** that *is* verifiable here. Mix of latent and current breaks; consumer files are named as the audit records them (they are not in this checkout).

1. **Double-CI triggers (current break, 5 repos).** Travel-Plan-Permission, Manager-Database, Inv-Man-Intake, Pension-Data, and trip-planner each have a `pull_request:` trigger in `ci.yml` *in addition to* the Gate. Verified in-repo: the template's own `ci.yml` warns against exactly this at `templates/consumer-repo/.github/workflows/ci.yml:14-20` — "Do NOT add a `pull_request:` trigger here. Gate (pr-00-gate.yml) already runs the same reusable Python CI on every pull request … causes a second concurrent invocation of the reusable workflow that hits a `startup_failure` … Production consumers (Counter_Risk, Inv-Man-Intake, Trend_Model_Project, etc.) all omit pull_request: from ci.yml." So CI runs twice per PR in the 5 affected repos.

2. **Stale model slots (latent, all 9 + WIT).** Per the audit, every consumer's `config/llm_slots.json` still pins `gpt-5.2` / `claude-sonnet-4-5-…`, while the canonical template has moved on. Verified in-repo: `templates/consumer-repo/config/llm_slots.json` pins `slot1`=`gpt-5.4`, `slot2`=`claude-sonnet-4-6`, `slot3`=`codex-mini-latest`. Because this file is `create_only`, the central sync never updates it, so consumers are frozen on the old versions.

3. **Trend phase-3 CI dark (current break).** Per the audit and project memory, `Trend_Model_Project/.github/workflows/ci.yml` triggers only on `push: branches: [main]`, but Trend's active development branch is `phase-3`. Post-merge CI therefore never fires on phase-3 merges.

4. **Workflows-Integration-Tests out of sync (current break) + stale consumer-local syncer.** Per the audit, WIT is missing `agents-80-pr-event-hub.yml` and `agents-81-gate-followups.yml` (keepalive broken on WIT PRs) and retains 7 legacy files past the sync-manifest removal deadline. Verified in-repo as the root cause: `maint-69-sync-integration-repo.yml` (375 lines) only copies `autofix-versions.env` (cp at line 104), `notify-workflows.yml` (cp at line 113), and `templates/integration-repo/scripts/.` (cp -r at line 122) into WIT — there is **no copy of the consumer-template workflow surface** (no agents-80/81), and WIT is absent from `.github/sync-manifest.yml`. Separately, `maint-sync-workflows.yml` is a consumer-local syncer in 7 repos that re-fetches removed workflows (`agents-63-issue-intake.yml`, `agents-70-orchestrator.yml`); confirmed it is NOT in this repo or the template (`ls .github/workflows/maint-sync-workflows.yml` and the template path → both absent), so it can only be removed per-repo + recorded as a manifest removal.

#### Tasks
- [ ] **(In-repo enabler)** Extend `.github/workflows/maint-69-sync-integration-repo.yml` so its sync step delivers the consumer-template workflow surface — at minimum `templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml` and `agents-81-gate-followups.yml` — into WIT (alongside the existing `autofix-versions.env` copy at line 104 and `notify-workflows.yml` copy at line 113), OR add `Workflows-Integration-Tests` to `.github/sync-manifest.yml` with `skip_repos`/exclusions for WIT-specific legacy files.
- [ ] **(In-repo enabler)** Add `maint-sync-workflows.yml` to the `removals` section of `.github/sync-manifest.yml` so the canonical sweep removes the stale consumer-local syncer (it re-fetches `agents-63-issue-intake.yml` / `agents-70-orchestrator.yml`, both already past their removal deadline).
- [ ] **(Per-consumer checkbox)** Remove the `pull_request:` trigger from `ci.yml` in Travel-Plan-Permission, Manager-Database, Inv-Man-Intake, Pension-Data, and trip-planner (matches the template guidance at `templates/consumer-repo/.github/workflows/ci.yml:14-20`).
- [ ] **(Per-consumer checkbox)** One-time update of `config/llm_slots.json` across all 9 consumers to the canonical template versions: `slot1` → `gpt-5.4`, `slot2` → `claude-sonnet-4-6` (template at `templates/consumer-repo/config/llm_slots.json`).
- [ ] **(Per-consumer checkbox)** Add `phase-3` to the `push.branches` list in `Trend_Model_Project/.github/workflows/ci.yml` so post-merge CI fires on the active branch.
- [ ] **(Per-consumer checkbox)** Remove `maint-sync-workflows.yml` from the 7 repos that carry it (Travel-Plan-Permission, Counter_Risk, Manager-Database, Inv-Man-Intake, Pension-Data, trip-planner, learning-management-system) once the manifest `removals` entry is in place.

#### Acceptance criteria
- [ ] **In-repo enabler gate (observable, deliberate-verify form):** after the `maint-69` (or sync-manifest) change, demonstrate that WIT would receive both `agents-80-pr-event-hub.yml` and `agents-81-gate-followups.yml`. Either (a) run the sync logic in dry-run / list mode (e.g. a `--dry-run` or a step that echoes the file list it would copy) and capture output containing both filenames, or (b) add a test under `tests/workflows/` that parses `maint-69-sync-integration-repo.yml` (or `sync-manifest.yml`) and asserts both filenames appear in WIT's delivered set; the test passes. Capture the dry-run output or test PASS.
- [ ] **Deliberate-break gate (for the enabler test):** temporarily remove `agents-81-gate-followups.yml` from the delivered-set list in `maint-69` (or the manifest). The dry-run/test from the prior criterion **must FAIL** (or omit `agents-81-gate-followups.yml` from its captured output). Restore the line; it passes. Capture both states. (Proves the gate actually verifies WIT receives agents-80/81.)
- [ ] `grep -n 'maint-sync-workflows.yml' .github/sync-manifest.yml` returns a line under the `removals` section (it was absent before — capture before/after).
- [ ] Each per-consumer checkbox records its observable post-fix state when that repo's PR lands: a PR in the 5 `ci.yml` repos shows a **single** `reusable-10-ci-python.yml` run per PR (not two); a Trend phase-3 push shows a `CI` run in the Actions tab; the 9 `config/llm_slots.json` files show `gpt-5.4` / `claude-sonnet-4-6`. (These are tracked as checkboxes in this issue, closed as the per-repo PRs merge.)

<!-- auto-status-summary:end -->