### PR TITLE
fix(selftest): treat skipped zero-scenario runs as a clean pass (#2307)

### DIFF
--- a/.github/workflows/selftest-reusable-ci.yml
+++ b/.github/workflows/selftest-reusable-ci.yml
@@ -512,7 +512,10 @@ jobs:
               if (!isRateLimitError(error)) {
                 throw error;
               }
-              const failures = workflowResult === 'success' ? 0 : 1;
+              const skippedNoScenarios =
+                workflowResult === 'skipped' && scenarioNames.length === 0;
+              const failures =
+                workflowResult === 'success' || skippedNoScenarios ? 0 : 1;
               const table = [
                 '| Scenario | Status | Missing | Unexpected |',
                 '|---|---|---|---|',
@@ -651,7 +654,7 @@ jobs:
           path: selftest-report.json
 
       - name: Fail on verification errors
-        if: ${{ steps.verify.outputs.failures != '0' }}
+        if: ${{ steps.verify.outputs.failures != '0' && !(needs.scenarios.result == 'skipped' && needs.select-scenarios.outputs.selected_count == '0') }}
         run: |
           echo 'Artifact expectation mismatches detected.' >&2
           exit 1

--- a/tests/workflows/test_workflow_selftest_consolidation.py
+++ b/tests/workflows/test_workflow_selftest_consolidation.py
@@ -368,6 +368,12 @@ def test_selftest_runner_jobs_contract() -> None:
     assert (
         ".split('/')[0]" in verify_script
     ), "Verification should normalize nested reusable workflow job names."
+    # The rate-limit fallback must not count a legitimately-skipped, zero-scenario run
+    # as a failure: when the artifact API is rate-limited on a PR that selected no
+    # scenarios, that is a clean no-op, otherwise FAILURE_COUNT=1 leaks to publish.
+    assert (
+        "skippedNoScenarios" in verify_script
+    ), "Rate-limit fallback must treat skipped/zero-scenario runs as non-failing."
 
     upload_step = _find_step(lambda step: step.get("name") == "Upload self-test report")
     assert upload_step, "Aggregate job must upload the self-test report artifact."
@@ -384,9 +390,17 @@ def test_selftest_runner_jobs_contract() -> None:
 
     fail_step = _find_step(lambda step: step.get("name") == "Fail on verification errors")
     assert fail_step, "Aggregate job must fail when verification mismatches occur."
+    fail_if = fail_step.get("if", "")
     assert (
-        fail_step.get("if") == "${{ steps.verify.outputs.failures != '0' }}"
+        "steps.verify.outputs.failures != '0'" in fail_if
     ), "Failure guard should inspect verification failure count."
+    # A legitimately-skipped run with no selected scenarios is a clean no-op, not a
+    # mismatch: the guard must mirror the skipped-handling at the publish/comment jobs
+    # so the Aggregate & Verify job does not red-fail on PRs that touch no reusable.
+    assert (
+        "needs.scenarios.result == 'skipped'" in fail_if
+        and "needs.select-scenarios.outputs.selected_count == '0'" in fail_if
+    ), "Failure guard must exempt the legitimately-skipped, zero-scenario case."
 
 
 def test_selftest_runner_publish_job_contract() -> None:

--- a/tests/workflows/test_workflow_selftest_consolidation.py
+++ b/tests/workflows/test_workflow_selftest_consolidation.py
@@ -401,6 +401,16 @@ def test_selftest_runner_jobs_contract() -> None:
         "needs.scenarios.result == 'skipped'" in fail_if
         and "needs.select-scenarios.outputs.selected_count == '0'" in fail_if
     ), "Failure guard must exempt the legitimately-skipped, zero-scenario case."
+    # Guard against an accidentally-inverted clause: the skipped/zero-scenario pair
+    # must be NEGATED as a group (so it SUPPRESSES failure), not OR'd in as an extra
+    # failure trigger. Pin the exact `&& !(...)` grouping so a flipped guard fails here.
+    assert (
+        "&& !(needs.scenarios.result == 'skipped'"
+        " && needs.select-scenarios.outputs.selected_count == '0')"
+    ) in fail_if, (
+        "Skipped/zero-scenario clause must be negated and AND-combined "
+        "(&& !(...)) so it exempts—not triggers—the failure."
+    )
 
 
 def test_selftest_runner_publish_job_contract() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2307 -->
> **Source:** Issue #2307

Closes #2307

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`selftest-reusable-ci.yml` triggers on `pull_request` (line 6), so it runs on **every** PR. Its `Aggregate & Verify` job (line 356) ends with `Fail on verification errors` (line 653: `echo 'Artifact expectation mismatches detected.' >&2; exit 1`) whenever the reusable-CI scenarios were **skipped** — i.e. the PR did not touch `reusable-10-ci-python.yml`. Verified: the job failed this way on PRs #2284 and #2298 with `WORKFLOW_RESULT: skipped` (line 392) and an empty `SCENARIO_LIST`. This is a **current, recurring failure** on essentially every non-reusable PR.

Impact today: the job is **not a required check**, so it does not block merges — but it paints a red ✗ on nearly every PR's check list (alarm fatigue; it masks genuine failures), and it directly blocks the #2297 effort: it cannot be added to the required set until it stops failing on unrelated PRs. The skipped-result case is already handled correctly elsewhere in the same file (lines 819 and 965: `if WORKFLOW_RESULT == "skipped" && SELECTED_COUNT == 0` → treated as a clean no-op), so the `Aggregate & Verify` job is simply missing that guard.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2284](https://github.com/stranske/Workflows/issues/2284)
- [#2298](https://github.com/stranske/Workflows/issues/2298)
- [#2297](https://github.com/stranske/Workflows/issues/2297)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] In `.github/workflows/selftest-reusable-ci.yml`, guard the `Fail on verification errors` step (line 653) so it does not fail when `WORKFLOW_RESULT == 'skipped'` and no scenarios were selected, reusing the same condition already used at lines 819 and 965.
- [ ] Confirm the `Aggregate & Verify` job (line 356) reports success (not failure) in the skipped case, and still fails when scenarios actually run and mismatch.
- [ ] Verify on a PR that changes only a non-reusable file (e.g. a doc) that `Aggregate & Verify` is green.

#### Acceptance criteria
- [ ] **Deliberate-break gate (live):** on a PR touching no reusable file, the `Aggregate & Verify` job concludes success (today it concludes failure). Capture the green run. Then, on a PR that DOES change `reusable-10-ci-python.yml` and induces a real artifact mismatch, confirm the job still fails (the guard must not mask real mismatches).
- [ ] `gh pr checks <non-reusable-PR>` shows `Aggregate & Verify` = pass.
- [ ] No change to the scenario matrix behavior when scenarios are selected.

<!-- auto-status-summary:end -->