### PR TITLE
fix(verifier): include retry classifier in sparse checkouts

### DIFF
--- a/.github/workflows/agents-64-verify-agent-assignment.yml
+++ b/.github/workflows/agents-64-verify-agent-assignment.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -206,6 +206,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -189,6 +189,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -75,6 +75,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -74,6 +74,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -206,6 +206,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -190,6 +190,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -255,6 +255,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/actions/setup-api-client
           sparse-checkout-cone-mode: false
@@ -320,6 +321,7 @@ jobs:
           sparse-checkout: |
             scripts/langchain
             tools
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
 
       - name: Set up Python

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             scripts/state_fingerprint.py

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -74,6 +74,7 @@ jobs:
             .github/actions/setup-api-client
             .github/agents/registry.yml
             .github/scripts/agent_registry.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js

--- a/tests/workflows/test_github_api_retry_standard.py
+++ b/tests/workflows/test_github_api_retry_standard.py
@@ -64,6 +64,22 @@ def _iter_job_scripts(workflow: dict[str, Any]) -> Iterable[tuple[str, str]]:
                 yield step.get("name", "<unnamed>"), script
 
 
+def _iter_checkout_sparse_paths(workflow: dict[str, Any]) -> Iterable[tuple[str, set[str]]]:
+    jobs = workflow.get("jobs") or {}
+    for job in jobs.values():
+        steps = job.get("steps") or []
+        for step in steps:
+            uses = step.get("uses")
+            if not (isinstance(uses, str) and uses.startswith("actions/checkout@")):
+                continue
+            checkout_with = step.get("with") or {}
+            sparse_checkout = checkout_with.get("sparse-checkout")
+            if not isinstance(sparse_checkout, str):
+                continue
+            paths = {line.strip() for line in sparse_checkout.splitlines() if line.strip()}
+            yield step.get("name", "<unnamed>"), paths
+
+
 def _rest_calls_missing_retry(script: str, step_name: str, workflow_path: Path) -> list[str]:
     failures: list[str] = []
     for match in re.finditer(r"github\.rest\.", script):
@@ -109,4 +125,24 @@ def test_retry_wrappers_cover_pagination() -> None:
         not failures
     ), "Use paginateWithRetry/paginateWithBackoff instead of github.paginate: " + ", ".join(
         sorted(failures)
+    )
+
+
+def test_sparse_retry_helper_checkouts_include_classifier_dependency() -> None:
+    failures: list[str] = []
+    for relative_path in WORKFLOW_PATHS:
+        workflow_path = REPO_ROOT / relative_path
+        assert workflow_path.exists(), f"Missing workflow: {relative_path}"
+        workflow = _load_workflow(workflow_path)
+        for step_name, paths in _iter_checkout_sparse_paths(workflow):
+            if (
+                ".github/scripts/github-api-with-retry.js" in paths
+                and ".github/scripts/error_classifier.js" not in paths
+                and ".github/scripts" not in paths
+            ):
+                failures.append(f"{relative_path.as_posix()}::{step_name}")
+    assert not failures, (
+        "Sparse checkouts that materialize github-api-with-retry.js must also include "
+        ".github/scripts/error_classifier.js, because the retry helper requires it: "
+        + ", ".join(sorted(failures))
     )


### PR DESCRIPTION
## Summary

- Add `.github/scripts/error_classifier.js` beside every governed sparse-checkout that materializes `.github/scripts/github-api-with-retry.js` directly.
- Cover the dependency contract in `tests/workflows/test_github_api_retry_standard.py` so future retry-helper sparse checkouts include the classifier.
- This is a bounded verifier-infrastructure follow-up for the failed Agents Verifier run 27473735808 on the recently merged reference-pack heredoc PR.

## Validation

- `python -m pytest tests/workflows/test_github_api_retry_standard.py -q`
- `python3 scripts/validate_template_completeness.py`
- `python3 scripts/validate_template_sync.py`
- `git diff --check`

## Next

- After merge, re-run the verifier for the original merged PR or reapply the intended `verify:compare` trigger so the source issue can receive durable verifier disposition.
