### PR TITLE
fix(verifier): include retry helper dependency

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -93,6 +93,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/github-api-with-retry.js
+            .github/scripts/error_classifier.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
       - name: Setup API client

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -897,6 +897,20 @@ def test_orchestrator_jobs_checkout_scripts_before_local_requires():
         ), f"Job {job_name} must warn against removing the checkout guard"
 
 
+def test_agents_verifier_checkout_includes_retry_helper_dependencies():
+    data = _load_workflow_yaml("agents-verifier.yml")
+    steps = data["jobs"]["check"]["steps"]
+    checkout = next(step for step in steps if step.get("name") == "Checkout retry helpers")
+    sparse_checkout = checkout["with"]["sparse-checkout"]
+    paths = {line.strip() for line in sparse_checkout.splitlines() if line.strip()}
+
+    assert ".github/actions/setup-api-client" in paths
+    assert ".github/scripts/github-api-with-retry.js" in paths
+    assert ".github/scripts/error_classifier.js" in paths
+    assert ".github/scripts/token_load_balancer.js" in paths
+    assert checkout["with"]["sparse-checkout-cone-mode"] is False
+
+
 def test_gate_workflow_uses_fork_head_for_script_tests_and_ledger():
     data = _load_workflow_yaml("pr-00-gate.yml")
     jobs = data.get("jobs", {})


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2278 -->
> **Source:** Issue #2278

Closes #2278

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`.github/scripts/` has accreted seven-plus overlapping GitHub-API wrapper modules with a redundant shim chain, five-plus reimplementations of the same rate-limit/transient predicates (one carrying a latent bug), and three cache factories that defeat each other. All anchors verified against the current checkout (origin/main, HEAD `2fb8e8b3`).

- **Wrapper sprawl (~2,100 LOC):** `github-api-cache.js` (234), `github-api-cache-client.js` (109), `github-api-with-retry.js` (618), `github-rate-limited-wrapper.js` (340), `github_api_retry.js` (155), `api-helpers.js` (348), plus the dead `rate-limit-aware-client.js` (299, deleted in issue 14) and the shared `error_classifier.js` (219). (Note: there is **no** `rate_limits.js` in the current tree — verified absent.)
- **Redundant shim chain:** `github_api_retry.js` is required by exactly one module — `api-helpers.js` (`grep -rln github_api_retry .github/scripts --include='*.js' | grep -v __tests__` → only `api-helpers.js`). `api-helpers.js` in turn is required by only `rate-limit-aware-client.js` (dead) and `keepalive_gate.js`. So once issue 14 deletes `rate-limit-aware-client.js`, the entire `github_api_retry.js`→`api-helpers.js` chain (503 LOC) exists solely to serve `keepalive_gate.js`, and it re-implements the exponential-backoff-with-jitter already present in `github-api-with-retry.js`.
- **Latent bug — over-broad 403:** `keepalive_gate.js:103` `isRateLimitError` returns `status === 403 || status === 429 || /rate\s*limit/i.test(message) || ...`. The bare `status === 403` classifies **any** HTTP 403 — including genuine permission/scope errors — as a rate-limit, which would route real auth failures into rate-limit backoff/retry instead of surfacing them. This is **latent** (the predicate is currently not exported and not on a hot call path), but it is a real semantic defect baked into the gate.
- **Predicate duplication:** `isRateLimitError` is reimplemented in 6 files with divergent behavior — `github-api-with-retry.js:48`, `api-helpers.js:23`, `keepalive_gate.js:103`, `agents_pr_meta_update_body.js:833`, `comment-dedupe.js:10`, `detect-changes.js:159`. `isTransientError` is reimplemented in 3 — `github-api-with-retry.js:110`, `agents_pr_meta_orchestrator.js:26`, `agents_pr_meta_keepalive.js:95`. Meanwhile `error_classifier.js` already centralizes this via `TRANSIENT_PATTERNS` (`:19`) and `classifyError` (exported at `:215` alongside `ERROR_CATEGORIES`).
- **Three cache factories fighting each other:** `getGithubApiCache({ github, core })` is defined three times — `keepalive_gate.js:42` (sentinel `__keepaliveGateApiCache`), `agents_pr_meta_keepalive.js:22` (`__agentsPrMetaApiCache`), `keepalive_loop.js:470` (`__keepaliveApiCache`). All three call `createGithubApiCache` from `github-api-cache-client.js` (exported at `:107`) but attach under different property names, so three independent caches live on the same `github` object instead of one shared cache.

Source: `dup-js.md` F-02, F-04, F-05.

#### Tasks
- [ ] In `error_classifier.js`, add an exported rate-limit predicate (e.g. `isRateLimitError(error)`) that returns `true` only when the status is `429`, OR the status is `403` AND (the message matches `TRANSIENT_PATTERNS`/`rate limit` OR a rate-limit header indicates exhaustion) — i.e. a 403 that is NOT a rate-limit returns `false`. Export it alongside the existing `classifyError`/`ERROR_CATEGORIES`/`suggestRecoveryAction` (`error_classifier.js:215`). Add/extend `error-classifier.test.js` to assert the 403-non-rate-limit case.
- [ ] Replace the local `isRateLimitError` definitions in `keepalive_gate.js:103`, `api-helpers.js:23`, `agents_pr_meta_update_body.js:833`, `comment-dedupe.js:10`, and `detect-changes.js:159` with imports of the centralized predicate from `error_classifier.js`; replace the `isTransientError` definitions in `agents_pr_meta_orchestrator.js:26` and `agents_pr_meta_keepalive.js:95` similarly (route through `classifyError` → `ERROR_CATEGORIES.transient`). Keep `github-api-with-retry.js`'s copies only if it must stay dependency-free, otherwise also route them.
- [ ] Merge `github_api_retry.js` (155 LOC) and `api-helpers.js` (348 LOC) into `github-api-with-retry.js`: move/alias `paginateWithBackoff`, `withBackoff`, `calculateBackoffDelay`, `resolveMaxRetries` (de-duping the byte-identical `normaliseHeaders` that appears in both `github_api_retry.js:33` and `github-api-with-retry.js:14`), then update the two `keepalive_gate.js` call sites that import from `api-helpers.js`, and delete `github_api_retry.js` and `api-helpers.js`.
- [ ] Move `getGithubApiCache` into `github-api-cache-client.js` (export it next to `createGithubApiCache` at `:107`) using one sentinel property (`__githubApiCache`); update the three callers `keepalive_gate.js:42`, `agents_pr_meta_keepalive.js:22`, `keepalive_loop.js:470` to import it and drop their local copies.
- [ ] Update `.github/sync-manifest.yml` and `templates/consumer-repo/.github/scripts/` for any added/removed/renamed module so the consumer template stays in lockstep, and run the sync drift check.

#### Acceptance criteria
- [ ] `node --test .github/scripts/__tests__/*.test.js` (the JS gate from `.github/workflows/selftest-ci.yml:49`) is green after consolidation, including the existing `api-helpers.test.js`, `github-api-retry.test.js`, `github-api-with-retry.test.js`, `github-api-cache-client.test.js`, `keepalive-gate.test.js`, and `error-classifier.test.js` (relocate/retarget the `api-helpers`/`github-api-retry` suites onto the consolidated module rather than dropping their assertions).
- [ ] **403-not-rate-limit assertion (new, named):** `error-classifier.test.js` contains a test asserting the centralized predicate returns `false` for a 403 that is NOT a rate-limit (e.g. `{ status: 403, message: 'Resource not accessible by integration' }`) and `true` for a 403 that IS (message contains `rate limit`, or header remaining `0`) and for `429`. This test passes.
- [ ] **Deliberate-break gate:** temporarily edit the centralized predicate in `error_classifier.js` to return `true` for any `status === 403` (re-introducing the `keepalive_gate.js:103` bug). With that change, the `error-classifier.test.js` 403-not-rate-limit assertion above **must FAIL** under `node --test .github/scripts/__tests__/error-classifier.test.js`. Revert the edit; the test passes again. Capture the FAIL output in the PR.
- [ ] **Single-cache verification:** after the change, `grep -rn '__keepaliveGateApiCache|__agentsPrMetaApiCache|__keepaliveApiCache' .github/scripts --include='*.js'` returns empty (all three callers now use the single `__githubApiCache` sentinel from `github-api-cache-client.js`), and `grep -rln 'require.*github_api_retry|require.*api-helpers' .github/scripts --include='*.js'` returns empty (both shim modules deleted).
- [ ] The `sync-manifest` drift/validation check is green (no orphaned entry for `github_api_retry.js`/`api-helpers.js`, consumer template aligned).

<!-- auto-status-summary:end -->