### PR TITLE
fix(verifier): pass checked PR number to reusable run

### DIFF
--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -216,6 +216,8 @@ jobs:
       ci_workflows: '["pr-00-gate.yml", "pr-11-ci-smoke.yml", "selftest-ci.yml"]'
       # Verification mode from label or manual input
       mode: ${{ needs.check.outputs.mode }}
+      # PR number from label trigger or manual dispatch
+      pr_number: ${{ needs.check.outputs.pr_number }}
       # Model selection (empty string uses default)
       model: ${{ needs.check.outputs.model }}
       # Provider selection (empty string uses default)

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             scripts/runner_lib

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             scripts/runner_lib

--- a/tests/workflows/test_github_api_retry_standard.py
+++ b/tests/workflows/test_github_api_retry_standard.py
@@ -146,3 +146,17 @@ def test_sparse_retry_helper_checkouts_include_classifier_dependency() -> None:
         ".github/scripts/error_classifier.js, because the retry helper requires it: "
         + ", ".join(sorted(failures))
     )
+
+
+def test_agents_verifier_callers_pass_checked_pr_number() -> None:
+    caller_paths = [
+        Path(".github/workflows/agents-verifier.yml"),
+        Path("templates/consumer-repo/.github/workflows/agents-verifier.yml"),
+    ]
+    for relative_path in caller_paths:
+        workflow = _load_workflow(REPO_ROOT / relative_path)
+        verifier_job = workflow["jobs"]["verifier"]
+        assert verifier_job["uses"] == (
+            "stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main"
+        )
+        assert verifier_job["with"]["pr_number"] == "${{ needs.check.outputs.pr_number }}"

--- a/tests/workflows/test_github_api_retry_standard.py
+++ b/tests/workflows/test_github_api_retry_standard.py
@@ -10,6 +10,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 WORKFLOW_PATHS = [
+    Path(".github/workflows/autofix.yml"),
     Path(".github/workflows/agents-71-codex-belt-dispatcher.yml"),
     Path(".github/workflows/agents-72-codex-belt-worker.yml"),
     Path(".github/workflows/agents-73-codex-belt-conveyor.yml"),
@@ -24,6 +25,7 @@ WORKFLOW_PATHS = [
     Path("templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-verifier.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml"),
+    Path("templates/consumer-repo/.github/workflows/autofix.yml"),
 ]
 
 RETRY_HELPERS = (


### PR DESCRIPTION
## Summary

- pass `needs.check.outputs.pr_number` from the root `agents-verifier.yml` caller into `reusable-agents-verifier.yml`
- add a regression test asserting both the root caller and consumer template pass the checked PR number

## Why

Manual verifier dispatches for source PRs #2287, #2304, and #2311 accepted the requested PR number in the `check` job, but the reusable verifier later ran with an empty `pr_number` input and posted PASS/PASS reports against #2313 instead. This keeps the original source issues open because their durable verifier reports are still missing.

This is a bounded verifier-infrastructure follow-up. It intentionally does not close any source issue.

## Validation

- `python -m pytest tests/workflows/test_github_api_retry_standard.py -q` -> 4 passed
- `python3 scripts/validate_template_completeness.py` -> pass
- `python3 scripts/validate_template_sync.py` -> pass
- YAML parse for root/template `agents-verifier.yml` -> pass
- `git diff --check` -> clean

<!-- workflow-source:review_followup -->
