### PR TITLE
feat(agents): wire agent:cursor into the autofix loop (Phase 1b)

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -66,6 +66,6 @@ agents:
       enabled: false   # issue-intake/invite flow deferred; PR keepalive + autofix only this phase
     capabilities:
       pr_keepalive: true
-      pr_autofix: false         # autofix-loop wiring lands in follow-up phase 1b
+      pr_autofix: true          # wired into agents-autofix-loop.yml (autofix-cursor job)
       belt: false              # belt routing deferred to a later phase
       verifier_checkbox: false  # verification stays on the existing judge (config/llm_slots.json)

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -722,16 +722,43 @@ jobs:
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 
+  autofix-cursor:
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.dispatch_should_run == 'true' &&
+      needs.prepare.outputs.agent_type == 'cursor'
+    name: Run Cursor autofix
+    uses: stranske/Workflows/.github/workflows/reusable-cursor-run.yml@main
+    with:
+      prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
+      mode: autofix
+      pr_number: ${{ needs.prepare.outputs.pr_number }}
+      pr_ref: ${{ needs.prepare.outputs.head_ref }}
+      appendix: ${{ needs.prepare.outputs.appendix }}
+      environment: >-
+        ${{
+          needs.prepare.outputs.has_high_privilege == 'true' &&
+          'agent-high-privilege' ||
+          'agent-standard'
+        }}
+    secrets:
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
   record-autofix-completion:
     name: Record autofix dispatch completion
     needs:
       - prepare
       - autofix
       - autofix-claude
+      - autofix-cursor
     if: >-
       always() &&
       needs.prepare.outputs.dispatch_should_run == 'true' &&
-      (needs.autofix.result != 'skipped' || needs.autofix-claude.result != 'skipped')
+      (needs.autofix.result != 'skipped' || needs.autofix-claude.result != 'skipped' ||
+       needs.autofix-cursor.result != 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout runner library
@@ -752,13 +779,17 @@ jobs:
           HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
           SUMMARY: >-
             ${{ needs.autofix.outputs.final-message-summary ||
-                needs.autofix-claude.outputs.final-message-summary || '' }}
+                needs.autofix-claude.outputs.final-message-summary ||
+                needs.autofix-cursor.outputs.final-message-summary || '' }}
           EXIT_CODE: >-
             ${{ needs.autofix.outputs.exit-code ||
-                needs.autofix-claude.outputs.exit-code || '' }}
+                needs.autofix-claude.outputs.exit-code ||
+                needs.autofix-cursor.outputs.exit-code || '' }}
           JOB_RESULT: >-
             ${{ needs.autofix.result != 'skipped' &&
-                needs.autofix.result || needs.autofix-claude.result }}
+                needs.autofix.result ||
+                (needs.autofix-claude.result != 'skipped' &&
+                 needs.autofix-claude.result || needs.autofix-cursor.result) }}
         run: |
           set -euo pipefail
           if [ -z "${PR_NUMBER:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
@@ -876,6 +907,7 @@ jobs:
       - prepare
       - autofix
       - autofix-claude
+      - autofix-cursor
     if: always()
     runs-on: ubuntu-latest
     environment: >-
@@ -942,10 +974,13 @@ jobs:
             const stopReason = '${{ needs.prepare.outputs.stop_reason }}';
             const codexAutofixResult = '${{ needs.autofix.result }}';
             const claudeAutofixResult = '${{ needs.autofix-claude.result }}';
+            const cursorAutofixResult = '${{ needs.autofix-cursor.result }}';
             const autofixResult =
               codexAutofixResult && codexAutofixResult !== 'skipped'
                 ? codexAutofixResult
-                : claudeAutofixResult;
+                : (claudeAutofixResult && claudeAutofixResult !== 'skipped'
+                    ? claudeAutofixResult
+                    : cursorAutofixResult);
 
             const { owner, repo } = context.repo;
             let fixApplied = false;

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -66,6 +66,6 @@ agents:
       enabled: false   # issue-intake/invite flow deferred; PR keepalive + autofix only this phase
     capabilities:
       pr_keepalive: true
-      pr_autofix: false         # autofix-loop wiring lands in follow-up phase 1b
+      pr_autofix: true          # wired into agents-autofix-loop.yml (autofix-cursor job)
       belt: false              # belt routing deferred to a later phase
       verifier_checkbox: false  # verification stays on the existing judge (config/llm_slots.json)


### PR DESCRIPTION
## Summary

Phase 1b follow-up to #2317 (Cursor keepalive). Completes Cursor's CI integration by adding it to the **autofix loop**, and flips `cursor.capabilities.pr_autofix` to `true`.

- **`agents-autofix-loop.yml`**: new gated `autofix-cursor` job (`agent_type == 'cursor'`, `uses: reusable-cursor-run.yml@main`, explicit `CURSOR_API_KEY` + `WORKFLOWS_APP_*` secrets), modeled on the existing `autofix` (codex) / `autofix-claude` jobs. Threaded through both aggregators — `record-autofix-completion` (needs / if / SUMMARY / EXIT_CODE / JOB_RESULT) and `metrics` (needs / `autofixResult`).
- **`registry.yml`** (+ consumer template): `cursor.capabilities.pr_autofix: true`.

`agents-autofix-loop.yml` is Workflows-first-party — `sync-manifest.yml` marks the consumer-template copy for removal (replaced by `agents-81-gate-followups.yml`) — so there's no consumer template workflow to update.

## Validation
- `yaml.safe_load` + `actionlint` clean (only pre-existing SC2129 style warnings).
- `test_workflow_agents_consolidation` + `test_agents_guard` + `test_workflow_naming` pass (98).

## Depends on / relation
- Builds on #2317 (merged). Independent of #2319 (Gemini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated CI autofix that can push fixes via Cursor API and workflow secrets on PR branches; prepare-step agent allowlist may still block `cursor` until updated separately.
> 
> **Overview**
> **Enables Cursor as a third provider in the Gate-driven autofix loop**, alongside Codex and Claude.
> 
> `agents-autofix-loop.yml` adds a gated **`autofix-cursor`** job that runs when `agent_type == 'cursor'`, calling `reusable-cursor-run.yml` in `autofix` mode with the same CI-failure prompt and appendix as the other runners, plus `CURSOR_API_KEY` and GitHub App secrets. **Completion and metrics** now treat Cursor like the existing jobs: `record-autofix-completion` pulls summary/exit code/result from `autofix-cursor`, and `metrics` includes cursor job outcome in `autofixResult`.
> 
> **Registry** (repo + consumer template): `cursor.capabilities.pr_autofix` is set to **`true`** with a comment pointing at the new workflow job.
> 
> **Note for reviewers:** the `prepare` evaluate step still lists `supportedAgents` as `['codex', 'claude']` only (unchanged in this diff). If Cursor-labeled PRs should enter the loop, that guard may need a follow-up change or lives elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e1319395b8881bfb423c987c5b01f90f008f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->