### PR TITLE
fix(keepalive): normaliseConfig preserves verifier_agent / progress_review_threshold / complete_gate_failure_rounds

### DIFF
--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -177,6 +177,18 @@ failure_threshold: 4 # stop after 4
   assert.equal(config.failure_threshold, 4);
 });
 
+test('normaliseConfig preserves verifier_agent / progress_review_threshold / complete_gate_failure_rounds', () => {
+  const body = `
+<!-- keepalive-config:start -->
+{"keepalive_enabled": true, "verifier_agent": "claude", "progress_review_threshold": 6, "complete_gate_failure_rounds": 5}
+<!-- keepalive-config:end -->
+`;
+  const config = parseConfig(body);
+  assert.equal(config.verifier_agent, 'claude');
+  assert.equal(config.progress_review_threshold, 6);
+  assert.equal(config.complete_gate_failure_rounds, 5);
+});
+
 test('evaluateKeepaliveLoop waits when agent label is missing', async () => {
   const pr = {
     number: 101,

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1599,6 +1599,9 @@ function normaliseConfig(config = {}) {
     prompt_mode: promptMode,
     prompt_file: promptFile,
     prompt_scenario: promptScenario,
+    verifier_agent: normalise(cfg.verifier_agent),
+    progress_review_threshold: cfg.progress_review_threshold != null ? toNumber(cfg.progress_review_threshold, 4) : undefined,
+    complete_gate_failure_rounds: cfg.complete_gate_failure_rounds != null ? toNumber(cfg.complete_gate_failure_rounds, 3) : undefined,
   };
 }
 

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -1599,6 +1599,9 @@ function normaliseConfig(config = {}) {
     prompt_mode: promptMode,
     prompt_file: promptFile,
     prompt_scenario: promptScenario,
+    verifier_agent: normalise(cfg.verifier_agent),
+    progress_review_threshold: cfg.progress_review_threshold != null ? toNumber(cfg.progress_review_threshold, 4) : undefined,
+    complete_gate_failure_rounds: cfg.complete_gate_failure_rounds != null ? toNumber(cfg.complete_gate_failure_rounds, 3) : undefined,
   };
 }
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2323 -->
> **Source:** Issue #2323

Closes #2323

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`normaliseConfig` in `.github/scripts/keepalive_loop.js` (L1583) is the canonical normalizer for the PR-body keepalive config block — `parseConfig(body)` returns `normaliseConfig(parsed)` (L1605), and every consumer reads the normalised object. Verified on current `main`: `normaliseConfig` returns a **fixed object** that includes `keepalive_enabled`, `autofix_enabled`, `iteration`, `max_iterations`, `failure_threshold`, `trace`, `prompt_*` — but **omits** `verifier_agent`, `progress_review_threshold`, and `complete_gate_failure_rounds`.

Those three keys are then read off the normalised `config` and silently resolve to `undefined`:
- `config.progress_review_threshold` at `:2505` → falls back to `state.progress_review_threshold` (never written) → default `4`.
- `config.complete_gate_failure_rounds` at `:2511` → falls back to `state.complete_gate_failure_rounds_max` → default `3`.
- `config.verifier_agent` at `:2829` → falls back to `AGENT_ALTERNATES[agentType]` (auto codex↔claude).

Missing behavior: a PR author who sets `verifier_agent: claude`, `progress_review_threshold: 6`, or `complete_gate_failure_rounds: 5` in the keepalive config block is **silently ignored** — the knob never reaches the decision engine. This is a **current break** (verified the keys are absent from the return), though not an outage (the defaults are sane), so the independent-verifier-routing and review-threshold overrides are inert.

#### Tasks
- [ ] In `.github/scripts/keepalive_loop.js` `normaliseConfig` (return object at `:1589-1600`), add `verifier_agent: normalise(cfg.verifier_agent)`, `progress_review_threshold: toNumber(cfg.progress_review_threshold, undefined)` and `complete_gate_failure_rounds: toNumber(cfg.complete_gate_failure_rounds, undefined)` (preserve `undefined` when unset so the existing `?? state ?? default` fallbacks at `:2505/2511/2829` are unchanged when the knob is absent).
- [ ] In `.github/scripts/__tests__/keepalive-loop.test.js`, add a test `normaliseConfig preserves verifier_agent / progress_review_threshold / complete_gate_failure_rounds` that calls `parseConfig` on a body whose config block sets all three and asserts they appear on the returned object.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `node --test .github/scripts/__tests__/keepalive-loop.test.js` runs `normaliseConfig preserves verifier_agent / progress_review_threshold / complete_gate_failure_rounds`, which passes — asserting `config.verifier_agent === 'claude'`, `config.progress_review_threshold === 6`, `config.complete_gate_failure_rounds === 5` for a body setting those.
- [ ] **Deliberate-break gate:** temporarily delete the `verifier_agent` line from `normaliseConfig`'s return. The named test **must FAIL** on the `verifier_agent` assertion (value becomes `undefined`). Revert after capturing the failure.
- [ ] Regression: existing `normaliseConfig`/`parseConfig` tests in `keepalive-loop.test.js` still pass (defaults unchanged when the keys are absent from the body).

**Head SHA:** b9a2420d9527aa7e5cf489ab0a1c6818d82e3bed
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480731046) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732296) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27480732288) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27480732227) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732232) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732231) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732222) |
| Keepalive E2E | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732310) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732225) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732223) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732235) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480732224) |
<!-- auto-status-summary:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-plumbing fix with a focused unit test; defaults and fallbacks when keys are absent stay the same.
> 
> **Overview**
> **`normaliseConfig`** in `keepalive_loop.js` now forwards three PR-body keepalive knobs that were previously stripped after `parseConfig`: **`verifier_agent`**, **`progress_review_threshold`**, and **`complete_gate_failure_rounds`**. Numeric fields stay **`undefined`** when omitted so existing `config ?? state ?? default` behavior in the decision loop is unchanged.
> 
> The same change is mirrored in **`templates/consumer-repo/.github/scripts/keepalive_loop.js`**. A **`parseConfig`** unit test asserts all three values survive normalization when set in the config block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a2420d9527aa7e5cf489ab0a1c6818d82e3bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->