### PR TITLE
fix: route lock-held instructions to skip in keepalive worker gate

### DIFF
--- a/.github/scripts/__tests__/keepalive-worker-gate.test.js
+++ b/.github/scripts/__tests__/keepalive-worker-gate.test.js
@@ -217,3 +217,30 @@ test('keepalive worker gate executes when keepalive disabled', async () => {
   assert.equal(result.prNumber, '');
   assert.equal(result.headSha, '');
 });
+
+test('keepalive worker gate skips a lock-held (already-processed) instruction', async () => {
+  const instructionId = 300;
+  const headSha = 'bcd234';
+  const instructionComment = buildInstructionComment({ id: instructionId, trace: 'trace-lock-held', createdAt: '2024-01-01T02:00:00Z' });
+  // Build a github stub whose paginate returns both the instruction reaction ('hooray')
+  // and the lock reaction ('rocket') for the instruction comment, causing detectKeepalive
+  // to return reason:'lock-held' with deduped:'true'.
+  const lockReactions = [{ content: 'hooray' }, { content: 'rocket' }];
+  const baseStub = makeGithubStub({ prNumber: 123, headSha, comments: [instructionComment] });
+  const github = {
+    ...baseStub,
+    async paginate(method, params) {
+      if (method === this.rest.issues.listComments) {
+        return [instructionComment];
+      }
+      if (method === this.rest.reactions.listForIssueComment) {
+        return lockReactions;
+      }
+      return [];
+    },
+  };
+  const result = await evaluateKeepaliveWorkerGate({ core: makeCore(), github, context: baseContext, env: baseEnv });
+  assert.equal(result.action, 'skip');
+  assert.equal(result.reason, 'lock-held');
+  assert.equal(result.instructionId, String(instructionId));
+});

--- a/.github/scripts/keepalive_worker_gate.js
+++ b/.github/scripts/keepalive_worker_gate.js
@@ -140,7 +140,8 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
     reason === 'duplicate-keepalive' ||
     reason === 'keepalive-detected' ||
     reason === 'no-automation-source-context' ||
-    reason === 'fork-pr';
+    reason === 'fork-pr' ||
+    reason === 'lock-held';
   if (!isValid) {
     return null;
   }
@@ -309,6 +310,9 @@ async function evaluateKeepaliveWorkerGate({ core, github, context, env = proces
   } else if (latestInstruction?.reason === 'fork-pr') {
     action = 'skip';
     reason = 'fork-pr';
+  } else if (latestInstruction?.reason === 'lock-held') {
+    action = 'skip';
+    reason = 'lock-held';
   } else if (!latestInstruction) {
     reason = 'missing-instruction';
   } else if (lastProcessed.commentId === 0n || !lastProcessed.headSha || !headSha) {

--- a/templates/consumer-repo/.github/scripts/keepalive_worker_gate.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_worker_gate.js
@@ -140,7 +140,8 @@ async function detectInstructionComment({ github, context, comment, prNumber, en
     reason === 'duplicate-keepalive' ||
     reason === 'keepalive-detected' ||
     reason === 'no-automation-source-context' ||
-    reason === 'fork-pr';
+    reason === 'fork-pr' ||
+    reason === 'lock-held';
   if (!isValid) {
     return null;
   }
@@ -309,6 +310,9 @@ async function evaluateKeepaliveWorkerGate({ core, github, context, env = proces
   } else if (latestInstruction?.reason === 'fork-pr') {
     action = 'skip';
     reason = 'fork-pr';
+  } else if (latestInstruction?.reason === 'lock-held') {
+    action = 'skip';
+    reason = 'lock-held';
   } else if (!latestInstruction) {
     reason = 'missing-instruction';
   } else if (lastProcessed.commentId === 0n || !lastProcessed.headSha || !headSha) {


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2324 -->
> **Source:** Issue #2324

Closes #2324

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The keepalive worker gate (`.github/scripts/keepalive_worker_gate.js`) is supposed to skip an instruction that was already processed. Verified on current `main` that it **fails open** on the normal already-processed path:

- `detectKeepalive` (`.github/scripts/agents_pr_meta_keepalive.js`) returns `reason: 'lock-held'` with `deduped: 'true'` exactly when the keepalive comment **already carries the lock reaction** — i.e. it was already handled (`:651`, and the 409-conflict path `:672`).
- But the worker gate's instruction-validity filter (`keepalive_worker_gate.js:140-145`) only accepts `dispatch==='true'` or `reason ∈ { 'duplicate-keepalive', 'keepalive-detected', 'no-automation-source-context', 'fork-pr' }`. `'lock-held'` is **not** in that set (and `'duplicate-keepalive'` is a string `detectKeepalive` never emits — verified by grep).
- So an already-processed (lock-held) comment fails `isValid` → the builder returns `null` → `findLatestInstruction` drops it → the gate decision hits `!latestInstruction → reason = 'missing-instruction'` with `action` left at its initial `'execute'` (`:304-313`). The worker **re-executes an already-processed instruction**.

The state-comparison dedup at `:316-322` (`'no-new-instruction-and-head-unchanged'`) only runs when a *valid* instruction survives, which the lock-held comment never does — so in production the dedup is bypassed. The existing test `keepalive worker gate skips when no new instruction and head unchanged` (`keepalive-worker-gate.test.js:121`) passes only because its fixture takes the valid-instruction path and never sets the lock reaction. This is a **current break** (verified the lock-held reason is excluded from the validity set).

#### Tasks
- [ ] In `.github/scripts/keepalive_worker_gate.js`, make the instruction-validity check (`:139-145`) accept the already-processed signal — add `reason === 'lock-held'` (and/or honor `result.deduped === 'true'`) so the lock-held instruction is not dropped.
- [ ] In the gate decision (`:304-322`), add a branch so an instruction with `reason === 'lock-held'` (already deduped) sets `action = 'skip'` (mirroring the `no-automation-source-context` / `fork-pr` skip branches), rather than falling through to `execute`.
- [ ] In `.github/scripts/__tests__/keepalive-worker-gate.test.js`, add a test `keepalive worker gate skips a lock-held (already-processed) instruction` whose fixture comment carries the lock reaction so `detectKeepalive` returns `reason:'lock-held'`, asserting `result.action === 'skip'`.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `node --test .github/scripts/__tests__/keepalive-worker-gate.test.js` runs `keepalive worker gate skips a lock-held (already-processed) instruction`, which passes asserting `action === 'skip'` for a lock-reaction-bearing comment.
- [ ] **Deliberate-break gate:** temporarily revert the validity-set change (remove `'lock-held'`) so the lock-held instruction is dropped again. The named test **must FAIL** (`action` becomes `'execute'` via `missing-instruction`). Revert after capturing the failure.
- [ ] Regression: existing tests `keepalive worker gate skips when no new instruction and head unchanged` (`:121`), `... new-instruction` (`:149`), `... head-changed` (`:163`) still pass.

**Head SHA:** 4d87ec542d612d5ae47821ff489e3a53c34a1b90
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480733098) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27480734408) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27480734392) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27480734355) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734348) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27480734346) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734369) |
| Keepalive E2E | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734412) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734360) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734356) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734366) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480734358) |
<!-- auto-status-summary:end -->