### PR TITLE
fix: resolve WORKFLOWS_STEWARD from env or module location in round2_runner

### DIFF
--- a/scripts/repo_review_round2_runner.py
+++ b/scripts/repo_review_round2_runner.py
@@ -83,7 +83,7 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution
 # ---------------------------------------------------------------------------
 
 WORKFLOWS_STEWARD = Path(
-    "/Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Workflows-steward"
+    os.environ.get("REPO_REVIEW_STEWARD_ROOT") or Path(__file__).resolve().parent.parent
 )
 PROMPT_FILE = WORKFLOWS_STEWARD / "docs/ops/REPO_REVIEW_ROUND2_PROMPT.md"
 PROTOCOL_FILE = WORKFLOWS_STEWARD / "docs/ops/REPO_REVIEW_ROUND2_PROTOCOL.md"

--- a/tests/scripts/test_repo_review_round2_runner.py
+++ b/tests/scripts/test_repo_review_round2_runner.py
@@ -166,10 +166,10 @@ def test_steward_root_resolves_from_env_or_module(
     # --- env-set branch ---
     monkeypatch.setenv("REPO_REVIEW_STEWARD_ROOT", str(tmp_path))
     reloaded = importlib.reload(mod)
-    assert reloaded.WORKFLOWS_STEWARD == tmp_path
+    assert tmp_path == reloaded.WORKFLOWS_STEWARD
 
     # --- env-unset branch ---
     monkeypatch.delenv("REPO_REVIEW_STEWARD_ROOT", raising=False)
     reloaded2 = importlib.reload(mod)
     expected = Path(reloaded2.__file__).resolve().parent.parent
-    assert reloaded2.WORKFLOWS_STEWARD == expected
+    assert expected == reloaded2.WORKFLOWS_STEWARD

--- a/tests/scripts/test_repo_review_round2_runner.py
+++ b/tests/scripts/test_repo_review_round2_runner.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 from pathlib import Path
 
@@ -154,3 +155,21 @@ def test_synthesize_converged_surfaces_pending_candidate_as_deadlocked(tmp_path:
     assert payload["converged_candidates"] == []
     assert payload["deadlocked_candidates"][0]["title"] == "Keep approved repo-local work"
     assert payload["deadlocked_candidates"][0]["source_agent"] == "codex"
+
+
+def test_steward_root_resolves_from_env_or_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.repo_review_round2_runner as mod
+
+    # --- env-set branch ---
+    monkeypatch.setenv("REPO_REVIEW_STEWARD_ROOT", str(tmp_path))
+    reloaded = importlib.reload(mod)
+    assert reloaded.WORKFLOWS_STEWARD == tmp_path
+
+    # --- env-unset branch ---
+    monkeypatch.delenv("REPO_REVIEW_STEWARD_ROOT", raising=False)
+    reloaded2 = importlib.reload(mod)
+    expected = Path(reloaded2.__file__).resolve().parent.parent
+    assert reloaded2.WORKFLOWS_STEWARD == expected


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2327 -->
> **Source:** Issue #2327

Closes #2327

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The round-2 runner hardcodes a machine-specific absolute path, so round-2 negotiation silently degrades on any machine that is not the author's. Verified on current `main`:

- `scripts/repo_review_round2_runner.py:85-86` sets `WORKFLOWS_STEWARD = Path("/Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Workflows-steward")`, and derives `PROMPT_FILE`, `PROTOCOL_FILE`, `SCHEMA_FILE`, `SCHEMA_VALIDATOR` from it (`:88-91`).
- Round-1 does NOT do this: `scripts/repo_review_round1_runner.py:120` reads `os.environ.get("REPO_REVIEW_PROMPT_DIR")` and `:124` falls back to `Path(__file__).resolve().parent.parent` (the repo root). The coordinator also already knows the root — it passes `workflows_steward_root` as `cwd` to the round-2 subprocess (`repo_review_coordinator.py:430`).
- The round-2 runner itself lives at `<steward>/scripts/repo_review_round2_runner.py`, so `Path(__file__).resolve().parent.parent` *is* the steward root — the hardcode is gratuitous.

Missing behavior: env/repo-relative resolution. On any checkout whose absolute path is not the literal `/Users/teacher/.../Workflows-steward`, round-2 reads its prompt/protocol/schema from a nonexistent path and degrades (FileNotFound / empty prompt). This is **latent fragility on the author's machine** (where the path happens to exist) but a **hard break anywhere else** (verified the literal hardcode at `:85-86`).

#### Tasks
- [ ] In `scripts/repo_review_round2_runner.py`, replace the hardcoded `WORKFLOWS_STEWARD` (`:85-86`) with `WORKFLOWS_STEWARD = Path(os.environ.get("REPO_REVIEW_STEWARD_ROOT") or Path(__file__).resolve().parent.parent)`, keeping `PROMPT_FILE`/`PROTOCOL_FILE`/`SCHEMA_FILE`/`SCHEMA_VALIDATOR` derived from it (`:88-91`).
- [ ] (Optional, recommended) In `scripts/repo_review_coordinator.py`, pass `REPO_REVIEW_STEWARD_ROOT=str(workflows_steward_root)` in the round-2 subprocess `env` so resolution is explicit.
- [ ] In `tests/scripts/test_repo_review_round2_runner.py`, add `test_steward_root_resolves_from_env_or_module` that, using `importlib.reload` under a monkeypatched env, asserts `WORKFLOWS_STEWARD` equals the env value when `REPO_REVIEW_STEWARD_ROOT` is set, and equals `Path(<module>).resolve().parent.parent` when it is unset.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/scripts/test_repo_review_round2_runner.py::test_steward_root_resolves_from_env_or_module` passes — env-set → `WORKFLOWS_STEWARD == <tmp dir>`; env-unset → `WORKFLOWS_STEWARD == Path(module).resolve().parent.parent`.
- [ ] **Deliberate-break gate:** temporarily restore the hardcoded `WORKFLOWS_STEWARD = Path("/Users/teacher/.../Workflows-steward")`. The named test **must FAIL** (resolves to the literal path, not the env/module root). Revert after capturing the failure.
- [ ] Regression: the existing `tests/scripts/test_repo_review_round2_runner.py` suite still passes.

**Head SHA:** a5e1b1272e8b830293c7a6a74df055250240e8e7
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479893973) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27479893977) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479893908) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479893971) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479893926) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479893909) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479893907) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479893919) |
<!-- auto-status-summary:end -->