### PR TITLE
fix: finaliseSkip writes skip-count marker comment (issue #2325)

### DIFF
--- a/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
+++ b/.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js
@@ -4,7 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
-const { SKIP_MARKER } = require('../keepalive_guard_utils');
+const { SKIP_MARKER, analyseSkipComments } = require('../keepalive_guard_utils');
 
 function createSummary() {
   return {
@@ -545,7 +545,61 @@ test('runKeepaliveGate routes incomplete draft PRs to human', async () => {
   assert.deepEqual(github.__calls.labelAdds.map((call) => call.labels), [
     ['agent:needs-attention', 'needs-human', 'agents:paused'],
   ]);
-  assert.equal(github.__calls.commentsCreated.length, 1);
-  assert.match(github.__calls.commentsCreated[0].body, /Draft PR requires human disposition/);
+  assert.ok(github.__calls.commentsCreated.length >= 1);
+  assert.ok(
+    github.__calls.commentsCreated.some((c) => /Draft PR requires human disposition/.test(c.body)),
+    'expected a draft-disposition comment to be posted'
+  );
+  restore();
+});
+
+test('finaliseSkip posts a skip-count marker comment that analyseSkipComments reads back', async () => {
+  const { core, outputs } = createCore();
+  const gateStub = async () => createGateResult();
+  const { runKeepaliveGate, restore } = loadRunnerWithGate(gateStub);
+
+  // PR with missing keepalive label so the runner will call finaliseSkip
+  const pr = makePullRequest({
+    labels: [],
+  });
+  const github = createGithub({
+    pull: pr,
+    runsByWorkflow: {
+      'pr-00-gate.yml': [
+        { head_sha: 'abc123', status: 'completed', conclusion: 'success' },
+      ],
+    },
+    // No prior skip comments — nextSkipCount will be 1 normally, but we
+    // supply a skipCount of 3 by pre-seeding highestCount via comments.
+    comments: [
+      { body: `${SKIP_MARKER}\n<!-- keepalive-skip-count: 2 -->\nKeepalive 1 trace-1 skipped: missing-label:agents:keepalive` },
+    ],
+  });
+
+  await runKeepaliveGate({
+    core,
+    github,
+    context: { repo: { owner: 'octo', repo: 'demo' }, runId: 42 },
+    env: makeEnv({ KEEPALIVE_MAX_RETRIES: '5' }),
+  });
+
+  assert.equal(outputs.proceed, 'false');
+
+  // Exactly one skip-count comment should have been posted (the draft-disposition
+  // comment is only posted for draft-needs-human; this is a label-missing skip).
+  const skipComments = github.__calls.commentsCreated.filter((c) =>
+    c.body.includes(SKIP_MARKER)
+  );
+  assert.equal(skipComments.length, 1, 'expected exactly one skip-count marker comment');
+
+  const postedBody = skipComments[0].body;
+
+  // The comment must carry the skip-count marker so analyseSkipComments can parse it.
+  assert.match(postedBody, /<!--\s*keepalive-skip-count:\s*3\s*-->/i);
+
+  // Round-trip: feed the posted comment to analyseSkipComments and verify highestCount.
+  const analysis = analyseSkipComments([{ body: postedBody }]);
+  assert.equal(analysis.highestCount, 3, `expected highestCount === 3, got ${analysis.highestCount}`);
+
   restore();
 });

--- a/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -5,6 +5,7 @@
 const {
   analyseSkipComments,
   isGateReason,
+  SKIP_MARKER,
 } = require('./keepalive_guard_utils.js');
 const { evaluateKeepaliveGate } = require('./keepalive_gate.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
@@ -272,6 +273,25 @@ async function runKeepaliveGate({ core, github, context, env }) {
     await summary.write();
 
     setOutputs(false, reason);
+
+    if (options.skipCount > 0 && Number.isFinite(options.skipCount)) {
+      const commentBody = [
+        SKIP_MARKER,
+        `<!-- keepalive-skip-count: ${options.skipCount} -->`,
+        line,
+      ].join('\n');
+      try {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: commentBody,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        core.warning(`Unable to post skip-count marker comment for PR #${prNumber}: ${message}`);
+      }
+    }
   };
 
   if (!keepaliveEnabled || !trace) {

--- a/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_orchestrator_gate_runner.js
@@ -5,6 +5,7 @@
 const {
   analyseSkipComments,
   isGateReason,
+  SKIP_MARKER,
 } = require('./keepalive_guard_utils.js');
 const { evaluateKeepaliveGate } = require('./keepalive_gate.js');
 const { ensureRateLimitWrapped } = require('./github-rate-limited-wrapper.js');
@@ -272,6 +273,25 @@ async function runKeepaliveGate({ core, github, context, env }) {
     await summary.write();
 
     setOutputs(false, reason);
+
+    if (options.skipCount > 0 && Number.isFinite(options.skipCount)) {
+      const commentBody = [
+        SKIP_MARKER,
+        `<!-- keepalive-skip-count: ${options.skipCount} -->`,
+        line,
+      ].join('\n');
+      try {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: prNumber,
+          body: commentBody,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        core.warning(`Unable to post skip-count marker comment for PR #${prNumber}: ${message}`);
+      }
+    }
   };
 
   if (!keepaliveEnabled || !trace) {


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2325 -->
> **Source:** Issue #2325

Closes #2325

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The keepalive skip-history circuit-breaker reads skip-count marker comments that **nothing writes**, so persistently-failing rounds never escalate. Verified on current `main`:

- The reader: `analyseSkipComments` in `.github/scripts/keepalive_guard_utils.js` scans PR comments for `SKIP_MARKER` (`<!-- keepalive-skip -->`, `:3`) and `SKIP_COUNT_REGEX` (`<!-- keepalive-skip-count: N -->`, `:4`), returning `highestCount` (read at `:61`/`:70`). The orchestrator gate runner uses that history to fire `too-many-failures` at `keepalive_orchestrator_gate_runner.js:571/:581`.
- The writer that should post those comments does not exist. `finaliseSkip` (`keepalive_orchestrator_gate_runner.js:268-275`) only does `summary.addRaw(line).addEOL(); await summary.write();` — it writes the **GitHub Step Summary**, not a PR comment — and it **ignores `options.skipCount`** even though every caller passes `{ skipCount: nextSkipCount }` (`:571-590`). Verified: there is **no `SKIP_MARKER` reference anywhere** in `keepalive_orchestrator_gate_runner.js`.

Result: `analyseSkipComments` always returns `highestCount: 0` in production, so `priorSkips`/`priorNonGate` never accumulate across rounds and `too-many-failures` never fires — a persistently-failing PR retries forever instead of escalating. This is a **current break** (verified the reader has no producer).

#### Tasks
- [ ] In `finaliseSkip` (`.github/scripts/keepalive_orchestrator_gate_runner.js:268`), when `options.skipCount` is a positive number, create-or-update a single PR comment whose body contains `SKIP_MARKER` (import from `keepalive_guard_utils.js`), a `<!-- keepalive-skip-count: ${options.skipCount} -->` line, and a reason line matching `SKIP_REASON_REGEX` (e.g. `Keepalive ${round} ${agent} skipped: ${reason}`).
- [ ] Reuse the existing `github.rest.issues.createComment` pattern (the file already calls it at `:213`); prefer find-and-update of a prior marker comment over duplicate posts.
- [ ] In `.github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js`, add a test `finaliseSkip posts a skip-count marker comment that analyseSkipComments reads back` that captures the posted comment body, feeds it to `analyseSkipComments`, and asserts `highestCount === <skipCount>`.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `node --test .github/scripts/__tests__/keepalive-orchestrator-gate-runner.test.js` runs `finaliseSkip posts a skip-count marker comment that analyseSkipComments reads back`, which passes — a skip with `skipCount: 3` posts a comment whose body, fed to `analyseSkipComments`, yields `highestCount === 3`.
- [ ] **Deliberate-break gate:** temporarily remove the comment-write from `finaliseSkip` (restore step-summary-only). The named test **must FAIL** (no marker comment captured → `highestCount === 0`). Revert after capturing the failure.
- [ ] Regression: existing `keepalive-orchestrator-gate-runner.test.js` tests still pass (step-summary + outputs behavior unchanged).

**Head SHA:** 6357844369becd5f19c14a102ac3a26b7421132c
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480735162) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736531) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27480736522) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27480736446) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736452) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736440) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736441) |
| Keepalive E2E | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736517) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736437) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736453) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736434) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27480736447) |
<!-- auto-status-summary:end -->