### PR TITLE
fix: spawn agent in new session and use killpg to terminate process group

### DIFF
--- a/scripts/repo_review_heartbeat.py
+++ b/scripts/repo_review_heartbeat.py
@@ -134,6 +134,7 @@ def run_with_heartbeat(
             stdout=log_handle,
             stderr=subprocess.STDOUT,
             text=True,
+            start_new_session=True,
         )
     except OSError as exc:
         log_handle.close()
@@ -245,11 +246,11 @@ def run_with_heartbeat(
 
         # Reached only on stuck or timed_out. Terminate.
         try:
-            proc.send_signal(signal.SIGTERM)
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             try:
                 proc.wait(timeout=15)
             except subprocess.TimeoutExpired:
-                proc.kill()
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                 proc.wait(timeout=5)
         except ProcessLookupError:
             pass

--- a/tests/scripts/test_repo_review_heartbeat.py
+++ b/tests/scripts/test_repo_review_heartbeat.py
@@ -21,8 +21,11 @@ would defeat the purpose. Each test runs in well under 5s.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import time
 from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
 from scripts import repo_review_heartbeat as heartbeat
 
@@ -253,3 +256,52 @@ def test_sentinel_directory_is_created_on_demand(tmp_path: Path) -> None:
     assert result.succeeded is True
     assert nested_log.exists()
     assert result.sentinel_path.exists()
+
+
+def test_spawn_uses_new_session_and_killpg(tmp_path: Path) -> None:
+    """Popen must be called with start_new_session=True, and the terminate path
+    must use os.killpg (not proc.send_signal / proc.kill) on stall/timeout."""
+    log = tmp_path / "killpg_test.log"
+    fake_pgid = 99999
+
+    # Build a mock proc that looks alive for one heartbeat tick then triggers
+    # the stall/timeout path by never advancing mtime.
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    # poll() returning None means the process is still running (drives the loop)
+    # then returning 0 after terminate to unblock proc.wait().
+    mock_proc.poll.return_value = None
+    mock_proc.wait.return_value = 0
+
+    with (
+        patch("subprocess.Popen", return_value=mock_proc) as mock_popen,
+        patch("os.killpg") as mock_killpg,
+        patch("os.getpgid", return_value=fake_pgid),
+    ):
+        # Use timeout=1 and stall_threshold=1 so the loop terminates quickly.
+        # log_file is never written, so mtime stays None and stall_for grows.
+        heartbeat.run_with_heartbeat(
+            ["fake-agent", "--arg"],
+            prompt=None,
+            cwd=tmp_path,
+            env=None,
+            log_file=log,
+            timeout=1,
+            heartbeat_interval=1,
+            stall_threshold=1,
+            label="killpg-test",
+        )
+
+    # Assert Popen was called with start_new_session=True
+    assert mock_popen.call_count == 1
+    _, popen_kwargs = mock_popen.call_args
+    assert popen_kwargs.get("start_new_session") is True, (
+        "Popen must be called with start_new_session=True"
+    )
+
+    # Assert os.killpg was called at least once with the process group id
+    assert mock_killpg.call_count >= 1, "os.killpg must be called on the terminate path"
+    first_killpg_call = mock_killpg.call_args_list[0]
+    assert first_killpg_call.args[0] == fake_pgid, (
+        f"os.killpg first arg must be the pgid ({fake_pgid}), got {first_killpg_call.args[0]}"
+    )

--- a/tests/scripts/test_repo_review_heartbeat.py
+++ b/tests/scripts/test_repo_review_heartbeat.py
@@ -21,11 +21,9 @@ would defeat the purpose. Each test runs in well under 5s.
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from scripts import repo_review_heartbeat as heartbeat
 
@@ -295,13 +293,13 @@ def test_spawn_uses_new_session_and_killpg(tmp_path: Path) -> None:
     # Assert Popen was called with start_new_session=True
     assert mock_popen.call_count == 1
     _, popen_kwargs = mock_popen.call_args
-    assert popen_kwargs.get("start_new_session") is True, (
-        "Popen must be called with start_new_session=True"
-    )
+    assert (
+        popen_kwargs.get("start_new_session") is True
+    ), "Popen must be called with start_new_session=True"
 
     # Assert os.killpg was called at least once with the process group id
     assert mock_killpg.call_count >= 1, "os.killpg must be called on the terminate path"
     first_killpg_call = mock_killpg.call_args_list[0]
-    assert first_killpg_call.args[0] == fake_pgid, (
-        f"os.killpg first arg must be the pgid ({fake_pgid}), got {first_killpg_call.args[0]}"
-    )
+    assert (
+        first_killpg_call.args[0] == fake_pgid
+    ), f"os.killpg first arg must be the pgid ({fake_pgid}), got {first_killpg_call.args[0]}"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2328 -->
> **Source:** Issue #2328

Closes #2328

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo-review heartbeat spawns agents in a way that orphans their descendant process trees on stall/timeout — a plausible contributor to the documented "leaked Claude Code agent processes" slowness incident that required a launchd reaper. Verified on current `main`:

- `scripts/repo_review_heartbeat.py:129` spawns the agent with `subprocess.Popen(cmd, cwd=…, env=…, stdin=…, stdout=log_handle, stderr=STDOUT)` — **no `start_new_session=True`**, so the child shares the parent's process group.
- The terminate path (`:248-252`) does `proc.send_signal(signal.SIGTERM)` → `proc.wait(15)` → `proc.kill()` — it signals/kills **only the direct child**, not its descendants. There is no `os.killpg`.
- The agent (`codex` / `claude`) spawns its own subprocess tree; when the heartbeat declares the agent stuck and kills only `proc`, those grandchildren are **orphaned and keep running**.

Missing behavior: group-based spawn + reap. This is a **current break** (verified `Popen` lacks `start_new_session=True` and the kill path is direct-child-only) on POSIX (macOS/Linux), which is where the lanes and CI run.

#### Tasks
- [ ] In `scripts/repo_review_heartbeat.py:129`, add `start_new_session=True` to the `subprocess.Popen(...)` call so the agent leads its own session/process group.
- [ ] In the terminate path (`:248-252`), replace the direct `proc.send_signal(SIGTERM)` / `proc.kill()` with `os.killpg(os.getpgid(proc.pid), signal.SIGTERM)` → `proc.wait(timeout=15)` → on `TimeoutExpired`, `os.killpg(os.getpgid(proc.pid), signal.SIGKILL)`, keeping the surrounding `ProcessLookupError` guard.
- [ ] In `tests/scripts/test_repo_review_heartbeat.py`, add `test_spawn_uses_new_session_and_killpg` that monkeypatches `subprocess.Popen` and `os.killpg`, asserts `Popen` was called with `start_new_session=True`, and asserts `os.killpg` is invoked (with the child's pgid) on the stall/timeout terminate path.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/scripts/test_repo_review_heartbeat.py::test_spawn_uses_new_session_and_killpg` passes — asserting `Popen(..., start_new_session=True)` and that `os.killpg` is called on terminate.
- [ ] **Deliberate-break gate:** temporarily remove `start_new_session=True` from the `Popen` call. The named test **must FAIL** on the `start_new_session` assertion. Revert after capturing the failure.
- [ ] Regression: the existing `tests/scripts/test_repo_review_heartbeat.py` suite still passes.

**Head SHA:** 13f1902e36d637962aab640534afe18c7201a918
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479915853) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27479915858) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479915849) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479915856) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479915843) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479915842) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479915846) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479915863) |
<!-- auto-status-summary:end -->