### PR TITLE
fix: size round-2 subprocess timeout to full multi-turn budget

### DIFF
--- a/scripts/repo_review_coordinator.py
+++ b/scripts/repo_review_coordinator.py
@@ -333,6 +333,22 @@ def run_subprocess(
 # ---------------------------------------------------------------------------
 
 
+def round2_subprocess_timeout(
+    round2_timeout: int,
+    max_turns: int,
+    n_agents: int,
+    buffer: int = 1500,
+) -> int:
+    """Return the subprocess wrapper timeout for the full multi-turn round-2 budget.
+
+    ``round2_timeout`` is the per-agent-turn budget (passed as ``--turn-timeout``
+    to the runner).  The runner's legitimate worst-case runtime is
+    ``max_turns * n_agents * round2_timeout`` plus a fixed buffer for synthesis
+    and overhead.
+    """
+    return max_turns * n_agents * round2_timeout + buffer
+
+
 def coordinate_repo(
     *,
     repo: str,
@@ -343,6 +359,7 @@ def coordinate_repo(
     log_dir: Path,
     round1_timeout: int,
     round2_timeout: int,
+    max_turns: int,
     skip_gate_enabled: bool,
 ) -> dict[str, Any]:
     """Run the full Phase-4 flow for one repo. Returns a small report dict."""
@@ -430,7 +447,7 @@ def coordinate_repo(
         cwd=workflows_steward_root,
         log_path=repo_log_dir / "round2-runner.log",
         name="round-2",
-        timeout=round2_timeout + 1500,
+        timeout=round2_subprocess_timeout(round2_timeout, max_turns, len(agents)),
     )
     report["round2"] = {
         "succeeded": r2_result.succeeded,
@@ -572,6 +589,7 @@ def run(args: argparse.Namespace) -> int:
             log_dir=log_dir,
             round1_timeout=args.round1_timeout,
             round2_timeout=args.round2_timeout,
+            max_turns=args.max_turns,
             skip_gate_enabled=not args.disable_skip_gate,
         )
         reports.append(report)
@@ -802,6 +820,12 @@ def main() -> int:
         type=int,
         default=45 * 60,
         help="hard timeout per round-2 agent-turn in seconds (default: 2700)",
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=3,
+        help="maximum negotiation turns per round-2 run (default: 3)",
     )
     parser.add_argument(
         "--disable-skip-gate",

--- a/tests/scripts/test_repo_review_coordinator.py
+++ b/tests/scripts/test_repo_review_coordinator.py
@@ -109,6 +109,7 @@ def test_coordinate_repo_writes_skip_converged_and_round2_state(
         log_dir=output_dir / "logs" / "coordinator",
         round1_timeout=30,
         round2_timeout=30,
+        max_turns=3,
         skip_gate_enabled=True,
     )
 
@@ -156,6 +157,7 @@ def test_coordinate_repo_allows_mocked_round1_to_round2_state_progression(
         log_dir=output_dir / "logs" / "coordinator",
         round1_timeout=30,
         round2_timeout=30,
+        max_turns=3,
         skip_gate_enabled=False,
     )
 
@@ -214,6 +216,7 @@ def test_run_orders_docs_drift_between_backlog_and_notify(tmp_path: Path, monkey
         skip_gitnexus_preflight=False,
         round1_timeout=30,
         round2_timeout=30,
+        max_turns=3,
         disable_skip_gate=True,
         skip_auto_archive=True,
     )
@@ -280,6 +283,7 @@ def test_run_keeps_docs_drift_failure_non_fatal(tmp_path: Path, monkeypatch) -> 
         skip_gitnexus_preflight=False,
         round1_timeout=30,
         round2_timeout=30,
+        max_turns=3,
         disable_skip_gate=True,
         skip_auto_archive=True,
     )
@@ -287,3 +291,13 @@ def test_run_keeps_docs_drift_failure_non_fatal(tmp_path: Path, monkeypatch) -> 
 
     assert rc == 0
     assert calls[-1] == "notify"
+
+
+def test_round2_subprocess_timeout_covers_multiturn_budget() -> None:
+    """The subprocess wrapper timeout must cover the full multi-turn budget.
+
+    Defaults: round2_timeout=2700, max_turns=3, n_agents=2.
+    Worst-case runtime = 3 * 2 * 2700 = 16200s.
+    """
+    result = coordinator.round2_subprocess_timeout(2700, 3, 2)
+    assert result >= 3 * 2 * 2700


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2326 -->
> **Source:** Issue #2326

Closes #2326

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo-review coordinator SIGKILLs legitimate multi-turn round-2 negotiations because its subprocess wrapper timeout is sized to a single turn. Verified on current `main`:

- `repo_review_coordinator.py:433` runs the round-2 runner with `timeout=round2_timeout + 1500`. `round2_timeout` defaults to `45 * 60 = 2700` (`--round2-timeout`, `:801-804`) and is the **per-agent-turn** budget — it is passed straight through as `--turn-timeout` at `:424-426`.
- The round-2 runner (`scripts/repo_review_round2_runner.py`) repeats up to `--max-turns` turns (`DEFAULT_MAX_TURNS = 3`, `:93`) across `DEFAULT_AGENTS = ("codex","claude")` (`:92`). Its legitimate worst-case runtime is therefore `max_turns × n_agents × round2_timeout = 3 × 2 × 2700 = 16,200s` (plus synthesis/overhead).
- But the wrapper kills the subprocess at `round2_timeout + 1500 = 4,200s` — roughly **3.8× too early**. A negotiation that legitimately needs multiple turns is `subprocess.TimeoutExpired`-killed mid-flight (`run_subprocess` at `:287-313`).

This is a **current break** (verified the wrapper cap is 4,200s while the multi-turn budget is ≥16,200s): the per-turn budget is being used as the whole-runner budget.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2272](https://github.com/stranske/Workflows/issues/2272)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] In `scripts/repo_review_coordinator.py`, add a helper `round2_subprocess_timeout(round2_timeout, max_turns, n_agents, buffer=1500)` returning `max_turns * n_agents * round2_timeout + buffer`, and use it for the `timeout=` of the round-2 `run_subprocess` call (currently `round2_timeout + 1500` at `:433`).
- [ ] Thread `max_turns` (from `args.max_turns` / `DEFAULT_MAX_TURNS`) and `n_agents = len(agents)` into the round-2 orchestration scope so the helper can be called (the function already has `agents` and `round2_timeout` at `:344-345`).
- [ ] In `tests/scripts/test_repo_review_coordinator.py`, add `test_round2_subprocess_timeout_covers_multiturn_budget` asserting `round2_subprocess_timeout(2700, 3, 2) >= 3 * 2 * 2700`.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/scripts/test_repo_review_coordinator.py::test_round2_subprocess_timeout_covers_multiturn_budget` passes — asserts the computed wrapper timeout for defaults is `>= 16200`.
- [ ] **Deliberate-break gate:** temporarily revert the round-2 `timeout=` back to `round2_timeout + 1500`. With that, `test_round2_subprocess_timeout_covers_multiturn_budget` **must FAIL** (4200 < 16200). Revert after capturing the failure.
- [ ] Regression: the existing `tests/scripts/test_repo_review_coordinator.py` suite still passes (`python -m pytest tests/scripts/test_repo_review_coordinator.py`).

**Head SHA:** 2c5317cd91eee10ee8fd670ac42e0b859851f3cd
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label Dependabot PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/27479806564) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806780) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27479806815) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479806959) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806706) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806703) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806689) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806688) |
| Running Copilot Code Review | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27479808262) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27479806707) |
<!-- auto-status-summary:end -->