### PR TITLE
fix: resolve reusable CI helper checkouts to the pinned ref (#2346)

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -172,13 +172,6 @@ on:
         description: Working directory for all run steps (useful for monorepos).
         required: false
         default: '.'
-      workflows_ref:
-        description: >-
-          The ref of the Workflows repo to check out for helper code/actions.
-          Defaults to main for manual workflow_dispatch runs.
-        required: false
-        default: 'main'
-        type: string
       python-versions:
         description: JSON array of Python versions to execute.
         required: false

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: '.'
         type: string
+      workflows_ref:
+        description: >-
+          The ref of the Workflows repo to check out for helper code/actions.
+          A consumer that pins this reusable at a tag or SHA should pass the
+          same ref here so the helper checkouts resolve to that pin instead of
+          main-HEAD. Defaults to main for backward compatibility with callers
+          that ride `@main`.
+        required: false
+        default: 'main'
+        type: string
       python-version:
         description: Primary Python version to use when `python-versions` is not provided.
         required: false
@@ -393,7 +403,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
-          ref: main
+          # Resolve helpers to the ref this reusable was pinned at (consumers
+          # pass workflows_ref matching their `@ref`); defaults to main.
+          ref: ${{ inputs.workflows_ref }}
           path: .workflows-lib
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -706,7 +718,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
-          ref: main
+          # Resolve helpers to the ref this reusable was pinned at (consumers
+          # pass workflows_ref matching their `@ref`); defaults to main.
+          ref: ${{ inputs.workflows_ref }}
           path: .workflows-lib
           sparse-checkout: |
             scripts/reusable_ci_scope.py
@@ -1501,7 +1515,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
-          ref: main
+          # Resolve helpers to the ref this reusable was pinned at (consumers
+          # pass workflows_ref matching their `@ref`); defaults to main.
+          ref: ${{ inputs.workflows_ref }}
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
@@ -2449,7 +2465,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
-          ref: main
+          # Resolve helpers to the ref this reusable was pinned at (consumers
+          # pass workflows_ref matching their `@ref`); defaults to main.
+          ref: ${{ inputs.workflows_ref }}
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -172,6 +172,13 @@ on:
         description: Working directory for all run steps (useful for monorepos).
         required: false
         default: '.'
+      workflows_ref:
+        description: >-
+          The ref of the Workflows repo to check out for helper code/actions.
+          Defaults to main for manual workflow_dispatch runs.
+        required: false
+        default: 'main'
+        type: string
       python-versions:
         description: JSON array of Python versions to execute.
         required: false
@@ -405,7 +412,7 @@ jobs:
           repository: stranske/Workflows
           # Resolve helpers to the ref this reusable was pinned at (consumers
           # pass workflows_ref matching their `@ref`); defaults to main.
-          ref: ${{ inputs.workflows_ref }}
+          ref: ${{ inputs.workflows_ref || 'main' }}
           path: .workflows-lib
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -720,7 +727,7 @@ jobs:
           repository: stranske/Workflows
           # Resolve helpers to the ref this reusable was pinned at (consumers
           # pass workflows_ref matching their `@ref`); defaults to main.
-          ref: ${{ inputs.workflows_ref }}
+          ref: ${{ inputs.workflows_ref || 'main' }}
           path: .workflows-lib
           sparse-checkout: |
             scripts/reusable_ci_scope.py
@@ -1517,7 +1524,7 @@ jobs:
           repository: stranske/Workflows
           # Resolve helpers to the ref this reusable was pinned at (consumers
           # pass workflows_ref matching their `@ref`); defaults to main.
-          ref: ${{ inputs.workflows_ref }}
+          ref: ${{ inputs.workflows_ref || 'main' }}
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
@@ -2467,7 +2474,7 @@ jobs:
           repository: stranske/Workflows
           # Resolve helpers to the ref this reusable was pinned at (consumers
           # pass workflows_ref matching their `@ref`); defaults to main.
-          ref: ${{ inputs.workflows_ref }}
+          ref: ${{ inputs.workflows_ref || 'main' }}
           path: .workflows-lib
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |

--- a/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
+++ b/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
@@ -34,10 +34,10 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_REL = ".github/workflows/reusable-10-ci-python.yml"
 WORKFLOW_PATH = ROOT / WORKFLOW_REL
 
-# A checkout step line of the form `        ref: main` (any indentation). The
-# input default `default: 'main'` and `ref: ${{ inputs.workflows_ref }}` must
-# NOT match. This is the line the issue's deliberate-break gate re-introduces.
-_REF_MAIN_LINE = re.compile(r"^\s*ref:\s*main\s*$", re.MULTILINE)
+# A checkout step line of the form `ref: main`, including quoted values and
+# trailing comments. The input default `default: 'main'` and expressions like
+# `ref: ${{ inputs.workflows_ref || 'main' }}` must NOT match.
+_REF_MAIN_LINE = re.compile(r"^\s*ref:\s*(['\"]?)main\1\s*(?:#.*)?$", re.MULTILINE)
 
 
 def _load_workflow() -> dict:
@@ -56,14 +56,36 @@ def test_no_hardcoded_ref_main() -> None:
     )
 
 
+def test_ref_main_guard_catches_quoted_and_commented_literals() -> None:
+    """The guard catches the common YAML spellings of a hardcoded main ref."""
+    offenders = [
+        "ref: main",
+        "  ref: main  # deliberate break",
+        'ref: "main"',
+        "ref: 'main'",
+    ]
+    allowed = [
+        "default: 'main'",
+        "ref: ${{ inputs.workflows_ref }}",
+        "ref: ${{ inputs.workflows_ref || 'main' }}",
+        "ref: mainline",
+    ]
+    for line in offenders:
+        assert _REF_MAIN_LINE.match(line), line
+    for line in allowed:
+        assert not _REF_MAIN_LINE.match(line), line
+
+
 def test_workflows_ref_input_declared() -> None:
     """The reusable exposes a backward-compatible ``workflows_ref`` input."""
     data = _load_workflow()
-    inputs = (data.get(True) or data.get("on") or {})["workflow_call"]["inputs"]
-    assert "workflows_ref" in inputs, "missing `workflows_ref` workflow_call input"
-    spec = inputs["workflows_ref"]
-    assert spec.get("required") is False, "`workflows_ref` must be optional"
-    assert spec.get("default") == "main", "`workflows_ref` must default to main"
+    triggers = data.get(True) or data.get("on") or {}
+    for trigger in ("workflow_call", "workflow_dispatch"):
+        inputs = triggers[trigger]["inputs"]
+        assert "workflows_ref" in inputs, f"missing `workflows_ref` {trigger} input"
+        spec = inputs["workflows_ref"]
+        assert spec.get("required") is False, f"{trigger} `workflows_ref` must be optional"
+        assert spec.get("default") == "main", f"{trigger} `workflows_ref` must default to main"
 
 
 def test_workflows_checkouts_use_workflows_ref_input() -> None:

--- a/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
+++ b/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
@@ -1,0 +1,90 @@
+"""Static guard: ``reusable-10-ci-python.yml`` must not hardcode ``ref: main``
+on its Workflows helper checkouts.
+
+Background — why this test exists
+=================================
+Issue #2346: ``.github/workflows/reusable-10-ci-python.yml`` checked out the
+Workflows helper code with a hardcoded ``ref: main`` at four sites. Because of
+this, a consumer who pinned the reusable at a tag or SHA
+(``uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@<sha>``)
+still executed **main-HEAD** helper scripts — so every merge to ``main`` was an
+instant, untestable-by-consumers, fleet-wide deploy of the helper layer.
+
+The fix mirrors the proven pattern already used by ``reusable-claude-run.yml``,
+``reusable-codex-run.yml`` and ``reusable-cursor-run.yml``: a ``workflows_ref``
+``workflow_call`` input (``required: false``, ``default: 'main'``) that the
+consumer passes to match the ``@ref`` it pinned the reusable at. The helper
+checkouts then resolve to ``${{ inputs.workflows_ref }}`` instead of the literal
+``main``. Callers that ride ``@main`` and pass nothing keep the old behaviour
+via the default, so the change is backward compatible.
+
+This test closes the regression gap: it asserts (a) no literal ``ref: main``
+remains on any line, and (b) every ``actions/checkout`` of ``stranske/Workflows``
+resolves its ref through the ``workflows_ref`` input.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_REL = ".github/workflows/reusable-10-ci-python.yml"
+WORKFLOW_PATH = ROOT / WORKFLOW_REL
+
+# A checkout step line of the form `        ref: main` (any indentation). The
+# input default `default: 'main'` and `ref: ${{ inputs.workflows_ref }}` must
+# NOT match. This is the line the issue's deliberate-break gate re-introduces.
+_REF_MAIN_LINE = re.compile(r"^\s*ref:\s*main\s*$", re.MULTILINE)
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_no_hardcoded_ref_main() -> None:
+    """No helper checkout may pin ``ref: main`` literally."""
+    assert WORKFLOW_PATH.exists(), f"missing workflow file: {WORKFLOW_REL}"
+    src = WORKFLOW_PATH.read_text(encoding="utf-8")
+    offenders = [i + 1 for i, line in enumerate(src.splitlines()) if _REF_MAIN_LINE.match(line)]
+    assert not offenders, (
+        f"{WORKFLOW_REL}: found hardcoded `ref: main` on line(s) {offenders}. "
+        "Use `ref: ${{ inputs.workflows_ref }}` so consumers that pin this "
+        "reusable get matching helper code instead of main-HEAD."
+    )
+
+
+def test_workflows_ref_input_declared() -> None:
+    """The reusable exposes a backward-compatible ``workflows_ref`` input."""
+    data = _load_workflow()
+    inputs = (data.get(True) or data.get("on") or {})["workflow_call"]["inputs"]
+    assert "workflows_ref" in inputs, "missing `workflows_ref` workflow_call input"
+    spec = inputs["workflows_ref"]
+    assert spec.get("required") is False, "`workflows_ref` must be optional"
+    assert spec.get("default") == "main", "`workflows_ref` must default to main"
+
+
+def test_workflows_checkouts_use_workflows_ref_input() -> None:
+    """Every ``stranske/Workflows`` helper checkout resolves via the input."""
+    data = _load_workflow()
+    jobs = data.get("jobs", {})
+    checked = 0
+    for job_name, job in jobs.items():
+        for step in job.get("steps", []) or []:
+            uses = step.get("uses", "")
+            if not uses.startswith("actions/checkout"):
+                continue
+            with_block = step.get("with", {}) or {}
+            if with_block.get("repository") != "stranske/Workflows":
+                continue
+            ref = str(with_block.get("ref", ""))
+            checked += 1
+            assert "inputs.workflows_ref" in ref, (
+                f"job {job_name!r}: checkout of stranske/Workflows uses "
+                f"ref={ref!r}; expected `${{{{ inputs.workflows_ref }}}}`."
+            )
+    assert checked >= 4, (
+        f"expected to inspect the 4 known Workflows helper checkouts, " f"found {checked}"
+    )

--- a/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
+++ b/tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py
@@ -80,12 +80,11 @@ def test_workflows_ref_input_declared() -> None:
     """The reusable exposes a backward-compatible ``workflows_ref`` input."""
     data = _load_workflow()
     triggers = data.get(True) or data.get("on") or {}
-    for trigger in ("workflow_call", "workflow_dispatch"):
-        inputs = triggers[trigger]["inputs"]
-        assert "workflows_ref" in inputs, f"missing `workflows_ref` {trigger} input"
-        spec = inputs["workflows_ref"]
-        assert spec.get("required") is False, f"{trigger} `workflows_ref` must be optional"
-        assert spec.get("default") == "main", f"{trigger} `workflows_ref` must default to main"
+    inputs = triggers["workflow_call"]["inputs"]
+    assert "workflows_ref" in inputs, "missing `workflows_ref` workflow_call input"
+    spec = inputs["workflows_ref"]
+    assert spec.get("required") is False, "`workflows_ref` must be optional"
+    assert spec.get("default") == "main", "`workflows_ref` must default to main"
 
 
 def test_workflows_checkouts_use_workflows_ref_input() -> None:
@@ -106,6 +105,10 @@ def test_workflows_checkouts_use_workflows_ref_input() -> None:
             assert "inputs.workflows_ref" in ref, (
                 f"job {job_name!r}: checkout of stranske/Workflows uses "
                 f"ref={ref!r}; expected `${{{{ inputs.workflows_ref }}}}`."
+            )
+            assert "|| 'main'" in ref, (
+                f"job {job_name!r}: checkout of stranske/Workflows uses "
+                f"ref={ref!r}; expected a main fallback for workflow_dispatch runs."
             )
     assert checked >= 4, (
         f"expected to inspect the 4 known Workflows helper checkouts, " f"found {checked}"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2346 -->
> **Source:** Issue #2346

Closes #2346

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`reusable-10-ci-python.yml` checks out the Workflows helper code with a **hardcoded `ref: main`** at 4 sites (verified: L396, L709, L1504, L2452). Because of this, a consumer who pins the reusable at a tag or SHA (`uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@<sha>`) still executes **main-HEAD** helper scripts — so every merge to `main` is an instant, untestable-by-consumers, fleet-wide deploy of the helper layer (audit `map-ci` F1). Compounding it: the floating `v1` tag never advanced past v1.0.0 and all 27 caller sites ride `@main`, so the version-pin story is fiction.

This is a **current break** (verified the 4 `ref: main` checkouts). Missing behavior: a pinned caller should get the helper code matching its pin, not `main`.

#### Tasks
- [ ] In `.github/workflows/reusable-10-ci-python.yml`, replace each `ref: main` (L396, L709, L1504, L2452) so the helper checkout uses the reusable's resolved ref (e.g. `github.workflow_sha` / the `${{ github.sha }}` of the reusable-call, or an explicit `workflow_call` input the consumer passes), not the literal `main`.
- [ ] Add `tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py` asserting `reusable-10-ci-python.yml` contains zero `ref: main` occurrences.
- [ ] Perform the deliberate-break verification (see Acceptance), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py` passes — asserts 0 `ref: main` in `reusable-10-ci-python.yml`.
- [ ] **Deliberate-break gate:** temporarily re-add a `ref: main` to one helper checkout. The named test **must FAIL**. Revert after capturing the failure.
- [ ] A consumer pinned at a non-`main` ref runs helpers from that ref (documented live-verification, or an inline comment proving the resolved ref is the call ref, captured in the PR).

<!-- auto-status-summary:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout ref resolution for shared CI infrastructure used fleet-wide; default preserves `@main` behavior but incorrect `workflows_ref` from pinned callers could run mismatched helper code.
> 
> **Overview**
> Fixes **#2346**: pinned consumers of `reusable-10-ci-python.yml` no longer silently run **main-HEAD** Workflows helpers while the workflow YAML itself came from a tag/SHA.
> 
> Adds optional `workflow_call` input **`workflows_ref`** (default `main`) and switches all four `stranske/Workflows` sparse checkouts to **`ref: ${{ inputs.workflows_ref || 'main' }}`** instead of literal `ref: main`. Callers that pin the reusable should pass the same ref as their `uses: …@ref`; `@main` callers keep prior behavior without changes.
> 
> Adds **`tests/workflows/test_reusable_ci_no_hardcoded_ref_main.py`** to block regressions: no literal `ref: main` on checkout lines, input declared correctly, and every Workflows helper checkout references `inputs.workflows_ref` with a `main` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a290110446d768e7cf97eaf5779f7ff246ff630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->