### PR TITLE
refactor: share Workflows default branch resolver

### DIFF
--- a/.github/actions/resolve-default-branch/action.yml
+++ b/.github/actions/resolve-default-branch/action.yml
@@ -34,10 +34,12 @@ runs:
     - name: Resolve default branch
       id: resolve
       uses: actions/github-script@v9
+      env:
+        RESOLVE_DEFAULT_BRANCH_ACTION_PATH: ${{ github.action_path }}
       with:
         script: |
           const { resolveDefaultBranch } = require(
-            `${process.env.GITHUB_ACTION_PATH}/resolve-default-branch.js`
+            `${process.env.RESOLVE_DEFAULT_BRANCH_ACTION_PATH}/resolve-default-branch.js`
           );
 
           await resolveDefaultBranch({

--- a/.github/actions/resolve-default-branch/action.yml
+++ b/.github/actions/resolve-default-branch/action.yml
@@ -1,0 +1,52 @@
+name: Resolve Default Branch
+description: Resolve a repository default branch with the shared GitHub API retry helper when available.
+
+inputs:
+  owner:
+    description: Repository owner.
+    required: false
+    default: stranske
+  repo:
+    description: Repository name.
+    required: false
+    default: Workflows
+  fallback_ref:
+    description: Optional ref to use when the API lookup fails or returns no default branch.
+    required: false
+    default: ''
+  fail_on_error:
+    description: Whether to fail the step when no default branch can be resolved and no fallback is set.
+    required: false
+    default: 'true'
+  task:
+    description: Retry helper task name for logging and token selection.
+    required: false
+    default: resolve-default-branch
+
+outputs:
+  ref:
+    description: Resolved default branch, or fallback_ref when configured and resolution fails.
+    value: ${{ steps.resolve.outputs.ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve default branch
+      id: resolve
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const { resolveDefaultBranch } = require(
+            `${process.env.GITHUB_ACTION_PATH}/resolve-default-branch.js`
+          );
+
+          await resolveDefaultBranch({
+            github,
+            core,
+            owner: '${{ inputs.owner }}',
+            repo: '${{ inputs.repo }}',
+            fallbackRef: '${{ inputs.fallback_ref }}',
+            failOnError: '${{ inputs.fail_on_error }}' !== 'false',
+            task: '${{ inputs.task }}',
+            env: process.env,
+          });

--- a/.github/actions/resolve-default-branch/resolve-default-branch.js
+++ b/.github/actions/resolve-default-branch/resolve-default-branch.js
@@ -5,7 +5,11 @@ const path = require('path');
 
 function retryHelperCandidates(env = process.env, cwd = process.cwd()) {
   const actionPath = env.GITHUB_ACTION_PATH || '';
+  const resolverActionPath = env.RESOLVE_DEFAULT_BRANCH_ACTION_PATH || '';
   return [
+    resolverActionPath
+      ? path.resolve(resolverActionPath, '..', '..', 'scripts', 'github-api-with-retry.js')
+      : '',
     actionPath ? path.resolve(actionPath, '..', '..', 'scripts', 'github-api-with-retry.js') : '',
     path.resolve(cwd, '.github/scripts/github-api-with-retry.js'),
     path.resolve(cwd, 'consumer/.github/scripts/github-api-with-retry.js'),

--- a/.github/actions/resolve-default-branch/resolve-default-branch.js
+++ b/.github/actions/resolve-default-branch/resolve-default-branch.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function retryHelperCandidates(env = process.env, cwd = process.cwd()) {
+  const actionPath = env.GITHUB_ACTION_PATH || '';
+  return [
+    actionPath ? path.resolve(actionPath, '..', '..', 'scripts', 'github-api-with-retry.js') : '',
+    path.resolve(cwd, '.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, 'consumer/.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, 'workflows-lib/.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, '.workflows-lib/.github/scripts/github-api-with-retry.js'),
+  ].filter(Boolean);
+}
+
+function loadRetryHelper({ env = process.env, cwd = process.cwd(), loader = require } = {}) {
+  for (const candidate of retryHelperCandidates(env, cwd)) {
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    return loader(candidate);
+  }
+  return null;
+}
+
+async function resolveDefaultBranch({
+  github,
+  core,
+  owner = 'stranske',
+  repo = 'Workflows',
+  fallbackRef = '',
+  failOnError = true,
+  task = 'resolve-default-branch',
+  env = process.env,
+  cwd = process.cwd(),
+  loader = require,
+}) {
+  const fallback = String(fallbackRef || '').trim();
+  const target = `${owner}/${repo}`;
+  let withRetry = (fn) => fn(github);
+
+  const retryHelper = loadRetryHelper({ env, cwd, loader });
+  if (retryHelper?.createTokenAwareRetry) {
+    const retry = await retryHelper.createTokenAwareRetry({
+      github,
+      core,
+      env,
+      task,
+      capabilities: ['contents:read'],
+    });
+    if (retry?.withRetry) {
+      withRetry = retry.withRetry;
+    }
+  }
+
+  const setResolvedRef = (ref) => {
+    core.setOutput('ref', ref);
+    return ref;
+  };
+
+  try {
+    const { data } = await withRetry((client) =>
+      client.rest.repos.get({
+        owner,
+        repo,
+      }),
+    );
+    if (data?.default_branch) {
+      return setResolvedRef(data.default_branch);
+    }
+    if (fallback) {
+      core.warning(`${target} default branch missing; falling back to ${fallback}`);
+      return setResolvedRef(fallback);
+    }
+    core.setFailed(`Could not determine ${target} default branch`);
+    return setResolvedRef('');
+  } catch (error) {
+    const message = error?.message || String(error);
+    if (fallback) {
+      core.warning(`Failed to resolve ${target} default branch; using ${fallback}. ${message}`);
+      return setResolvedRef(fallback);
+    }
+    if (failOnError) {
+      core.setFailed(`Failed to resolve ${target} default branch: ${message}`);
+    } else {
+      core.warning(`Failed to resolve ${target} default branch: ${message}`);
+    }
+    return setResolvedRef('');
+  }
+}
+
+module.exports = {
+  loadRetryHelper,
+  resolveDefaultBranch,
+  retryHelperCandidates,
+};

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -630,6 +630,10 @@ actions:
     is_directory: true
     description: "Unified API client setup - installs @octokit deps and exports all load balancer tokens"
 
+  - source: .github/actions/resolve-default-branch/
+    is_directory: true
+    description: "Resolves repository default branches for Workflows dual-checkout patterns"
+
   - source: .github/actions/export-load-balancer-tokens/
     is_directory: true
     description: "Export load balancer tokens action - required by reusable-10-ci-python.yml (deprecated, use setup-api-client)"

--- a/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -178,24 +178,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({ github, core });
-            const { data } = await withRetry((client) =>
-              client.rest.repos.get({
-                owner: 'stranske',
-                repo: 'Workflows'
-              })
-            );
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./.github/actions/resolve-default-branch
 
       - name: Checkout (for retry helpers)
         uses: actions/checkout@v6

--- a/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/.github/workflows/agents-72-codex-belt-worker.yml
@@ -301,24 +301,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ env.GH_BELT_TOKEN }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({ github, core });
-            const { data } = await withRetry((client) =>
-              client.rest.repos.get({
-                owner: 'stranske',
-                repo: 'Workflows'
-              })
-            );
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./.github/actions/resolve-default-branch
 
       - name: Checkout Workflows scripts
         uses: actions/checkout@v6

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -172,29 +172,12 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         if: steps.check_enabled.outputs.enabled == 'true'
         id: workflows_ref
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: ./.github/actions/resolve-default-branch
         with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({
-              github,
-              core,
-              env: process.env,
-              task: 'auto-pilot-resolve-workflows-ref',
-            });
-
-            const { data } = await withRetry((client) => client.rest.repos.get({
-              owner: 'stranske',
-              repo: 'Workflows'
-            }));
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+          task: auto-pilot-resolve-workflows-ref
 
       - name: Checkout Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'

--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -1000,24 +1000,9 @@ jobs:
           fetch-depth: 1
           path: consumer
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@v9
-        with:
-          script: |
-            // NOTE: github-api-with-retry.js is NOT available here because the
-            // Workflows repo hasn't been checked out yet (that happens in the next
-            // step). Use a plain GitHub API call — no retry wrapper needed for this
-            // single low-risk read.
-            const { data } = await github.rest.repos.get({
-              owner: 'stranske',
-              repo: 'Workflows'
-            });
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./consumer/.github/actions/resolve-default-branch
       - name: Checkout Workflows scripts
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -1000,9 +1000,44 @@ jobs:
           fetch-depth: 1
           path: consumer
 
+      - name: Determine Workflows workflow ref
+        id: workflows_workflow_ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+          ref="${WORKFLOW_REF##*@}"
+          if [ -z "$ref" ] || [ "$ref" = "$WORKFLOW_REF" ]; then
+            ref="main"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout resolver action
+        uses: actions/checkout@v6
+        with:
+          repository: stranske/Workflows
+          ref: ${{ steps.workflows_workflow_ref.outputs.ref }}
+          sparse-checkout: |
+            .github/actions/resolve-default-branch
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          path: workflows-resolver
+          fetch-depth: 1
+          token: >-
+            ${{
+              secrets.ACTIONS_BOT_PAT ||
+              secrets.service_bot_pat ||
+              github.token
+            }}
+
       - name: Resolve Workflows ref
         id: workflows_ref
-        uses: ./consumer/.github/actions/resolve-default-branch
+        uses: ./workflows-resolver/.github/actions/resolve-default-branch
+        with:
+          fallback_ref: main
+          fail_on_error: 'false'
+          task: keepalive-workflows-ref
       - name: Checkout Workflows scripts
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -260,6 +260,7 @@ jobs:
           sparse-checkout-cone-mode: false
           path: workflows-resolver
           fetch-depth: 1
+          token: ${{ secrets.service_bot_pat || github.token }}
 
       - name: Resolve Workflows ref
         id: workflows_ref

--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -236,50 +236,38 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Dual checkout pattern: Workflows scripts as supplement to consumer repo
-      - name: Resolve Workflows default branch
-        id: workflows_ref
-        uses: actions/github-script@v9
+      - name: Determine Workflows workflow ref
+        id: workflows_workflow_ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+          ref="${WORKFLOW_REF##*@}"
+          if [ -z "$ref" ] || [ "$ref" = "$WORKFLOW_REF" ]; then
+            ref="main"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout resolver action
+        uses: actions/checkout@v6
         with:
-          script: |
-            const fs = require('fs');
-            const retryHelperPath = './.github/scripts/github-api-with-retry.js';
-            const retryHelpers = fs.existsSync(retryHelperPath)
-              ? require(retryHelperPath)
-              : {
-                  createTokenAwareRetry: async () => ({
-                    withRetry: (fn) => fn(github),
-                  }),
-                };
-            const { createTokenAwareRetry } = retryHelpers;
-            const { withRetry } = await createTokenAwareRetry({
-              github,
-              core,
-              env: process.env,
-              task: 'autofix-resolve-workflows-ref',
-              capabilities: ['contents:read'],
-            });
-            const fallback = 'main';
-            try {
-              const { data } = await withRetry((client) =>
-                client.rest.repos.get({
-                  owner: 'stranske',
-                  repo: 'Workflows',
-                }),
-              );
-              const ref = data?.default_branch || fallback;
-              if (!data?.default_branch) {
-                core.warning(
-                  `Workflows default branch missing; falling back to ${fallback}`,
-                );
-              }
-              core.setOutput('ref', ref);
-            } catch (error) {
-              const message = error?.message || String(error);
-              core.warning(
-                `Failed to resolve Workflows default branch; using ${fallback}. ${message}`,
-              );
-              core.setOutput('ref', fallback);
-            }
+          repository: stranske/Workflows
+          ref: ${{ steps.workflows_workflow_ref.outputs.ref }}
+          sparse-checkout: |
+            .github/actions/resolve-default-branch
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          path: workflows-resolver
+          fetch-depth: 1
+
+      - name: Resolve Workflows ref
+        id: workflows_ref
+        uses: ./workflows-resolver/.github/actions/resolve-default-branch
+        with:
+          fallback_ref: main
+          fail_on_error: 'false'
+          task: autofix-resolve-workflows-ref
       - name: Checkout Workflows scripts (for autofix utilities)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/reusable-20-pr-meta.yml
+++ b/.github/workflows/reusable-20-pr-meta.yml
@@ -133,9 +133,40 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
+      - name: Determine Workflows workflow ref
+        id: workflows_workflow_ref
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+          ref="${WORKFLOW_REF##*@}"
+          if [ -z "$ref" ] || [ "$ref" = "$WORKFLOW_REF" ]; then
+            ref="main"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout resolver action
+        uses: actions/checkout@v6
+        with:
+          repository: stranske/Workflows
+          ref: ${{ steps.workflows_workflow_ref.outputs.ref }}
+          sparse-checkout: |
+            .github/actions/resolve-default-branch
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          path: workflows-resolver
+          fetch-depth: 1
+          token: >-
+            ${{
+              secrets.ACTIONS_BOT_PAT ||
+              secrets.service_bot_pat ||
+              github.token
+            }}
+
       - name: Resolve Workflows ref
         id: workflows_ref
-        uses: ./consumer/.github/actions/resolve-default-branch
+        uses: ./workflows-resolver/.github/actions/resolve-default-branch
         with:
           fallback_ref: main
           fail_on_error: 'false'

--- a/.github/workflows/reusable-20-pr-meta.yml
+++ b/.github/workflows/reusable-20-pr-meta.yml
@@ -133,52 +133,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
-
-
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@v9
+        uses: ./consumer/.github/actions/resolve-default-branch
         with:
-          script: |
-            const payloadDefault = context.payload?.repository?.default_branch;
-            if (payloadDefault) {
-              core.setOutput('ref', payloadDefault);
-              return;
-            }
-
-            const { createTokenAwareRetry } = require(
-              './consumer/.github/scripts/github-api-with-retry.js'
-            );
-
-            const { withRetry, github: retryGithub } = await createTokenAwareRetry({
-              github,
-              core,
-              env: process.env,
-              task: 'pr-meta-workflows-ref',
-              capabilities: ['read-repo'],
-            });
-
-            const client = retryGithub || github;
-            try {
-              const { data } = await withRetry((octokit) =>
-                octokit.rest.repos.get({ owner: 'stranske', repo: 'Workflows' })
-              );
-              if (data?.default_branch) {
-                core.setOutput('ref', data.default_branch);
-                return;
-              }
-            } catch (error) {
-              core.warning(`Failed to resolve Workflows default branch: ${error.message}`);
-            }
-
-            core.warning('Falling back to Workflows ref "main".');
-            core.setOutput('ref', 'main');
+          fallback_ref: main
+          fail_on_error: 'false'
+          task: pr-meta-workflows-ref
 
       - name: Checkout Workflows scripts
         uses: actions/checkout@v6
         with:
           repository: stranske/Workflows
-          ref: main
+          ref: ${{ steps.workflows_ref.outputs.ref }}
           sparse-checkout: |
             scripts
             .github/scripts

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -110,24 +110,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({ github, core });
-            const { data } = await withRetry((client) =>
-              client.rest.repos.get({
-                owner: 'stranske',
-                repo: 'Workflows'
-              })
-            );
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./.github/actions/resolve-default-branch
 
       - name: Checkout Workflows scripts
         uses: actions/checkout@v6

--- a/templates/consumer-repo/.github/actions/resolve-default-branch/action.yml
+++ b/templates/consumer-repo/.github/actions/resolve-default-branch/action.yml
@@ -34,10 +34,12 @@ runs:
     - name: Resolve default branch
       id: resolve
       uses: actions/github-script@v9
+      env:
+        RESOLVE_DEFAULT_BRANCH_ACTION_PATH: ${{ github.action_path }}
       with:
         script: |
           const { resolveDefaultBranch } = require(
-            `${process.env.GITHUB_ACTION_PATH}/resolve-default-branch.js`
+            `${process.env.RESOLVE_DEFAULT_BRANCH_ACTION_PATH}/resolve-default-branch.js`
           );
 
           await resolveDefaultBranch({

--- a/templates/consumer-repo/.github/actions/resolve-default-branch/action.yml
+++ b/templates/consumer-repo/.github/actions/resolve-default-branch/action.yml
@@ -1,0 +1,52 @@
+name: Resolve Default Branch
+description: Resolve a repository default branch with the shared GitHub API retry helper when available.
+
+inputs:
+  owner:
+    description: Repository owner.
+    required: false
+    default: stranske
+  repo:
+    description: Repository name.
+    required: false
+    default: Workflows
+  fallback_ref:
+    description: Optional ref to use when the API lookup fails or returns no default branch.
+    required: false
+    default: ''
+  fail_on_error:
+    description: Whether to fail the step when no default branch can be resolved and no fallback is set.
+    required: false
+    default: 'true'
+  task:
+    description: Retry helper task name for logging and token selection.
+    required: false
+    default: resolve-default-branch
+
+outputs:
+  ref:
+    description: Resolved default branch, or fallback_ref when configured and resolution fails.
+    value: ${{ steps.resolve.outputs.ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve default branch
+      id: resolve
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const { resolveDefaultBranch } = require(
+            `${process.env.GITHUB_ACTION_PATH}/resolve-default-branch.js`
+          );
+
+          await resolveDefaultBranch({
+            github,
+            core,
+            owner: '${{ inputs.owner }}',
+            repo: '${{ inputs.repo }}',
+            fallbackRef: '${{ inputs.fallback_ref }}',
+            failOnError: '${{ inputs.fail_on_error }}' !== 'false',
+            task: '${{ inputs.task }}',
+            env: process.env,
+          });

--- a/templates/consumer-repo/.github/actions/resolve-default-branch/resolve-default-branch.js
+++ b/templates/consumer-repo/.github/actions/resolve-default-branch/resolve-default-branch.js
@@ -5,7 +5,11 @@ const path = require('path');
 
 function retryHelperCandidates(env = process.env, cwd = process.cwd()) {
   const actionPath = env.GITHUB_ACTION_PATH || '';
+  const resolverActionPath = env.RESOLVE_DEFAULT_BRANCH_ACTION_PATH || '';
   return [
+    resolverActionPath
+      ? path.resolve(resolverActionPath, '..', '..', 'scripts', 'github-api-with-retry.js')
+      : '',
     actionPath ? path.resolve(actionPath, '..', '..', 'scripts', 'github-api-with-retry.js') : '',
     path.resolve(cwd, '.github/scripts/github-api-with-retry.js'),
     path.resolve(cwd, 'consumer/.github/scripts/github-api-with-retry.js'),

--- a/templates/consumer-repo/.github/actions/resolve-default-branch/resolve-default-branch.js
+++ b/templates/consumer-repo/.github/actions/resolve-default-branch/resolve-default-branch.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function retryHelperCandidates(env = process.env, cwd = process.cwd()) {
+  const actionPath = env.GITHUB_ACTION_PATH || '';
+  return [
+    actionPath ? path.resolve(actionPath, '..', '..', 'scripts', 'github-api-with-retry.js') : '',
+    path.resolve(cwd, '.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, 'consumer/.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, 'workflows-lib/.github/scripts/github-api-with-retry.js'),
+    path.resolve(cwd, '.workflows-lib/.github/scripts/github-api-with-retry.js'),
+  ].filter(Boolean);
+}
+
+function loadRetryHelper({ env = process.env, cwd = process.cwd(), loader = require } = {}) {
+  for (const candidate of retryHelperCandidates(env, cwd)) {
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    return loader(candidate);
+  }
+  return null;
+}
+
+async function resolveDefaultBranch({
+  github,
+  core,
+  owner = 'stranske',
+  repo = 'Workflows',
+  fallbackRef = '',
+  failOnError = true,
+  task = 'resolve-default-branch',
+  env = process.env,
+  cwd = process.cwd(),
+  loader = require,
+}) {
+  const fallback = String(fallbackRef || '').trim();
+  const target = `${owner}/${repo}`;
+  let withRetry = (fn) => fn(github);
+
+  const retryHelper = loadRetryHelper({ env, cwd, loader });
+  if (retryHelper?.createTokenAwareRetry) {
+    const retry = await retryHelper.createTokenAwareRetry({
+      github,
+      core,
+      env,
+      task,
+      capabilities: ['contents:read'],
+    });
+    if (retry?.withRetry) {
+      withRetry = retry.withRetry;
+    }
+  }
+
+  const setResolvedRef = (ref) => {
+    core.setOutput('ref', ref);
+    return ref;
+  };
+
+  try {
+    const { data } = await withRetry((client) =>
+      client.rest.repos.get({
+        owner,
+        repo,
+      }),
+    );
+    if (data?.default_branch) {
+      return setResolvedRef(data.default_branch);
+    }
+    if (fallback) {
+      core.warning(`${target} default branch missing; falling back to ${fallback}`);
+      return setResolvedRef(fallback);
+    }
+    core.setFailed(`Could not determine ${target} default branch`);
+    return setResolvedRef('');
+  } catch (error) {
+    const message = error?.message || String(error);
+    if (fallback) {
+      core.warning(`Failed to resolve ${target} default branch; using ${fallback}. ${message}`);
+      return setResolvedRef(fallback);
+    }
+    if (failOnError) {
+      core.setFailed(`Failed to resolve ${target} default branch: ${message}`);
+    } else {
+      core.warning(`Failed to resolve ${target} default branch: ${message}`);
+    }
+    return setResolvedRef('');
+  }
+}
+
+module.exports = {
+  loadRetryHelper,
+  resolveDefaultBranch,
+  retryHelperCandidates,
+};

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -178,24 +178,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ env.GH_DISPATCH_TOKEN || github.token }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({ github, core });
-            const { data } = await withRetry((client) =>
-              client.rest.repos.get({
-                owner: 'stranske',
-                repo: 'Workflows'
-              })
-            );
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./.github/actions/resolve-default-branch
 
       - name: Checkout (for retry helpers)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -301,24 +301,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ env.GH_BELT_TOKEN }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         id: workflows_ref
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({ github, core });
-            const { data } = await withRetry((client) =>
-              client.rest.repos.get({
-                owner: 'stranske',
-                repo: 'Workflows'
-              })
-            );
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+        uses: ./.github/actions/resolve-default-branch
 
       - name: Checkout Workflows scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -172,29 +172,12 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
 
-      - name: Resolve Workflows default branch
+      - name: Resolve Workflows ref
         if: steps.check_enabled.outputs.enabled == 'true'
         id: workflows_ref
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: ./.github/actions/resolve-default-branch
         with:
-          script: |
-            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-            const { withRetry } = await createTokenAwareRetry({
-              github,
-              core,
-              env: process.env,
-              task: 'auto-pilot-resolve-workflows-ref',
-            });
-
-            const { data } = await withRetry((client) => client.rest.repos.get({
-              owner: 'stranske',
-              repo: 'Workflows'
-            }));
-            if (!data?.default_branch) {
-              core.setFailed('Could not determine Workflows default branch');
-              return;
-            }
-            core.setOutput('ref', data.default_branch);
+          task: auto-pilot-resolve-workflows-ref
 
       - name: Checkout Workflows scripts
         if: steps.check_enabled.outputs.enabled == 'true'

--- a/tests/workflows/test_resolve_default_branch.py
+++ b/tests/workflows/test_resolve_default_branch.py
@@ -1,7 +1,9 @@
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -9,6 +11,7 @@ ACTION_DIR = REPO_ROOT / ".github" / "actions" / "resolve-default-branch"
 TEMPLATE_ACTION_DIR = (
     REPO_ROOT / "templates" / "consumer-repo" / ".github" / "actions" / "resolve-default-branch"
 )
+skip_if_no_node = pytest.mark.skipif(shutil.which("node") is None, reason="Node.js required")
 
 
 def test_resolve_default_branch_action_contract_and_template_copy() -> None:
@@ -34,6 +37,7 @@ def test_resolve_default_branch_action_contract_and_template_copy() -> None:
     ).read_text(encoding="utf-8")
 
 
+@skip_if_no_node
 def test_resolve_default_branch_logic_with_stubbed_client() -> None:
     script = r"""
 const assert = require('assert');
@@ -88,6 +92,7 @@ const { resolveDefaultBranch } = require('./.github/actions/resolve-default-bran
     assert result.returncode == 0, result.stderr + result.stdout
 
 
+@skip_if_no_node
 def test_resolve_default_branch_fallback_preserves_lenient_callers() -> None:
     script = r"""
 const assert = require('assert');
@@ -160,7 +165,7 @@ def test_resolve_default_branch_inline_workflow_copies_removed() -> None:
 
     uses_pattern = re.compile(r"^\s*uses:\s+.*resolve-default-branch(?:@.*)?$", re.MULTILINE)
     action_uses = sum(len(uses_pattern.findall(text)) for text in texts.values())
-    assert action_uses == 10
+    assert action_uses >= 10
 
 
 def test_pr_meta_bootstraps_resolver_from_workflows_checkout() -> None:

--- a/tests/workflows/test_resolve_default_branch.py
+++ b/tests/workflows/test_resolve_default_branch.py
@@ -1,0 +1,158 @@
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTION_DIR = REPO_ROOT / ".github" / "actions" / "resolve-default-branch"
+TEMPLATE_ACTION_DIR = (
+    REPO_ROOT / "templates" / "consumer-repo" / ".github" / "actions" / "resolve-default-branch"
+)
+
+
+def test_resolve_default_branch_action_contract_and_template_copy() -> None:
+    action = yaml.safe_load((ACTION_DIR / "action.yml").read_text(encoding="utf-8"))
+    template_action = yaml.safe_load(
+        (TEMPLATE_ACTION_DIR / "action.yml").read_text(encoding="utf-8")
+    )
+
+    assert action == template_action
+    assert action["outputs"]["ref"]["value"] == "${{ steps.resolve.outputs.ref }}"
+    assert action["inputs"]["owner"]["default"] == "stranske"
+    assert action["inputs"]["repo"]["default"] == "Workflows"
+    assert action["runs"]["steps"][0]["uses"] == "actions/github-script@v9"
+    assert "resolve-default-branch.js" in action["runs"]["steps"][0]["with"]["script"]
+
+    assert (ACTION_DIR / "resolve-default-branch.js").read_text(encoding="utf-8") == (
+        TEMPLATE_ACTION_DIR / "resolve-default-branch.js"
+    ).read_text(encoding="utf-8")
+
+
+def test_resolve_default_branch_logic_with_stubbed_client() -> None:
+    script = r"""
+const assert = require('assert');
+const { resolveDefaultBranch } = require('./.github/actions/resolve-default-branch/resolve-default-branch.js');
+
+(async () => {
+  const outputs = {};
+  const failures = [];
+  const warnings = [];
+  const calls = [];
+  const github = {
+    rest: {
+      repos: {
+        get: async (args) => {
+          calls.push(args);
+          return { data: { default_branch: 'main' } };
+        },
+      },
+    },
+  };
+  const core = {
+    setOutput: (name, value) => {
+      outputs[name] = value;
+    },
+    setFailed: (message) => failures.push(message),
+    warning: (message) => warnings.push(message),
+  };
+
+  const ref = await resolveDefaultBranch({
+    github,
+    core,
+    owner: 'stranske',
+    repo: 'Workflows',
+    env: {},
+    cwd: process.cwd(),
+  });
+
+  assert.strictEqual(ref, 'main');
+  assert.strictEqual(outputs.ref, 'main');
+  assert.deepStrictEqual(calls, [{ owner: 'stranske', repo: 'Workflows' }]);
+  assert.deepStrictEqual(failures, []);
+  assert.deepStrictEqual(warnings, []);
+})();
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_resolve_default_branch_fallback_preserves_lenient_callers() -> None:
+    script = r"""
+const assert = require('assert');
+const { resolveDefaultBranch } = require('./.github/actions/resolve-default-branch/resolve-default-branch.js');
+
+(async () => {
+  const outputs = {};
+  const warnings = [];
+  const github = {
+    rest: {
+      repos: {
+        get: async () => {
+          throw new Error('network unavailable');
+        },
+      },
+    },
+  };
+  const core = {
+    setOutput: (name, value) => {
+      outputs[name] = value;
+    },
+    setFailed: (message) => {
+      throw new Error(`unexpected failure: ${message}`);
+    },
+    warning: (message) => warnings.push(message),
+  };
+
+  const ref = await resolveDefaultBranch({
+    github,
+    core,
+    fallbackRef: 'main',
+    failOnError: false,
+    env: {},
+    cwd: process.cwd(),
+  });
+
+  assert.strictEqual(ref, 'main');
+  assert.strictEqual(outputs.ref, 'main');
+  assert.strictEqual(warnings.length, 1);
+  assert.match(warnings[0], /using main/);
+})();
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_resolve_default_branch_inline_workflow_copies_removed() -> None:
+    workflow_dirs = [
+        REPO_ROOT / ".github" / "workflows",
+        REPO_ROOT / "templates" / "consumer-repo" / ".github" / "workflows",
+    ]
+    texts = {
+        path: path.read_text(encoding="utf-8")
+        for workflow_dir in workflow_dirs
+        for path in workflow_dir.glob("*.yml")
+    }
+
+    offenders = [
+        str(path.relative_to(REPO_ROOT))
+        for path, text in texts.items()
+        if "Resolve Workflows default branch" in text
+    ]
+    assert offenders == []
+
+    uses_pattern = re.compile(r"^\s*uses:\s+.*resolve-default-branch(?:@.*)?$", re.MULTILINE)
+    action_uses = sum(len(uses_pattern.findall(text)) for text in texts.values())
+    assert action_uses == 10

--- a/tests/workflows/test_resolve_default_branch.py
+++ b/tests/workflows/test_resolve_default_branch.py
@@ -22,7 +22,12 @@ def test_resolve_default_branch_action_contract_and_template_copy() -> None:
     assert action["inputs"]["owner"]["default"] == "stranske"
     assert action["inputs"]["repo"]["default"] == "Workflows"
     assert action["runs"]["steps"][0]["uses"] == "actions/github-script@v9"
-    assert "resolve-default-branch.js" in action["runs"]["steps"][0]["with"]["script"]
+    resolve_step = action["runs"]["steps"][0]
+    assert resolve_step["env"]["RESOLVE_DEFAULT_BRANCH_ACTION_PATH"] == "${{ github.action_path }}"
+    script = resolve_step["with"]["script"]
+    assert "resolve-default-branch.js" in script
+    assert "RESOLVE_DEFAULT_BRANCH_ACTION_PATH" in script
+    assert "GITHUB_ACTION_PATH" not in script
 
     assert (ACTION_DIR / "resolve-default-branch.js").read_text(encoding="utf-8") == (
         TEMPLATE_ACTION_DIR / "resolve-default-branch.js"
@@ -156,3 +161,27 @@ def test_resolve_default_branch_inline_workflow_copies_removed() -> None:
     uses_pattern = re.compile(r"^\s*uses:\s+.*resolve-default-branch(?:@.*)?$", re.MULTILINE)
     action_uses = sum(len(uses_pattern.findall(text)) for text in texts.values())
     assert action_uses == 10
+
+
+def test_pr_meta_bootstraps_resolver_from_workflows_checkout() -> None:
+    """PR meta cannot require unsynced consumers to already have the new action."""
+    workflow = REPO_ROOT / ".github" / "workflows" / "reusable-20-pr-meta.yml"
+    data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    steps = next(
+        job["steps"]
+        for job in data["jobs"].values()
+        if any(step.get("name") == "Resolve Workflows ref" for step in job.get("steps", []))
+    )
+
+    resolver_checkout = next(
+        step for step in steps if step.get("name") == "Checkout resolver action"
+    )
+    assert resolver_checkout["uses"] == "actions/checkout@v6"
+    assert resolver_checkout["with"]["path"] == "workflows-resolver"
+    assert ".github/actions/resolve-default-branch" in resolver_checkout["with"]["sparse-checkout"]
+
+    resolve_step = next(step for step in steps if step.get("name") == "Resolve Workflows ref")
+    assert resolve_step["uses"] == "./workflows-resolver/.github/actions/resolve-default-branch"
+    assert "./consumer/.github/actions/resolve-default-branch" not in workflow.read_text(
+        encoding="utf-8"
+    )

--- a/tests/workflows/test_resolve_default_branch.py
+++ b/tests/workflows/test_resolve_default_branch.py
@@ -37,6 +37,12 @@ def test_resolve_default_branch_action_contract_and_template_copy() -> None:
     ).read_text(encoding="utf-8")
 
 
+def test_retry_helper_prefers_explicit_resolver_action_path() -> None:
+    script = (ACTION_DIR / "resolve-default-branch.js").read_text(encoding="utf-8")
+    assert "RESOLVE_DEFAULT_BRANCH_ACTION_PATH" in script
+    assert script.index("resolverActionPath") < script.index("actionPath ?")
+
+
 @skip_if_no_node
 def test_resolve_default_branch_logic_with_stubbed_client() -> None:
     script = r"""
@@ -170,7 +176,16 @@ def test_resolve_default_branch_inline_workflow_copies_removed() -> None:
 
 def test_pr_meta_bootstraps_resolver_from_workflows_checkout() -> None:
     """PR meta cannot require unsynced consumers to already have the new action."""
-    workflow = REPO_ROOT / ".github" / "workflows" / "reusable-20-pr-meta.yml"
+    assert_workflow_bootstraps_resolver_from_workflows_checkout("reusable-20-pr-meta.yml")
+
+
+def test_keepalive_bootstraps_resolver_from_workflows_checkout() -> None:
+    """Keepalive cannot require unsynced consumers to already have the new action."""
+    assert_workflow_bootstraps_resolver_from_workflows_checkout("reusable-16-agents.yml")
+
+
+def assert_workflow_bootstraps_resolver_from_workflows_checkout(workflow_name: str) -> None:
+    workflow = REPO_ROOT / ".github" / "workflows" / workflow_name
     data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
     steps = next(
         job["steps"]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2342 -->
> **Source:** Issue #2342

Closes #2342

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The "Resolve Workflows default branch" `github-script` step is duplicated across **10** workflow files (verified by grep), each re-hardcoding `stranske/Workflows` and the same resolution logic (~126+ lines total). This is **latent fragility, not a current break**: a fix to the resolution (or the repo slug) must be applied in 10 places.

#### Tasks
- [ ] Create `.github/actions/resolve-default-branch/action.yml` (composite) exposing the resolved branch as an output, encapsulating the current `github-script` logic.
- [ ] Replace the inline "Resolve Workflows default branch" step in all 10 workflows with `uses: ./.github/actions/resolve-default-branch` (+ consume its output).
- [ ] Add `tests/workflows/test_resolve_default_branch.py` (or a node test) exercising the action's resolution logic against a stubbed client.

#### Acceptance criteria
- [ ] Named test: the new test for the resolution logic passes, asserting it returns the repo's default branch for a stubbed API response.
- [ ] **Deliberate-break gate:** temporarily make the action return an empty string. The named test **must FAIL**. Revert after capturing the failure.
- [ ] `grep -rl "Resolve Workflows default branch" .github/workflows/` returns **0** inline copies (all now `uses:` the action).

<!-- auto-status-summary:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dual-checkout workflows pick the Workflows ref; mis-resolution or bootstrap failures could check out the wrong branch or scripts, though fallbacks and new tests reduce that risk.
> 
> **Overview**
> Introduces a reusable **`resolve-default-branch`** composite action (plus a consumer-repo template copy) that resolves `stranske/Workflows`’ default branch via the GitHub API, optionally using the shared retry helper, with configurable **`fallback_ref`** and **`fail_on_error`**.
> 
> **Workflows** that previously inlined `github-script` “Resolve Workflows default branch” steps now call `./.github/actions/resolve-default-branch` (belt dispatcher/worker, auto-pilot, verifier, and matching template workflows). **Reusable** `reusable-16-agents`, `reusable-18-autofix`, and `reusable-20-pr-meta` add a bootstrap path: derive the Workflows workflow ref from `github.workflow_ref`, sparse-checkout the resolver into `workflows-resolver`, then run the action with **`fallback_ref: main`** so consumers do not need the action synced yet. **PR meta** also wires the subsequent Workflows scripts checkout to **`steps.workflows_ref.outputs.ref`** instead of a hardcoded `main`.
> 
> The action is listed in **`.github/sync-manifest.yml`** for consumer sync. **`tests/workflows/test_resolve_default_branch.py`** covers the action contract, Node resolution/fallback behavior, removal of inline steps, and the bootstrap pattern for keepalive/PR meta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004e551c60294b44904bf0a3f9277ba1f5722677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->