### PR TITLE
chore(orchestrator): shadow the 30-min orchestrator (A1, reversible) — automatic runs dry-run

### DIFF
--- a/.github/workflows/agents-70-orchestrator.yml
+++ b/.github/workflows/agents-70-orchestrator.yml
@@ -105,8 +105,14 @@ jobs:
           ) ||
           ''
         }}
+      # A1 orchestrator-retirement shadow: automatic runs (schedule / workflow_run) run
+      # dry (no writes) while we confirm the event-driven keepalive loop + hourly sweep
+      # cover the orchestrator's role, before deleting agents-70 + reusable-70-orchestrator-main.
+      # Manual `workflow_dispatch` with dry_run=false still runs live. Revert: remove the
+      # first clause below.
       dry_run: >-
         ${{
+          (github.event_name == 'schedule' || github.event_name == 'workflow_run') && 'true' ||
           github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run ||
           github.event_name == 'repository_dispatch' && (
             github.event.client_payload && github.event.client_payload.dry_run || ''


### PR DESCRIPTION
**A1, step 1 of orchestrator retirement — reversible shadow.**

Makes `agents-70-orchestrator` automatic runs (`schedule` + `workflow_run`) resolve `dry_run: 'true'`, so the 30-min orchestrator (and the 3554-line `reusable-70-orchestrator-main` it calls) **logs what it would do but writes nothing**. Manual `workflow_dispatch` with `dry_run=false` still runs live.

**Why this is safe** — the orchestrator's three roles are already covered:
- keepalive → event-driven `agents-keepalive-loop` + hourly `agents-keepalive-sweep` (verified: no local dependency),
- the belt → standalone `agents-71/72/73` (reusable-70 only `uses:` them, doesn't re-implement),
- automerge → the #2270 guarded-merge.

It's **Workflows-repo-only** (not in the consumer template) → no fleet/consumer impact.

**Verification (post-merge, observable):** the next scheduled `agents-70` run shows `dry_run=true` and performs **no** write operations, while open agent PRs keep progressing via the event loop + sweep. Observe a few days; if nothing stalls, the follow-up PR deletes `agents-70` + `reusable-70-orchestrator-main`.

**Revert:** remove the `(schedule || workflow_run) && 'true'` clause.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables write side effects on the periodic orchestrator path, so any behavior still relying on those automatic runs (vs keepalive loop/sweep) could stall until manual dispatch or follow-up deletion.
> 
> **Overview**
> **Automatic** `agents-70-orchestrator` triggers (`schedule` and `workflow_run`) now pass **`dry_run: 'true'`** into `reusable-70-orchestrator-init`, so those runs log planned work but perform **no writes**. Manual `workflow_dispatch` (including `dry_run=false`) and `repository_dispatch` payloads are unchanged.
> 
> This is the reversible **A1 shadow** step before retiring the 30‑minute orchestrator and `reusable-70-orchestrator-main`; revert by removing the new first clause in the `dry_run` expression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7965a5c52f248a6c0640c064a2cbc208e47214e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->