### PR TITLE
refactor(langchain): extract shared _get_llm_client into _llm_client module (#2343)

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -521,6 +521,9 @@ scripts:
 
   - source: scripts/langchain/_llm_client.py
     description: "Shared LangChain chat-client construction (get_llm_client/get_llm_clients)"
+    # delivery: copy -- imported transitively by copy-delivered LangChain scripts
+    # such as issue_optimizer.py, issue_formatter.py, and task_validator.py.
+    delivery: copy
 
   - source: scripts/langchain/verifier_config.py
     description: "Shared verifier prompt budgets, schema-repair policy, and terminal artifact validation"

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -519,6 +519,9 @@ scripts:
     description: "Shared LangSmith trace metadata helpers for LangChain workflows"
     delivery: copy
 
+  - source: scripts/langchain/_llm_client.py
+    description: "Shared LangChain chat-client construction (get_llm_client/get_llm_clients)"
+
   - source: scripts/langchain/verifier_config.py
     description: "Shared verifier prompt budgets, schema-repair policy, and terminal artifact validation"
     delivery: copy

--- a/scripts/langchain/_llm_client.py
+++ b/scripts/langchain/_llm_client.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Shared LangChain chat-client construction for the agent scripts.
+
+The ``_get_llm_client`` helper used to be copy-pasted across the langchain
+agent scripts (``context_extractor``, ``capability_check``, ``issue_optimizer``,
+``topic_splitter``, ``issue_formatter``, ``task_decomposer``,
+``followup_issue_generator``, ``pr_verifier``, ``task_validator``). The bodies
+were all variations on the same construction: import
+``tools.langchain_client.build_chat_client``, return ``None`` if the import or
+credential lookup failed, otherwise return ``(client, <label>)``.
+
+This module hosts that construction once. Per-script differences (forcing
+OpenAI, an explicit model/provider override, and which ``ClientInfo`` attribute
+is returned as the label) are expressed as parameters rather than divergent
+copies. Scripts whose provider selection is genuinely script-specific
+(``task_decomposer``'s env-based resolution, ``followup_issue_generator``'s
+reasoning-model selection and diagnostics) keep that logic locally and delegate
+only the import-guarded construction here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_llm_client(
+    *,
+    force_openai: bool = False,
+    model: str | None = None,
+    provider: str | None = None,
+    return_field: str = "provider",
+) -> tuple[Any, str] | None:
+    """Build a single LangChain chat client.
+
+    Wraps :func:`tools.langchain_client.build_chat_client`, preserving the exact
+    behavior of the former per-script ``_get_llm_client`` helpers.
+
+    Args:
+        force_openai: Force the OpenAI provider (used for retry after a GitHub
+            Models 401). Equivalent to ``provider="openai"``.
+        model: Optional model-name override passed through to ``build_chat_client``.
+        provider: Optional provider override (``"openai"``/``"github-models"``/...).
+        return_field: Which ``ClientInfo`` attribute to return as the second
+            tuple element — ``"provider"`` (default), ``"model"``, or
+            ``"provider_label"``.
+
+    Returns:
+        ``(client, label)`` or ``None`` when ``langchain`` deps are missing or no
+        credentials are available.
+    """
+    info = build_client(model=model, provider=provider, force_openai=force_openai)
+    if not info:
+        return None
+    return info.client, getattr(info, return_field)
+
+
+def build_client(
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    force_openai: bool = False,
+) -> Any | None:
+    """Return the raw ``ClientInfo`` (or ``None``) from ``build_chat_client``.
+
+    Exposes the import-guarded construction for callers that need more than the
+    ``(client, label)`` shape — e.g. ``followup_issue_generator`` which logs both
+    provider and model and returns the model as its label.
+    """
+    try:
+        from tools.langchain_client import build_chat_client
+    except ImportError:
+        return None
+    return build_chat_client(model=model, provider=provider, force_openai=force_openai)
+
+
+def get_llm_clients(
+    model1: str | None = None,
+    model2: str | None = None,
+) -> list[tuple[Any, str, str]]:
+    """Build the dual-client comparison list used by ``pr_verifier``.
+
+    Mirrors the former ``pr_verifier._get_llm_clients`` exactly: returns a list
+    of ``(client, provider, model)`` tuples, or ``[]`` when deps are missing.
+    """
+    try:
+        from tools.langchain_client import build_chat_clients
+    except ImportError:
+        return []
+    clients = build_chat_clients(model1=model1, model2=model2)
+    return [(entry.client, entry.provider, entry.model) for entry in clients]

--- a/scripts/langchain/_llm_client.py
+++ b/scripts/langchain/_llm_client.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from typing import Any
 
+_RETURN_FIELDS = frozenset({"provider", "model", "provider_label"})
+
 
 def get_llm_client(
     *,
@@ -48,6 +50,10 @@ def get_llm_client(
         ``(client, label)`` or ``None`` when ``langchain`` deps are missing or no
         credentials are available.
     """
+    if return_field not in _RETURN_FIELDS:
+        allowed = ", ".join(sorted(_RETURN_FIELDS))
+        raise ValueError(f"return_field must be one of: {allowed}")
+
     info = build_client(model=model, provider=provider, force_openai=force_openai)
     if not info:
         return None

--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct invocation
+    from _llm_client import get_llm_client as _get_llm_client
+
 ChatPromptTemplate: Any | None = None
 
 
@@ -100,18 +105,6 @@ class CapabilityCheckResult:
         if self.langsmith_trace_url:
             result["langsmith_trace_url"] = self.langsmith_trace_url
         return result
-
-
-def _get_llm_client() -> tuple[object, str] | None:
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client()
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _build_llm_config(

--- a/scripts/langchain/context_extractor.py
+++ b/scripts/langchain/context_extractor.py
@@ -17,9 +17,11 @@ from collections.abc import Iterable
 from pathlib import Path
 
 try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
     from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ModuleNotFoundError:
+    from _llm_client import get_llm_client as _get_llm_client
     from issue_pr_context import ContextOptions, build_issue_context
     from trace_utils import TraceInfo, invoke_with_trace
 
@@ -100,24 +102,6 @@ def _load_prompt() -> str:
     if PROMPT_PATH.is_file():
         return PROMPT_PATH.read_text(encoding="utf-8").strip()
     return CONTEXT_EXTRACTOR_PROMPT
-
-
-def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
-    """Get LLM client using slot order (OpenAI, Claude, GitHub Models).
-
-    Args:
-        force_openai: If True, skip GitHub Models and use OpenAI directly.
-                      Use this for retry after GitHub Models 401 error.
-    """
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client(provider="openai" if force_openai else None)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _strip_code_fences(lines: Iterable[str]) -> list[str]:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -37,6 +37,11 @@ from scripts.langchain.issue_pr_context import estimate_tokens
 from scripts.langchain.verifier_config import EVAL_FOLLOW_UP_BUDGET_TOKENS
 
 try:
+    from scripts.langchain._llm_client import build_client
+except ImportError:  # pragma: no cover - fallback for direct invocation
+    from _llm_client import build_client
+
+try:
     from scripts.langchain.checklist_utils import is_placeholder_checklist_text
 except ImportError:  # pragma: no cover - fallback for direct invocation
     from checklist_utils import is_placeholder_checklist_text
@@ -905,22 +910,22 @@ def _parse_checklist(lines: list[str]) -> list[str]:
     return items
 
 
-def _get_llm_client(reasoning: bool = False) -> tuple[Any, str] | None:
-    """Get LLM client using slot order with optional reasoning model override."""
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError as e:
-        print(f"Warning: langchain_client not available: {e}", file=sys.stderr)
-        return None
+def _get_followup_client(reasoning: bool = False) -> tuple[Any, str] | None:
+    """Get LLM client using slot order with optional reasoning model override.
 
+    The reasoning-model selection and diagnostics are followup-specific; the
+    actual import-guarded construction is delegated to the shared
+    :func:`build_client`. Returns ``(client, model)`` to preserve the prior
+    behavior (this helper returns the *model* label, not the provider).
+    """
     if reasoning:
         model = os.environ.get("FOLLOWUP_REASONING_MODEL", "o3-mini")
-        resolved = build_chat_client(model=model, provider="openai")
+        resolved = build_client(model=model, provider="openai")
         if not resolved:
-            resolved = build_chat_client()
+            resolved = build_client()
     else:
         model = os.environ.get("FOLLOWUP_MODEL", "gpt-5.4")
-        resolved = build_chat_client(model=model)
+        resolved = build_client(model=model)
 
     if not resolved:
         print("Warning: No LLM API keys found", file=sys.stderr)
@@ -1329,9 +1334,9 @@ def generate_followup_issue(
         )
 
     # Get reasoning model for analysis (o3-mini)
-    reasoning_client_info = _get_llm_client(reasoning=True)
+    reasoning_client_info = _get_followup_client(reasoning=True)
     # Get standard model for follow-up generation/formatting (gpt-5.4)
-    standard_client_info = _get_llm_client(reasoning=False)
+    standard_client_info = _get_followup_client(reasoning=False)
 
     # Handle partial availability: use whatever client(s) we have
     if reasoning_client_info and standard_client_info:

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -928,7 +928,16 @@ def _get_followup_client(reasoning: bool = False) -> tuple[Any, str] | None:
         resolved = build_client(model=model)
 
     if not resolved:
-        print("Warning: No LLM API keys found", file=sys.stderr)
+        # Shared build_client collapses both "langchain deps missing" and "no
+        # credentials" to None. Re-probe the import in this (rare) failure path
+        # so the diagnostic names the actual cause, restoring the distinct
+        # import-failure signal the pre-refactor helper emitted.
+        try:
+            import tools.langchain_client  # noqa: F401
+        except ImportError as exc:
+            print(f"Warning: langchain_client not available: {exc}", file=sys.stderr)
+        else:
+            print("Warning: No LLM API keys found", file=sys.stderr)
         return None
 
     print(

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
     from scripts.langchain.checklist_utils import is_placeholder_checklist_text
     from scripts.langchain.injection_guard import check_prompt_injection
     from scripts.langchain.issue_pr_context import (
@@ -29,6 +30,7 @@ try:
     )
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ImportError:  # pragma: no cover - fallback for direct invocation
+    from _llm_client import get_llm_client as _get_llm_client
     from checklist_utils import is_placeholder_checklist_text
     from injection_guard import check_prompt_injection
     from issue_pr_context import (
@@ -182,24 +184,6 @@ def _load_prompt() -> str:
         if feedback:
             return f"{base_prompt}\n\n{feedback}\n"
     return base_prompt
-
-
-def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
-    """Get LLM client, trying GitHub Models first (cheaper), then OpenAI.
-
-    Args:
-        force_openai: If True, skip GitHub Models and use OpenAI directly.
-                      Use this for retry after GitHub Models 401 error.
-    """
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client(force_openai=force_openai)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _normalize_heading(text: str) -> str:

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -27,9 +27,11 @@ from scripts.langchain.structured_output import (
 )
 
 try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
     from scripts.langchain.injection_guard import check_prompt_injection
     from scripts.langchain.issue_pr_context import ContextOptions, build_issue_context
 except ModuleNotFoundError:
+    from _llm_client import get_llm_client as _get_llm_client
     from injection_guard import check_prompt_injection
     from issue_pr_context import ContextOptions, build_issue_context
 
@@ -342,18 +344,6 @@ def _load_apply_prompt() -> str:
     if APPLY_PROMPT_PATH.is_file():
         return APPLY_PROMPT_PATH.read_text(encoding="utf-8").strip()
     return APPLY_SUGGESTIONS_PROMPT
-
-
-def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client(force_openai=force_openai)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _build_llm_config(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -19,11 +19,13 @@ import re
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
 from scripts import api_client
+from scripts.langchain._llm_client import get_llm_client, get_llm_clients
 from scripts.langchain.structured_output import (
     build_repair_callback,
     parse_structured_output,
@@ -33,6 +35,12 @@ from scripts.langchain.verifier_config import (
     EVAL_SCHEMA_REPAIR_BUDGET_TOKENS,
     SchemaRepairPolicy,
 )
+
+# The shared client builder returns the ClientInfo ``provider_label`` for the
+# verifier (the historical ``_get_llm_client`` returned that field). Bound under
+# the module name so existing tests can monkeypatch ``pr_verifier._get_llm_client``.
+_get_llm_client = partial(get_llm_client, return_field="provider_label")
+_get_llm_clients = get_llm_clients
 
 LOGGER = logging.getLogger(__name__)
 SCHEMA_REPAIR_POLICY = SchemaRepairPolicy()
@@ -274,43 +282,6 @@ def _load_prompt() -> str:
         prompt = PROMPT_PATH.read_text(encoding="utf-8").strip()
         return _ensure_prompt_rubric(prompt)
     return _ensure_prompt_rubric(PR_EVALUATION_PROMPT)
-
-
-def _get_llm_client(
-    model: str | None = None, provider: str | None = None
-) -> tuple[object, str] | None:
-    """Get an LLM client for evaluation.
-
-    Args:
-        model: Optional model name override.
-        provider: Optional provider override ('openai' or 'github-models').
-                  If not specified, uses OpenAI if OPENAI_API_KEY is set and model
-                  is specified, otherwise falls back to GitHub Models.
-
-    Returns:
-        Tuple of (client, provider_name) or None if no credentials available.
-    """
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client(model=model, provider=provider)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider_label
-
-
-def _get_llm_clients(
-    model1: str | None = None, model2: str | None = None
-) -> list[tuple[object, str, str]]:
-    try:
-        from tools.langchain_client import build_chat_clients
-    except ImportError:
-        return []
-
-    clients = build_chat_clients(model1=model1, model2=model2)
-    return [(entry.client, entry.provider, entry.model) for entry in clients]
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/task_decomposer.py
+++ b/scripts/langchain/task_decomposer.py
@@ -16,8 +16,10 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.langchain._llm_client import get_llm_client
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ModuleNotFoundError:
+    from _llm_client import get_llm_client
     from trace_utils import TraceInfo, invoke_with_trace
 
 TASK_DECOMPOSITION_PROMPT = """
@@ -123,31 +125,25 @@ def _load_prompt() -> str:
     return TASK_DECOMPOSITION_PROMPT
 
 
-def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
-    """Get LLM client using slot order (OpenAI, Claude, GitHub Models).
+def _resolve_decomposer_provider(force_openai: bool = False) -> str | None:
+    """Resolve the provider for task decomposition.
+
+    Script-specific slot logic preserved from the former ``_get_llm_client``:
+    force OpenAI on retry, otherwise honor ``LANGCHAIN_PROVIDER`` and fall back to
+    GitHub Models when only a ``GITHUB_TOKEN`` is present. The actual client
+    construction is delegated to :func:`get_llm_client`.
 
     Args:
         force_openai: If True, force OpenAI for retry after GitHub Models 401 error.
     """
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    provider = None
     if force_openai:
-        provider = "openai"
-    else:
-        env_provider = os.environ.get("LANGCHAIN_PROVIDER")
-        if env_provider:
-            provider = env_provider
-        elif os.environ.get("GITHUB_TOKEN") and not os.environ.get("OPENAI_API_KEY"):
-            provider = "github-models"
-
-    resolved = build_chat_client(provider=provider)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
+        return "openai"
+    env_provider = os.environ.get("LANGCHAIN_PROVIDER")
+    if env_provider:
+        return env_provider
+    if os.environ.get("GITHUB_TOKEN") and not os.environ.get("OPENAI_API_KEY"):
+        return "github-models"
+    return None
 
 
 def _ensure_verification(text: str) -> str:
@@ -616,7 +612,7 @@ def decompose_task(task: str, *, use_llm: bool = True) -> dict[str, Any]:
         return {"sub_tasks": [], "provider_used": None, "used_llm": False}
 
     if use_llm:
-        client_info = _get_llm_client()
+        client_info = get_llm_client(provider=_resolve_decomposer_provider())
         if client_info:
             client, provider = client_info
             try:
@@ -637,7 +633,9 @@ def decompose_task(task: str, *, use_llm: bool = True) -> dict[str, Any]:
                 except Exception as e:
                     # If GitHub Models fails with 401, retry with OpenAI
                     if provider == "github-models" and _is_github_models_auth_error(e):
-                        fallback_info = _get_llm_client(force_openai=True)
+                        fallback_info = get_llm_client(
+                            provider=_resolve_decomposer_provider(force_openai=True)
+                        )
                         if fallback_info:
                             client, provider = fallback_info
                             chain = template | client

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -21,8 +21,10 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
     from scripts.langchain.trace_utils import TraceInfo, invoke_with_trace
 except ModuleNotFoundError:
+    from _llm_client import get_llm_client as _get_llm_client
     from trace_utils import TraceInfo, invoke_with_trace
 
 # ---------------------------------------------------------------------------
@@ -292,19 +294,6 @@ def triage_tasks(tasks: list[str]) -> TriageResult:
 # ---------------------------------------------------------------------------
 # LLM client utilities
 # ---------------------------------------------------------------------------
-
-
-def _get_llm_client(force_openai: bool = False) -> tuple[object, str] | None:
-    """Get LLM client using slot order (OpenAI, Claude, GitHub Models)."""
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        return None
-
-    resolved = build_chat_client(provider="openai" if force_openai else None)
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _is_github_models_auth_error(exc: Exception) -> bool:

--- a/scripts/langchain/topic_splitter.py
+++ b/scripts/langchain/topic_splitter.py
@@ -21,8 +21,10 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts.langchain._llm_client import get_llm_client as _get_llm_client
     from scripts.langchain.trace_utils import invoke_with_trace
 except ModuleNotFoundError:
+    from _llm_client import get_llm_client as _get_llm_client
     from trace_utils import invoke_with_trace
 
 TOPIC_SPLITTER_PROMPT = """
@@ -56,20 +58,6 @@ Output format - respond with ONLY valid JSON, no other text:
 Input text to split:
 {input_text}
 """.strip()
-
-
-def _get_llm_client() -> tuple[object, str] | None:
-    """Get LangChain LLM client using slot order."""
-    try:
-        from tools.langchain_client import build_chat_client
-    except ImportError:
-        print("langchain_client not available", file=sys.stderr)
-        return None
-
-    resolved = build_chat_client()
-    if not resolved:
-        return None
-    return resolved.client, resolved.provider
 
 
 def _generate_guid(title: str) -> str:

--- a/tests/scripts/test_llm_client_shared.py
+++ b/tests/scripts/test_llm_client_shared.py
@@ -98,6 +98,13 @@ def test_get_llm_client_return_field_selects_label(
     assert result[1] == expected
 
 
+def test_get_llm_client_rejects_unknown_return_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_langchain_client(monkeypatch, info=_fake_info())
+
+    with pytest.raises(ValueError, match="return_field must be one of"):
+        _llm_client.get_llm_client(return_field="provider_lable")
+
+
 def test_get_llm_client_returns_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_langchain_client(monkeypatch, info=None)
 

--- a/tests/scripts/test_llm_client_shared.py
+++ b/tests/scripts/test_llm_client_shared.py
@@ -1,0 +1,147 @@
+"""Tests for the shared ``scripts/langchain/_llm_client`` module (issue #2343).
+
+The ``get_llm_client`` / ``get_llm_clients`` helpers replace the ``_get_llm_client``
+bodies that were copy-pasted across the langchain agent scripts. These tests stub
+``tools.langchain_client`` so they run without the optional langchain deps or any
+real credentials.
+"""
+
+from __future__ import annotations
+
+import functools
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from scripts.langchain import _llm_client
+
+
+def _install_fake_langchain_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    info: object | None = None,
+    clients: list[object] | None = None,
+) -> ModuleType:
+    """Install a fake ``tools.langchain_client`` module and record calls."""
+    fake = ModuleType("tools.langchain_client")
+    fake.calls = []  # type: ignore[attr-defined]
+    fake.clients_calls = []  # type: ignore[attr-defined]
+
+    def build_chat_client(*, model=None, provider=None, force_openai=False):
+        fake.calls.append(  # type: ignore[attr-defined]
+            {"model": model, "provider": provider, "force_openai": force_openai}
+        )
+        return info
+
+    def build_chat_clients(*, model1=None, model2=None):
+        fake.clients_calls.append({"model1": model1, "model2": model2})  # type: ignore[attr-defined]
+        return clients or []
+
+    fake.build_chat_client = build_chat_client  # type: ignore[attr-defined]
+    fake.build_chat_clients = build_chat_clients  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tools.langchain_client", fake)
+    return fake
+
+
+def _fake_info() -> SimpleNamespace:
+    return SimpleNamespace(
+        client=object(),
+        provider="openai",
+        model="gpt-5.4",
+        provider_label="openai:gpt-5.4",
+    )
+
+
+def test_get_llm_client_returns_configured_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Named test (acceptance + deliberate-break gate): a configured client is returned.
+
+    If ``get_llm_client`` is made to return ``None`` this test fails, proving the
+    deliberate-break gate from issue #2343.
+    """
+    info = _fake_info()
+    _install_fake_langchain_client(monkeypatch, info=info)
+
+    result = _llm_client.get_llm_client()
+
+    assert result is not None
+    client, label = result
+    assert client is info.client
+    assert label == "openai"
+
+
+def test_get_llm_client_passes_through_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = _fake_info()
+    fake = _install_fake_langchain_client(monkeypatch, info=info)
+
+    _llm_client.get_llm_client(force_openai=True, model="o3-mini", provider="openai")
+
+    assert fake.calls == [{"model": "o3-mini", "provider": "openai", "force_openai": True}]
+
+
+@pytest.mark.parametrize(
+    ("return_field", "expected"),
+    [
+        ("provider", "openai"),
+        ("model", "gpt-5.4"),
+        ("provider_label", "openai:gpt-5.4"),
+    ],
+)
+def test_get_llm_client_return_field_selects_label(
+    monkeypatch: pytest.MonkeyPatch, return_field: str, expected: str
+) -> None:
+    info = _fake_info()
+    _install_fake_langchain_client(monkeypatch, info=info)
+
+    result = _llm_client.get_llm_client(return_field=return_field)
+
+    assert result is not None
+    assert result[1] == expected
+
+
+def test_get_llm_client_returns_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_langchain_client(monkeypatch, info=None)
+
+    assert _llm_client.get_llm_client() is None
+
+
+def test_get_llm_client_returns_none_without_langchain(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Setting the module to None makes ``import tools.langchain_client`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "tools.langchain_client", None)
+
+    assert _llm_client.get_llm_client() is None
+    assert _llm_client.build_client() is None
+
+
+def test_get_llm_clients_returns_tuples(monkeypatch: pytest.MonkeyPatch) -> None:
+    entries = [
+        SimpleNamespace(client=object(), provider="openai", model="m1"),
+        SimpleNamespace(client=object(), provider="github-models", model="m2"),
+    ]
+    _install_fake_langchain_client(monkeypatch, clients=entries)
+
+    result = _llm_client.get_llm_clients(model1="m1", model2="m2")
+
+    assert [(c, p, m) for (c, p, m) in result] == [
+        (entries[0].client, "openai", "m1"),
+        (entries[1].client, "github-models", "m2"),
+    ]
+
+
+def test_get_llm_clients_returns_empty_without_langchain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "tools.langchain_client", None)
+
+    assert _llm_client.get_llm_clients() == []
+
+
+def test_representative_scripts_import_shared_helper() -> None:
+    """Each script wires its client construction to the shared module."""
+    from scripts.langchain import context_extractor, pr_verifier
+
+    # Simple scripts bind the shared helper under the historical mockable name.
+    assert context_extractor._get_llm_client is _llm_client.get_llm_client
+
+    # pr_verifier returns the provider_label and reuses the shared dual builder.
+    assert isinstance(pr_verifier._get_llm_client, functools.partial)
+    assert pr_verifier._get_llm_client.func is _llm_client.get_llm_client
+    assert pr_verifier._get_llm_client.keywords == {"return_field": "provider_label"}
+    assert pr_verifier._get_llm_clients is _llm_client.get_llm_clients

--- a/tests/scripts/test_task_decomposer.py
+++ b/tests/scripts/test_task_decomposer.py
@@ -464,7 +464,10 @@ def test_get_llm_client_missing_dependency(monkeypatch) -> None:
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr("builtins.__import__", fake_import)
-    assert task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider()) is None
+    assert (
+        task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+        is None
+    )
 
 
 def test_get_llm_client_no_tokens(monkeypatch) -> None:
@@ -472,7 +475,10 @@ def test_get_llm_client_no_tokens(monkeypatch) -> None:
     _install_fake_langchain_openai(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    assert task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider()) is None
+    assert (
+        task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+        is None
+    )
 
 
 def test_get_llm_client_with_github_token(monkeypatch) -> None:
@@ -480,7 +486,9 @@ def test_get_llm_client_with_github_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+    client_info = task_decomposer.get_llm_client(
+        provider=task_decomposer._resolve_decomposer_provider()
+    )
     assert client_info is not None
     client, provider = client_info
     assert provider == "github-models"
@@ -493,7 +501,9 @@ def test_get_llm_client_github_token_defaults(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+    client_info = task_decomposer.get_llm_client(
+        provider=task_decomposer._resolve_decomposer_provider()
+    )
     assert client_info is not None
     client, provider = client_info
     assert provider == "github-models"
@@ -509,7 +519,9 @@ def test_get_llm_client_with_openai_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
-    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+    client_info = task_decomposer.get_llm_client(
+        provider=task_decomposer._resolve_decomposer_provider()
+    )
     assert client_info is not None
     client, provider = client_info
     assert provider == "openai"
@@ -523,7 +535,9 @@ def test_get_llm_client_prefers_openai_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
-    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
+    client_info = task_decomposer.get_llm_client(
+        provider=task_decomposer._resolve_decomposer_provider()
+    )
     assert client_info is not None
     client, provider = client_info
     assert provider == "openai"

--- a/tests/scripts/test_task_decomposer.py
+++ b/tests/scripts/test_task_decomposer.py
@@ -464,7 +464,7 @@ def test_get_llm_client_missing_dependency(monkeypatch) -> None:
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr("builtins.__import__", fake_import)
-    assert task_decomposer._get_llm_client() is None
+    assert task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider()) is None
 
 
 def test_get_llm_client_no_tokens(monkeypatch) -> None:
@@ -472,7 +472,7 @@ def test_get_llm_client_no_tokens(monkeypatch) -> None:
     _install_fake_langchain_openai(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    assert task_decomposer._get_llm_client() is None
+    assert task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider()) is None
 
 
 def test_get_llm_client_with_github_token(monkeypatch) -> None:
@@ -480,7 +480,7 @@ def test_get_llm_client_with_github_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    client_info = task_decomposer._get_llm_client()
+    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
     assert client_info is not None
     client, provider = client_info
     assert provider == "github-models"
@@ -493,7 +493,7 @@ def test_get_llm_client_github_token_defaults(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    client_info = task_decomposer._get_llm_client()
+    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
     assert client_info is not None
     client, provider = client_info
     assert provider == "github-models"
@@ -509,7 +509,7 @@ def test_get_llm_client_with_openai_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
-    client_info = task_decomposer._get_llm_client()
+    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
     assert client_info is not None
     client, provider = client_info
     assert provider == "openai"
@@ -523,7 +523,7 @@ def test_get_llm_client_prefers_openai_token(monkeypatch) -> None:
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
-    client_info = task_decomposer._get_llm_client()
+    client_info = task_decomposer.get_llm_client(provider=task_decomposer._resolve_decomposer_provider())
     assert client_info is not None
     client, provider = client_info
     assert provider == "openai"

--- a/tests/scripts/test_task_decomposer.py
+++ b/tests/scripts/test_task_decomposer.py
@@ -451,7 +451,7 @@ def _install_fake_langchain_openai(monkeypatch):
 
 
 def test_get_llm_client_missing_dependency(monkeypatch) -> None:
-    """_get_llm_client returns None when langchain_openai is unavailable."""
+    """get_llm_client returns None when langchain_openai is unavailable."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delitem(sys.modules, "langchain_openai", raising=False)
@@ -471,7 +471,7 @@ def test_get_llm_client_missing_dependency(monkeypatch) -> None:
 
 
 def test_get_llm_client_no_tokens(monkeypatch) -> None:
-    """_get_llm_client returns None when no API tokens are set."""
+    """get_llm_client returns None when no API tokens are set."""
     _install_fake_langchain_openai(monkeypatch)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -482,7 +482,7 @@ def test_get_llm_client_no_tokens(monkeypatch) -> None:
 
 
 def test_get_llm_client_with_github_token(monkeypatch) -> None:
-    """_get_llm_client uses GitHub Models when GITHUB_TOKEN is set."""
+    """get_llm_client uses GitHub Models when GITHUB_TOKEN is set."""
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -878,12 +878,14 @@ def test_extract_structural_issues():
     assert any("code snippets" in issue.lower() for issue in data.structural_issues)
 
 
-def test_get_llm_client_defaults_to_expected_models(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_followup_client_defaults_to_expected_models(monkeypatch: pytest.MonkeyPatch) -> None:
     """Standard and reasoning follow-up paths should use the documented defaults."""
 
     calls: list[tuple[str | None, str | None]] = []
 
-    def fake_build_chat_client(*, model: str | None = None, provider: str | None = None):
+    def fake_build_chat_client(
+        *, model: str | None = None, provider: str | None = None, force_openai: bool = False
+    ):
         calls.append((model, provider))
         return SimpleNamespace(
             client=object(), model=model or "fallback", provider=provider or "auto"
@@ -896,8 +898,8 @@ def test_get_llm_client_defaults_to_expected_models(monkeypatch: pytest.MonkeyPa
     monkeypatch.delenv("FOLLOWUP_MODEL", raising=False)
     monkeypatch.delenv("FOLLOWUP_REASONING_MODEL", raising=False)
 
-    standard_client = followup_issue_generator._get_llm_client(reasoning=False)
-    reasoning_client = followup_issue_generator._get_llm_client(reasoning=True)
+    standard_client = followup_issue_generator._get_followup_client(reasoning=False)
+    reasoning_client = followup_issue_generator._get_followup_client(reasoning=True)
 
     assert standard_client is not None
     assert reasoning_client is not None

--- a/tests/test_followup_issue_generator.py
+++ b/tests/test_followup_issue_generator.py
@@ -372,6 +372,29 @@ def test_build_why_section_explains_mixed_surface_deemphasis() -> None:
     assert "Workflow-sync acceptance criteria were de-emphasized" in why
 
 
+def test_get_followup_client_distinguishes_missing_deps_from_missing_keys(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A None from build_client must report the actual cause.
+
+    The shared build_client collapses an ``ImportError`` (langchain deps
+    missing) and a credential miss to the same ``None``. _get_followup_client
+    must still emit a distinct diagnostic for each, as the pre-refactor helper
+    did.
+    """
+    monkeypatch.setattr(followup_issue_generator, "build_client", lambda **_: None)
+
+    # Deps importable -> credential-miss message.
+    monkeypatch.setitem(sys.modules, "tools.langchain_client", ModuleType("tools.langchain_client"))
+    assert followup_issue_generator._get_followup_client() is None
+    assert "No LLM API keys found" in capsys.readouterr().err
+
+    # Deps not importable -> distinct import-failure message.
+    monkeypatch.setitem(sys.modules, "tools.langchain_client", None)
+    assert followup_issue_generator._get_followup_client() is None
+    assert "langchain_client not available" in capsys.readouterr().err
+
+
 class TestExtractVerificationData:
     """Tests for extract_verification_data function."""
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2343 -->
> **Source:** Issue #2343

Closes #2343

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`_get_llm_client` is copied across **9** langchain scripts (verified `grep -rln _get_llm_client scripts/`): `context_extractor.py`, `capability_check.py`, `issue_optimizer.py`, `topic_splitter.py`, `issue_formatter.py`, `task_decomposer.py`, `followup_issue_generator.py`, `pr_verifier.py`, `task_validator.py`. This is **latent fragility, not a current break**: a fix to client construction (model id, base-url, auth fallback) must be applied 9×, and they will diverge.

#### Tasks
- [ ] Create `scripts/langchain/_llm_client.py` with `get_llm_client(...)` capturing the common construction (consolidate any divergence to the richest variant; note any intentional per-script differences as params).
- [ ] Replace the local `_get_llm_client` in all 9 scripts with an import of the shared function.
- [ ] Add `tests/scripts/test_llm_client_shared.py` asserting `get_llm_client` returns a configured client (with env/secrets stubbed) and that a representative script imports it.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/scripts/test_llm_client_shared.py` passes — `get_llm_client` returns the expected configured client for stubbed env.
- [ ] **Deliberate-break gate:** temporarily make `get_llm_client` return `None`. The named test **must FAIL**. Revert after capturing the failure.
- [ ] `grep -rl "def _get_llm_client" scripts/langchain/` returns **0** after the change.

<!-- auto-status-summary:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LLM provider selection and auth-fallback paths across many agent workflows; behavior is intended to be preserved but regressions would affect all LangChain automation.
> 
> **Overview**
> **Centralizes LangChain chat client setup** in new `scripts/langchain/_llm_client.py` (`get_llm_client`, `build_client`, `get_llm_clients`), replacing duplicated `_get_llm_client` helpers across nine agent scripts.
> 
> **Scripts now import the shared module** (with direct-invocation fallbacks where needed). Per-script behavior is preserved via parameters (`force_openai`, `model`, `provider`, `return_field`) or thin local wrappers: `pr_verifier` binds `return_field="provider_label"` for test monkeypatching; `task_decomposer` keeps env-based provider resolution in `_resolve_decomposer_provider`; `followup_issue_generator` renames to `_get_followup_client` and uses `build_client` while restoring distinct stderr messages for missing deps vs missing API keys.
> 
> **Consumer sync** adds `_llm_client.py` to `.github/sync-manifest.yml` as a copy-delivered transitive dependency.
> 
> **Tests** add `tests/scripts/test_llm_client_shared.py` and update `task_decomposer` / follow-up generator tests for the new entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93f5166118f88351c33b3a15b5e5e7bbb960221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->