### PR TITLE
Annotate sync-manifest delivery channel; drop runtime-fetched langchain from copy-sync (#2347)

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -487,101 +487,149 @@ scripts:
     description: "Scans agent belt for available tools"
 
   # LangChain scripts for agent workflows
+  #
+  # delivery: channel annotation (issue #2347)
+  #   copy    = physically copy-synced into the consumer tree by maint-68 and
+  #             read from the consumer's own working directory at runtime.
+  #   runtime = NOT copy-synced; the consuming consumer-template workflow does a
+  #             runtime sparse-checkout of stranske/Workflows `scripts/langchain`
+  #             (whole-directory) and runs the script from that fetched tree.
+  # Entries with `delivery: runtime` MUST NOT appear in any copy-synced section
+  # (they live under `runtime_fetched:` below); see
+  # tests/workflows/test_sync_manifest_delivery.py.
   - source: scripts/api_client.py
     description: "Shared GitHub API client used by synced Python automation scripts"
 
   # Issue optimization (Phase 1) - agents-issue-optimizer.yml
   - source: scripts/langchain/issue_optimizer.py
     description: "Issue optimizer - analyzes issues and suggests improvements"
+    # delivery: copy -- read from the consumer working tree by agents-auto-pilot.yml
+    # (optimize/apply steps: `python scripts/langchain/issue_optimizer.py` +
+    # `sys.path.insert(0, 'scripts/langchain')`), which does NOT runtime-fetch
+    # scripts/langchain. Must stay copy-synced.
+    delivery: copy
 
   - source: scripts/langchain/structured_output.py
     description: "Shared structured output helpers for LangChain workflows"
+    # delivery: copy -- imported transitively by issue_optimizer.py on auto-pilot's
+    # copy-path (`from scripts.langchain.structured_output import ...`).
+    delivery: copy
 
   - source: scripts/langchain/trace_utils.py
     description: "Shared LangSmith trace metadata helpers for LangChain workflows"
+    delivery: copy
 
   - source: scripts/langchain/verifier_config.py
     description: "Shared verifier prompt budgets, schema-repair policy, and terminal artifact validation"
+    delivery: copy
 
   - source: scripts/langchain/checklist_utils.py
     description: "Shared checklist parsing helpers for issue and follow-up generation"
+    delivery: copy
 
   - source: scripts/langchain/issue_formatter.py
     description: "Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format"
+    # delivery: copy -- read from the consumer working tree by agents-auto-pilot.yml
+    # (format step: `python scripts/langchain/issue_formatter.py`), which does NOT
+    # runtime-fetch scripts/langchain. Must stay copy-synced.
+    delivery: copy
 
   - source: scripts/langchain/issue_pr_context.py
     description: "Issue/PR context assembly helper with shared token budget caps"
+    delivery: copy
 
   - source: scripts/langchain/issue_dedup.py
     description: "Issue deduplication - finds similar open issues"
+    delivery: copy
 
   - source: scripts/langchain/injection_guard.py
     description: "Prompt injection guard - validates prompts before LLM submission"
+    delivery: copy
 
   - source: scripts/langchain/progress_reviewer.py
     description: "Progress reviewer - evaluates agent progress for keepalive rounds"
+    delivery: copy
 
   # Context and semantic analysis
   - source: scripts/langchain/context_extractor.py
     description: "Context extractor - extracts relevant context from issues/PRs"
+    delivery: copy
 
   - source: scripts/langchain/semantic_matcher.py
     description: "Semantic matcher - vector similarity for issues/labels"
+    delivery: copy
 
   # Agent capability and task management
   - source: scripts/langchain/capability_check.py
     description: "Capability check - pre-flight agent feasibility assessment"
+    delivery: copy
 
   - source: scripts/langchain/task_decomposer.py
     description: "Task decomposer - breaks large issues into sub-tasks"
+    delivery: copy
 
   - source: scripts/langchain/task_validator.py
     description: "Task validator - refines generated issue tasks for actionability"
+    delivery: copy
 
   - source: scripts/langchain/label_matcher.py
     description: "Label matcher - suggests labels based on semantic matching"
+    delivery: copy
 
   # PR verification and follow-up
   - source: scripts/langchain/pr_verifier.py
     description: "PR verifier - validates PR changes against acceptance criteria"
+    delivery: copy
 
-  - source: scripts/langchain/followup_issue_generator.py
-    description: "Follow-up issue generator - creates issues from verification feedback"
+  # NOTE (issue #2347): scripts/langchain/followup_issue_generator.py was MOVED
+  # out of this copy-sync set into the `runtime_fetched:` section below. It is
+  # delivered to consumers ONLY via runtime sparse-checkout (see that section).
 
   # Integration layer for LangChain components
   - source: scripts/langchain/integration_layer.py
     description: "Integration layer - coordinates LangChain components"
+    delivery: copy
 
   - source: scripts/langchain/topic_splitter.py
     description: "Topic splitter - splits conversations into discrete issues"
+    delivery: copy
 
   # LangChain prompt templates
   - source: scripts/langchain/prompts/format_issue.md
     description: "Prompt template for LLM-based issue formatting"
+    delivery: copy
 
   - source: scripts/langchain/prompts/analyze_issue.md
     description: "Prompt template for issue analysis/optimization"
+    delivery: copy
 
   - source: scripts/langchain/prompts/apply_suggestions.md
     description: "Prompt template for applying optimization suggestions"
+    delivery: copy
 
   - source: scripts/langchain/prompts/context_extract.md
     description: "Prompt template for context extraction"
+    delivery: copy
 
   - source: scripts/langchain/prompts/decompose_task.md
     description: "Prompt template for task decomposition"
+    delivery: copy
 
   - source: scripts/langchain/prompts/pr_evaluation.md
     description: "Prompt template for PR evaluation/verification"
+    delivery: copy
 
   - source: scripts/langchain/prompts/refine_tasks.md
     description: "Prompt template for task refinement and validation"
+    delivery: copy
 
   - source: scripts/langchain/verdict_extract.py
     description: "Verdict extractor - parses verification verdicts from LLM output"
+    delivery: copy
 
   - source: scripts/langchain/verdict_policy.py
     description: "Verdict policy engine - applies pass/fail rules to verification results"
+    delivery: copy
 
   - source: tools/llm_provider.py
     description: "LLM provider configuration - GitHub Models and OpenAI client setup"
@@ -737,6 +785,40 @@ git_config:
 
 
 # Files that exist in templates but are NOT synced (consumer creates their own)
+# Runtime-fetched scripts (issue #2347)
+#
+# These files are intentionally NOT copy-synced into consumer repos. The
+# consumer-template workflows that use them perform a runtime sparse-checkout of
+# stranske/Workflows `scripts/langchain` (whole-directory) and run the script
+# directly from that fetched tree, so a copy in the consumer working tree would
+# only create a second, skew-prone delivery path during the daily sync window.
+#
+# This section is deliberately NOT in the list of sections processed by the
+# sync engine (maint-68-sync-consumer-repos.yml) or the drift checker
+# (scripts/check_consumer_sync_drift.py), so entries here are never copied and
+# never drift-probed. Each entry MUST carry `delivery: runtime`.
+# Enforced by tests/workflows/test_sync_manifest_delivery.py.
+runtime_fetched:
+  - source: scripts/langchain/followup_issue_generator.py
+    delivery: runtime
+    description: "Follow-up issue generator - creates issues from verification feedback. Runtime-fetched only."
+    # Runtime-fetch evidence (consumer-delivered workflows, both in the manifest
+    # `workflows:` set):
+    #   * templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+    #     - L315-323: actions/checkout repository: stranske/Workflows,
+    #       sparse-checkout includes `scripts/langchain` + `tools`, NO `path:`
+    #       (lands in the workspace root).
+    #     - L434: `python scripts/langchain/followup_issue_generator.py ...`
+    #       runs from that runtime-fetched root.
+    #   * templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+    #     - L67-83: the ONLY checkout is repository: stranske/Workflows with
+    #       `scripts/langchain` in sparse-checkout and NO `path:`; the consumer's
+    #       own repo is never checked out into root in this job.
+    #     - L576: `python scripts/langchain/followup_issue_generator.py ...`.
+    # No consumer-delivered workflow reads this module from the copy-synced tree,
+    # and no script/tool imports it (grep: zero importers), so dropping it from
+    # copy-sync is safe.
+
 excluded:
 
   - path: .gitignore

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -486,7 +486,7 @@ scripts:
   - source: .github/scripts/agents_belt_scan.js
     description: "Scans agent belt for available tools"
 
-  # LangChain scripts for agent workflows
+  # Agent helper scripts and copy-delivered LangChain workflow support
   #
   # delivery: channel annotation (issue #2347)
   #   copy    = physically copy-synced into the consumer tree by maint-68 and
@@ -784,8 +784,7 @@ git_config:
     description: "Git attributes - merge strategies to prevent pr_body.md conflicts"
 
 
-# Files that exist in templates but are NOT synced (consumer creates their own)
-# Runtime-fetched scripts (issue #2347)
+# Workflows-owned runtime-fetched scripts (issue #2347)
 #
 # These files are intentionally NOT copy-synced into consumer repos. The
 # consumer-template workflows that use them perform a runtime sparse-checkout of

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -161,7 +161,9 @@ def test_all_langchain_entries_have_a_delivery_channel() -> None:
                 "runtime",
             }:
                 missing.append(source)
-    assert not missing, f"scripts/langchain/* entries missing a delivery: channel: {sorted(missing)}"
+    assert (
+        not missing
+    ), f"scripts/langchain/* entries missing a delivery: channel: {sorted(missing)}"
 
 
 def test_runtime_fetched_section_is_not_copy_processed() -> None:
@@ -173,9 +175,9 @@ def test_runtime_fetched_section_is_not_copy_processed() -> None:
     """
     sync_text = SYNC_WORKFLOW_PATH.read_text(encoding="utf-8")
     drift_text = DRIFT_CHECK_PATH.read_text(encoding="utf-8")
-    assert "runtime_fetched" not in sync_text, (
-        "maint-68 must not process the runtime_fetched section (would copy-deliver it)"
-    )
-    assert "runtime_fetched" not in drift_text, (
-        "check_consumer_sync_drift must not probe the runtime_fetched section"
-    )
+    assert (
+        "runtime_fetched" not in sync_text
+    ), "maint-68 must not process the runtime_fetched section (would copy-deliver it)"
+    assert (
+        "runtime_fetched" not in drift_text
+    ), "check_consumer_sync_drift must not probe the runtime_fetched section"

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -1,0 +1,181 @@
+"""Delivery-channel invariants for .github/sync-manifest.yml (issue #2347).
+
+Background
+----------
+LangChain helper scripts were being delivered to consumer repos two ways at
+once: copy-synced into the consumer tree by ``maint-68-sync-consumer-repos.yml``
+*and* fetched at runtime by the consumer-template workflows that use them (which
+sparse-checkout ``stranske/Workflows`` ``scripts/langchain`` as a whole directory
+and run the script straight from that fetched tree). During the daily sync
+window the two channels can disagree for ~30 minutes, a latent version skew.
+
+Fix
+---
+Every LangChain manifest entry now carries a ``delivery:`` channel:
+
+* ``copy``    -- physically copy-synced into the consumer tree and read from the
+  consumer's own working directory at runtime.
+* ``runtime`` -- NOT copy-synced; delivered only via the runtime sparse-checkout.
+
+Entries marked ``runtime`` live in the dedicated ``runtime_fetched:`` section,
+which is intentionally absent from the section lists processed by the sync
+engine and the drift checker, so they are never copied and never drift-probed.
+
+These tests assert the load-bearing invariant: **no manifest entry is both
+``delivery: runtime`` and present in a copy-synced section** (that would
+re-create the double delivery this issue removes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / ".github" / "sync-manifest.yml"
+SYNC_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "maint-68-sync-consumer-repos.yml"
+DRIFT_CHECK_PATH = REPO_ROOT / "scripts" / "check_consumer_sync_drift.py"
+
+# Manifest sections whose entries are physically copied into consumer repos by
+# maint-68-sync-consumer-repos.yml. Kept in lockstep with that workflow's
+# add_target() loop and the per-section sync_file/sync_directory calls. The
+# `runtime_fetched:` section is deliberately NOT in this set.
+COPY_SYNCED_SECTIONS = (
+    "workflows",
+    "prompts",
+    "scripts",
+    "codex_config",
+    "copilot_config",
+    "templates",
+    "actions",
+    "docs",
+    "llm_config",
+    "git_config",
+    "issue_templates",
+    "user_docs",
+)
+
+
+def _load_manifest() -> dict:
+    return yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8")) or {}
+
+
+def _sources_in_sections(manifest: dict, sections: tuple[str, ...]) -> set[str]:
+    sources: set[str] = set()
+    for section in sections:
+        entries = manifest.get(section)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("source"):
+                sources.add(str(entry["source"]))
+    return sources
+
+
+def _runtime_sources(manifest: dict) -> set[str]:
+    sources: set[str] = set()
+    for value in manifest.values():
+        if not isinstance(value, list):
+            continue
+        for entry in value:
+            if (
+                isinstance(entry, dict)
+                and entry.get("delivery") == "runtime"
+                and entry.get("source")
+            ):
+                sources.add(str(entry["source"]))
+    return sources
+
+
+def test_no_entry_is_both_runtime_and_copy_synced() -> None:
+    """The crux invariant: a runtime-delivered entry must not also be copy-synced."""
+    manifest = _load_manifest()
+    copy_sources = _sources_in_sections(manifest, COPY_SYNCED_SECTIONS)
+    runtime_sources = _runtime_sources(manifest)
+
+    double_delivered = sorted(copy_sources & runtime_sources)
+    assert not double_delivered, (
+        "These entries are delivery: runtime but still present in a copy-synced "
+        f"section (double delivery, the skew this issue removes): {double_delivered}"
+    )
+
+
+def test_followup_issue_generator_is_runtime_only() -> None:
+    """The proven runtime-fetched langchain script is dropped from copy-sync.
+
+    followup_issue_generator.py is invoked only from a runtime sparse-checkout of
+    scripts/langchain in agents-80-pr-event-hub.yml and agents-verify-to-new-pr.yml
+    (both check out stranske/Workflows into the workspace root with no `path:`).
+    No consumer-delivered workflow reads it from the copy-synced tree.
+    """
+    manifest = _load_manifest()
+    source = "scripts/langchain/followup_issue_generator.py"
+
+    copy_sources = _sources_in_sections(manifest, COPY_SYNCED_SECTIONS)
+    assert source not in copy_sources, f"{source} must not be copy-synced"
+
+    runtime_entries = {
+        e["source"]: e
+        for e in (manifest.get("runtime_fetched") or [])
+        if isinstance(e, dict) and e.get("source")
+    }
+    assert source in runtime_entries, f"{source} must be declared under runtime_fetched:"
+    assert runtime_entries[source].get("delivery") == "runtime"
+
+
+def test_copy_dependent_langchain_scripts_stay_copy_synced() -> None:
+    """Regression guard against an over-aggressive future drop.
+
+    agents-auto-pilot.yml runs issue_formatter.py / issue_optimizer.py from the
+    consumer's own working tree (it does NOT runtime-fetch scripts/langchain), and
+    issue_optimizer.py imports scripts.langchain.structured_output. These three
+    must remain copy-synced or auto-pilot breaks in consumers.
+    """
+    manifest = _load_manifest()
+    copy_sources = _sources_in_sections(manifest, COPY_SYNCED_SECTIONS)
+    for required in (
+        "scripts/langchain/issue_formatter.py",
+        "scripts/langchain/issue_optimizer.py",
+        "scripts/langchain/structured_output.py",
+    ):
+        assert required in copy_sources, (
+            f"{required} is a copy-path dependency of agents-auto-pilot.yml and "
+            "must stay in a copy-synced section"
+        )
+
+
+def test_all_langchain_entries_have_a_delivery_channel() -> None:
+    """Every scripts/langchain/* entry must declare its delivery channel."""
+    manifest = _load_manifest()
+    missing: list[str] = []
+    for value in manifest.values():
+        if not isinstance(value, list):
+            continue
+        for entry in value:
+            if not isinstance(entry, dict):
+                continue
+            source = str(entry.get("source", ""))
+            if source.startswith("scripts/langchain/") and entry.get("delivery") not in {
+                "copy",
+                "runtime",
+            }:
+                missing.append(source)
+    assert not missing, f"scripts/langchain/* entries missing a delivery: channel: {sorted(missing)}"
+
+
+def test_runtime_fetched_section_is_not_copy_processed() -> None:
+    """`runtime_fetched` must not be wired into the sync engine or drift checker.
+
+    If a future change adds `runtime_fetched` to either consumer of the section
+    list, entries here would start being copied/drift-probed -- re-introducing the
+    double delivery. This test fails loudly in that case.
+    """
+    sync_text = SYNC_WORKFLOW_PATH.read_text(encoding="utf-8")
+    drift_text = DRIFT_CHECK_PATH.read_text(encoding="utf-8")
+    assert "runtime_fetched" not in sync_text, (
+        "maint-68 must not process the runtime_fetched section (would copy-deliver it)"
+    )
+    assert "runtime_fetched" not in drift_text, (
+        "check_consumer_sync_drift must not probe the runtime_fetched section"
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2347 -->
> **Source:** Issue #2347

Closes #2347

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The langchain scripts are delivered to consumers **two ways at once**: ~30 langchain entries are copy-synced via `.github/sync-manifest.yml` (verified: 30 `langchain` matches) **and** the same scripts are fetched at runtime via sparse-checkout by the workflows that use them (audit `func-sync` F2). During the daily sync window (05:00 sync → ~05:30 auto-merge) the two channels have different latencies, so a consumer can run last week's copy-synced `issue_formatter.py` while `issue-optimizer` runtime-fetches today's — a version skew across the same logical module.

This is **latent fragility, not a current break**: nothing fails, but the two delivery paths can disagree for ~30 minutes daily, and the copy-synced langchain tree is dead weight the moment the runtime fetch exists.

#### Tasks
- [ ] Determine which `langchain/` manifest entries are imported by runtime sparse-checked-out code (grep the workflows for the runtime fetch of `scripts/langchain/`).
- [ ] Annotate each `sync-manifest.yml` entry with a `delivery:` channel (`copy` | `runtime`) and drop the runtime-only langchain entries from the copy-sync set.
- [ ] Add `tests/workflows/test_sync_manifest_delivery.py` asserting no entry is both `runtime`-delivered and present in the copy-sync set.
- [ ] Perform the deliberate-break verification (see Acceptance), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/workflows/test_sync_manifest_delivery.py` passes — asserts the runtime-fetched langchain scripts are NOT in the copy-sync set.
- [ ] **Deliberate-break gate:** temporarily re-add one runtime-fetched langchain script to the copy-sync set. The named test **must FAIL** (double-delivery detected). Revert after capturing the failure.
- [ ] The drift/parity check (`health-74` / sync selftests) still passes for the genuinely copy-synced files (triggers/prompts/templates).

**Head SHA:** 95d9242aad299e3b724befa8700b1913fd2b430c
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483473003) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27483472978) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27483472941) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472924) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472923) |
| Health 72 Template Sync | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472926) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472938) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472950) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472975) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472936) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27483472952) |
<!-- auto-status-summary:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and test-only changes; runtime workflows already fetch followup_issue_generator, and copy-synced auto-pilot LangChain paths are explicitly guarded by tests.
> 
> **Overview**
> Stops LangChain helpers from being delivered to consumer repos on **two paths at once** (daily copy-sync vs runtime sparse-checkout of `stranske/Workflows`), which could skew versions during the sync window.
> 
> **`.github/sync-manifest.yml`** now documents `delivery: copy` vs `delivery: runtime`, tags every remaining `scripts/langchain/*` copy-sync entry with **`delivery: copy`**, and **removes** `scripts/langchain/followup_issue_generator.py` from the copy-sync `scripts:` list. That script is declared only under a new **`runtime_fetched:`** section with **`delivery: runtime`** (not processed by maint-68 or drift checks).
> 
> **`tests/workflows/test_sync_manifest_delivery.py`** adds regression tests: no runtime entry may also appear in copy-synced sections, follow-up generator is runtime-only, auto-pilot copy dependencies stay synced, all langchain entries have a channel, and `runtime_fetched` is not referenced in the sync workflow or drift script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d9242aad299e3b724befa8700b1913fd2b430c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->