### PR TITLE
docs: add operator GLOSSARY and QUICK_REFERENCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ After PR merge, applying a `verify:*` label (typically `verify:evaluate` via aut
 ### Documentation (docs)
 
 Start with:
+- `docs/GLOSSARY.md` — plain-language definitions of the system's key terms
+- `docs/QUICK_REFERENCE.md` — two-page operator cheat-sheet (pause/resume, keepalive, labels)
 - `docs/USAGE.md`
 - `docs/INTEGRATION_GUIDE.md`
 - `docs/ci-workflow.md`
@@ -222,6 +224,8 @@ MIT License - See [LICENSE](LICENSE) for details.
 
 **Links:**
 - Documentation: docs/README.md
+- Glossary: docs/GLOSSARY.md
+- Quick reference: docs/QUICK_REFERENCE.md
 - Usage: docs/USAGE.md
 - Integration guide: docs/INTEGRATION_GUIDE.md
 - CI wiring: docs/ci-workflow.md

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,250 @@
+# Glossary
+
+Plain-language definitions of the recurring terms in this repository's
+automation system, each grounded in the workflow, script, or doc that owns the
+behavior. Use this when a label name, workflow name, or piece of pipeline jargon
+is unfamiliar.
+
+For the full label inventory see [`LABELS.md`](LABELS.md). For the keepalive
+contract see [`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md).
+For a one-page operator cheat-sheet see
+[`QUICK_REFERENCE.md`](QUICK_REFERENCE.md).
+
+> **Source-of-truth rule.** Where this glossary names a label, the canonical
+> definition is in [`LABELS.md`](LABELS.md). Where it names a workflow, the
+> canonical behavior is the workflow file under `.github/workflows/`. This file
+> is a navigational summary, not a second source of truth — if it ever disagrees
+> with those, they win.
+
+---
+
+## Pipeline & loop terms
+
+### Auto-pilot
+The fully automated issue-to-merge pipeline triggered by the `agents:auto-pilot`
+label on an issue. Stages: Format → Optimize → Apply → Capability Check →
+Create PR → Keepalive → Verify → (optional) Follow-up. Self-chains between
+stages via `workflow_dispatch` with a `force_step` input rather than label
+triggers, which avoids race conditions. Implemented by `agents-auto-pilot.yml`.
+See the "Auto-Pilot Pipeline" section of the top-level
+[`README.md`](../README.md).
+
+### Keepalive
+The iterative loop that nudges an agent through small, verifiable increments on
+a single PR until every acceptance criterion is checked complete. It injects the
+PR's Scope/Tasks/Acceptance Criteria into the agent prompt, dispatches the
+matching agent runner, watches for the PR head SHA to advance, and repeats.
+Enabled by the `agents:keepalive` label on a PR (alongside a concrete `agent:*`
+label). The canonical contract is
+[`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md); the
+implementation is `agents-keepalive-loop.yml` plus
+`.github/scripts/keepalive_loop.js` and `keepalive_gate.js`.
+
+### Event-driven loop
+How keepalive is *normally* driven: it reacts to events rather than polling.
+`agents-keepalive-loop.yml` triggers on `workflow_run` completion of the **Gate**
+workflow, on `pull_request: labeled`, and on manual `workflow_dispatch`. Each
+Gate completion re-evaluates the PR and dispatches the next round if unchecked
+tasks remain. Concurrency is keyed `keepalive-<pr>` with
+`cancel-in-progress: false` so rounds never cancel each other.
+
+### Hourly sweep (keepalive sweep)
+The safety net for the event-driven loop. A round that ends with **zero commits**
+produces no follow-up event, so a silently stalled PR would otherwise never be
+re-evaluated. `agents-keepalive-sweep.yml` runs on a cron (`23 * * * *`, hourly)
+and re-dispatches the existing keepalive loop for every open PR carrying an
+`agent:*` label, so stalls resurface on their own. It makes **no dispatch
+decision of its own** — it only re-runs the loop, whose state-fingerprint makes
+an unchanged PR a near-free no-op. It honors the operator guardrails
+`agents:paused`, `needs-human`, and `agents:max-runs:0` (issue #2267), so a
+paused or human-blocked PR is never re-dispatched by the sweep.
+
+### Bootstrap PR
+The initial draft PR an orchestrator/opener creates for an issue before any real
+agent work exists — a branch (e.g. `codex/issue-<n>`) plus a PR body carrying the
+issue context, used as the surface keepalive then iterates on. Whether bootstrap
+PRs open as drafts is controlled by the `draft_pr` output of
+`reusable-70-orchestrator-init.yml` (see
+[`INTEGRATION_GUIDE.md`](INTEGRATION_GUIDE.md)); the lightweight bootstrap path is
+the `.github/actions/codex-bootstrap-lite/` composite action. Belt and verifier
+tooling treat a bootstrap-only placeholder (no substantive diff) as not yet
+mergeable.
+
+---
+
+## The belt (Agents 71–73)
+
+The belt automates the *queue → branch → PR → merge* conveyor for labeled Codex
+issues, as three workflows that hand off in sequence. See the executive summary
+at the top of [`WORKFLOW_GUIDE.md`](WORKFLOW_GUIDE.md).
+
+### Dispatcher
+`agents-71-codex-belt-dispatcher.yml`. Cron + manual entry point that **selects**
+the next eligible issue (an `agent:codex` + `status:ready` issue), prepares the
+deterministic `codex/issue-<n>` branch, marks the source issue
+`status:in-progress`, and dispatches the worker.
+
+### Worker
+`agents-72-codex-belt-worker.yml`. Repository-dispatch consumer that re-validates
+labels, ensures the branch diverges from the base (adding an empty commit if
+needed), and **opens or refreshes** the Codex automation PR with labels,
+assignees, and an activation comment.
+
+### Conveyor
+`agents-73-codex-belt-conveyor.yml`. The Gate follower that **closes the loop**:
+squash-merges a successful belt PR, deletes the branch, closes the originating
+issue, posts audit breadcrumbs, and re-dispatches the dispatcher so the queue
+keeps moving. Requires Gate success before merging and blocks bootstrap-only
+placeholders. It is the consumer that removes `status:in-progress`.
+
+---
+
+## Lanes (local automation)
+
+The opener and closer **lanes** are local automations (Codex CLI + Claude Code
+scheduled tasks) that drive issue→PR→merge→verify work across the supported
+`stranske/*` repos. The in-repo system-of-record contract is
+[`ops/LOCAL_LANES.md`](ops/LOCAL_LANES.md); the implementation lives outside this
+checkout under `~/.codex`.
+
+### Opener lane
+*Discover-and-create.* Reads the human-approved review queue and live fleet
+issues, then materializes the highest-priority unlinked implementation issue as
+a new issue (when needed) plus a ready-for-review PR, applying the matching
+`agent:*` label to the PR. Cap: **at most 5 active opener-owned PRs** across the
+whole fleet at any time. Round outcomes: `new_issue` | `advance` | `no_op`.
+
+### Closer lane
+*Cleanup-merge-verify.* Drives existing PRs through merge → verify → close →
+optional bounded follow-up. Round outcomes: `merge` | `close` | `followup_only`
+| `no_op`.
+
+### Sentinel / handoff
+The two lanes alternate via a shared baton **sentinel** at
+`~/.codex/handoff/lane-handoff.json` (a single cross-lane JSON holding the baton,
+the most-recent productive action, queue pressures, and scoped blockers) and
+hand off through the relay helper `~/.codex/bin/handoff-relay.sh`. Described in
+[`ops/LOCAL_LANES.md`](ops/LOCAL_LANES.md) ("State locations").
+
+### Capacity-stuck
+A recovery state for a PR whose assigned agent has stalled — e.g. an
+`agent:<X>` label co-present with `agent:rate-limited`, or `agent:<X>` with no
+commits for hours despite keepalive enabled. The fix is to **add** `agent:auto`
+alongside the existing label (do not remove it); the delegation policy
+(`.github/scripts/agent_delegation_policy.js`) then detects the stall and
+switches to the alternative agent. See `agent:auto` in [`LABELS.md`](LABELS.md).
+
+---
+
+## The Gate and merge
+
+### The Gate
+`pr-00-gate.yml` — the single PR-required check that orchestrates CI enforcement.
+Its final `summary` job aggregates artifacts, computes coverage deltas,
+**publishes the commit status**, and maintains the consolidated PR comment.
+Doc-only PRs skip the core CI legs (`doc_only` / `run_core` detection). The Gate
+is the event that drives the keepalive loop: keepalive and gate-followups both
+trigger on its `workflow_run: completed`. The Gate is distributed to consumers as
+a create-only starting point (see [`CLAUDE.md`](../CLAUDE.md)).
+
+### Guarded merge / `automerge`
+The automated merge path for completed agent PRs, gated so it cannot bypass
+safety. The `automerge` label marks a PR eligible; `.github/scripts/merge_manager.js`
+then checks an allowlist file (`.github/autoapprove-allowlist.json`, with `patterns`
+and `max_lines_changed`) and requires Gate success. Per [`LABELS.md`](LABELS.md),
+`automerge` **does not** bypass required checks, branch protection, or review
+policy — hence "guarded." Applied by keepalive on a tasks-complete terminal when
+appropriate.
+
+### Autofix
+The automated formatting/hygiene repair loop. Applying the `autofix` label (or
+`autofix:clean` for a more aggressive pass) runs the CI Autofix Loop
+(`autofix.yml`), which commits formatting/import/whitespace/type fixes and posts
+a summary. There is also a **Gate-driven** repair path: when Gate fails,
+`agents-81-gate-followups.yml` (via `workflow_run`) routes the failure to
+`agents-autofix-loop.yml`, which handles larger fix-ups (pyproject sync, scripted
+rewrites, merge-conflict handling). `agents-autofix-dispatcher.yml` is now only a
+compatibility bridge for the legacy `autofix_gate_failure` `repository_dispatch`
+signal.
+
+---
+
+## Verification
+
+### Verifier / `verify:*` labels
+The post-merge quality check. Applying a `verify:*` label to a **merged** PR
+triggers `agents-verifier.yml`:
+
+- `verify:checkbox` — verifies acceptance-criteria checkbox completion.
+- `verify:evaluate` — runs an LLM evaluation and posts a report.
+- `verify:compare` — runs the comparison across multiple models (two providers
+  must unanimously PASS).
+- `verify:create-issue` / `verify:create-new-pr` — turn verification feedback
+  into a follow-up issue (and, for the latter, a bootstrapped follow-up PR).
+
+**CI-failure hard gate:** if any polled CI workflow concludes `failure` on the
+merge commit, the verdict is floored at CONCERNS before the LLM runs, so a merge
+that breaks `main` can never verify PASS. See the Verifier Labels section of
+[`LABELS.md`](LABELS.md).
+
+### Repo-review evaluator
+The weekly design-vs-implementation review tooling. `scripts/repo_review_coordinator.py`
+is the Phase-4 entry point that drives the per-repo round-1 fan-out and round-2
+negotiation and renders `human-decision-packet.md`; `scripts/repo_review_evaluator.py`
+is the standalone preflight that produces the per-repo `review-inputs.md`
+artifacts. Human decisions recorded in `config/repo_review_feedback.json` feed the
+approved issue queue that the opener lane consumes. Full lifecycle:
+[`ops/REPO_REVIEW_PROCESS.md`](ops/REPO_REVIEW_PROCESS.md).
+
+---
+
+## Control labels
+
+### Run cap — `agents:max-runs:<K>`
+Caps how many keepalive **rounds** a PR may run. `agents:max-runs:0` is an
+explicit hold that prevents dispatch entirely (one of the three sweep
+guardrails); values `K >= 1` are enforced by the keepalive loop when it evaluates
+the PR. The prefix is parsed by `.github/scripts/keepalive_gate.js` and enforced
+by `keepalive_loop.js`. (Distinct from the per-PR *concurrency* default — by
+default at most one agent run is in progress per PR; see Run Cap Enforcement in
+[`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md).) See
+[`LABELS.md`](LABELS.md).
+
+### `agents:paused`
+Pauses **all keepalive activity on one PR**. Scope: a single PR. Resume by
+removing the label. Consumer: `.github/scripts/keepalive_gate.js` (`PAUSE_LABEL`).
+This is the canonical per-PR pause spelling — see the
+[Pause/Resume Runbook](ops/PAUSE_RESUME_RUNBOOK.md) for the related
+repo-scoped `keepalive:paused` (existence-semantics) and the legacy
+`agents:pause` alias.
+
+### `needs-human`
+A durable human blocker on an issue or PR. Stops automation until a human removes
+the label; marks a policy/product/access/repeated-failure blocker that should not
+be retried blindly. Applied by verifier follow-up policy, auto-pilot blockers,
+capability checks, and repeated keepalive failures (default: 3 failures →
+`needs-human`). One of the three sweep guardrails. See [`LABELS.md`](LABELS.md).
+
+### `agent:auto`
+Delegates agent routing to the auto-delegation policy
+(`.github/scripts/agent_delegation_policy.js`), which switches between Codex and
+Claude based on stall/effectiveness signals. Do **not** combine with a concrete
+`agent:<name>` label as a steady state — but the documented capacity-stuck
+recovery is to *add* `agent:auto` alongside the existing label, after which
+`agent:auto` wins and routes through delegation. See [`LABELS.md`](LABELS.md).
+
+---
+
+## See also
+
+- [`LABELS.md`](LABELS.md) — canonical label inventory (source of truth for every
+  label named above).
+- [`QUICK_REFERENCE.md`](QUICK_REFERENCE.md) — one-page operator cheat-sheet.
+- [`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md) — keepalive
+  contract and guardrails.
+- [`ops/PAUSE_RESUME_RUNBOOK.md`](ops/PAUSE_RESUME_RUNBOOK.md) — the three pause
+  spellings and their scopes.
+- [`ops/LOCAL_LANES.md`](ops/LOCAL_LANES.md) — opener/closer lane contract.
+- [`ops/REPO_REVIEW_PROCESS.md`](ops/REPO_REVIEW_PROCESS.md) — weekly review →
+  approved-queue lifecycle.
+- [`WORKFLOW_GUIDE.md`](WORKFLOW_GUIDE.md) — full workflow inventory.

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,0 +1,156 @@
+# Quick Reference
+
+A two-page operator cheat-sheet for the day-to-day controls of the automation
+system. For definitions of the terms used here, see [`GLOSSARY.md`](GLOSSARY.md).
+For the authoritative label inventory, see [`LABELS.md`](LABELS.md). Where this
+page and those disagree, **they win.**
+
+---
+
+## Pause and resume
+
+There are **three pause spellings with different scopes — they are not
+interchangeable.** Pick by scope first. Full detail:
+[`ops/PAUSE_RESUME_RUNBOOK.md`](ops/PAUSE_RESUME_RUNBOOK.md).
+
+| Scope | Label | How to pause | How to resume |
+|-------|-------|--------------|---------------|
+| **One PR** (canonical) | `agents:paused` | Add the label to the PR | Remove the label; next Gate/keepalive event resumes |
+| **One repo** | `keepalive:paused` | **Create** the label in the repo | **Delete** the label from the repo |
+| One PR (legacy alias) | `agents:pause` | Add to the PR | See trap below — do not just remove |
+
+> **Existence-semantics trap (`keepalive:paused`).** This label pauses *every*
+> keepalive run in the repository **by merely existing** — it does **not** need to
+> be applied to any issue or PR. To pause, create the label; to resume, **delete
+> the label from the repo**. Removing it from an issue/PR does nothing; the repo
+> stays paused as long as the label exists. Consumer:
+> `.github/scripts/agents_orchestrator_resolve.js` (`KEEPALIVE_PAUSE_LABEL`).
+
+> **Legacy `agents:pause` trap.** `agents:pause` is a legacy alias still honored
+> by `keepalive_loop.js` and the PR-health checks (but **not** by
+> `keepalive_gate.js`, which only checks `agents:paused`). If a PR already carries
+> `agents:pause`, either leave it until the blocker clears or **replace** it with
+> `agents:paused` in the same operation — removing it by itself can resume
+> keepalive unexpectedly. Use `agents:paused` for all new pauses.
+
+**Other holds (not "pause" labels but stop work):**
+
+- `agents:max-runs:0` — explicit per-PR hold; prevents any keepalive dispatch.
+- `needs-human` — durable human blocker on an issue/PR; clear only after the
+  blocker is resolved.
+- `agents:auto-pilot-pause` — pauses auto-pilot dispatch on an issue.
+
+**Resume checklist** (from the runbook):
+
+1. Remove the relevant pause control.
+2. Confirm no durable blocker remains (`needs-human`, `agent:needs-attention`).
+3. Confirm the PR still has one concrete `agent:<name>` label **and**
+   `agents:keepalive`.
+4. Add `agent:retry` if you need an immediate keepalive dispatch (otherwise the
+   next Gate pass resumes it).
+5. Record why work resumed in the PR/issue.
+
+---
+
+## How keepalive is driven
+
+Keepalive nudges an agent through a PR until all acceptance criteria are checked
+complete. It runs in two complementary ways:
+
+- **Event-driven loop** — `agents-keepalive-loop.yml`. Triggers on the **Gate**
+  workflow's `workflow_run: completed`, on `pull_request: labeled`, and on manual
+  `workflow_dispatch`. Each Gate completion re-evaluates the PR and dispatches the
+  next round if unchecked tasks remain.
+- **Hourly sweep** — `agents-keepalive-sweep.yml`, cron `23 * * * *`. A round
+  ending with zero commits emits no event, so a stalled PR would never be
+  re-evaluated; the sweep re-runs the loop for every open `agent:*` PR to
+  resurface stalls. It makes no dispatch decision of its own and honors
+  `agents:paused` / `needs-human` / `agents:max-runs:0`.
+
+**Activation guardrails** (all must hold, per
+[`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md)):
+
+1. PR carries an `agent:*` label (e.g. `agent:codex`, `agent:claude`).
+2. Gate for the current head SHA completed **successfully**.
+3. The PR body's Automated Status Summary has **unchecked tasks**.
+
+To force one immediate re-dispatch on a healthy PR: add `agent:retry` (keepalive
+consumes and removes it, and co-removes any stale `agent:rate-limited`).
+
+After repeated failures (default 3), keepalive pauses and adds `needs-human`.
+To reset: investigate, fix, remove `needs-human`; the next Gate pass restarts the
+loop. (Or edit the keepalive summary comment and set `failure: {}`.)
+
+---
+
+## How to find a verification result
+
+After a PR is **merged**, a `verify:*` label triggers `agents-verifier.yml`,
+which posts a **verification report comment on the PR**.
+
+- The verdict is **PASS / CONCERNS / FAIL**.
+- **CI-failure hard gate:** if any polled CI workflow concluded `failure` on the
+  merge commit, the verdict is floored at **CONCERNS** before the LLM even runs —
+  a merge that breaks `main` can never PASS.
+- To turn concerns into follow-up work: apply `verify:create-issue` (issue only)
+  or `verify:create-new-pr` (issue + bootstrapped PR).
+
+**Fleet/aggregate metrics** are surfaced via the weekly summary tracker (issue
+#1796, posted Mondays 06:00 UTC) and the LangSmith dashboard wired by
+`maint-80-langsmith-metrics-dashboard.yml`. See the README "Verification
+Pipeline" section.
+
+---
+
+## Key labels at a glance
+
+Canonical definitions: [`LABELS.md`](LABELS.md).
+
+| Label | What it does |
+|-------|--------------|
+| `agents:auto-pilot` | Runs the full issue-to-merge pipeline (on an issue) |
+| `agent:codex` / `agent:claude` | Route the issue/PR to that agent runner |
+| `agent:auto` | Delegate routing to the auto-delegation policy (capacity-stuck recovery) |
+| `agent:retry` | Force one keepalive re-dispatch (auto-removed) |
+| `agents:keepalive` | Enable the keepalive loop on a PR |
+| `agents:paused` | Pause keepalive on one PR (canonical) |
+| `agents:max-runs:<K>` | Cap keepalive rounds; `:0` is an explicit hold |
+| `needs-human` | Durable human blocker; stops automation |
+| `autofix` / `autofix:clean` | Run the formatting/hygiene repair loop |
+| `automerge` | Mark a completed PR for guarded automerge (does not bypass branch protection) |
+| `verify:evaluate` / `verify:compare` | Run the post-merge verifier |
+| `status:ready` | Issue ready for the belt dispatcher |
+| `status:in-progress` | Issue claimed by the belt (set by dispatcher/worker, cleared by conveyor) |
+
+> Labels trigger on the `labeled` event — **re-applying an already-present label
+> does not re-trigger.** Remove and re-add to fire again.
+
+---
+
+## Key consumer-present workflows
+
+These run inside each consumer repo (synced from
+`templates/consumer-repo/.github/workflows/`). When a doc cites a workflow not in
+the Workflows-root `.github/workflows/`, check the consumer template directory
+before assuming drift.
+
+| Workflow | Role |
+|----------|------|
+| **`pr-00-gate.yml`** (the Gate) | Single PR-required check; its `summary` job publishes the commit status and the consolidated PR comment. Drives keepalive via `workflow_run`. Doc-only PRs skip core CI. |
+| **`agents-80-pr-event-hub.yml`** | Consolidated PR event hub (pr-meta + bot-comment handlers); reacts to PR events, comments, and Gate completion. |
+| **`agents-81-gate-followups.yml`** | Gate-completion follow-ups: keepalive evaluation plus the Gate-driven **autofix repair** routing (replaces the legacy `agents-autofix-dispatcher.yml` `repository_dispatch` path). |
+| `agents-issue-intake.yml`, `agents-verifier.yml`, `autofix.yml`, `ci.yml` | Other current consumer entry points (see [`CLAUDE.md`](../CLAUDE.md)). |
+
+On the **Workflows repo itself**, the equivalent keepalive plumbing is
+`agents-keepalive-loop.yml` + `agents-keepalive-sweep.yml`, and the belt is
+`agents-71/72/73-codex-belt-*.yml`.
+
+---
+
+## See also
+
+- [`GLOSSARY.md`](GLOSSARY.md) — term definitions.
+- [`LABELS.md`](LABELS.md) — canonical label inventory.
+- [`ops/PAUSE_RESUME_RUNBOOK.md`](ops/PAUSE_RESUME_RUNBOOK.md) — pause scopes.
+- [`keepalive/GoalsAndPlumbing.md`](keepalive/GoalsAndPlumbing.md) — keepalive contract.
+- [`ops/RUNBOOK.md`](ops/RUNBOOK.md) — operational runbook.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ This folder contains the source-of-truth documentation for this repository.
 
 | Document | Description |
 |----------|-------------|
+| [GLOSSARY.md](GLOSSARY.md) | Plain-language definitions of the system's key terms |
+| [QUICK_REFERENCE.md](QUICK_REFERENCE.md) | Two-page operator cheat-sheet (pause/resume, keepalive, labels) |
 | [USAGE.md](USAGE.md) | Quick start and common setup patterns |
 | [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) | Full integration guide for consumers |
 | [ci-workflow.md](ci-workflow.md) | CI workflow wiring and local validation |


### PR DESCRIPTION
## Why

The system's jargon (keepalive, the event-loop vs. the hourly sweep, the belt, opener/closer lanes, capacity-stuck, run-cap, the Gate, guarded-merge, the verifier, the three pause spellings) is a barrier for a solo operator. This implements §4 usability recommendation #3: a `docs/GLOSSARY.md` and a two-page `docs/QUICK_REFERENCE.md`.

## What

- **`docs/GLOSSARY.md`** — 21 `###` term entries (several documenting multiple sub-labels inline, ~30 terms total). Every definition is grounded in the actual repo and cross-links to `LABELS.md` and the owning workflow:
  - Pipeline/loop: auto-pilot, keepalive, event-driven loop, hourly sweep (`agents-keepalive-sweep.yml`, cron `23 * * * *`, #2267 guardrails), bootstrap PR.
  - Belt (Agents 71–73): dispatcher / worker / conveyor.
  - Lanes: opener, closer, sentinel/handoff, capacity-stuck — grounded in `ops/LOCAL_LANES.md`.
  - Gate & merge: the Gate (`pr-00-gate.yml`), guarded merge / `automerge` (allowlist `.github/autoapprove-allowlist.json`, does not bypass branch protection), autofix.
  - Verification: verifier / `verify:*` labels (incl. the CI-failure hard gate), repo-review evaluator.
  - Control labels: `agents:max-runs:<K>` (run cap), `agents:paused`, `needs-human`, `agent:auto`.
- **`docs/QUICK_REFERENCE.md`** — operator cheat-sheet: pause/resume (the three spellings with scopes, **the `keepalive:paused` existence-semantics trap**, the legacy `agents:pause` alias trap), how keepalive is driven (event loop + sweep + activation guardrails), how to find a verification result, key labels, and the key consumer-present workflows (`pr-00-gate.yml`, `agents-80-pr-event-hub.yml`, `agents-81-gate-followups.yml`).
- Linked both from `README.md` (Documentation list + Links) and `docs/README.md` (Start Here table).

## Grounding

Definitions are sourced from `LABELS.md`, `keepalive/GoalsAndPlumbing.md`, `ops/PAUSE_RESUME_RUNBOOK.md`, `ops/LOCAL_LANES.md`, `ops/REPO_REVIEW_PROCESS.md`, `WORKFLOW_GUIDE.md`, the workflow files under `.github/workflows/`, and `.github/scripts/{keepalive_gate,merge_manager}.js`. The run-cap entry deliberately documents the *implemented* `agents:max-runs:<K>` label (per `keepalive_gate.js`) rather than the `agents:max-parallel` spelling that appears only in prose.

## Validation

- `python -m pytest tests/docs -q` → **31 passed**.
- All relative markdown links in both new docs resolve to real files.

Docs-only, pure-add. No code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions and index links; no runtime, workflow, or automation behavior changes.
> 
> **Overview**
> Adds **operator-facing documentation** so pipeline jargon is easier to navigate without changing any workflows or scripts.
> 
> **`docs/GLOSSARY.md`** defines ~30 terms (auto-pilot, keepalive, event loop vs hourly sweep, belt 71–73, local lanes, Gate, verifier, control labels) with pointers to `LABELS.md`, workflows, and scripts. It states explicitly that those sources win if the glossary disagrees.
> 
> **`docs/QUICK_REFERENCE.md`** is a short cheat sheet: the three pause spellings (including `keepalive:paused` existence semantics and the `agents:pause` alias trap), keepalive activation and sweep guardrails, finding verification results, key labels, and consumer vs Workflows-repo workflows.
> 
> **`README.md`** and **`docs/README.md`** now link both docs from the documentation “Start Here” lists and footer links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad26ef2f1b495f51fe818114df3349997c9a2089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->