### PR TITLE
feat(ci): maint-48 monthly docs-drift audit

### DIFF
--- a/.github/docs-drift-audit-template.md
+++ b/.github/docs-drift-audit-template.md
@@ -1,0 +1,31 @@
+## Summary
+Monthly docs-drift audit. Doc-rot is this system's most pervasive defect class (the 2026-06 audit found stale counts/claims across the canonical docs). Diff the canonical docs below against the **current tree** and open focused fix PR(s) for any claim that no longer matches reality.
+
+## Scope — canonical docs to verify (this round)
+For each, check that every concrete claim (file paths, counts, workflow names, command names, described behavior) matches the current repo:
+- [ ] `README.md` — pipeline overview, consumer list, entry points
+- [ ] `docs/ci/WORKFLOWS.md` + `docs/ci/WORKFLOW_SYSTEM.md` — workflow inventory (names, triggers, counts)
+- [ ] `docs/STRUCTURE.md` — directory/file counts and key-directory prose
+- [ ] `docs/INTEGRATION_GUIDE.md` — inputs/secrets/versioning claims vs the reusables
+- [ ] `docs/keepalive/GoalsAndPlumbing.md` + `docs/keepalive/Agents.md` — labels, guardrails, agent routing
+- [ ] `docs/AGENTS_POLICY.md` + `docs/LABELS.md` — protected-workflow list + canonical label inventory
+
+## How to verify (no hand-waving)
+- Cross-check each claim against the actual file/command/workflow it describes; cite the source `path:line` in the fix PR.
+- Where a doc-validation test exists it must stay green: `pytest tests/workflows/ -q` (e.g. `test_workflow_naming.py::test_inventory_docs_list_all_workflows` enforces that the inventory docs list every workflow).
+
+## Tasks
+- [ ] For each drifted claim found, open a focused fix PR correcting the doc to match reality (link the source `path:line`).
+- [ ] Keep PRs small and per-doc where practical; don't rewrite docs wholesale.
+- [ ] If a doc is already accurate, tick its box with a one-line "verified vs `<evidence>`" note.
+
+## Non-Goals
+- No scaffolding, no TODO-only edits, no net-new docs.
+- Don't restructure/rewrite prose that is accurate — fix only drifted claims.
+- Not a consumer-template sync (that's `maint-68`); fix the source docs here.
+
+## Done
+All scope boxes ticked (verified or fixed); `tests/workflows/` green; doc claims match the tree.
+
+---
+_Seeded monthly by `maint-48-docs-drift-audit.yml`. Dedup: one open `[Docs Drift Audit]` issue at a time._

--- a/.github/workflows/maint-48-docs-drift-audit.yml
+++ b/.github/workflows/maint-48-docs-drift-audit.yml
@@ -1,0 +1,70 @@
+name: Maint 48 Docs Drift Audit
+
+# Monthly docs-drift audit. Doc-rot is this system's most pervasive defect class (the 2026-06
+# audit found stale counts/claims across the canonical docs). This seeds one scoped,
+# agent-actionable issue per month so the lane fleet diffs the canonical docs against the
+# current tree and opens fix PRs.
+#
+# Design note: the LLM diffing is done by whichever lane/keepalive agent picks the issue up
+# (cost-managed via the configured models, Sonnet-pinned) rather than a dedicated inline Claude
+# Action — which post-2026-06-15 bills against the metered Agent-SDK credit. Same outcome as the
+# audit's "monthly docs-drift agent", routed through the system's own issue->agent mechanism
+# (mirrors maint-66's monthly-audit-issue pattern). To diff inline instead, swap the create step
+# for a claude-code-action run.
+
+on:
+  schedule:
+    - cron: '0 7 1 * *'  # 1st of each month, 07:00 UTC (after maint-66 monthly audit at 06:00)
+  workflow_dispatch:
+    inputs:
+      create_issue:
+        description: 'Create the docs-drift audit issue'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  seed-audit:
+    name: Seed monthly docs-drift audit issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Create the docs-drift audit issue (deduped)
+        if: ${{ inputs.create_issue != false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="[Docs Drift Audit] $(date +%B' '%Y)"
+          # Dedup: one open audit at a time (skip if last month's isn't done yet).
+          existing=$(gh issue list --repo "$REPO" --state open \
+            --search '"[Docs Drift Audit]" in:title' --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Open docs-drift audit issue already exists: #$existing — skipping."
+            exit 0
+          fi
+          gh issue create --repo "$REPO" --title "$title" \
+            --body-file .github/docs-drift-audit-template.md \
+            --label "documentation,maintenance"
+          echo "Created docs-drift audit issue: $title"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Maint 48 Docs Drift Audit"
+            echo "Seeds one scoped \`[Docs Drift Audit]\` issue per month (deduped) for the lane fleet"
+            echo "to diff the canonical docs against reality and open fix PRs."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -123,6 +123,7 @@ The gate uses the shared `.github/scripts/detect-changes.js` helper to decide wh
 * [`maint-62-integration-consumer.yml`](../../.github/workflows/maint-62-integration-consumer.yml) runs daily at 05:05 UTC, on release publication, or by manual dispatch to execute the integration-repo scenarios via the reusable Python CI template and keep the integration failure issue updated.
 * [`maint-65-sync-label-docs.yml`](../../.github/workflows/maint-65-sync-label-docs.yml) synchronizes `docs/LABELS.md` to consumer repositories weekly (Sundays 00:00 UTC) or via manual dispatch.
 * [`maint-66-monthly-audit.yml`](../../.github/workflows/maint-66-monthly-audit.yml) performs comprehensive monthly workflow health audits, collecting statistics and creating actionable tracking issues.
+* [`maint-48-docs-drift-audit.yml`](../../.github/workflows/maint-48-docs-drift-audit.yml) seeds a monthly scoped docs-drift audit issue (deduped) for the lane fleet to diff the canonical docs against reality and open fix PRs.
 * [`maint-60-release.yml`](../../.github/workflows/maint-60-release.yml) creates GitHub releases automatically when version tags (`v*`) are pushed.
 ## Agents Control Plane
 

--- a/docs/ci/WORKFLOW_SYSTEM.md
+++ b/docs/ci/WORKFLOW_SYSTEM.md
@@ -563,6 +563,10 @@ Keep this table handy when you are triaging automation: it confirms which workfl
   at 06:00 UTC), collecting run statistics, identifying high-failure workflows,
   listing never-run workflows, and creating/updating a tracking issue with an
   actionable checklist.
+- **Maint 48 Docs Drift Audit** – `.github/workflows/maint-48-docs-drift-audit.yml`
+  seeds one scoped docs-drift audit issue per month (1st at 07:00 UTC, deduped)
+  so the lane fleet diffs the canonical docs against the current tree and opens
+  fix PRs. Doc-rot is the audit's most pervasive defect class.
 - **Maint 45 Cosmetic Repair** – `.github/workflows/maint-45-cosmetic-repair.yml`
   is a manual workflow. It runs pytest and the guardrail fixers, then opens a
   labelled PR if changes are needed.

--- a/tests/workflows/test_workflow_naming.py
+++ b/tests/workflows/test_workflow_naming.py
@@ -239,6 +239,7 @@ EXPECTED_NAMES = {
     "maint-45-cosmetic-repair.yml": "Maint 45 Cosmetic Repair",
     "maint-46-post-ci.yml": "Maint 46 Post CI",
     "maint-47-disable-legacy-workflows.yml": "Maint 47 Disable Legacy Workflows",
+    "maint-48-docs-drift-audit.yml": "Maint 48 Docs Drift Audit",
     "maint-50-tool-version-check.yml": "Maint 50 Tool Version Check",
     "maint-51-dependency-refresh.yml": "Maint 51 Dependency Refresh",
     "maint-sync-action-versions.yml": "Maint Sync Action Versions",


### PR DESCRIPTION
## What
Adds `maint-48-docs-drift-audit.yml` — a monthly workflow that seeds one deduped, scoped `[Docs Drift Audit]` issue for the lane fleet to diff the canonical docs against the current tree and open fix PRs. Body template in `.github/docs-drift-audit-template.md`.

## Why
Doc-rot was the audit's most pervasive defect class (most of §1/§4 findings were stale docs). `maint-66`'s monthly audit only carries a *static* "update docs" checklist; nothing systematically detects drift. This closes that gap on a monthly cadence.

## Design choice (issue-seeder vs inline Claude Action)
The audit sketched "a monthly claude-code-action that diffs docs and opens a fix PR." I implemented the **same outcome** via the system's issue→agent mechanism (mirrors `maint-66`) rather than a dedicated inline Claude Action, because:
- Post-2026-06-15, inline Claude Code Actions bill against the **metered Agent-SDK credit** (overflow is set to degrade-to-Codex); the lane fleet is cost-managed + Sonnet-pinned.
- The picked-up agent diffs with **full repo context** and reuses proven plumbing (no fragile new action wiring).

To diff inline instead, swap the issue-create step for a `claude-code-action` run — easy follow-up.

## Validation
- Registered in `EXPECTED_NAMES` + both inventory docs; `tests/workflows/` green (24 passed).
- zizmor-clean (dogfooded), `persist-credentials: false`, scoped `issues: write`.
- Deduped: one open `[Docs Drift Audit]` issue at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduled issue-seeder with read-only checkout and narrow `issues: write`; no changes to auth, Gate, or agent execution paths beyond a new maintenance entry point.
> 
> **Overview**
> Adds a **monthly maintenance workflow** (`maint-48-docs-drift-audit.yml`) that runs on the 1st at 07:00 UTC (and via `workflow_dispatch`) to create at most one open **`[Docs Drift Audit]`** issue per month, using a new checklist body template (`.github/docs-drift-audit-template.md`) so lane agents diff canonical docs against the repo and open small fix PRs—instead of relying only on `maint-66`’s static “update docs” checklist.
> 
> The workflow **dedupes** on open issues with that title prefix, uses scoped `issues: write` + `persist-credentials: false`, and documents the choice to route LLM work through the existing issue→agent path rather than an inline Claude Action.
> 
> **Inventory alignment:** `docs/ci/WORKFLOWS.md`, `docs/ci/WORKFLOW_SYSTEM.md`, and `tests/workflows/test_workflow_naming.py` (`EXPECTED_NAMES`) register **Maint 48 Docs Drift Audit** so workflow inventory tests stay green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065de8819a698114562e47f4489780d02b25da8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->