### PR TITLE
fix(cursor): default cursor-agent to --model auto (stop gpt-5.5 Max API burn)

### DIFF
--- a/.github/workflows/reusable-cursor-run.yml
+++ b/.github/workflows/reusable-cursor-run.yml
@@ -831,6 +831,12 @@ jobs:
           # the final assistant message to stdout. --output-format text keeps the
           # captured output a clean final message (the contract base64-encodes it).
           # Tee to $SESSION_LOG so we keep a debug artifact even if the run fails.
+          # COST GUARD (2026-06-14): never let an EMPTY $MODEL fall back to cursor-agent's server
+          # default — on a fresh runner that is gpt-5.5-high Max Mode (Cloud Agents), which drained the
+          # $60/mo Cursor API pool in a single day. Default to 'auto': Cursor's free Auto routing, which
+          # draws the Auto bucket (verified 2026-06-14: headless `--model auto` runs even when the metered
+          # API bucket is 100% spent). Callers may still override MODEL explicitly.
+          MODEL="${MODEL:-auto}"
           set +e
           "$CURSOR_BIN" -p "$prompt_content" \
             "${perm_flag[@]}" \


### PR DESCRIPTION
## What

Default `cursor-agent`'s model to **`auto`** in the headless run step. Previously `MODEL` was never set, so `${MODEL:+--model "$MODEL"}` expanded to nothing and `cursor-agent` fell back to its **server default — `gpt-5.5-high` Max Mode** on a fresh runner (no `~/.cursor/cli-config.json`). Those are metered Cloud Agents that **drained the entire $60/mo Cursor API allowance in one day** (keepalive runs hourly across PRs).

## Fix

```bash
MODEL="${MODEL:-auto}"
```

`auto` is Cursor's free **Auto routing**, which draws the **Auto bucket** (separate from the metered API allowance). Verified 2026-06-14: headless `cursor-agent -p … --model auto --force --trust` returns output and exit 0 **even when the metered API bucket is 100% spent** — i.e. it no longer touches the paid pool. Callers may still pass an explicit `MODEL` to override.

## Why it matters

This is the keepalive/autofix cursor lane fleet-wide. Without the guard, every cursor tick risked the premium-default burn. No behavior change for callers that already set `MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
