### PR TITLE
chore: add CodeRabbit review config (advisory, fleet-tuned)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,26 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Tuned for the stranske autonomous-agent fleet:
+#   - strict review of agent-authored PRs (profile: assertive)
+#   - ADVISORY / non-gating, matching the fleet rule that review never blocks a merge
+#   - a workflow-injection guard, since workflow YAML is synced to 9 consumer repos
+language: en-US
+reviews:
+  profile: assertive
+  request_changes_workflow: false      # advisory: never auto-block a merge (fleet rule)
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false                      # opener creates drafts; review when marked ready
+  path_filters:
+    - "!**/*.lock"
+    - "!**/vendor/**"
+    - "!**/.workflows-lib/**"
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Flag template-injection, unpinned third-party actions, and spoofable bot-actor
+        checks — this workflow YAML is synced to 9 consumer repos, so one bug replicates
+        fleet-wide.
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds a root `.coderabbit.yaml` tuned for the autonomous-agent fleet: assertive review of agent PRs, **advisory/non-gating** (review never blocks a merge, per the fleet rule), and a workflow-injection guard since workflow YAML syncs to 9 repos.

Part of replacing metered GitHub Copilot Code Review (~$88/mo) with CodeRabbit (ranked #1 on the independent Martian benchmark, flat-rate unlimited). Fleet-wide propagation via the consumer template + sync-manifest is a follow-up.

This PR also serves as a live CodeRabbit quality sample — its own review will show on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration settings for automated code review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->