### PR TITLE
test(orchestrator): Renovate shared preset (least-risky integration test)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "description": "Shared Workflows Renovate preset: grouped devDependencies with automerge-on-green; vendored minimatch cascade grouping.",
+  "extends": ["config:recommended"],
+  "platformAutomerge": true,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group non-major devDependency updates and automerge when CI is green",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "devDependencies (non-major)",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Vendored minimatch cascade: keep minimatch, brace-expansion, and balanced-match in one PR",
+      "matchFileNames": [".github/scripts/**"],
+      "matchPackageNames": ["minimatch", "brace-expansion", "balanced-match"],
+      "groupName": "vendored minimatch cascade"
+    }
+  ]
 }


### PR DESCRIPTION
Orchestrator↔keepalive integration test (gates #1-4). **Task for the assigned agent:** extend renovate.json into a shared preset — grouped updates + automerge-on-green for devDependencies — addressing the vendored-minimatch cascade. Keep it a single **inert** renovate.json (Renovate app not installed, so this is safe). Throwaway/low-risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enable automated dependency updates using recommended presets, including grouping and automerging minor/patch changes when CI is green.
  * Added automated grouping for vendored minimatch-related packages into a single update PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->