### PR TITLE
chore(renovate): extract shared fleet preset (phase 1 of consumer-fleet migration)

### DIFF
--- a/renovate-presets/fleet.json
+++ b/renovate-presets/fleet.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "stranske fleet-shared Renovate preset — single source of truth for dependency automation across all stranske/* repos. Replaces Dependabot for runtime pip deps + GitHub Actions, grouped with automerge-on-green. Dev-tool pins (ruff/black/mypy/pytest/...) are EXCLUDED: they move through autofix-versions.env via the maint workflows, NOT the bumper (mirrors the retired Dependabot ignore list). The vendored .github/scripts npm cascade (minimatch/brace-expansion/balanced-match) is kept in one PR. Each repo's renovate.json extends this via `github>stranske/Workflows//renovate-presets/fleet`, so a fleet-wide policy change is one edit here — no per-repo re-sync.",
+  "extends": ["config:recommended"],
+  "platformAutomerge": true,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Dev-tool pins are owned by autofix-versions.env + the maint workflows — Renovate must not bump them",
+      "matchPackageNames": ["ruff", "black", "mypy", "pytest", "pytest-cov", "pytest-xdist", "coverage", "isort", "docformatter"],
+      "enabled": false
+    },
+    {
+      "description": "Runtime/test-support minor+patch: group + automerge on green (majors stay separate for review)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major updates",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "GitHub Actions minor+patch: group + automerge on green",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions",
+      "automerge": true
+    },
+    {
+      "description": "Vendored minimatch cascade — keep minimatch, brace-expansion, balanced-match in one PR",
+      "matchFileNames": [".github/scripts/**"],
+      "matchPackageNames": ["minimatch", "brace-expansion", "balanced-match"],
+      "groupName": "vendored minimatch cascade"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Workflows Renovate config — replaces Dependabot for runtime pip deps + GitHub Actions, grouped with automerge-on-green. Shared dev-tool pins (ruff/black/mypy/pytest/...) are EXCLUDED here: they move through autofix-versions.env via maint-auto-update-pypi-versions.yml + maint-51-dependency-refresh.yml, NOT the bumper (mirrors the retired dependabot ignore list).",
-  "extends": ["config:recommended"],
-  "platformAutomerge": true,
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "description": "Dev-tool pins are owned by autofix-versions.env + the maint workflows — Renovate must not bump them",
-      "matchPackageNames": ["ruff", "black", "mypy", "pytest", "pytest-cov", "pytest-xdist", "coverage", "isort", "docformatter"],
-      "enabled": false
-    },
-    {
-      "description": "Runtime/test-support minor+patch: group + automerge on green (majors stay separate for review)",
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "non-major updates",
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
-      "description": "GitHub Actions minor+patch: group + automerge on green",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "github-actions",
-      "automerge": true
-    },
-    {
-      "description": "Vendored minimatch cascade — keep minimatch, brace-expansion, balanced-match in one PR",
-      "matchFileNames": [".github/scripts/**"],
-      "matchPackageNames": ["minimatch", "brace-expansion", "balanced-match"],
-      "groupName": "vendored minimatch cascade"
-    }
-  ]
+  "description": "Workflows Renovate config — extends the stranske fleet-shared preset (renovate-presets/fleet.json), the single source of truth for grouping, automerge-on-green, dev-tool exclusions, and the vendored-minimatch cascade. Workflows dogfoods the same preset every consumer repo extends. Repo-specific overrides, if ever needed, go in packageRules below.",
+  "extends": ["github>stranske/Workflows//renovate-presets/fleet"]
 }


### PR DESCRIPTION
## What

Phase 1 of migrating the consumer fleet (~10 repos) off Dependabot onto Renovate.

- **New `renovate-presets/fleet.json`** — the single source of truth for fleet dependency automation: `config:recommended`, `platformAutomerge`, grouped non-major + github-actions automerge-on-green, dev-tool exclusions (owned by `autofix-versions.env`), and the vendored `minimatch`/`brace-expansion`/`balanced-match` cascade.
- **`renovate.json` → thin extends** of `github>stranske/Workflows//renovate-presets/fleet`. Workflows dogfoods the exact preset every consumer will extend.

## Why a preset

So a fleet-wide policy change is **one edit here, no per-repo re-sync** — the opposite of `dependabot.yml`, which is `create_only`-synced and drifts. Consumers will carry a 2-line `renovate.json` that just extends this.

## Safety

- **No behavior change for Workflows**: the rules are byte-identical to the current inline config, just relocated. The preset + the extends land in the same merge, so the self-reference resolves atomically (no pre-merge resolution gap — Workflows keeps using main's inline config until merge).
- **Zero consumer impact**: `sync-manifest.yml` and `templates/consumer-repo/` are untouched, so nothing distributes fleet-wide. `health-70` (template-orphan check) is unaffected because these are root-level files.

## Not in this PR (deliberately staged — see follow-ups)

Fleet activation is a separate, deliberate step because **adding `renovate.json` to the sync-manifest auto-distributes it to all 13 consumers on the next 05:00 cron**:

1. **Fleet-distribution PR**: thin consumer-template `renovate.json` (extends this preset) + sync-manifest entry (`create_only`) + retarget the dependabot-campaign (`sync_dependabot_campaign.js`) to also watch `renovate[bot]` + re-seed the campaign sync-hash. Riskiest step (load-bearing fleet coordination) — staged with a canary repo.
2. **Per-consumer cutover**: remove each consumer's `dependabot.yml` (the manifest can't delete it) in an atomic swap, canary → fleet, monitored over a dependency cycle.
3. **Cleanup**: retire `maint-dependabot-*` workflows once dual-run is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined dependency update configuration by introducing a fleet-wide Renovate preset that consolidates settings previously defined inline.
  * Configured intelligent grouping of dependency updates by type (runtime, test, dev tools, GitHub Actions, and vendored packages).
  * Enabled automatic merging of grouped minor and patch updates when tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->