### PR TITLE
chore(renovate): distribute fleet preset to consumers + renovate[bot] CI parity (P2b)

### DIFF
--- a/.github/scripts/__tests__/sync_dependabot_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependabot_campaign.test.js
@@ -68,6 +68,8 @@ test('detects sync and dependabot pull requests', () => {
 
   assert.equal(isDependabotPullRequest({ user: { login: 'dependabot[bot]' } }), true);
   assert.equal(isDependabotPullRequest({ head: { ref: 'dependabot/npm/lodash-5' } }), true);
+  assert.equal(isDependabotPullRequest({ user: { login: 'renovate[bot]' } }), true);
+  assert.equal(isDependabotPullRequest({ head: { ref: 'renovate/non-major-updates' } }), true);
   assert.equal(isDependabotPullRequest({ user: { login: 'stranske' } }), false);
 });
 

--- a/.github/scripts/sync_dependabot_campaign.js
+++ b/.github/scripts/sync_dependabot_campaign.js
@@ -101,7 +101,12 @@ function isSyncPullRequest(pr = {}) {
 function isDependabotPullRequest(pr = {}) {
   const login = normaliseLogin(pr.user?.login || pr.author?.login || pr.author);
   const headRef = cleanString(pr.head?.ref || pr.headRefName || pr.headRef || pr.head_ref);
-  return login === 'dependabot[bot]' || login === 'app/dependabot' || headRef.startsWith('dependabot/');
+  // Detects both Dependabot and Renovate dependency PRs. Renovate replaces Dependabot fleet-wide;
+  // the campaign keeps tracking both under the 'dependabot' classification for backward compatibility.
+  return (
+    login === 'dependabot[bot]' || login === 'app/dependabot' || headRef.startsWith('dependabot/') ||
+    login === 'renovate[bot]' || login === 'app/renovate' || headRef.startsWith('renovate/')
+  );
 }
 
 function classifyPullRequest(pr = {}) {

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -127,6 +127,14 @@ workflows:
     description: "Dependabot config - ignores dev tools synced via maint-52"
     sync_mode: create_only
 
+  # Renovate configuration - extends the shared fleet preset (renovate-presets/fleet.json).
+  # create_only so a consumer that already onboarded (e.g. a Mend generic config) is not clobbered;
+  # supersedes per-repo Renovate onboarding by giving consumers the fleet preset (dev-tool exclusions
+  # owned by autofix-versions.env, grouped automerge, vendored-minimatch cascade).
+  - source: .github/renovate.json
+    description: "Renovate config - extends stranske/Workflows//renovate-presets/fleet (shared fleet preset)"
+    sync_mode: create_only
+
   - source: .github/workflows/dependabot-automerge.yml
     description: "Dependabot auto-merge - automatically merges dependabot PRs when checks pass"
 

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -104,11 +104,27 @@ jobs:
               ''
             }}
           GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+          PR_ACTOR: ${{ github.actor }}
         run: |
           if [ -z "${PR_NUMBER:-}" ]; then
             {
               echo "should_run=true"
               echo "reason=no-pr-context"
+              echo "current_hash="
+              echo "prior_hash="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Dependency-bot PRs (Dependabot/Renovate) are not agent work. Route them to the existing
+          # should_run=false path BEFORE the authenticated fingerprint API calls, which 403 on the
+          # restricted bot-PR token (a non-required, non-blocking but noisy keepalive failure).
+          # Dependabot is already implicitly skipped by GitHub's token restrictions; this makes both
+          # explicit. Normal (human/agent) PRs are unaffected.
+          if [ "${PR_ACTOR:-}" = "dependabot[bot]" ] || [ "${PR_ACTOR:-}" = "renovate[bot]" ]; then
+            {
+              echo "should_run=false"
+              echo "reason=dependency-bot-pr"
               echo "current_hash="
               echo "prior_hash="
             } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/maint-dependabot-auto-label.yml
+++ b/.github/workflows/maint-dependabot-auto-label.yml
@@ -13,7 +13,8 @@ concurrency:
 
 jobs:
   label:
-    if: github.actor == 'dependabot[bot]'
+    # Dependabot and Renovate both produce dependency PRs that should carry agents:allow-change.
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Add agents:allow-change label

--- a/scripts/keepalive-runner.js
+++ b/scripts/keepalive-runner.js
@@ -328,7 +328,8 @@ const NON_ASSIGNABLE_LOGINS = new Set([
   'chatgpt-codex-connector',
   'stranske-automation-bot',
   'github-actions',
-  'dependabot'
+  'dependabot',
+  'renovate'
 ]);
 
 const KEEPALIVE_INSTRUCTION_REACTION = 'hooray';

--- a/templates/consumer-repo/.github/renovate.json
+++ b/templates/consumer-repo/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>stranske/Workflows//renovate-presets/fleet"]
+}


### PR DESCRIPTION
## What

P2b of the Dependabot→Renovate fleet migration: get the **consumer fleet** onto the shared preset (not generic Mend onboarding configs), and make the agent CI **renovate[bot]-aware**.

### Distribution
- **`templates/consumer-repo/.github/renovate.json`** (new) — 2-line config extending `github>stranske/Workflows//renovate-presets/fleet`.
- **`sync-manifest.yml`** — `create_only` entry so `maint-68` distributes it to consumers on the next sync. This is the point: consumers get the **fleet preset** (dev-tool exclusions owned by `autofix-versions.env`, grouped automerge-on-green, the vendored-minimatch cascade) instead of Renovate's generic `config:recommended` onboarding — which would otherwise fight `autofix-versions.env` over ruff/black/etc.

### `renovate[bot]` CI parity
Renovate is a normal GitHub App, so (unlike Dependabot) it is **not** subject to GitHub's built-in bot-PR restrictions — the agent workflows run on its PRs and produced a noisy (non-required, non-blocking) keepalive 403. Parity:
- **`agents-keepalive-loop.yml`** — the fingerprint step routes `dependabot[bot]`/`renovate[bot]` PRs to the **existing `should_run=false` path** *before* the authenticated API calls that 403 on the restricted bot-PR token. This reaches an already-handled state early; normal (human/agent) PRs are untouched.
- **`maint-dependabot-auto-label.yml`** — also label `renovate[bot]` PRs `agents:allow-change`.
- **`keepalive-runner.js`** — add `renovate` to `NON_ASSIGNABLE_LOGINS`.
- **`sync_dependabot_campaign.js`** — campaign PR detector also matches `renovate[bot]` + `renovate/` branches (+ test), kept under the `dependabot` classification for backward compat.

## Why this is safe
- The keepalive change only adds an early-exit for two bot actors to a path the workflow already handles (`should_run=false`); it cannot affect normal PRs.
- `create_only` won't clobber a consumer that already has a `renovate.json`.
- Validated locally: campaign test **24/24**, `renovate-config-validator` resolves the consumer config against the live preset, **health-70** template-completeness passes, workflows + JS parse.

## Context / proven on the canary
Renovate is already live on Workflows: #2389 (grouped non-major) **automerged on green** via the required `summary` check; the keepalive 403 was confirmed non-blocking. This PR makes that clean fleet-wide.

## Not in this PR (follow-ups)
- **integration-repo template** (`templates/integration-repo/`, e.g. WIT) syncs via a separate mechanism (health-67) — deferred to avoid that path until verified.
- **Rollout**: after merge, `maint-68` distributes on its next cron (or manual dispatch); in-flight Mend "Configure Renovate" onboarding PRs (e.g. trip-planner #1378) are superseded once the fleet-preset `renovate.json` lands.
- **P4 cleanup**: retire `maint-dependabot-{auto-lock,weekly-sweep}.yml` and check `dependabot-automerge.yml` once dual-run is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended system support to recognize and handle Renovate bot pull requests alongside Dependabot pull requests with automatic labeling.

* **Chores**
  * Added Renovate configuration template for consumer repositories.
  * Updated workflow automation to treat Renovate bot accounts consistently with dependency automation best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->