### PR TITLE
fix(templates): add error_classifier.js to sparse-checkout in 11 consumer workflows

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -849,6 +849,7 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/prompt_injection_guard.js
             .github/scripts/github-rate-limited-wrapper.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             scripts/runner_lib

--- a/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
@@ -33,6 +33,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -34,6 +34,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/bot_comment_auth_coverage.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/terminal_disposition_coverage.js

--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js

--- a/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
+++ b/templates/consumer-repo/.github/workflows/maint-coverage-guard.yml
@@ -38,6 +38,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
## Bug
`.github/scripts/github-api-with-retry.js` gained a top-level `require('./error_classifier')` (line 20). `autofix.yml`'s sparse-checkout was updated to include `error_classifier.js`, but **11 other consumer-template workflows that sparse-checkout `github-api-with-retry.js` individually were missed** — so when they load the retry client they fail with `Cannot find module './error_classifier'`.

**How it surfaced:** `stranske/Template#800`'s `Resolve review target` job failed during the Renovate fleet sync (P2b). Triage confirmed it's a regression vs the prior sync #797, and an audit found 10 more workflows with the same gap. These all synced to consumers this generation, so the breakage is latent fleet-wide (manifests when each workflow runs).

## Fix
Add `.github/scripts/error_classifier.js` to the sparse-checkout of the 11 individually-listing workflows:
`agents-81-gate-followups`, `agents-auto-label`, `agents-autofix-dispatcher`, `agents-capability-check`, `agents-decompose`, `agents-dedup`, `agents-issue-optimizer`, `agents-weekly-metrics`, `dependabot-automerge`, `maint-76-claude-code-review`, `maint-coverage-guard`.

Workflows that sparse-checkout the whole `.github/scripts` dir (e.g. `pr-00-gate`) already get the file and were **not** touched — which is why consumer gates kept passing.

## Impact
Re-syncs to consumers via `maint-68`, fixing the latent breakage in the repos that already synced this generation. Unblocks Template#800 (`Resolve review target`) on the next sync. Each change is `+1` sparse-checkout line; adding an extra file to a sparse-checkout is inherently safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)