### PR TITLE
fix(workflows): error_classifier.js in root sparse-checkouts (+ green up the two pre-existing CI failures)

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -1338,6 +1338,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-autofix-dispatcher.yml
+++ b/.github/workflows/agents-autofix-dispatcher.yml
@@ -33,6 +33,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -108,6 +108,7 @@ jobs:
             .github/scripts/agent_registry.js
             .github/scripts/prompt_injection_guard.js
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js
@@ -839,6 +840,7 @@ jobs:
 
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -933,6 +935,7 @@ jobs:
 
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/actions/setup-api-client
             .github/scripts/github-rate-limited-wrapper.js

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -168,6 +168,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/bot-comment-handler.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
@@ -562,6 +563,7 @@ jobs:
               github.ref_name
             }}
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/actions/setup-api-client
             .github/scripts/github-rate-limited-wrapper.js

--- a/.github/workflows/agents-capability-check.yml
+++ b/.github/workflows/agents-capability-check.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-decompose.yml
+++ b/.github/workflows/agents-decompose.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-dedup.yml
+++ b/.github/workflows/agents-dedup.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-moderate-connector.yml
+++ b/.github/workflows/agents-moderate-connector.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -24,6 +24,7 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/bot_comment_auth_coverage.js
             .github/scripts/coverage_monitor_summary.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/pr_source_context_coverage.js
             .github/scripts/terminal_disposition.js

--- a/.github/workflows/health-codex-auth-check.yml
+++ b/.github/workflows/health-codex-auth-check.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/maint-46-post-ci.yml
+++ b/.github/workflows/maint-46-post-ci.yml
@@ -99,6 +99,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             tools/__init__.py

--- a/.github/workflows/maint-62-integration-consumer.yml
+++ b/.github/workflows/maint-62-integration-consumer.yml
@@ -200,6 +200,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/maint-72-fix-pr-body-conflicts.yml
+++ b/.github/workflows/maint-72-fix-pr-body-conflicts.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -29,6 +29,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/actions/artifact-cache
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -105,6 +106,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/artifact-cache
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -2488,6 +2488,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token || github.token }}
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/token_load_balancer.js

--- a/.github/workflows/reusable-16-agents.yml
+++ b/.github/workflows/reusable-16-agents.yml
@@ -154,6 +154,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             .github/scripts/agent_registry.js
@@ -369,6 +370,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/agent_registry.js
             .github/actions/setup-api-client

--- a/.github/workflows/reusable-70-orchestrator-init.yml
+++ b/.github/workflows/reusable-70-orchestrator-init.yml
@@ -207,6 +207,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reusable-70-orchestrator-main.yml
+++ b/.github/workflows/reusable-70-orchestrator-main.yml
@@ -363,6 +363,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reusable-agents-pr-health.yml
+++ b/.github/workflows/reusable-agents-pr-health.yml
@@ -219,6 +219,7 @@ jobs:
           repository: stranske/Workflows
           sparse-checkout: |
             .github/actions/setup-api-client
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -593,6 +594,7 @@ jobs:
         with:
           repository: stranske/Workflows
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -804,6 +806,7 @@ jobs:
         with:
           repository: stranske/Workflows
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reusable-bot-comment-handler.yml
+++ b/.github/workflows/reusable-bot-comment-handler.yml
@@ -251,6 +251,7 @@ jobs:
             .github/actions/setup-api-client
             .github/scripts/agent_registry.js
             .github/scripts/bot-comment-handler.js
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
@@ -754,6 +755,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/bot-comment-handler.js
             .github/actions/setup-api-client

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -7,7 +7,7 @@
 [pair.1]
 main = .github/workflows/agents-63-issue-intake.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-intake.yml
-main_sha256 = cf922877984f7d7a5f4f197def3b2ef8be763f83441d5c47409026b6cb4db783
+main_sha256 = b9c4c9d5c48a48fd6307277fc724d8d1f6aff742fe3cde5c606b178ec8f529ce
 template_sha256 = 689d22e20cc6f21df006a2f7ed54924fc05d63adea5ef89251788f888f2a5495
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
@@ -35,36 +35,36 @@ reason = Existing reviewed baseline drift; align the template or update this fin
 [pair.5]
 main = .github/workflows/agents-auto-label.yml
 template = templates/consumer-repo/.github/workflows/agents-auto-label.yml
-main_sha256 = f94e7f767264ca700c2a07b8097795e3eda5d2e9a5b8df63e1936a0c202d174b
-template_sha256 = bb9d21d51b02c28c2d8f6ffd5d81ef151f5be2bc75ce4373de61e8c59486ad1d
+main_sha256 = 4dacff89dfef1ffadcd1e3d781aa8cc82bafa6433e3f0d65208f4576ffefe6bd
+template_sha256 = b6e4ff7bef753216bde90ccd4cc6e505b02a02df7be8b5aaa7e191077a1335d6
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.6]
 main = .github/workflows/agents-autofix-dispatcher.yml
 template = templates/consumer-repo/.github/workflows/agents-autofix-dispatcher.yml
-main_sha256 = bb6841b5b89107ada1e823b9e21bc00f325ce723665bfc9555e4231d12b7e45e
-template_sha256 = a4703ccd7b04ba958d9807d875f86ac1d9b1f305345b66ff6c55c0059c117a94
+main_sha256 = f8584d92f218da726690e349cf8513d6eb4db2edfcace1b388e48388eb8eb3d2
+template_sha256 = c699daf54422f6e7548211a55d88ca34df0b752b0cc8c8e8d60c9dec219149e9
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.7]
 main = .github/workflows/agents-capability-check.yml
 template = templates/consumer-repo/.github/workflows/agents-capability-check.yml
-main_sha256 = 27d58d8709538b6be76d0972b30e59d03a40b67b3036478e84afd27951a16041
-template_sha256 = e1e8a6817da55d877670cf683c2d4d3417842ae47ba5e0a3a69c2b3835cfcf97
+main_sha256 = 039a8f5dbb1b7e455c076c15036840226e6b5d4e54004c1e67543b5decb36cae
+template_sha256 = 4286693c0f9701fc4a0e550821a5a0229ad140c154c36db3b8cb3fd8089e233e
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.8]
 main = .github/workflows/agents-decompose.yml
 template = templates/consumer-repo/.github/workflows/agents-decompose.yml
-main_sha256 = e9a0d1764e5524604dcda3a1eaafb6e9b914b7b3624546062d043fe0c8ef4af4
-template_sha256 = 9d0fd14edf785c459206377811240b08921f3ce12b23a691294c88634bb0473a
+main_sha256 = 55db24f3678614f71da81df2f1d80a7fc93fdaf84d06c943da1013d74f5aebd8
+template_sha256 = 0687139513b4b148b1a792a652bdd55e13eef88fc661659f597c2506d967a7e7
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.9]
 main = .github/workflows/agents-dedup.yml
 template = templates/consumer-repo/.github/workflows/agents-dedup.yml
-main_sha256 = fa039946022efce3163f050b6664a9f95f6652d970f6f6e95af2b3b7852c50c1
-template_sha256 = 18bd729d35dddcf225c770dabce548a69479f9f808b3a9e3bc4a02fd86496a03
+main_sha256 = 73665af908b2f725958ed1e895e457fdc902ea367478bedc2be6d86518ed44f5
+template_sha256 = 5f008bf68d1e59d3011d30a1a7ea9136476f1b85509aff3c31807e97084605e4
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.10]
@@ -77,8 +77,8 @@ reason = Existing reviewed baseline drift; align the template or update this fin
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
-main_sha256 = 36c786476b92f638133bef25a36361ab197c1a5302f4499adb89cb1e7a29477d
-template_sha256 = 04fe11354ae1b337a7fc371f7154c0476e9ccbdee3e8bb5cfb9ea50cd07ee36a
+main_sha256 = 66e1b7a23c0178d558c0e88f1c75de00f228d2eda23e7bb9c744a6fd909aaf5f
+template_sha256 = d64c0ed82527ed7aea9a85aa163659baa55d118a17a984b00cbb28fb18afe2dd
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.
 
 [pair.12]
@@ -105,6 +105,6 @@ reason = Existing reviewed baseline drift; align the template or update this fin
 [pair.15]
 main = .github/workflows/agents-weekly-metrics.yml
 template = templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
-main_sha256 = 56386f02373d50afff04e99a753a004f08c8960771989cc6e92b10340901c163
-template_sha256 = f512b96005535ac15bb27ca87c0434b77d9fae63008cdb5f1766bacabcf7b368
+main_sha256 = 3798ce82e746acc4036c191404fe2b3954ba9c09b183d07adcf42c4650108b2c
+template_sha256 = 1b8606bf9cfa446e04db2fb6b6d53569fa14fd375deac1be9818dd90a135ebd2
 reason = Existing reviewed baseline drift; align the template or update this fingerprint deliberately.

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -21,10 +21,13 @@ def _manifest_entries() -> dict[str, dict]:
 def test_consumer_create_only_files_are_manifested() -> None:
     entries = _manifest_entries()
 
+    # .github/dependabot.yml was intentionally dropped from the template and the
+    # manifest in #2401 (P3b of the Renovate fleet migration): create_only sync
+    # would otherwise resurrect Dependabot on every re-sync. It must no longer be
+    # manifested.
     for source in (
         ".github/workflows/pr-00-gate.yml",
         ".github/workflows/ci.yml",
-        ".github/dependabot.yml",
     ):
         assert source in entries
         assert entries[source]["sync_mode"] == "create_only"
@@ -34,6 +37,10 @@ def test_consumer_create_only_files_are_manifested() -> None:
         ".github/workflows/ci.yml",
     ):
         assert entries[source]["overwrite_repos"] == ["stranske/Template"]
+
+    # Guard against re-adding the Dependabot config to the manifest (would
+    # resurrect Dependabot on consumers via create_only sync). See #2401.
+    assert ".github/dependabot.yml" not in entries
 
 
 def test_gate_manifest_entry_documents_fresh_consumer_bootstrap_risk() -> None:


### PR DESCRIPTION
## Problem

`.github/scripts/github-api-with-retry.js` does a **top-level** `require('./error_classifier')` (line 20). ~20 **root** workflows sparse-checkout the retry client *without* `.github/scripts/error_classifier.js`, so any step that loads the client throws `Cannot find module './error_classifier'`. This is the root-repo equivalent of the consumer-template bug fixed in #2398.

## Fix (3 commits)

### 1. `error_classifier.js` in root sparse-checkouts (the actual bug)
Added `.github/scripts/error_classifier.js` to **every** sparse-checkout block that pulls `github-api-with-retry.js` — **28 insertions across 20 files, 0 deletions**. Six files have multiple sparse-checkout blocks (`agents-autofix-loop` ×3, `reusable-agents-pr-health` ×3, etc.); each block was fixed.

Prioritized reusables: `reusable-10-ci-python`, `reusable-16-agents`, `reusable-70-orchestrator-{init,main}`, `reusable-agents-pr-health`, `reusable-bot-comment-handler`. Plus: `agents-63-issue-intake`, `agents-autofix-dispatcher`, `agents-autofix-loop`, `agents-bot-comment-handler`, `agents-capability-check`, `agents-decompose`, `agents-dedup`, `agents-moderate-connector`, `agents-weekly-metrics`, `health-codex-auth-check`, `maint-46-post-ci`, `maint-62-integration-consumer`, `maint-72-fix-pr-body-conflicts`, `maint-coverage-guard`.

### 2. Stale dependabot manifest test (pre-existing red on every PR)
`test_consumer_create_only_files_are_manifested` still asserted `.github/dependabot.yml` is manifested, but #2401 intentionally removed it from the template + manifest. This failed `Python Tests`, all six `Scenario - */python 3.12` jobs, and the `Aggregate & Verify` / `Publish Results` roll-ups. Dropped the stale expectation; added a guard that it is **not** re-added.

### 3. Stale Health-74 template-drift fingerprints (pre-existing red on every PR)
The drift allowlist already covers all 8 drifting pairs, but their SHA fingerprints went stale (renovate bumps, #2398's template edits, and this PR's sparse-checkout additions). Recomputed every entry's normalized SHA in place: 7 still-valid entries unchanged, 8 stale ones refreshed. Divergence is the intentional health-74 baseline (root floating tags + concurrency vs. template SHA-pins) — re-baselined, not aligned.

## Verification (local)
- Audit: 20 → **0** broken sparse-checkouts; every inserted line sits among `.github/scripts/*.js` entries (no `require`/`run:` adjacency); all 20 YAML-parse.
- `scripts/check_template_drift.py` → **0 unallowlisted drift, exit 0**.
- `tests/workflows` + `tests/scripts`: **2252 passed, 3 skipped** (needs-human), including the previously-failing manifest test and `test_template_drift_workflow.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows to include an error-classification helper during their sparse checkouts, improving consistency of automated error reporting across jobs and pipelines.
  * Refreshed template drift allowlist fingerprints for several workflow template pairs.
* **Tests**
  * Updated consumer sync manifest tests to ensure the Dependabot configuration is excluded from generated manifest entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->