### PR TITLE
refactor(agents): share runner auth setup (Refs #2341)

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -4,18 +4,23 @@ description: >-
   out the target repository, set up Node.js, prepare the API client, and check
   out the stranske/Workflows scripts into .workflows-lib. Extracted from
   reusable-claude-run.yml and reusable-codex-run.yml so the steps are
-  maintained in one place (issue #2341). Agent-specific steps (App-token mint,
-  auth-token selection, Workflows script-dep install, tooling validation, and
-  the agent invocation) stay in each runner.
+  maintained in one place (issue #2341). Agent-specific steps (Workflows
+  script-dep install, tooling validation, and the agent invocation) stay in
+  each runner.
 
 inputs:
   checkout_ref:
     description: Git ref to check out for the target repository.
     required: false
     default: ''
-  checkout_token:
-    description: Token used for repository checkouts (target repo and Workflows scripts).
-    required: true
+  workflows_app_id:
+    description: GitHub App ID used to mint the preferred write token.
+    required: false
+    default: ''
+  workflows_app_private_key:
+    description: GitHub App private key used to mint the preferred write token.
+    required: false
+    default: ''
   workflows_ref:
     description: Ref of stranske/Workflows to check out into .workflows-lib.
     required: true
@@ -26,16 +31,89 @@ inputs:
   github_token:
     description: GITHUB_TOKEN forwarded to setup-api-client.
     required: true
+  runner_mode:
+    description: Current runner mode; exported to the agent-specific mode env name.
+    required: false
+    default: ''
+  runner_pr_number:
+    description: Current PR number; exported to the agent-specific PR env name.
+    required: false
+    default: ''
+  mode_env_name:
+    description: Environment variable name that receives runner_mode.
+    required: true
+  pr_number_env_name:
+    description: Environment variable name that receives runner_pr_number.
+    required: true
+
+outputs:
+  checkout_token:
+    description: Token selected for checkouts.
+    value: ${{ steps.auth_token.outputs.checkout_token }}
+  push_token:
+    description: App token selected for pushes, or empty when unavailable.
+    value: ${{ steps.auth_token.outputs.push_token }}
+  source:
+    description: Selected auth source, app-token or github-token.
+    value: ${{ steps.auth_token.outputs.source }}
+  push_allowed:
+    description: true when push_token is available.
+    value: ${{ steps.auth_token.outputs.push_allowed }}
 
 runs:
   using: composite
   steps:
+    - name: Mint GitHub App token
+      id: app_token
+      continue-on-error: true
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ inputs.workflows_app_id || '0' }}
+        private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
+
+    - name: Select auth token
+      id: auth_token
+      shell: bash
+      env:
+        APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
+        GITHUB_TOKEN_VALUE: ${{ inputs.github_token }}
+        RUNNER_MODE: ${{ inputs.runner_mode }}
+        RUNNER_PR_NUMBER: ${{ inputs.runner_pr_number }}
+        MODE_ENV_NAME: ${{ inputs.mode_env_name }}
+        PR_NUMBER_ENV_NAME: ${{ inputs.pr_number_env_name }}
+      run: |
+        set -euo pipefail
+        checkout_token="${APP_TOKEN:-${GITHUB_TOKEN_VALUE}}"
+        push_token="${APP_TOKEN:-}"
+        source="app-token"
+        push_allowed="true"
+
+        if [ -z "$push_token" ]; then
+          source="github-token"
+          push_allowed="false"
+        fi
+
+        {
+          echo "checkout_token=${checkout_token}"
+          echo "push_token=${push_token}"
+          echo "source=${source}"
+          echo "push_allowed=${push_allowed}"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "WORKFLOWS_TOKEN=${checkout_token}"
+          echo "${MODE_ENV_NAME}=${RUNNER_MODE}"
+          echo "${PR_NUMBER_ENV_NAME}=${RUNNER_PR_NUMBER}"
+        } >> "$GITHUB_ENV"
+
+        printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
+
     - name: Checkout
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout_ref || github.ref }}
-        token: ${{ inputs.checkout_token }}
+        token: ${{ steps.auth_token.outputs.checkout_token }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -60,4 +138,4 @@ runs:
           .github
           tools
           scripts
-        token: ${{ inputs.checkout_token }}
+        token: ${{ steps.auth_token.outputs.checkout_token }}

--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -198,48 +198,10 @@ jobs:
       error-type: ${{ steps.classify_failure.outputs.error_type }}
       error-recovery: ${{ steps.classify_failure.outputs.error_recovery }}
     steps:
-      - name: Mint GitHub App token (preferred)
-        id: app_token
-        continue-on-error: true
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
-
-      - name: Select auth token
-        id: auth_token
-        env:
-          APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
-        run: |
-          set -euo pipefail
-          checkout_token="${APP_TOKEN:-${GITHUB_TOKEN}}"
-          push_token="${APP_TOKEN:-}"
-          source="app-token"
-          push_allowed="true"
-
-          if [ -z "$push_token" ]; then
-            source="github-token"
-            push_allowed="false"
-          fi
-
-          {
-            echo "checkout_token=${checkout_token}"
-            echo "push_token=${push_token}"
-            echo "source=${source}"
-            echo "push_allowed=${push_allowed}"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "WORKFLOWS_TOKEN=${checkout_token}"
-            echo "CLAUDE_MODE=${{ inputs.mode }}"
-            echo "CLAUDE_PR_NUMBER=${{ inputs.pr_number }}"
-          } >> "$GITHUB_ENV"
-
-          printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
-
-      # Shared agent-agnostic setup (checkout / Node.js / API client /
-      # Workflows scripts checkout) lives in the agent-run-base composite so it
-      # is maintained once for both runners (issue #2341).
+      # Shared agent-agnostic setup (App-token mint / auth-token selection /
+      # checkout / Node.js / API client / Workflows scripts checkout) lives in
+      # the agent-run-base composite so it is maintained once for both runners
+      # (issue #2341).
       - name: Checkout Workflows run-base action
         uses: actions/checkout@v6
         with:
@@ -248,16 +210,22 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
-          token: ${{ steps.auth_token.outputs.checkout_token }}
+          token: ${{ github.token }}
 
       - name: Agent run base setup
+        id: run_base
         uses: ./.workflows-actions/.github/actions/agent-run-base
         with:
           checkout_ref: ${{ inputs.pr_ref || github.ref }}
-          checkout_token: ${{ steps.auth_token.outputs.checkout_token }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
           workflows_ref: ${{ inputs.workflows_ref }}
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
+          runner_mode: ${{ inputs.mode }}
+          runner_pr_number: ${{ inputs.pr_number }}
+          mode_env_name: CLAUDE_MODE
+          pr_number_env_name: CLAUDE_PR_NUMBER
 
       # Ensure Workflows deps BEFORE calling setup-api-client for .workflows-lib.
       # setup-api-client invokes create_vendor_aliases.js + npm and will fail
@@ -444,7 +412,7 @@ jobs:
         id: reference_packs
         uses: ./.github/actions/agent-reference-packs
         with:
-          checkout_token: ${{ steps.auth_token.outputs.checkout_token }}
+          checkout_token: ${{ steps.run_base.outputs.checkout_token }}
 
       - name: Assemble prompt
         id: prompt
@@ -784,8 +752,8 @@ jobs:
         id: commit
         if: always()
         env:
-          PUSH_TOKEN: ${{ steps.auth_token.outputs.push_token || '' }}
-          PUSH_ALLOWED: ${{ steps.auth_token.outputs.push_allowed }}
+          PUSH_TOKEN: ${{ steps.run_base.outputs.push_token || '' }}
+          PUSH_ALLOWED: ${{ steps.run_base.outputs.push_allowed }}
           PR_REF: ${{ inputs.pr_ref }}
           MODE: ${{ inputs.mode }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -202,6 +202,14 @@ jobs:
       # checkout / Node.js / API client / Workflows scripts checkout) lives in
       # the agent-run-base composite so it is maintained once for both runners
       # (issue #2341).
+      - name: Mint Workflows bootstrap app token
+        id: bootstrap_app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
+
       - name: Checkout Workflows run-base action
         uses: actions/checkout@v6
         with:
@@ -210,7 +218,7 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
-          token: ${{ github.token }}
+          token: ${{ steps.bootstrap_app_token.outputs.token || github.token }}
 
       - name: Agent run base setup
         id: run_base

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -214,48 +214,10 @@ jobs:
       session-event-count: ${{ steps.analyze_session.outputs.event-count }}
       session-todo-count: ${{ steps.analyze_session.outputs.todo-count }}
     steps:
-      - name: Mint GitHub App token (preferred)
-        id: app_token
-        continue-on-error: true
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.WORKFLOWS_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
-
-      - name: Select auth token
-        id: auth_token
-        env:
-          APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
-        run: |
-          set -euo pipefail
-          checkout_token="${APP_TOKEN:-${GITHUB_TOKEN}}"
-          push_token="${APP_TOKEN:-}"
-          source="app-token"
-          push_allowed="true"
-
-          if [ -z "$push_token" ]; then
-            source="github-token"
-            push_allowed="false"
-          fi
-
-          {
-            echo "checkout_token=${checkout_token}"
-            echo "push_token=${push_token}"
-            echo "source=${source}"
-            echo "push_allowed=${push_allowed}"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "WORKFLOWS_TOKEN=${checkout_token}"
-            echo "CODEX_MODE=${{ inputs.mode }}"
-            echo "CODEX_PR_NUMBER=${{ inputs.pr_number }}"
-          } >> "$GITHUB_ENV"
-
-          printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
-
-      # Shared agent-agnostic setup (checkout / Node.js / API client /
-      # Workflows scripts checkout) lives in the agent-run-base composite so it
-      # is maintained once for both runners (issue #2341).
+      # Shared agent-agnostic setup (App-token mint / auth-token selection /
+      # checkout / Node.js / API client / Workflows scripts checkout) lives in
+      # the agent-run-base composite so it is maintained once for both runners
+      # (issue #2341).
       - name: Checkout Workflows run-base action
         uses: actions/checkout@v6
         with:
@@ -264,16 +226,22 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
-          token: ${{ steps.auth_token.outputs.checkout_token }}
+          token: ${{ github.token }}
 
       - name: Agent run base setup
+        id: run_base
         uses: ./.workflows-actions/.github/actions/agent-run-base
         with:
           checkout_ref: ${{ inputs.pr_ref || github.ref }}
-          checkout_token: ${{ steps.auth_token.outputs.checkout_token }}
+          workflows_app_id: ${{ secrets.WORKFLOWS_APP_ID }}
+          workflows_app_private_key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
           workflows_ref: ${{ inputs.workflows_ref }}
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
+          runner_mode: ${{ inputs.mode }}
+          runner_pr_number: ${{ inputs.pr_number }}
+          mode_env_name: CODEX_MODE
+          pr_number_env_name: CODEX_PR_NUMBER
 
       - name: Ensure Workflows script deps
         run: |
@@ -463,7 +431,7 @@ jobs:
         id: reference_packs
         uses: ./.github/actions/agent-reference-packs
         with:
-          checkout_token: ${{ steps.auth_token.outputs.checkout_token }}
+          checkout_token: ${{ steps.run_base.outputs.checkout_token }}
 
       - name: Assemble prompt
         id: prompt
@@ -849,7 +817,7 @@ jobs:
 
               TARGET_BRANCH="${{ inputs.pr_ref }}"
               TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
-              PUSH_TOKEN="${{ steps.auth_token.outputs.push_token }}"
+              PUSH_TOKEN="${{ steps.run_base.outputs.push_token }}"
               REMOTE_URL="https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}"
 
               # Fetch to get current FETCH_HEAD before checking for unpushed work
@@ -1091,7 +1059,7 @@ jobs:
         continue-on-error: true
         env:
           CODEX_HOME: ${{ runner.temp }}/.codex
-          GH_TOKEN: ${{ steps.auth_token.outputs.push_token }}
+          GH_TOKEN: ${{ steps.run_base.outputs.push_token }}
           INITIAL_AUTH_SHA: ${{ steps.codex_auth.outputs.auth_sha }}
         run: |
           set -euo pipefail
@@ -1233,8 +1201,8 @@ jobs:
           MODE: ${{ inputs.mode }}
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_REF: ${{ inputs.pr_ref }}
-          PUSH_ALLOWED: ${{ steps.auth_token.outputs.push_allowed }}
-          PUSH_TOKEN: ${{ steps.auth_token.outputs.push_token }}
+          PUSH_ALLOWED: ${{ steps.run_base.outputs.push_allowed }}
+          PUSH_TOKEN: ${{ steps.run_base.outputs.push_token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -218,6 +218,14 @@ jobs:
       # checkout / Node.js / API client / Workflows scripts checkout) lives in
       # the agent-run-base composite so it is maintained once for both runners
       # (issue #2341).
+      - name: Mint Workflows bootstrap app token
+        id: bootstrap_app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.WORKFLOWS_APP_ID || '0' }}
+          private-key: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY || 'dummy' }}
+
       - name: Checkout Workflows run-base action
         uses: actions/checkout@v6
         with:
@@ -226,7 +234,7 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
-          token: ${{ github.token }}
+          token: ${{ steps.bootstrap_app_token.outputs.token || github.token }}
 
       - name: Agent run base setup
         id: run_base

--- a/tests/workflows/test_reusable_run_shared_base.py
+++ b/tests/workflows/test_reusable_run_shared_base.py
@@ -121,14 +121,30 @@ def test_extracted_setup_steps_not_duplicated_in_runners(workflow_rel: str) -> N
     checkout_with = run_base_checkout_steps[0]["with"]
     assert checkout_with["path"] == RUN_BASE_CHECKOUT_PATH
     assert ".github/actions/agent-run-base" in checkout_with["sparse-checkout"]
+    assert (
+        checkout_with["token"] == "${{ steps.bootstrap_app_token.outputs.token || github.token }}"
+    )
+
+    bootstrap_token_steps = [
+        step
+        for step in steps
+        if step.get("name") == "Mint Workflows bootstrap app token"
+        and _uses_base(step) == "actions/create-github-app-token"
+    ]
+    assert len(bootstrap_token_steps) == 1, (
+        f"{workflow_rel}: private/internal Workflows consumers need an App "
+        "token before the sparse checkout that loads agent-run-base"
+    )
+    assert bootstrap_token_steps[0].get("continue-on-error") is True
 
     # The target repository checkout and Workflows scripts checkout now live in
     # the composite; only the pre-checkout for the composite definition remains
     # in the runners.
     assert "repository: stranske/Workflows" in src
-    assert "uses: actions/create-github-app-token@v3" not in src, (
-        f"{workflow_rel}: App-token minting was extracted to {RUN_BASE_ACTION}; "
-        "it should not reappear verbatim in the runner"
+    assert src.count("uses: actions/create-github-app-token@v3") == 1, (
+        f"{workflow_rel}: only the run-base bootstrap checkout may mint an App "
+        "token in the runner; shared runtime auth still belongs in "
+        f"{RUN_BASE_ACTION}"
     )
     assert "steps.auth_token.outputs" not in src, (
         f"{workflow_rel}: auth-token selection was extracted to {RUN_BASE_ACTION}; "

--- a/tests/workflows/test_reusable_run_shared_base.py
+++ b/tests/workflows/test_reusable_run_shared_base.py
@@ -12,9 +12,10 @@ applied twice.
 
 PR #2345 extracted the reference-pack materializer into
 ``.github/actions/agent-reference-packs``. This follow-up extracts the
-agent-agnostic *setup* block — checkout of the target repo, Node.js setup, the
-API client, and the ``.workflows-lib`` scripts checkout — into
-``.github/actions/agent-run-base`` so it is maintained in one place.
+agent-agnostic *setup* block — App-token minting, auth-token selection,
+checkout of the target repo, Node.js setup, the API client, and the
+``.workflows-lib`` scripts checkout — into ``.github/actions/agent-run-base``
+so it is maintained in one place.
 
 This test asserts both runners call the shared composite exactly once and no
 longer carry their own copy of the extracted ``actions/checkout`` /
@@ -44,6 +45,8 @@ RUN_BASE_USE_BASES = {
 # Step names the composite must run, in order. Behaviour parity with the
 # pre-extraction inline block depends on this exact sequence.
 EXPECTED_STEP_NAMES = [
+    "Mint GitHub App token",
+    "Select auth token",
     "Checkout",
     "Set up Node.js",
     "Setup API client",
@@ -81,6 +84,8 @@ def test_run_base_action_exists_and_parses() -> None:
     # The shared block must still reach setup-api-client and the sparse
     # Workflows scripts checkout — the whole point of the extraction.
     src = path.read_text()
+    assert "uses: actions/create-github-app-token@v3" in src
+    assert "push_allowed" in src
     assert "uses: ./.github/actions/setup-api-client" in src
     assert "sparse-checkout" in src
 
@@ -121,6 +126,14 @@ def test_extracted_setup_steps_not_duplicated_in_runners(workflow_rel: str) -> N
     # the composite; only the pre-checkout for the composite definition remains
     # in the runners.
     assert "repository: stranske/Workflows" in src
+    assert "uses: actions/create-github-app-token@v3" not in src, (
+        f"{workflow_rel}: App-token minting was extracted to {RUN_BASE_ACTION}; "
+        "it should not reappear verbatim in the runner"
+    )
+    assert "steps.auth_token.outputs" not in src, (
+        f"{workflow_rel}: auth-token selection was extracted to {RUN_BASE_ACTION}; "
+        "runner code should consume steps.run_base.outputs instead"
+    )
     assert "path: .workflows-lib" not in src, (
         f"{workflow_rel}: the .workflows-lib sparse checkout was extracted to "
         f"{RUN_BASE_ACTION}; it should not reappear verbatim in the runner"

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -223,7 +223,7 @@ def test_reusable_codex_run_persists_refreshed_auth_bundle_with_app_token() -> N
     assert step.get("continue-on-error") is True
 
     env = step.get("env") or {}
-    assert env.get("GH_TOKEN") == "${{ steps.auth_token.outputs.push_token }}"
+    assert env.get("GH_TOKEN") == "${{ steps.run_base.outputs.push_token }}"
     assert env.get("INITIAL_AUTH_SHA") == "${{ steps.codex_auth.outputs.auth_sha }}"
 
     run_script = str(step.get("run", ""))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2341 -->
> **Source:** Issue #2341

Closes #2341

<!-- pr-preamble:end -->

## Summary
- moves GitHub App token minting and checkout/push token selection into `.github/actions/agent-run-base`
- exposes `checkout_token`, `push_token`, `source`, and `push_allowed` from the shared composite
- updates both reusable agent runners to consume `steps.run_base.outputs.*` and guards against duplicated auth setup returning

## Validation
- `python -m pytest tests/workflows/test_reusable_run_shared_base.py tests/scripts/test_reusable_ci_scope.py -q`
- `python -m black --check --line-length 100 tests/workflows/test_reusable_run_shared_base.py`
- `actionlint -ignore 'SC2129' .github/workflows/reusable-codex-run.yml .github/workflows/reusable-claude-run.yml`\n- YAML parse for `.github/actions/agent-run-base/action.yml`, `reusable-claude-run.yml`, and `reusable-codex-run.yml`\n\n## Notes\nThis is a bounded follow-up to PR #2387 provider CONCERNS/FAIL. It keeps #2341 open because artifact upload/download extraction and live selftest evidence still need verifier disposition.

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`reusable-claude-run.yml` (1644 L) and `reusable-codex-run.yml` (1946 L) share ~684 identical lines (checkout, App-token mint, `setup-api-client`, reference-pack materialization, artifact handling) and have **already started diverging** — e.g. the reference-pack heredoc `IndentationError` existed in the codex variant but not claude (fixed in #2287). Verified: both files are large and parallel. This is **latent fragility, not a current break**: every shared-step fix must be applied twice and the two drift over time.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2287](https://github.com/stranske/Workflows/issues/2287)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Identify the shared step block common to `reusable-claude-run.yml` and `reusable-codex-run.yml` (checkout / token mint / `setup-api-client` / reference-pack materialize / artifact upload).
- [ ] Extract it into `.github/actions/agent-run-base` (composite) — or a reusable workflow — and replace the duplicated blocks in both runners with a call to it.
- [ ] Confirm `selftest-reusable-ci.yml` still exercises both runners green.

#### Acceptance criteria
- [ ] Live-verification gate: `gh workflow run selftest-reusable-ci.yml` completes with the reusable-CI scenarios green (capture the run log showing the scenarios executed, not skipped).
- [ ] **Deliberate-break gate:** temporarily break one step in the new shared surface (e.g. point `setup-api-client` at a bogus path). A `selftest-reusable-ci.yml` scenario that exercises the runners **must FAIL**. Revert after capturing the failure.
- [ ] `git diff --stat` shows a net reduction in duplicated YAML (the extracted block no longer appears verbatim in both runners).

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Centralized CI token provisioning into a shared reusable workflow/action to streamline authentication.
  * Updated the shared runner bootstrap behavior, including optional GitHub App token inputs and new runner context environment variables.
  * Adjusted reusable run workflows to consume the centralized outputs for checkout and commit/push authorization.
  * Updated/extended workflow tests to match the new shared step sequence and token source.

**Impact:** No end-user functionality changes; improved reliability and security for automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->