### PR TITLE
chore(renovate): P4a — durable lock-regen (fleet pip-compile manager + auto-lock backstop)

### DIFF
--- a/.github/workflows/maint-dependabot-auto-lock.yml
+++ b/.github/workflows/maint-dependabot-auto-lock.yml
@@ -1,6 +1,14 @@
 name: Dependabot Auto-Lock
-# Automatically regenerate requirements.lock when dependabot updates any
-# declared lock input file so the checked-in lock stays in sync.
+# Backstop that regenerates requirements.lock when a dependency bot updates a
+# declared lock input file, so the checked-in lock stays in sync.
+#
+# Primary mechanism is now the fleet Renovate preset's pip-compile manager
+# (renovate-presets/fleet.json), which regenerates the lock IN the same PR by
+# re-running the command recorded in the lock header. This workflow is a
+# Workflows-local backstop for when that in-PR regeneration is unavailable
+# (e.g. Dependabot PRs, or a Renovate run that could not run uv). To avoid
+# fighting Renovate it re-runs the SAME header command verbatim, producing
+# byte-identical output. (Not synced to consumers; consumers rely on the preset.)
 
 on:
   pull_request:
@@ -10,6 +18,7 @@ on:
       - 'tools/requirements-llm.txt'
     branches:
       - 'dependabot/**'
+      - 'renovate/**'
 
 permissions:
   contents: write
@@ -23,7 +32,7 @@ jobs:
   regenerate-lock:
     name: Regenerate requirements.lock
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
 
     steps:
       - uses: actions/checkout@v6
@@ -39,60 +48,43 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      - name: Build compile arguments
-        id: compile_args
-        run: |
-          python - <<'PY'
-          import shlex
-          import tomllib
-          from pathlib import Path
-
-          pyproject_path = Path("pyproject.toml")
-          pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-          extras = sorted(pyproject.get("project", {}).get("optional-dependencies", {}))
-
-          args = ["--python-version", "3.12", "pyproject.toml"]
-          for extra in extras:
-              args.extend(["--extra", extra])
-
-          for candidate in ("requirements.txt", "tools/requirements-llm.txt"):
-              if Path(candidate).is_file():
-                  args.append(candidate)
-
-          args.extend(["--universal", "--output-file"])
-
-          github_output = Path(__import__("os").environ["GITHUB_OUTPUT"])
-          with github_output.open("a", encoding="utf-8") as fh:
-              fh.write(f"compile_args={shlex.join(args)}\n")
-              fh.write(f"extras={','.join(extras)}\n")
-          PY
-
-      - name: Check if lock file needs update
+      - name: Regenerate requirements.lock from its recorded header command
         id: check
         run: |
-          out=requirements.check
-          log=compile.log
-          compile_args="${{ steps.compile_args.outputs.compile_args }}"
-          uv pip compile ${compile_args} "$out" 2>&1 | tee "$log" || {
+          set -euo pipefail
+          if [ ! -f requirements.lock ]; then
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+            echo "No requirements.lock present; nothing to regenerate."
+            exit 0
+          fi
+
+          # Re-run the EXACT command recorded in the lock header. Renovate's
+          # pip-compile manager regenerates the lock the same way (it reads this
+          # header), so producing byte-identical output keeps this backstop from
+          # fighting Renovate with flip-flop commits. The header carries only
+          # flags/paths (including the --output-file / -o target), so the
+          # unquoted word-splitting below is intentional.
+          args=$(sed -n 's/^#[[:space:]]*uv pip compile[[:space:]]\{1,\}\(.*\)$/\1/p' requirements.lock | head -n1)
+          if [ -z "${args}" ]; then
+            echo "::error::Could not parse a 'uv pip compile' command from the requirements.lock header."
+            exit 1
+          fi
+          echo "Recorded command: uv pip compile ${args}"
+
+          # shellcheck disable=SC2086
+          uv pip compile ${args} 2>&1 | tee compile.log || {
             echo "❌ Compilation failed:"
-            cat "$log"
+            cat compile.log
             exit 1
           }
 
-          if git diff --exit-code requirements.lock requirements.check > /dev/null 2>&1; then
+          if git diff --exit-code requirements.lock > /dev/null 2>&1; then
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
             echo "✓ Lock file is already up to date"
           else
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
-            echo "⚠ Lock file needs regeneration"
+            echo "⚠ Lock file regenerated; committing the refreshed lock"
           fi
-
-      - name: Regenerate lock file
-        if: steps.check.outputs.needs_update == 'true'
-        run: |
-          compile_args="${{ steps.compile_args.outputs.compile_args }}"
-          uv pip compile ${compile_args} requirements.lock
-          echo "✓ Generated new lock file"
 
       - name: Commit updated lock file
         if: steps.check.outputs.needs_update == 'true'
@@ -102,6 +94,6 @@ jobs:
           git add requirements.lock
           git commit \
             -m "chore(deps): regenerate requirements.lock" \
-            -m "Includes all optional dependencies"
+            -m "Backstop regeneration via the command recorded in the lock header."
           git push
           echo "✓ Committed and pushed updated lock file"

--- a/renovate-presets/fleet.json
+++ b/renovate-presets/fleet.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "stranske fleet-shared Renovate preset — single source of truth for dependency automation across all stranske/* repos. Replaces Dependabot for runtime pip deps + GitHub Actions, grouped with automerge-on-green. Dev-tool pins (ruff/black/mypy/pytest/...) are EXCLUDED: they move through autofix-versions.env via the maint workflows, NOT the bumper (mirrors the retired Dependabot ignore list). The vendored .github/scripts npm cascade (minimatch/brace-expansion/balanced-match) is kept in one PR. Each repo's renovate.json extends this via `github>stranske/Workflows//renovate-presets/fleet`, so a fleet-wide policy change is one edit here — no per-repo re-sync.",
+  "description": "stranske fleet-shared Renovate preset — single source of truth for dependency automation across all stranske/* repos. Replaces Dependabot for runtime pip deps + GitHub Actions, grouped with automerge-on-green. Dev-tool pins (ruff/black/mypy/pytest/...) are EXCLUDED: they move through autofix-versions.env via the maint workflows, NOT the bumper (mirrors the retired Dependabot ignore list). The vendored .github/scripts npm cascade (minimatch/brace-expansion/balanced-match) is kept in one PR. The pip-compile manager is enabled against requirements.lock so that uv-compiled lock (a `uv pip compile` output) is regenerated in-PR whenever a source dep changes — this is what kept consumers' locks fresh under Dependabot's native lock update; consumers have NO auto-lock workflow and rely on this preset. Each repo's renovate.json extends this via `github>stranske/Workflows//renovate-presets/fleet`, so a fleet-wide policy change is one edit here — no per-repo re-sync.",
   "extends": ["config:recommended"],
   "platformAutomerge": true,
   "labels": ["dependencies"],
+  "pip-compile": {
+    "managerFilePatterns": ["/(^|/)requirements\\.lock$/"]
+  },
   "packageRules": [
     {
       "description": "Dev-tool pins are owned by autofix-versions.env + the maint workflows — Renovate must not bump them",

--- a/requirements.lock
+++ b/requirements.lock
@@ -252,7 +252,6 @@ pygments==2.20.0
     # via pytest
 pytest==9.1.0
     # via
-    #   -r requirements.txt
     #   workflows (pyproject.toml)
     #   pytest-cov
     #   pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
 # Core runtime dependencies
+# Note: pytest and other dev/test tools are NOT pinned here — they are owned by
+# autofix-versions.env and the pyproject.toml [dev] extra (synced via maint-52 /
+# scripts/sync_dev_dependencies.py, which updates pyproject + requirements.lock
+# but NOT this file). A pytest pin here drifted out of sync and made the lock
+# unsatisfiable (fixed once in #2404); removing it keeps the dev-tool pin in a
+# single owner so the now-enabled Renovate pip-compile manager can always
+# recompile the lock.
 requests==2.34.2
-pytest==9.1.0
 pyyaml==6.0.3
 pydantic==2.13.4
 numpy==2.4.6


### PR DESCRIPTION
## Priority 1 — lock-regen gap (durable / systemic fix)

Builds on **#2404**, which already fixed the **one-time symptoms** (regenerated the stale lock after Renovate #2389, and reconciled the conflicting `pytest` pin to 9.1.0 so `uv pip compile` is satisfiable again). This PR adds the **systemic fix** so the gap cannot recur, and wires the consumer story that Dependabot's native lock update used to cover.

### Why #2404 alone isn't enough
`#2404` noted *"Renovate's pip-compile manager is not enabled in the fleet preset, so it does not regenerate this uv-pip-compile lock."* That's the root gap — without it, **every** future Renovate source bump leaves `requirements.lock` stale (and consumers, which have no auto-lock workflow, never regenerate at all).

### Changes
- **`renovate-presets/fleet.json`** — enable the **pip-compile manager** against `requirements.lock`. The hosted Renovate app re-runs the `uv pip compile` command recorded in the lock header and regenerates the lock **in the same PR**, fleet-wide (Workflows + every consumer extends this preset). This is the answer to the consumer investigation: consumers relied on Dependabot's native lock update; this preset restores it. `lockFileMaintenance` is on by default in the manager — no `postUpdateOptions` needed.
- **`maint-dependabot-auto-lock.yml`** — extend to `renovate[bot]` + `renovate/**` as a **Workflows-local backstop**, and rewrite it to re-run the **same header command verbatim** instead of recomputing args. The old dynamic args added the empty `app` extra + `tools/requirements-llm.txt`, diverging from the header → would have **flip-flopped commits** against Renovate's regen (the "fight automerge" failure mode). Re-running the header guarantees byte-identical output, so the backstop no-ops when Renovate already regenerated and only acts if that ever fails.
- **`requirements.txt`** — remove the `pytest` pin entirely. #2404 aligned it to 9.1.0, but `sync_dev_dependencies.py` syncs `autofix-versions.env` → `pyproject` + `requirements.lock` and **not** `requirements.txt`, so a pin here re-drifts on the next pytest bump and re-breaks the lock — defeating the pip-compile manager. Removing it keeps the dev-tool pin in a single owner; the lock still carries pytest 9.1.0 via the `dev` extra (lock diff is the single now-stale `# -r requirements.txt` annotation).

### Verification
- `uv pip compile` (main's header command) succeeds; lock diff vs `main` is one annotation line.
- `tests/test_dependency_version_alignment.py`, `tests/scripts/test_sync_{dev_dependencies,tool_versions}.py` — **30 passed**.
- `actionlint` clean on the rewritten workflow.

Part of P4 (finish retiring Dependabot). Follows #2386/#2394/#2401/#2404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI automation for lock-file regeneration, including a safer backstop that reuses the exact compile command recorded in the existing lock file header.
  * Updated the Renovate fleet configuration to explicitly enable `pip-compile`/`uv pip compile`-based regeneration scoped to `requirements.lock`.
  * Refined dependency version management by removing the pinned `pytest` line from `requirements.txt` and clarifying that dev/test versions are managed via existing synchronization tooling and config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->