### PR TITLE
fix: route aggregate agent metrics through canonical NDJSON parser

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from src.ndjson_parser import read_ndjson_file
+
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
 _DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
@@ -289,79 +291,30 @@ def _parse_error_counter(parse_error_details: list[ParseErrorDetail], field: str
     return counts
 
 
-def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
+def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
+    line_match = re.search(r":(\d+): ", error)
+    line = int(line_match.group(1)) if line_match else None
+    if "invalid JSON" in error:
+        reason = "invalid-json"
+    elif "expected object" in error:
+        reason = "non-object-json"
+    elif "legacy-json-fallback-buffer-limit" in error:
+        reason = "legacy-json-fallback-buffer-limit"
+    else:
+        reason = "unreadable-file"
+    return _parse_error_detail(path, line, reason)
+
+
+def read_metric_ndjson_files(
+    files: Iterable[Path],
+) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        try:
-            handle = path.open("r", encoding="utf-8")
-        except OSError:
-            errors.append(_parse_error_detail(path, None, "unreadable-file"))
-            continue
-        file_entries: list[dict[str, Any]] = []
-        file_errors: list[ParseErrorDetail] = []
-        raw_lines_for_fallback: list[str] = []
-        raw_fallback_bytes = 0
-        raw_fallback_truncated = False
-        with handle:
-            for line_number, line in enumerate(handle, start=1):
-                raw = line.strip()
-                if not raw:
-                    continue
-                if not file_entries and not raw_fallback_truncated:
-                    raw_bytes = len(raw.encode("utf-8")) + 1
-                    fallback_within_limit = (
-                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
-                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
-                    )
-                    if fallback_within_limit:
-                        raw_fallback_bytes += raw_bytes
-                        raw_lines_for_fallback.append(raw)
-                    else:
-                        raw_fallback_truncated = True
-                        raw_lines_for_fallback = []
-                try:
-                    parsed = json.loads(raw)
-                except json.JSONDecodeError:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "invalid-json"),
-                    )
-                    continue
-                if isinstance(parsed, dict):
-                    file_entries.append(_attach_metric_source(parsed, path))
-                    raw_lines_for_fallback = []
-                else:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "non-object-json"),
-                    )
-        if file_errors and not file_entries and raw_fallback_truncated:
-            _append_parse_error_detail(
-                file_errors,
-                _parse_error_detail(path, None, "legacy-json-fallback-buffer-limit"),
-            )
-        if (
-            file_errors
-            and not file_entries
-            and raw_lines_for_fallback
-            and not raw_fallback_truncated
-        ):
-            try:
-                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
-            except json.JSONDecodeError:
-                pass
-            else:
-                if isinstance(parsed_file, dict):
-                    file_entries.append(_attach_metric_source(parsed_file, path))
-                    file_errors = []
-                elif isinstance(parsed_file, list) and all(
-                    isinstance(item, dict) for item in parsed_file
-                ):
-                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
-                    file_errors = []
-        entries.extend(file_entries)
-        errors.extend(file_errors)
+        file_entries, file_errors = read_ndjson_file(path)
+        entries.extend(_attach_metric_source(entry, path) for entry in file_entries)
+        for error in file_errors:
+            _append_parse_error_detail(errors, _canonical_parse_error_detail(path, error))
     return entries, errors
 
 
@@ -1599,7 +1552,7 @@ def main() -> int:
         print("No metrics files found to aggregate.", file=sys.stderr)
         return 0
 
-    entries, parse_error_details = _read_ndjson(files)
+    entries, parse_error_details = read_metric_ndjson_files(files)
     summary = build_summary(
         entries,
         _parse_error_count(parse_error_details),

--- a/src/ndjson_parser.py
+++ b/src/ndjson_parser.py
@@ -7,6 +7,9 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+_MAX_LEGACY_JSON_FALLBACK_LINES = 5000
+_MAX_LEGACY_JSON_FALLBACK_BYTES = 1024 * 1024
+
 
 def parse_ndjson_lines(
     lines: Iterable[str],
@@ -35,7 +38,58 @@ def parse_ndjson_lines(
 def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
     """Read an NDJSON file and return entries plus any parsing errors."""
     try:
-        content = path.read_text(encoding="utf-8")
+        handle = path.open("r", encoding="utf-8")
     except OSError as exc:
         return [], [f"{path}: {exc}"]
-    return parse_ndjson_lines(content.splitlines(), source=str(path))
+
+    entries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    raw_lines_for_fallback: list[str] = []
+    raw_fallback_bytes = 0
+    raw_fallback_truncated = False
+    with handle:
+        for line_number, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw:
+                continue
+            if not entries and not raw_fallback_truncated:
+                raw_bytes = len(raw.encode("utf-8")) + 1
+                fallback_within_limit = (
+                    len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                    and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                )
+                if fallback_within_limit:
+                    raw_fallback_bytes += raw_bytes
+                    raw_lines_for_fallback.append(raw)
+                else:
+                    raw_fallback_truncated = True
+                    raw_lines_for_fallback = []
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}:{line_number}: invalid JSON ({exc.msg})")
+                continue
+            if isinstance(parsed, dict):
+                entries.append(parsed)
+                raw_lines_for_fallback = []
+            else:
+                errors.append(f"{path}:{line_number}: expected object, got {type(parsed).__name__}")
+
+    if entries or not errors:
+        return entries, errors
+
+    raw_text = "\n".join(raw_lines_for_fallback)
+    if raw_fallback_truncated:
+        errors.append(f"{path}: legacy-json-fallback-buffer-limit")
+        return entries, errors
+
+    try:
+        parsed_file = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return entries, errors
+
+    if isinstance(parsed_file, dict):
+        return [parsed_file], []
+    if isinstance(parsed_file, list) and all(isinstance(item, dict) for item in parsed_file):
+        return list(parsed_file), []
+    return entries, errors

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from src.ndjson_parser import read_ndjson_file
+
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
 _DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
@@ -289,79 +291,30 @@ def _parse_error_counter(parse_error_details: list[ParseErrorDetail], field: str
     return counts
 
 
-def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
+def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
+    line_match = re.search(r":(\d+): ", error)
+    line = int(line_match.group(1)) if line_match else None
+    if "invalid JSON" in error:
+        reason = "invalid-json"
+    elif "expected object" in error:
+        reason = "non-object-json"
+    elif "legacy-json-fallback-buffer-limit" in error:
+        reason = "legacy-json-fallback-buffer-limit"
+    else:
+        reason = "unreadable-file"
+    return _parse_error_detail(path, line, reason)
+
+
+def read_metric_ndjson_files(
+    files: Iterable[Path],
+) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        try:
-            handle = path.open("r", encoding="utf-8")
-        except OSError:
-            errors.append(_parse_error_detail(path, None, "unreadable-file"))
-            continue
-        file_entries: list[dict[str, Any]] = []
-        file_errors: list[ParseErrorDetail] = []
-        raw_lines_for_fallback: list[str] = []
-        raw_fallback_bytes = 0
-        raw_fallback_truncated = False
-        with handle:
-            for line_number, line in enumerate(handle, start=1):
-                raw = line.strip()
-                if not raw:
-                    continue
-                if not file_entries and not raw_fallback_truncated:
-                    raw_bytes = len(raw.encode("utf-8")) + 1
-                    fallback_within_limit = (
-                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
-                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
-                    )
-                    if fallback_within_limit:
-                        raw_fallback_bytes += raw_bytes
-                        raw_lines_for_fallback.append(raw)
-                    else:
-                        raw_fallback_truncated = True
-                        raw_lines_for_fallback = []
-                try:
-                    parsed = json.loads(raw)
-                except json.JSONDecodeError:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "invalid-json"),
-                    )
-                    continue
-                if isinstance(parsed, dict):
-                    file_entries.append(_attach_metric_source(parsed, path))
-                    raw_lines_for_fallback = []
-                else:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "non-object-json"),
-                    )
-        if file_errors and not file_entries and raw_fallback_truncated:
-            _append_parse_error_detail(
-                file_errors,
-                _parse_error_detail(path, None, "legacy-json-fallback-buffer-limit"),
-            )
-        if (
-            file_errors
-            and not file_entries
-            and raw_lines_for_fallback
-            and not raw_fallback_truncated
-        ):
-            try:
-                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
-            except json.JSONDecodeError:
-                pass
-            else:
-                if isinstance(parsed_file, dict):
-                    file_entries.append(_attach_metric_source(parsed_file, path))
-                    file_errors = []
-                elif isinstance(parsed_file, list) and all(
-                    isinstance(item, dict) for item in parsed_file
-                ):
-                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
-                    file_errors = []
-        entries.extend(file_entries)
-        errors.extend(file_errors)
+        file_entries, file_errors = read_ndjson_file(path)
+        entries.extend(_attach_metric_source(entry, path) for entry in file_entries)
+        for error in file_errors:
+            _append_parse_error_detail(errors, _canonical_parse_error_detail(path, error))
     return entries, errors
 
 
@@ -1599,7 +1552,7 @@ def main() -> int:
         print("No metrics files found to aggregate.", file=sys.stderr)
         return 0
 
-    entries, parse_error_details = _read_ndjson(files)
+    entries, parse_error_details = read_metric_ndjson_files(files)
     summary = build_summary(
         entries,
         _parse_error_count(parse_error_details),

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -479,7 +479,7 @@ def test_gather_metrics_files_missing_dir(tmp_path: Path) -> None:
     assert files == []
 
 
-def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
+def test_read_metric_ndjson_counts_parse_errors(tmp_path: Path) -> None:
     path = tmp_path / "metrics.ndjson"
     path.write_text(
         "\n".join(
@@ -494,7 +494,7 @@ def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert len(entries) == 1
     assert entries[0]["key"] == "value"
@@ -504,7 +504,7 @@ def test_read_ndjson_counts_parse_errors(tmp_path: Path) -> None:
     assert errors[0].line == 2
 
 
-def test_read_ndjson_does_not_buffer_valid_ndjson_for_fallback(
+def test_read_metric_ndjson_does_not_buffer_valid_ndjson_for_fallback(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     path = tmp_path / "metrics.ndjson"
@@ -520,14 +520,16 @@ def test_read_ndjson_does_not_buffer_valid_ndjson_for_fallback(
 
     monkeypatch.setattr(aggregate_agent_metrics.json, "loads", counting_loads)
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert len(entries) == 2
     assert errors == []
     assert calls == 2
 
 
-def test_read_ndjson_streams_file_lines(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_read_metric_ndjson_streams_file_lines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     path = tmp_path / "metrics.ndjson"
     path.write_text('{"key": "value"}\n', encoding="utf-8")
 
@@ -536,22 +538,22 @@ def test_read_ndjson_streams_file_lines(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     monkeypatch.setattr(Path, "read_text", fail_read_text)
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert len(entries) == 1
     assert entries[0]["key"] == "value"
     assert errors == []
 
 
-def test_read_ndjson_counts_unreadable_file(tmp_path: Path) -> None:
+def test_read_metric_ndjson_counts_unreadable_file(tmp_path: Path) -> None:
     missing = tmp_path / "missing.ndjson"
-    entries, errors = aggregate_agent_metrics._read_ndjson([missing])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([missing])
     assert entries == []
     assert len(errors) == 1
     assert errors[0].reason == "unreadable-file"
 
 
-def test_read_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) -> None:
+def test_read_metric_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) -> None:
     metrics_dir = (
         tmp_path / "artifacts" / "review-thread-terminal-disposition-123" / "agent-metrics"
     )
@@ -559,7 +561,7 @@ def test_read_ndjson_attributes_parse_errors_to_artifact_family(tmp_path: Path) 
     path = metrics_dir / "terminal.ndjson"
     path.write_text('{"ok": true}\n{"broken": true\n', encoding="utf-8")
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert len(entries) == 1
     assert entries[0]["ok"] is True
@@ -765,7 +767,7 @@ def test_parse_error_detail_overflow_does_not_use_incoming_identity() -> None:
     assert "third-artifact" not in contract["by_artifact"]
 
 
-def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Path) -> None:
+def test_read_metric_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Path) -> None:
     metrics_dir = (
         tmp_path
         / "artifacts"
@@ -777,7 +779,7 @@ def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Pa
     path = metrics_dir / "terminal.ndjson"
     path.write_text('{"schema":"workflows-terminal-disposition/v1"}\n', encoding="utf-8")
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert errors == []
     assert len(entries) == 1
@@ -787,7 +789,7 @@ def test_read_ndjson_preserves_artifact_name_with_id_extraction_dir(tmp_path: Pa
     assert entries[0]["metric_artifact_family"] == "review-thread-terminal-disposition"
 
 
-def test_read_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
+def test_read_metric_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
     metrics_dir = tmp_path / "artifacts" / "keepalive-metrics"
     metrics_dir.mkdir(parents=True)
     path = metrics_dir / "keepalive-metrics.ndjson"
@@ -804,7 +806,7 @@ def test_read_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert errors == []
     assert len(entries) == 1
@@ -814,14 +816,14 @@ def test_read_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) -> None:
     assert entries[0]["artifact_name"] == "keepalive-metrics"
 
 
-def test_read_ndjson_bounds_legacy_json_fallback_buffer(tmp_path: Path) -> None:
+def test_read_metric_ndjson_bounds_legacy_json_fallback_buffer(tmp_path: Path) -> None:
     path = tmp_path / "large-invalid.ndjson"
     path.write_text(
         "\n".join(["{"] * (aggregate_agent_metrics._MAX_LEGACY_JSON_FALLBACK_LINES + 1)) + "\n",
         encoding="utf-8",
     )
 
-    entries, errors = aggregate_agent_metrics._read_ndjson([path])
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
 
     assert entries == []
     assert len(errors) <= aggregate_agent_metrics._MAX_STORED_PARSE_ERROR_DETAILS


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2337 -->
> **Source:** Issue #2337

Refs #2337

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`_read_ndjson` is copied into **5** metrics scripts while a richer canonical parser already exists. Verified copies (`grep -rln _read_ndjson scripts/*.py`):
`scripts/aggregate_repo_metrics.py`, `scripts/aggregate_agent_metrics.py`, `scripts/keepalive_metrics_dashboard.py`, `scripts/metrics_alerting.py`, `scripts/metrics_dashboard_generator.py`.
The canonical lives at `src/ndjson_parser.py` — `read_ndjson_file(path) -> (records, errors)` (`:35`) and `parse_ndjson_lines(...)` (`:11`). This is **latent fragility, not a current break**: five divergent copies mean a parsing fix (e.g. malformed-line handling) lands in one and not the others.

#### Tasks
- [ ] In each of the 5 scripts, delete the local `_read_ndjson` and import `from src.ndjson_parser import read_ndjson_file` (or the repo's import convention), updating call sites to unpack `records, _errors = read_ndjson_file(path)`.
- [ ] Add `tests/scripts/test_ndjson_consolidation.py` that writes a small `.ndjson` (incl. one malformed line) to a tmp path, calls `read_ndjson_file`, and asserts the parsed records + that the migrated `aggregate_repo_metrics` path consumes it without error.
- [ ] Perform the deliberate-break verification (see Acceptance), capture the FAIL, then revert.

#### Acceptance criteria
- [ ] Named test: `python -m pytest tests/scripts/test_ndjson_consolidation.py` passes — `read_ndjson_file` returns the expected records for a known sample (and surfaces the malformed line in `errors`).
- [ ] **Deliberate-break gate:** temporarily make `src/ndjson_parser.read_ndjson_file` return `([], [])` unconditionally. The named test **must FAIL** (record assertions break). Revert after capturing the failure.
- [ ] `grep -rl "_read_ndjson" scripts/*.py` returns **empty** after the change (no local copies remain).

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric file parsing with better error handling and compatibility for legacy JSON formats.

* **Refactor**
  * Streamlined internal NDJSON parsing logic with enhanced error categorization.

* **Tests**
  * Updated test coverage for new parsing functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
