### PR TITLE
feat: add deterministic docs-drift detector (scripts/check_docs_drift.py)

### DIFF
--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Detect documentation drift in workflow inventories and repo-path references."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+DriftRecord = dict[str, str]
+
+DEFAULT_DOCS = ("docs/ci/WORKFLOWS.md",)
+WORKFLOWS_DOC = Path("docs/ci/WORKFLOWS.md")
+WORKFLOW_SUFFIXES = (".yml", ".yaml")
+REPO_PATH_PREFIXES = ("scripts/", ".github/workflows/", "tests/", "docs/")
+
+WORKFLOW_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_])([A-Za-z0-9_./-]+\.ya?ml)(?![A-Za-z0-9_])"
+)
+INLINE_CODE_RE = re.compile(r"(?<!`)`(?!`)([^`\n]+?)(?<!`)`(?!`)")
+FILE_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
+GLOB_CHARS = set("*?[]{}")
+
+
+def _workflow_files_on_disk(root: Path) -> set[str]:
+    workflows_dir = root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return set()
+    return {
+        path.name
+        for path in workflows_dir.iterdir()
+        if path.is_file() and path.suffix in WORKFLOW_SUFFIXES
+    }
+
+
+def _mentioned_workflow_filenames(text: str) -> set[str]:
+    filenames: set[str] = set()
+    for match in WORKFLOW_TOKEN_RE.finditer(text):
+        token = match.group(1)
+        if "/" in token:
+            token_path = PurePosixPath(token)
+            if "templates" in token_path.parts or ".github/workflows/" not in token:
+                continue
+        if token.startswith("n.") and match.start(1) > 0 and text[match.start(1) - 1] == "\\":
+            token = token[2:]
+        filename = PurePosixPath(token).name
+        if filename.startswith("."):
+            filename = filename[1:]
+        if filename.endswith(WORKFLOW_SUFFIXES) and filename not in WORKFLOW_SUFFIXES:
+            filenames.add(filename)
+    return filenames
+
+
+def check_workflow_inventory(root: Path) -> list[DriftRecord]:
+    """Compare .github/workflows files against docs/ci/WORKFLOWS.md mentions."""
+    root = Path(root)
+    workflows_doc = root / WORKFLOWS_DOC
+    doc_text = workflows_doc.read_text(encoding="utf-8")
+
+    on_disk = _workflow_files_on_disk(root)
+    documented = _mentioned_workflow_filenames(doc_text)
+
+    drift: list[DriftRecord] = []
+    for filename in sorted(on_disk - documented):
+        drift.append(
+            {
+                "type": "undocumented_workflow",
+                "path": filename,
+                "detail": (
+                    "Exists in .github/workflows/ but is not mentioned in "
+                    "docs/ci/WORKFLOWS.md"
+                ),
+            }
+        )
+    for filename in sorted(documented - on_disk):
+        drift.append(
+            {
+                "type": "documented_but_missing",
+                "path": filename,
+                "detail": "Mentioned in docs/ci/WORKFLOWS.md but missing from .github/workflows/",
+            }
+        )
+    return drift
+
+
+def _resolve_doc_path(root: Path, doc: str | Path) -> Path:
+    doc_path = Path(doc)
+    if doc_path.is_absolute():
+        return doc_path
+    return root / doc_path
+
+
+def _display_path(path: Path, root: Path) -> str:
+    return os.path.relpath(path, root).replace(os.sep, "/")
+
+
+def _inline_code_tokens(text: str) -> list[str]:
+    return [match.group(1) for match in INLINE_CODE_RE.finditer(text)]
+
+
+def _is_repo_path_token(token: str) -> bool:
+    if token != token.strip() or any(char.isspace() for char in token):
+        return False
+    if "\\" in token or any(char in token for char in GLOB_CHARS):
+        return False
+    if not token.startswith(REPO_PATH_PREFIXES):
+        return False
+    path = PurePosixPath(token)
+    if path.is_absolute() or ".." in path.parts:
+        return False
+    return bool(FILE_EXTENSION_RE.search(token))
+
+
+def check_dangling_references(
+    root: Path, docs: Sequence[str | Path] | None = None
+) -> list[DriftRecord]:
+    """Find missing repo-relative file paths cited in inline code spans."""
+    root = Path(root)
+    docs_to_scan = docs if docs is not None else DEFAULT_DOCS
+    drift: list[DriftRecord] = []
+
+    for doc in docs_to_scan:
+        doc_path = _resolve_doc_path(root, doc)
+        doc_text = doc_path.read_text(encoding="utf-8")
+        cited_in = _display_path(doc_path, root)
+        seen_in_doc: set[str] = set()
+
+        for token in _inline_code_tokens(doc_text):
+            if token in seen_in_doc or not _is_repo_path_token(token):
+                continue
+            seen_in_doc.add(token)
+
+            candidate = root.joinpath(*PurePosixPath(token).parts)
+            if candidate.is_file():
+                continue
+            drift.append(
+                {
+                    "type": "dangling_reference",
+                    "path": token,
+                    "detail": f"Referenced in {cited_in}",
+                }
+            )
+
+    return sorted(
+        drift, key=lambda record: (record["type"], record["path"], record["detail"])
+    )
+
+
+def check_docs_drift(
+    root: Path, docs: Sequence[str | Path] | None = None
+) -> list[DriftRecord]:
+    """Run all docs-drift checks for a repository root."""
+    return check_workflow_inventory(root) + check_dangling_references(root, docs)
+
+
+def build_report(drift: Sequence[DriftRecord]) -> dict[str, object]:
+    """Build the deterministic machine-readable report."""
+    sorted_drift = sorted(
+        (dict(record) for record in drift),
+        key=lambda record: (record["type"], record["path"], record.get("detail", "")),
+    )
+    by_type = Counter(record["type"] for record in sorted_drift)
+    return {
+        "summary": {
+            "drift": len(sorted_drift),
+            "by_type": {key: by_type[key] for key in sorted(by_type)},
+        },
+        "drift": sorted_drift,
+    }
+
+
+def format_human_report(report: dict[str, object]) -> str:
+    """Format a stable human summary."""
+    summary = report["summary"]
+    assert isinstance(summary, dict)
+    drift_count = summary["drift"]
+    lines = [f"Docs drift: {drift_count}"]
+    for record in report["drift"]:
+        assert isinstance(record, dict)
+        lines.append(
+            f"{record['type']}  {record['path']}  \u2014 {record.get('detail', '')}"
+        )
+    return "\n".join(lines)
+
+
+def detect_repo_root() -> Path:
+    """Find the git top-level directory, falling back to this script's repository."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=False,
+            cwd=Path.cwd(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        result = None
+
+    if result and result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path(__file__).resolve().parent.parent
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect drift between workflow docs and repository files."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        help="Repository root to scan. Defaults to git rev-parse --show-toplevel.",
+    )
+    parser.add_argument(
+        "--docs",
+        nargs="+",
+        metavar="PATH",
+        help="Docs to scan for dangling repo-path references.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the deterministic JSON report instead of a human summary.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="Write the deterministic JSON report to this path as well.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        root = (
+            args.repo_root if args.repo_root is not None else detect_repo_root()
+        ).expanduser()
+        root = root.resolve()
+        if not root.exists() or not root.is_dir():
+            raise FileNotFoundError(
+                f"repo root not found: {_display_path(root, Path.cwd())}"
+            )
+
+        docs = tuple(args.docs) if args.docs is not None else DEFAULT_DOCS
+        report = build_report(check_docs_drift(root, docs))
+        json_report = json.dumps(report, indent=2) + "\n"
+
+        if args.report is not None:
+            args.report.write_text(json_report, encoding="utf-8")
+
+        if args.json:
+            sys.stdout.write(json_report)
+        else:
+            print(format_human_report(report))
+
+        summary = report["summary"]
+        assert isinstance(summary, dict)
+        return 1 if int(summary["drift"]) else 0
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -4,14 +4,14 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
 import json
 import os
-from pathlib import Path, PurePosixPath
 import re
 import subprocess
 import sys
-from typing import Sequence
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
 
 DriftRecord = dict[str, str]
 
@@ -20,12 +20,14 @@ WORKFLOWS_DOC = Path("docs/ci/WORKFLOWS.md")
 WORKFLOW_SUFFIXES = (".yml", ".yaml")
 REPO_PATH_PREFIXES = ("scripts/", ".github/workflows/", "tests/", "docs/")
 
-WORKFLOW_TOKEN_RE = re.compile(
-    r"(?<![A-Za-z0-9_])([A-Za-z0-9_./-]+\.ya?ml)(?![A-Za-z0-9_])"
-)
+WORKFLOW_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z0-9_./-]+\.ya?ml)(?![A-Za-z0-9_])")
 INLINE_CODE_RE = re.compile(r"(?<!`)`(?!`)([^`\n]+?)(?<!`)`(?!`)")
 FILE_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]+$")
-GLOB_CHARS = set("*?[]{}")
+GLOB_CHARS = set("*?[]{}!")
+NON_ROOT_WORKFLOW_CONTEXT_RE = re.compile(
+    r"\b(?:consumer|consumer-template|template|templates|integration-repo)\b",
+    re.IGNORECASE,
+)
 
 
 def _workflow_files_on_disk(root: Path) -> set[str]:
@@ -39,14 +41,43 @@ def _workflow_files_on_disk(root: Path) -> set[str]:
     }
 
 
+def _is_root_workflow_path(token: str) -> bool:
+    parts = PurePosixPath(token).parts
+    for index, part in enumerate(parts[:-1]):
+        if part == ".github" and index + 1 < len(parts) and parts[index + 1] == "workflows":
+            return "templates" not in parts and "template" not in parts
+    return False
+
+
+def _workflow_token_context(text: str, token_start: int, token_end: int) -> str:
+    line_start = text.rfind("\n", 0, token_start) + 1
+    line_end = text.find("\n", token_end)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    relative_start = token_start - line_start
+    relative_end = token_end - line_start
+    return line[:relative_start] + line[relative_end:]
+
+
+def _is_bare_workflow_reference(text: str, match: re.Match[str]) -> bool:
+    token_start, token_end = match.span(1)
+    context = _workflow_token_context(text, token_start, token_end)
+    if NON_ROOT_WORKFLOW_CONTEXT_RE.search(context):
+        return False
+
+    return token_start > 0 and text[token_start - 1] == "`"
+
+
 def _mentioned_workflow_filenames(text: str) -> set[str]:
     filenames: set[str] = set()
     for match in WORKFLOW_TOKEN_RE.finditer(text):
         token = match.group(1)
         if "/" in token:
-            token_path = PurePosixPath(token)
-            if "templates" in token_path.parts or ".github/workflows/" not in token:
+            if not _is_root_workflow_path(token):
                 continue
+        elif not _is_bare_workflow_reference(text, match):
+            continue
         if token.startswith("n.") and match.start(1) > 0 and text[match.start(1) - 1] == "\\":
             token = token[2:]
         filename = PurePosixPath(token).name
@@ -73,8 +104,7 @@ def check_workflow_inventory(root: Path) -> list[DriftRecord]:
                 "type": "undocumented_workflow",
                 "path": filename,
                 "detail": (
-                    "Exists in .github/workflows/ but is not mentioned in "
-                    "docs/ci/WORKFLOWS.md"
+                    "Exists in .github/workflows/ but is not mentioned in " "docs/ci/WORKFLOWS.md"
                 ),
             }
         )
@@ -147,14 +177,10 @@ def check_dangling_references(
                 }
             )
 
-    return sorted(
-        drift, key=lambda record: (record["type"], record["path"], record["detail"])
-    )
+    return sorted(drift, key=lambda record: (record["type"], record["path"]))
 
 
-def check_docs_drift(
-    root: Path, docs: Sequence[str | Path] | None = None
-) -> list[DriftRecord]:
+def check_docs_drift(root: Path, docs: Sequence[str | Path] | None = None) -> list[DriftRecord]:
     """Run all docs-drift checks for a repository root."""
     return check_workflow_inventory(root) + check_dangling_references(root, docs)
 
@@ -163,7 +189,7 @@ def build_report(drift: Sequence[DriftRecord]) -> dict[str, object]:
     """Build the deterministic machine-readable report."""
     sorted_drift = sorted(
         (dict(record) for record in drift),
-        key=lambda record: (record["type"], record["path"], record.get("detail", "")),
+        key=lambda record: (record["type"], record["path"]),
     )
     by_type = Counter(record["type"] for record in sorted_drift)
     return {
@@ -183,9 +209,7 @@ def format_human_report(report: dict[str, object]) -> str:
     lines = [f"Docs drift: {drift_count}"]
     for record in report["drift"]:
         assert isinstance(record, dict)
-        lines.append(
-            f"{record['type']}  {record['path']}  \u2014 {record.get('detail', '')}"
-        )
+        lines.append(f"{record['type']}  {record['path']}  \u2014 {record.get('detail', '')}")
     return "\n".join(lines)
 
 
@@ -240,14 +264,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
 
     try:
-        root = (
-            args.repo_root if args.repo_root is not None else detect_repo_root()
-        ).expanduser()
+        root = (args.repo_root if args.repo_root is not None else detect_repo_root()).expanduser()
         root = root.resolve()
         if not root.exists() or not root.is_dir():
-            raise FileNotFoundError(
-                f"repo root not found: {_display_path(root, Path.cwd())}"
-            )
+            raise FileNotFoundError(f"repo root not found: {_display_path(root, Path.cwd())}")
 
         docs = tuple(args.docs) if args.docs is not None else DEFAULT_DOCS
         report = build_report(check_docs_drift(root, docs))

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -60,7 +60,12 @@ def _workflow_token_context(text: str, token_start: int, token_end: int) -> str:
     return line[:relative_start] + line[relative_end:]
 
 
-def _is_bare_workflow_reference(text: str, match: re.Match[str]) -> bool:
+def _is_bare_workflow_reference(
+    text: str, match: re.Match[str], root_workflows: set[str] | None = None
+) -> bool:
+    if match.group(1) in (root_workflows or set()):
+        return True
+
     token_start, token_end = match.span(1)
     context = _workflow_token_context(text, token_start, token_end)
     if NON_ROOT_WORKFLOW_CONTEXT_RE.search(context):
@@ -69,14 +74,14 @@ def _is_bare_workflow_reference(text: str, match: re.Match[str]) -> bool:
     return token_start > 0 and text[token_start - 1] == "`"
 
 
-def _mentioned_workflow_filenames(text: str) -> set[str]:
+def _mentioned_workflow_filenames(text: str, root_workflows: set[str] | None = None) -> set[str]:
     filenames: set[str] = set()
     for match in WORKFLOW_TOKEN_RE.finditer(text):
         token = match.group(1)
         if "/" in token:
             if not _is_root_workflow_path(token):
                 continue
-        elif not _is_bare_workflow_reference(text, match):
+        elif not _is_bare_workflow_reference(text, match, root_workflows):
             continue
         if token.startswith("n.") and match.start(1) > 0 and text[match.start(1) - 1] == "\\":
             token = token[2:]
@@ -92,10 +97,9 @@ def check_workflow_inventory(root: Path) -> list[DriftRecord]:
     """Compare .github/workflows files against docs/ci/WORKFLOWS.md mentions."""
     root = Path(root)
     workflows_doc = root / WORKFLOWS_DOC
-    doc_text = workflows_doc.read_text(encoding="utf-8")
-
     on_disk = _workflow_files_on_disk(root)
-    documented = _mentioned_workflow_filenames(doc_text)
+    doc_text = workflows_doc.read_text(encoding="utf-8") if workflows_doc.is_file() else ""
+    documented = _mentioned_workflow_filenames(doc_text, on_disk)
 
     drift: list[DriftRecord] = []
     for filename in sorted(on_disk - documented):

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -112,6 +112,31 @@ Config names such as sync-manifest.yml and labels-core.yml are not workflows.
     assert drift == []
 
 
+def test_bare_root_workflow_ref_counts_even_with_template_context(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("health-72-template-sync.yml",),
+        workflows_doc="""
+The `health-72-template-sync.yml` workflow validates consumer template sync.
+""",
+    )
+
+    drift = check_workflow_inventory(root)
+
+    assert drift == []
+
+
+def test_missing_workflow_inventory_doc_reports_drift(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(root / ".github/workflows/build.yml", "name: Build\n")
+
+    drift = check_workflow_inventory(root)
+
+    assert [(record["type"], record["path"]) for record in drift] == [
+        ("undocumented_workflow", "build.yml")
+    ]
+
+
 def test_missing_backtick_repo_path_is_dangling_reference(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,
@@ -184,3 +209,35 @@ def test_cli_report_write_io_error_returns_two(tmp_path: Path, capsys) -> None:
     assert exit_code == 2
     assert captured.out == ""
     assert "error:" in captured.err
+
+
+def test_cli_json_orders_mixed_drift_records(tmp_path: Path, capsys) -> None:
+    root = _repo(
+        tmp_path / "repo",
+        workflows=("zeta.yml", "alpha.yml"),
+        workflows_doc="""
+Retired workflow: `beta.yml`.
+Path drift: `scripts/missing.py`.
+""",
+    )
+    report_path = tmp_path / "drift.json"
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(root),
+            "--json",
+            "--report",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert [(record["type"], record["path"]) for record in report["drift"]] == [
+        ("dangling_reference", "scripts/missing.py"),
+        ("documented_but_missing", "beta.yml"),
+        ("undocumented_workflow", "alpha.yml"),
+        ("undocumented_workflow", "zeta.yml"),
+    ]
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.check_docs_drift import (  # noqa: E402
+    check_dangling_references,
+    check_docs_drift,
+    check_workflow_inventory,
+    main,
+)
+
+
+def _write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _repo(
+    root: Path,
+    *,
+    workflows: Iterable[str] = (),
+    workflows_doc: str = "",
+    extra_files: Iterable[str] = (),
+) -> Path:
+    _write(root / "docs/ci/WORKFLOWS.md", workflows_doc)
+    for workflow in workflows:
+        _write(root / ".github/workflows" / workflow, "name: test\n")
+    for extra_file in extra_files:
+        _write(root / extra_file, "")
+    return root
+
+
+def test_clean_tree_reports_zero_drift_and_cli_exit_zero(tmp_path: Path, capsys) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("alpha.yml", "beta.yaml"),
+        workflows_doc="""
+Active workflows include `alpha.yml` and
+[Beta](../../.github/workflows/beta.yaml).
+
+Existing repo paths: `scripts/existing.py`, `tests/test_existing.py`,
+`docs/ci/WORKFLOWS.md`.
+
+Ignored non-path tokens: `alpha`, `scripts/no extension`, `scripts/*.py`.
+""",
+        extra_files=("scripts/existing.py", "tests/test_existing.py"),
+    )
+
+    assert check_workflow_inventory(root) == []
+    assert check_dangling_references(root) == []
+    assert check_docs_drift(root) == []
+
+    exit_code = main(["--repo-root", str(root), "--json"])
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report == {"summary": {"drift": 0, "by_type": {}}, "drift": []}
+
+
+def test_workflow_on_disk_absent_from_docs_is_undocumented(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("extra.yml",),
+        workflows_doc="This doc intentionally names no workflow files.\n",
+    )
+
+    drift = check_workflow_inventory(root)
+
+    assert [(record["type"], record["path"]) for record in drift] == [
+        ("undocumented_workflow", "extra.yml")
+    ]
+
+
+def test_workflow_mentioned_in_docs_but_missing_on_disk(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows_doc="The retired `missing.yml` workflow is still listed.\n",
+    )
+
+    drift = check_docs_drift(root)
+
+    assert [(record["type"], record["path"]) for record in drift] == [
+        ("documented_but_missing", "missing.yml")
+    ]
+
+
+def test_missing_backtick_repo_path_is_dangling_reference(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("build.yml",),
+        workflows_doc="`build.yml` cites `scripts/does_not_exist.py`.\n",
+    )
+
+    drift = check_docs_drift(root)
+
+    assert len(drift) == 1
+    assert drift[0]["type"] == "dangling_reference"
+    assert drift[0]["path"] == "scripts/does_not_exist.py"
+    assert "docs/ci/WORKFLOWS.md" in drift[0]["detail"]
+
+
+def test_template_workflow_is_not_part_of_runtime_inventory(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows_doc="Template workflows are not runtime workflow inventory.\n",
+    )
+    _write(
+        root / "templates/consumer-repo/.github/workflows/template-only.yml",
+        "name: Template only\n",
+    )
+
+    drift = check_workflow_inventory(root)
+
+    assert drift == []

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import sys
-from typing import Iterable
+from collections.abc import Iterable
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -91,6 +91,27 @@ def test_workflow_mentioned_in_docs_but_missing_on_disk(tmp_path: Path) -> None:
     ]
 
 
+def test_dotted_and_slash_workflow_refs_count_but_template_refs_do_not(
+    tmp_path: Path,
+) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("release.pipeline.v2.yml", "health-72-template-sync.yml"),
+        workflows_doc="""
+Root workflow link: [Release](../../.github/workflows/release.pipeline.v2.yml).
+Root inline workflow: `health-72-template-sync.yml`.
+Consumer-template examples use `agents-80-pr-event-hub.yml` and
+[Template](../../templates/consumer-repo/.github/workflows/template-only.yml).
+Opt-in consumer `cross-repo-smoke.yml` callers are not Workflows inventory.
+Config names such as sync-manifest.yml and labels-core.yml are not workflows.
+""",
+    )
+
+    drift = check_workflow_inventory(root)
+
+    assert drift == []
+
+
 def test_missing_backtick_repo_path_is_dangling_reference(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,
@@ -106,6 +127,37 @@ def test_missing_backtick_repo_path_is_dangling_reference(tmp_path: Path) -> Non
     assert "docs/ci/WORKFLOWS.md" in drift[0]["detail"]
 
 
+def test_repo_path_glob_tokens_are_ignored(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("build.yml",),
+        workflows_doc="""
+`build.yml` cites glob-style paths `scripts/*.py`, `scripts/file?.py`,
+`scripts/[abc].py`, `docs/{old,new}.md`, and `tests/!excluded.py`.
+It also cites a real missing file: `scripts/does_not_exist.py`.
+""",
+    )
+
+    drift = check_dangling_references(root)
+
+    assert [(record["type"], record["path"]) for record in drift] == [
+        ("dangling_reference", "scripts/does_not_exist.py")
+    ]
+
+
+def test_dangling_reference_ties_preserve_scan_order(tmp_path: Path) -> None:
+    root = _repo(tmp_path, workflows_doc="")
+    _write(root / "docs/a.md", "`scripts/missing.py`\n")
+    _write(root / "docs/b.md", "`scripts/missing.py`\n")
+
+    drift = check_dangling_references(root, ["docs/b.md", "docs/a.md"])
+
+    assert [record["detail"] for record in drift] == [
+        "Referenced in docs/b.md",
+        "Referenced in docs/a.md",
+    ]
+
+
 def test_template_workflow_is_not_part_of_runtime_inventory(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,
@@ -119,3 +171,16 @@ def test_template_workflow_is_not_part_of_runtime_inventory(tmp_path: Path) -> N
     drift = check_workflow_inventory(root)
 
     assert drift == []
+
+
+def test_cli_report_write_io_error_returns_two(tmp_path: Path, capsys) -> None:
+    root = _repo(tmp_path / "repo", workflows=("build.yml",), workflows_doc="`build.yml`\n")
+    report_dir = tmp_path / "report-dir"
+    report_dir.mkdir()
+
+    exit_code = main(["--repo-root", str(root), "--report", str(report_dir)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "error:" in captured.err


### PR DESCRIPTION
## What

Adds `scripts/check_docs_drift.py` — a deterministic, CI-able detector for structural documentation drift — plus `tests/test_check_docs_drift.py`. Standard library only, no new dependencies.

## Why

Doc-rot is this repo's most pervasive defect class (the 2026 audit found stale counts and dangling references across the canonical docs). `maint-48-docs-drift-audit.yml` seeds a monthly audit issue, but defers the actual doc-vs-reality diffing to whichever agent picks the issue up — there is no *repeatable, mechanical* detector. This is that detector. (maint-48's own design note anticipates it: "to diff inline instead, swap the create step.")

## What it checks

1. **Workflow-inventory completeness (bidirectional)** between `.github/workflows/*.yml` and `docs/ci/WORKFLOWS.md`:
   - a workflow on disk not mentioned in the doc → `undocumented_workflow`
   - a workflow filename cited in the doc with no file on disk → `documented_but_missing`
   - consumer-template workflows under `templates/` are correctly excluded from the root inventory
2. **Dangling repo-path references** — backtick-quoted `scripts/…`, `.github/workflows/…`, `tests/…`, `docs/…` paths cited in the docs that don't resolve to a file on disk → `dangling_reference`

## Interface

- `python3 scripts/check_docs_drift.py [--repo-root P] [--docs P …] [--json] [--report P]`
- Exit code: `0` clean · `1` drift found (so CI can gate) · `2` usage/IO error
- Deterministic JSON report — `{"summary": {"drift": N, "by_type": {…}}, "drift": [{type, path, detail}, …]}`, records sorted by `(type, path)`, no timestamps/absolute paths

## Tests

`tests/test_check_docs_drift.py` — self-contained `tmp_path` fixtures (independent of the real tree's current state) covering: clean tree → exit 0; both inventory-drift directions; dangling reference; template-workflow exclusion; and the hardened edge cases (dotted/slash workflow tokens, glob-token filtering, tie ordering, report-write IO failure).

## Scope / follow-up

Detector + tests only — **not** yet wired into CI. The natural follow-up is a check job (or swapping `maint-48`'s seed-issue step for an inline run) to gate PRs on `--json` exit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool that checks documentation drift by comparing on-disk workflow files with the workflows documented in the repo.
  * Reports undocumented workflows, missing documented workflows, and dangling backticked file references.
  * Supports deterministic human-readable and JSON output, optional report file writing, and distinct exit codes for clean, drift, and error states.
  * Automatically detects repository root with override options.

* **Tests**
  * Added integration-style tests covering clean runs, mixed drift cases, parsing edge cases, exclusion rules, report ordering, and JSON/report write error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- workflow-source:manual_remote -->