### PR TITLE
fix: keep synced metrics script self-contained

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -14,8 +14,6 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from src.ndjson_parser import read_ndjson_file
-
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
 _DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
@@ -303,6 +301,66 @@ def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
     else:
         reason = "unreadable-file"
     return _parse_error_detail(path, line, reason)
+
+
+def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read an NDJSON file without depending on Workflows-only modules."""
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{path}: {exc}"]
+
+    entries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    raw_lines_for_fallback: list[str] = []
+    raw_fallback_bytes = 0
+    raw_fallback_truncated = False
+    with handle:
+        for line_number, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw:
+                continue
+            if not entries and not raw_fallback_truncated:
+                raw_bytes = len(raw.encode("utf-8")) + 1
+                fallback_within_limit = (
+                    len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                    and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                )
+                if fallback_within_limit:
+                    raw_fallback_bytes += raw_bytes
+                    raw_lines_for_fallback.append(raw)
+                else:
+                    raw_fallback_truncated = True
+                    raw_lines_for_fallback = []
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}:{line_number}: invalid JSON ({exc.msg})")
+                continue
+            if isinstance(parsed, dict):
+                entries.append(parsed)
+                raw_lines_for_fallback = []
+            else:
+                errors.append(f"{path}:{line_number}: expected object, got {type(parsed).__name__}")
+
+    if entries or not errors:
+        return entries, errors
+
+    raw_text = "\n".join(raw_lines_for_fallback)
+    if raw_fallback_truncated:
+        errors.append(f"{path}: legacy-json-fallback-buffer-limit")
+        return entries, errors
+
+    try:
+        parsed_file = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return entries, errors
+
+    if isinstance(parsed_file, dict):
+        return [parsed_file], []
+    if isinstance(parsed_file, list) and all(isinstance(item, dict) for item in parsed_file):
+        return list(parsed_file), []
+    return entries, errors
 
 
 def read_metric_ndjson_files(

--- a/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
+++ b/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
@@ -146,7 +146,6 @@ Issue: "Add user authentication"
 | `agents:optimize` | Issue | Analyze and suggest improvements |
 | `agents:apply-suggestions` | Issue | Apply optimization suggestions |
 | `agents:auto-pilot` | Issue | Full end-to-end automation |
-| `agents:allow-change` | PR | Permission signal for `agents-guard`; automatically applied to dependency-bot PRs by `maint-auto-label-dep-prs.yml` |
 | `agents:capability-check` | Issue | Check if agent can complete |
 | `agents:decompose` | Issue | Break into smaller issues |
 | `agents:dedup` | Issue | Check for duplicates |
@@ -166,6 +165,7 @@ Issue: "Add user authentication"
 | `agent:needs-attention` | Human intervention required |
 | `agents:auto-pilot-pause` | Auto-pilot paused |
 | `agents:auto-pilot-failed` | Auto-pilot stopped due to errors |
+| `agents:allow-change` | Permission signal for `agents-guard`; bypasses CODEOWNER approval only for automated dependency PRs from Dependabot/Renovate. Auto-applied by `maint-auto-label-dep-prs.yml`; manual application does not bypass guard enforcement. |
 | `needs-human` | Escalated to human |
 | `follow-up` | Created as follow-up to another issue/PR |
 | `duplicate` | Potential duplicate detected |

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -14,8 +14,6 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from src.ndjson_parser import read_ndjson_file
-
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
 _DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
@@ -303,6 +301,66 @@ def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
     else:
         reason = "unreadable-file"
     return _parse_error_detail(path, line, reason)
+
+
+def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read an NDJSON file without depending on Workflows-only modules."""
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError as exc:
+        return [], [f"{path}: {exc}"]
+
+    entries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    raw_lines_for_fallback: list[str] = []
+    raw_fallback_bytes = 0
+    raw_fallback_truncated = False
+    with handle:
+        for line_number, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw:
+                continue
+            if not entries and not raw_fallback_truncated:
+                raw_bytes = len(raw.encode("utf-8")) + 1
+                fallback_within_limit = (
+                    len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                    and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                )
+                if fallback_within_limit:
+                    raw_fallback_bytes += raw_bytes
+                    raw_lines_for_fallback.append(raw)
+                else:
+                    raw_fallback_truncated = True
+                    raw_lines_for_fallback = []
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}:{line_number}: invalid JSON ({exc.msg})")
+                continue
+            if isinstance(parsed, dict):
+                entries.append(parsed)
+                raw_lines_for_fallback = []
+            else:
+                errors.append(f"{path}:{line_number}: expected object, got {type(parsed).__name__}")
+
+    if entries or not errors:
+        return entries, errors
+
+    raw_text = "\n".join(raw_lines_for_fallback)
+    if raw_fallback_truncated:
+        errors.append(f"{path}: legacy-json-fallback-buffer-limit")
+        return entries, errors
+
+    try:
+        parsed_file = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return entries, errors
+
+    if isinstance(parsed_file, dict):
+        return [parsed_file], []
+    if isinstance(parsed_file, list) and all(isinstance(item, dict) for item in parsed_file):
+        return list(parsed_file), []
+    return entries, errors
 
 
 def read_metric_ndjson_files(


### PR DESCRIPTION
## Summary
- inline the NDJSON reader in the synced agent metrics script so consumer repos do not import Workflows-only `src.ndjson_parser`
- move `agents:allow-change` into the auto-applied label section and document the dependency-bot-only guard bypass scope
- sync the exact-copy template script

## Validation
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m pytest tests/scripts/test_aggregate_agent_metrics.py tests/scripts/test_ndjson_consolidation.py tests/unit/test_ndjson_parser.py -q`
- `python -m py_compile scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py`
- `python -m ruff check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py`
- `python -m black --check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py`
- `git diff --check`

Campaign note: unblocks current sync PRs `stranske/Template#811`, `stranske/trip-planner#1400`, and `stranske/Ready#326`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR label reference documentation. The `agents:allow-change` label now explicitly applies only to automated dependency updates, bypassing CODEOWNER approval in those cases while maintaining standard guard enforcement for manual applications.

* **Chores**
  * Improved data processing reliability with enhanced error handling and fallback mechanisms in internal metrics aggregation utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->