### PR TITLE
fix: harden synced metrics parser

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -303,63 +303,99 @@ def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
     return _parse_error_detail(path, line, reason)
 
 
-def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
-    """Read an NDJSON file without depending on Workflows-only modules."""
+def _format_parse_error(path: Path, line: int | None, reason: str, detail: str = "") -> str:
+    if reason == "invalid-json":
+        suffix = f" ({detail})" if detail else ""
+        return f"{path}:{line}: invalid JSON{suffix}"
+    if reason == "non-object-json":
+        return f"{path}:{line}: expected object, got {detail}"
+    if reason == "legacy-json-fallback-buffer-limit":
+        return f"{path}: legacy-json-fallback-buffer-limit"
+    return f"{path}: {detail}" if detail else f"{path}: unreadable file"
+
+
+def _read_ndjson_file_streaming(
+    path: Path,
+    record_error: Callable[[int | None, str, str], None],
+) -> tuple[list[dict[str, Any]], bool]:
     try:
         handle = path.open("r", encoding="utf-8")
     except OSError as exc:
-        return [], [f"{path}: {exc}"]
+        record_error(None, "unreadable-file", str(exc))
+        return [], False
 
     entries: list[dict[str, Any]] = []
-    errors: list[str] = []
     raw_lines_for_fallback: list[str] = []
     raw_fallback_bytes = 0
     raw_fallback_truncated = False
+    saw_parse_error = False
+    saw_read_error = False
     with handle:
-        for line_number, line in enumerate(handle, start=1):
-            raw = line.strip()
-            if not raw:
-                continue
-            if not entries and not raw_fallback_truncated:
-                raw_bytes = len(raw.encode("utf-8")) + 1
-                fallback_within_limit = (
-                    len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
-                    and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
-                )
-                if fallback_within_limit:
-                    raw_fallback_bytes += raw_bytes
-                    raw_lines_for_fallback.append(raw)
+        try:
+            for line_number, line in enumerate(handle, start=1):
+                raw = line.strip()
+                if not raw:
+                    continue
+                if not raw_fallback_truncated and (not entries or saw_parse_error):
+                    raw_bytes = len(raw.encode("utf-8")) + 1
+                    fallback_within_limit = (
+                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                    )
+                    if fallback_within_limit:
+                        raw_fallback_bytes += raw_bytes
+                        raw_lines_for_fallback.append(raw)
+                    else:
+                        raw_fallback_truncated = True
+                        raw_lines_for_fallback = []
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    saw_parse_error = True
+                    record_error(line_number, "invalid-json", exc.msg)
+                    continue
+                if isinstance(parsed, dict):
+                    entries.append(parsed)
+                    if not saw_parse_error:
+                        raw_lines_for_fallback = []
+                        raw_fallback_bytes = 0
                 else:
-                    raw_fallback_truncated = True
-                    raw_lines_for_fallback = []
-            try:
-                parsed = json.loads(raw)
-            except json.JSONDecodeError as exc:
-                errors.append(f"{path}:{line_number}: invalid JSON ({exc.msg})")
-                continue
-            if isinstance(parsed, dict):
-                entries.append(parsed)
-                raw_lines_for_fallback = []
-            else:
-                errors.append(f"{path}:{line_number}: expected object, got {type(parsed).__name__}")
+                    saw_parse_error = True
+                    record_error(line_number, "non-object-json", type(parsed).__name__)
+        except (OSError, UnicodeDecodeError) as exc:
+            saw_read_error = True
+            record_error(None, "unreadable-file", str(exc))
 
-    if entries or not errors:
-        return entries, errors
+    if not saw_parse_error or saw_read_error:
+        return entries, False
 
     raw_text = "\n".join(raw_lines_for_fallback)
     if raw_fallback_truncated:
-        errors.append(f"{path}: legacy-json-fallback-buffer-limit")
-        return entries, errors
+        record_error(None, "legacy-json-fallback-buffer-limit", "")
+        return entries, False
 
     try:
         parsed_file = json.loads(raw_text)
     except json.JSONDecodeError:
-        return entries, errors
+        return entries, False
 
     if isinstance(parsed_file, dict):
-        return [parsed_file], []
+        return [parsed_file], True
     if isinstance(parsed_file, list) and all(isinstance(item, dict) for item in parsed_file):
-        return list(parsed_file), []
+        return list(parsed_file), True
+    return entries, False
+
+
+def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read an NDJSON file without depending on Workflows-only modules."""
+    errors: list[str] = []
+
+    def record_error(line: int | None, reason: str, detail: str) -> None:
+        errors.append(_format_parse_error(path, line, reason, detail))
+
+    entries, legacy_fallback_used = _read_ndjson_file_streaming(path, record_error)
+    if legacy_fallback_used:
+        return entries, []
     return entries, errors
 
 
@@ -369,10 +405,27 @@ def read_metric_ndjson_files(
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        file_entries, file_errors = read_ndjson_file(path)
+        file_errors: list[ParseErrorDetail] = []
+
+        def record_error(
+            line: int | None,
+            reason: str,
+            _detail: str,
+            *,
+            target_errors: list[ParseErrorDetail] = file_errors,
+            current_path: Path = path,
+        ) -> None:
+            _append_parse_error_detail(
+                target_errors,
+                _parse_error_detail(current_path, line, reason),
+            )
+
+        file_entries, legacy_fallback_used = _read_ndjson_file_streaming(path, record_error)
+        if legacy_fallback_used:
+            file_errors = []
         entries.extend(_attach_metric_source(entry, path) for entry in file_entries)
         for error in file_errors:
-            _append_parse_error_detail(errors, _canonical_parse_error_detail(path, error))
+            _append_parse_error_detail(errors, error)
     return entries, errors
 
 

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -303,63 +303,99 @@ def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
     return _parse_error_detail(path, line, reason)
 
 
-def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
-    """Read an NDJSON file without depending on Workflows-only modules."""
+def _format_parse_error(path: Path, line: int | None, reason: str, detail: str = "") -> str:
+    if reason == "invalid-json":
+        suffix = f" ({detail})" if detail else ""
+        return f"{path}:{line}: invalid JSON{suffix}"
+    if reason == "non-object-json":
+        return f"{path}:{line}: expected object, got {detail}"
+    if reason == "legacy-json-fallback-buffer-limit":
+        return f"{path}: legacy-json-fallback-buffer-limit"
+    return f"{path}: {detail}" if detail else f"{path}: unreadable file"
+
+
+def _read_ndjson_file_streaming(
+    path: Path,
+    record_error: Callable[[int | None, str, str], None],
+) -> tuple[list[dict[str, Any]], bool]:
     try:
         handle = path.open("r", encoding="utf-8")
     except OSError as exc:
-        return [], [f"{path}: {exc}"]
+        record_error(None, "unreadable-file", str(exc))
+        return [], False
 
     entries: list[dict[str, Any]] = []
-    errors: list[str] = []
     raw_lines_for_fallback: list[str] = []
     raw_fallback_bytes = 0
     raw_fallback_truncated = False
+    saw_parse_error = False
+    saw_read_error = False
     with handle:
-        for line_number, line in enumerate(handle, start=1):
-            raw = line.strip()
-            if not raw:
-                continue
-            if not entries and not raw_fallback_truncated:
-                raw_bytes = len(raw.encode("utf-8")) + 1
-                fallback_within_limit = (
-                    len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
-                    and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
-                )
-                if fallback_within_limit:
-                    raw_fallback_bytes += raw_bytes
-                    raw_lines_for_fallback.append(raw)
+        try:
+            for line_number, line in enumerate(handle, start=1):
+                raw = line.strip()
+                if not raw:
+                    continue
+                if not raw_fallback_truncated and (not entries or saw_parse_error):
+                    raw_bytes = len(raw.encode("utf-8")) + 1
+                    fallback_within_limit = (
+                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
+                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
+                    )
+                    if fallback_within_limit:
+                        raw_fallback_bytes += raw_bytes
+                        raw_lines_for_fallback.append(raw)
+                    else:
+                        raw_fallback_truncated = True
+                        raw_lines_for_fallback = []
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    saw_parse_error = True
+                    record_error(line_number, "invalid-json", exc.msg)
+                    continue
+                if isinstance(parsed, dict):
+                    entries.append(parsed)
+                    if not saw_parse_error:
+                        raw_lines_for_fallback = []
+                        raw_fallback_bytes = 0
                 else:
-                    raw_fallback_truncated = True
-                    raw_lines_for_fallback = []
-            try:
-                parsed = json.loads(raw)
-            except json.JSONDecodeError as exc:
-                errors.append(f"{path}:{line_number}: invalid JSON ({exc.msg})")
-                continue
-            if isinstance(parsed, dict):
-                entries.append(parsed)
-                raw_lines_for_fallback = []
-            else:
-                errors.append(f"{path}:{line_number}: expected object, got {type(parsed).__name__}")
+                    saw_parse_error = True
+                    record_error(line_number, "non-object-json", type(parsed).__name__)
+        except (OSError, UnicodeDecodeError) as exc:
+            saw_read_error = True
+            record_error(None, "unreadable-file", str(exc))
 
-    if entries or not errors:
-        return entries, errors
+    if not saw_parse_error or saw_read_error:
+        return entries, False
 
     raw_text = "\n".join(raw_lines_for_fallback)
     if raw_fallback_truncated:
-        errors.append(f"{path}: legacy-json-fallback-buffer-limit")
-        return entries, errors
+        record_error(None, "legacy-json-fallback-buffer-limit", "")
+        return entries, False
 
     try:
         parsed_file = json.loads(raw_text)
     except json.JSONDecodeError:
-        return entries, errors
+        return entries, False
 
     if isinstance(parsed_file, dict):
-        return [parsed_file], []
+        return [parsed_file], True
     if isinstance(parsed_file, list) and all(isinstance(item, dict) for item in parsed_file):
-        return list(parsed_file), []
+        return list(parsed_file), True
+    return entries, False
+
+
+def read_ndjson_file(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read an NDJSON file without depending on Workflows-only modules."""
+    errors: list[str] = []
+
+    def record_error(line: int | None, reason: str, detail: str) -> None:
+        errors.append(_format_parse_error(path, line, reason, detail))
+
+    entries, legacy_fallback_used = _read_ndjson_file_streaming(path, record_error)
+    if legacy_fallback_used:
+        return entries, []
     return entries, errors
 
 
@@ -369,10 +405,27 @@ def read_metric_ndjson_files(
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        file_entries, file_errors = read_ndjson_file(path)
+        file_errors: list[ParseErrorDetail] = []
+
+        def record_error(
+            line: int | None,
+            reason: str,
+            _detail: str,
+            *,
+            target_errors: list[ParseErrorDetail] = file_errors,
+            current_path: Path = path,
+        ) -> None:
+            _append_parse_error_detail(
+                target_errors,
+                _parse_error_detail(current_path, line, reason),
+            )
+
+        file_entries, legacy_fallback_used = _read_ndjson_file_streaming(path, record_error)
+        if legacy_fallback_used:
+            file_errors = []
         entries.extend(_attach_metric_source(entry, path) for entry in file_entries)
         for error in file_errors:
-            _append_parse_error_detail(errors, _canonical_parse_error_detail(path, error))
+            _append_parse_error_detail(errors, error)
     return entries, errors
 
 

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -1,5 +1,6 @@
 import json
 from collections import Counter
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -814,6 +815,59 @@ def test_read_metric_ndjson_accepts_legacy_pretty_json_object(tmp_path: Path) ->
     assert entries[0]["pr_number"] == 1872
     assert entries[0]["iteration_count"] == 0
     assert entries[0]["artifact_name"] == "keepalive-metrics"
+
+
+def test_read_metric_ndjson_accepts_legacy_pretty_json_array(tmp_path: Path) -> None:
+    path = tmp_path / "keepalive-metrics.ndjson"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "schema": "workflows-keepalive-metrics/v1",
+                    "pr_number": 1872,
+                },
+                {
+                    "schema": "workflows-keepalive-metrics/v1",
+                    "pr_number": 1873,
+                },
+            ],
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
+
+    assert errors == []
+    assert [entry["pr_number"] for entry in entries] == [1872, 1873]
+
+
+def test_read_metric_ndjson_counts_read_error_during_iteration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "metrics.ndjson"
+
+    class FailingHandle:
+        def __enter__(self) -> "FailingHandle":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def __iter__(self) -> Iterator[str]:
+            yield '{"key": "value"}\n'
+            raise OSError("downloaded artifact became unreadable")
+
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: FailingHandle())
+
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
+
+    assert len(entries) == 1
+    assert entries[0]["key"] == "value"
+    assert len(errors) == 1
+    assert errors[0].reason == "unreadable-file"
+    assert errors[0].line is None
 
 
 def test_read_metric_ndjson_bounds_legacy_json_fallback_buffer(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve full legacy JSON fallback for pretty-printed arrays even when an interior line parses as an object
- record metric parse errors through bounded ParseErrorDetail storage while streaming
- catch read-time decode/I/O failures after a file opens so one artifact cannot crash aggregation
- sync the consumer-template copy of scripts/aggregate_agent_metrics.py

## Validation
- python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m ruff check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- python -m black --check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py
- git diff --check

Related to sync/dependabot cleanup campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced metric file parsing with improved error detection and structured error reporting for parse failures.
  * Added support for reading legacy JSON array formatted metric files.
  * Improved handling of unreadable metric files with detailed error tracking.

* **Tests**
  * Extended test coverage for metric file parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->