### PR TITLE
fix: preserve metrics after partial parse errors

### DIFF
--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -289,20 +289,6 @@ def _parse_error_counter(parse_error_details: list[ParseErrorDetail], field: str
     return counts
 
 
-def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
-    line_match = re.search(r":(\d+): ", error)
-    line = int(line_match.group(1)) if line_match else None
-    if "invalid JSON" in error:
-        reason = "invalid-json"
-    elif "expected object" in error:
-        reason = "non-object-json"
-    elif "legacy-json-fallback-buffer-limit" in error:
-        reason = "legacy-json-fallback-buffer-limit"
-    else:
-        reason = "unreadable-file"
-    return _parse_error_detail(path, line, reason)
-
-
 def _format_parse_error(path: Path, line: int | None, reason: str, detail: str = "") -> str:
     if reason == "invalid-json":
         suffix = f" ({detail})" if detail else ""
@@ -328,6 +314,7 @@ def _read_ndjson_file_streaming(
     raw_lines_for_fallback: list[str] = []
     raw_fallback_bytes = 0
     raw_fallback_truncated = False
+    parsed_entry_before_parse_error = False
     saw_parse_error = False
     saw_read_error = False
     with handle:
@@ -357,6 +344,7 @@ def _read_ndjson_file_streaming(
                 if isinstance(parsed, dict):
                     entries.append(parsed)
                     if not saw_parse_error:
+                        parsed_entry_before_parse_error = True
                         raw_lines_for_fallback = []
                         raw_fallback_bytes = 0
                 else:
@@ -366,7 +354,7 @@ def _read_ndjson_file_streaming(
             saw_read_error = True
             record_error(None, "unreadable-file", str(exc))
 
-    if not saw_parse_error or saw_read_error:
+    if not saw_parse_error or saw_read_error or parsed_entry_before_parse_error:
         return entries, False
 
     raw_text = "\n".join(raw_lines_for_fallback)

--- a/templates/consumer-repo/scripts/aggregate_agent_metrics.py
+++ b/templates/consumer-repo/scripts/aggregate_agent_metrics.py
@@ -289,20 +289,6 @@ def _parse_error_counter(parse_error_details: list[ParseErrorDetail], field: str
     return counts
 
 
-def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
-    line_match = re.search(r":(\d+): ", error)
-    line = int(line_match.group(1)) if line_match else None
-    if "invalid JSON" in error:
-        reason = "invalid-json"
-    elif "expected object" in error:
-        reason = "non-object-json"
-    elif "legacy-json-fallback-buffer-limit" in error:
-        reason = "legacy-json-fallback-buffer-limit"
-    else:
-        reason = "unreadable-file"
-    return _parse_error_detail(path, line, reason)
-
-
 def _format_parse_error(path: Path, line: int | None, reason: str, detail: str = "") -> str:
     if reason == "invalid-json":
         suffix = f" ({detail})" if detail else ""
@@ -328,6 +314,7 @@ def _read_ndjson_file_streaming(
     raw_lines_for_fallback: list[str] = []
     raw_fallback_bytes = 0
     raw_fallback_truncated = False
+    parsed_entry_before_parse_error = False
     saw_parse_error = False
     saw_read_error = False
     with handle:
@@ -357,6 +344,7 @@ def _read_ndjson_file_streaming(
                 if isinstance(parsed, dict):
                     entries.append(parsed)
                     if not saw_parse_error:
+                        parsed_entry_before_parse_error = True
                         raw_lines_for_fallback = []
                         raw_fallback_bytes = 0
                 else:
@@ -366,7 +354,7 @@ def _read_ndjson_file_streaming(
             saw_read_error = True
             record_error(None, "unreadable-file", str(exc))
 
-    if not saw_parse_error or saw_read_error:
+    if not saw_parse_error or saw_read_error or parsed_entry_before_parse_error:
         return entries, False
 
     raw_text = "\n".join(raw_lines_for_fallback)

--- a/tests/scripts/test_aggregate_agent_metrics.py
+++ b/tests/scripts/test_aggregate_agent_metrics.py
@@ -843,6 +843,27 @@ def test_read_metric_ndjson_accepts_legacy_pretty_json_array(tmp_path: Path) -> 
     assert [entry["pr_number"] for entry in entries] == [1872, 1873]
 
 
+def test_read_metric_ndjson_accepts_compact_legacy_json_array(tmp_path: Path) -> None:
+    path = tmp_path / "compact-array.ndjson"
+    path.write_text(
+        "\n".join(
+            [
+                "[",
+                '{"schema":"workflows-keepalive-metrics/v1","pr_number":1872},',
+                '{"schema":"workflows-keepalive-metrics/v1","pr_number":1873}',
+                "]",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
+
+    assert errors == []
+    assert [entry["pr_number"] for entry in entries] == [1872, 1873]
+
+
 def test_read_metric_ndjson_counts_read_error_during_iteration(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -896,6 +917,28 @@ def test_read_metric_ndjson_bounds_legacy_json_fallback_buffer(tmp_path: Path) -
     )
     assert errors[-1].line is None
     assert errors[-1].reason == "legacy-json-fallback-buffer-limit"
+
+
+def test_read_metric_ndjson_preserves_entries_after_parse_error(tmp_path: Path) -> None:
+    path = tmp_path / "mixed.ndjson"
+    path.write_text(
+        "\n".join(
+            [
+                '{"schema":"workflows-keepalive-metrics/v1","pr_number":1872}',
+                "not-json",
+                '{"schema":"workflows-keepalive-metrics/v1","pr_number":1873}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries, errors = aggregate_agent_metrics.read_metric_ndjson_files([path])
+
+    assert [entry["pr_number"] for entry in entries] == [1872, 1873]
+    assert len(errors) == 1
+    assert errors[0].line == 2
+    assert errors[0].reason == "invalid-json"
 
 
 def test_classify_entry_prefers_explicit_type() -> None:


### PR DESCRIPTION
## Summary

- Preserve valid NDJSON metrics when a later malformed line is encountered instead of letting the legacy pretty-JSON fallback replace earlier entries.
- Remove the unused `_canonical_parse_error_detail` helper from the source and consumer template copies.
- Add regression coverage for valid NDJSON entries around a parse error.

## Validation

- `python -m pytest tests/scripts/test_aggregate_agent_metrics.py -q`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `git diff --check`
- `python -m py_compile scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py`
- `python -m ruff check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py`
- `python -m black --check scripts/aggregate_agent_metrics.py templates/consumer-repo/scripts/aggregate_agent_metrics.py tests/scripts/test_aggregate_agent_metrics.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NDJSON ingestion to keep and return successfully parsed entries even when later lines are malformed, while avoiding unnecessary “legacy” reprocessing when valid records were already read.
  * Parse errors are now handled more consistently, ensuring accurate error reporting for partially corrupted files.

* **Tests**
  * Added unit tests covering legacy JSON array input and mixed valid/invalid NDJSON streams, including verification of recorded parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->