### PR TITLE
Retain LangSmith fleet rollup artifact

### DIFF
--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Upload dashboard diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: langsmith-metrics-diagnostics-${{ github.run_id }}
           path: |
@@ -301,23 +301,37 @@ jobs:
             .metrics-tmp/workflow_errors.log
             .metrics-tmp/run_ids.txt
             .metrics-tmp/combined-metrics.ndjson
+            .metrics-tmp/fleet/combined-fleet.ndjson
             .metrics-tmp/fleet/fleet-status.md
             .metrics-tmp/fleet/fleet-status.json
             .metrics-tmp/fleet/fleet_errors.log
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Upload fleet rollup artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: langsmith-fleet-rollup-${{ github.run_id }}
+          path: .metrics-tmp/fleet/combined-fleet.ndjson
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 90
 
       - name: Upload report artifact
         if: env.REPORT_AVAILABLE == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: langsmith-metrics-report-${{ github.run_id }}
           path: |
             .metrics-tmp/report.md
             .metrics-tmp/summary.json
             .metrics-tmp/combined-metrics.ndjson
+            .metrics-tmp/fleet/combined-fleet.ndjson
             .metrics-tmp/fleet/fleet-status.md
             .metrics-tmp/fleet/fleet-status.json
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 90
 

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -70,3 +70,11 @@ def test_fleet_rollup_and_publication_paths_are_wired() -> None:
     assert "REPORT=$(cat .metrics-tmp/report.md)" in source
     assert "$REPORT" in source
     assert "$(cat .metrics-tmp/report.md)" in source
+
+    # The raw combined NDJSON is retained for downstream durable ingestion.
+    assert "name: langsmith-fleet-rollup-${{ github.run_id }}" in source
+    assert "path: .metrics-tmp/fleet/combined-fleet.ndjson" in source
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7" in source
+    assert "actions/upload-artifact@v7" not in source
+    assert source.count("include-hidden-files: true") >= 3
+    assert source.count("            .metrics-tmp/fleet/combined-fleet.ndjson") >= 2


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- upload the raw `.metrics-tmp/fleet/combined-fleet.ndjson` dashboard rollup as a distinct `langsmith-fleet-rollup-<run_id>` artifact
- include the raw rollup in dashboard diagnostics/report artifacts for easier inspection
- add workflow test coverage so the downstream ingestion handoff remains wired

## Validation
- `uv run pytest tests/workflows/test_langsmith_metrics_dashboard.py tests/scripts/test_langsmith_fleet.py tests/scripts/test_langsmith_fleet_conformance.py`
- `uv run pytest tests/workflows/test_workflow_naming.py`

## Notes
The artifact name is intentionally distinct from per-repo `langsmith-fleet.ndjson` producer artifacts to avoid double-counting when individual registered repos start publishing their own fleet records. The local Orchestrator fetcher has been updated separately to use this rollup only as a fallback when no direct per-repo artifacts are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced dashboard diagnostics uploads by bundling combined fleet NDJSON with fleet status outputs in both Markdown and JSON, plus fleet error logs.
  * Added an always-run “fleet rollup” artifact upload for dedicated downstream retrieval.

* **Chores**
  * Extended the main report artifact bundle to include the combined fleet NDJSON and enabled hidden-file inclusion for the relevant uploads.

* **Tests**
  * Strengthened workflow checks to verify the fleet rollup artifact name, exact upload path, and expected upload-artifact configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
