### PR TITLE
fix: unblock renovate workflow updates

### DIFF
--- a/scripts/workflow_validator.py
+++ b/scripts/workflow_validator.py
@@ -13,8 +13,8 @@ import yaml
 DEPRECATED_ACTIONS = {
     "actions/checkout@v2": "actions/checkout@v4",
     "actions/checkout@v3": "actions/checkout@v4",
-    "actions/upload-artifact@v2": "actions/upload-artifact@v6",
-    "actions/upload-artifact@v3": "actions/upload-artifact@v6",
+    "actions/upload-artifact@v2": "actions/upload-artifact@v7",
+    "actions/upload-artifact@v3": "actions/upload-artifact@v7",
     "actions/download-artifact@v2": "actions/download-artifact@v7",
     "actions/download-artifact@v3": "actions/download-artifact@v7",
 }
@@ -87,7 +87,7 @@ def check_missing_timeout(workflow: dict) -> list[str]:
 
 
 def check_upload_artifact_major(
-    workflow: dict, expected_major: int = 6
+    workflow: dict, expected_major: int = 7
 ) -> list[tuple[str, str, str]]:
     """Check that actions/upload-artifact uses the expected major version.
 

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -81,6 +81,7 @@ jobs:
         with:
 
           token: ${{ steps.app_token.outputs.token || github.token }}
+          persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: |
@@ -206,6 +207,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -239,6 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Detect optional script test suites
@@ -343,6 +346,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token || github.token }}
+          persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -407,6 +411,7 @@ jobs:
         with:
 
           token: ${{ steps.app_token.outputs.token || github.token }}
+          persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: |

--- a/tests/test_workflow_validator.py
+++ b/tests/test_workflow_validator.py
@@ -121,19 +121,19 @@ class TestCheckUploadArtifactMajor:
     """Tests for check_upload_artifact_major function."""
 
     def test_accepts_expected_major(self) -> None:
-        """Test that v6 is accepted."""
+        """Test that v7 is accepted."""
         workflow = {
-            "jobs": {"build": {"steps": [{"name": "Upload", "uses": "actions/upload-artifact@v6"}]}}
+            "jobs": {"build": {"steps": [{"name": "Upload", "uses": "actions/upload-artifact@v7"}]}}
         }
 
         issues = check_upload_artifact_major(workflow)
         assert issues == []
 
     def test_accepts_expected_major_with_patch(self) -> None:
-        """Test that v6.x.y is accepted."""
+        """Test that v7.x.y is accepted."""
         workflow = {
             "jobs": {
-                "build": {"steps": [{"name": "Upload", "uses": "actions/upload-artifact@v6.1.2"}]}
+                "build": {"steps": [{"name": "Upload", "uses": "actions/upload-artifact@v7.0.1"}]}
             }
         }
 
@@ -141,14 +141,14 @@ class TestCheckUploadArtifactMajor:
         assert issues == []
 
     def test_flags_other_major(self) -> None:
-        """Test that non-v6 major versions are flagged."""
+        """Test that non-v7 major versions are flagged."""
         workflow = {
             "jobs": {"build": {"steps": [{"name": "Upload", "uses": "actions/upload-artifact@v4"}]}}
         }
 
         issues = check_upload_artifact_major(workflow)
         assert len(issues) == 1
-        assert "v6" in issues[0][2]
+        assert "v7" in issues[0][2]
 
     def test_ignores_other_actions(self) -> None:
         """Test that unrelated actions are ignored."""


### PR DESCRIPTION
## Summary
- update the workflow validator standard from actions/upload-artifact v6 to v7
- refresh validator tests for the v7 artifact standard
- disable persisted checkout credentials for read-only gate template checkouts

## Why
This addresses active Renovate review blockers:
- stranske/Trend_Model_Project#5572 needs the Workflows validator moved to upload-artifact v7 before that consumer major can merge.
- checkout digest PR review debt asks the gate template to avoid unnecessary persisted credentials.

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m pytest tests/test_workflow_validator.py -q
- git diff --check
- python -m pytest tests/workflows/test_template_drift_workflow.py tests/scripts/test_check_workflow_action_pins.py -q
- python scripts/validate_workflow_yaml.py templates/consumer-repo/.github/workflows/pr-00-gate.yml
- python -m pytest tests/workflows/test_workflow_on_triggers_valid.py tests/workflows/test_workflow_agents_consolidation.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workflow validator to recommend `actions/upload-artifact@v7` as the standard version (previously v6)
  * Enhanced GitHub Actions workflow security by disabling git credential persistence on checkout steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->