### PR TITLE
fix: sync gate summary helper to consumers

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -225,6 +225,15 @@ scripts:
   - source: tools/coverage_guard.py
     description: "Checks coverage guard artifacts - required by maint-coverage-guard.yml"
 
+  - source: tools/__init__.py
+    description: "Tools package marker for Python helpers imported by synced workflows"
+
+  - source: tools/ci_failure_triage.py
+    description: "Classifies CI failure logs - required by pr-00-gate.yml summary generation"
+
+  - source: tools/post_ci_summary.py
+    description: "Builds consolidated Gate summary comments - required by pr-00-gate.yml"
+
   # Scripts directory - CI helpers used by reusable-10-ci-python.yml
   - source: scripts/state_fingerprint.py
     description: "Computes workflow state fingerprints for unchanged-state skip gates"

--- a/templates/consumer-repo/tools/__init__.py
+++ b/templates/consumer-repo/tools/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers used by synced consumer workflows."""
+
+__all__ = ["ci_failure_triage", "post_ci_summary", "resolve_mypy_pin"]

--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -1,0 +1,454 @@
+"""CI failure triage helpers.
+
+Ported from the keepalive triage prototype to provide deterministic failure
+classification and fix suggestions without an LLM dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TriagePattern:
+    error_type: str
+    regexes: tuple[re.Pattern[str], ...]
+    root_cause: str
+    suggested_fix: str
+    file_regexes: tuple[re.Pattern[str], ...] = ()
+    playbook_url: str | None = None
+
+
+@dataclass(frozen=True)
+class TriageFinding:
+    error_type: str
+    root_cause: str
+    suggested_fix: str
+    relevant_files: list[str]
+    playbook_url: str | None = None
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TriageReport:
+    findings: list[TriageFinding]
+    summary: str
+    failed_tests: list[str] = field(default_factory=list)
+
+
+_DEFAULT_FILE_REGEX = re.compile(r"(?P<path>[A-Za-z0-9_./-]+\.(?:py|js|ts|tsx|json|ya?ml))")
+
+
+def _compile(patterns: list[str]) -> tuple[re.Pattern[str], ...]:
+    return tuple(re.compile(pat, re.IGNORECASE) for pat in patterns)
+
+
+SUGGESTED_FIX_TEMPLATES: dict[str, str] = {
+    "mypy": "Fix the reported type errors in {files} or update typing stubs to satisfy mypy.",
+    "pytest": "Inspect failing tests in {files} and fix the regression or update expectations.",
+    "coverage": "Add or expand tests covering {files} to meet the coverage threshold.",
+    "import_error": "Ensure imports in {files} resolve by fixing module paths or packaging.",
+    "syntax_error": "Fix the syntax error in {files} and rerun the formatter or linter if needed.",
+}
+
+
+DEFAULT_TRIAGE_PATTERNS: tuple[TriagePattern, ...] = (
+    TriagePattern(
+        error_type="mypy",
+        regexes=_compile(
+            [
+                r"\bmypy\b",
+                r"\berror:\s+.*\[(attr-defined|assignment|arg-type|return-value)\]",
+                r"Found \d+ errors? in \d+ files?",
+            ]
+        ),
+        root_cause="Type checking failed during mypy.",
+        suggested_fix=SUGGESTED_FIX_TEMPLATES["mypy"],
+        file_regexes=_compile([r"(?P<path>[A-Za-z0-9_./-]+\.py):\d+:"]),
+        playbook_url="docs/INTEGRATION_GUIDE.md#scenario-2-mypy-errors",
+    ),
+    TriagePattern(
+        error_type="pytest",
+        regexes=_compile(
+            [
+                r"=+ FAILURES =+",
+                r"E\s+AssertionError",
+                r"FAILED\s+[A-Za-z0-9_./-]+::",
+            ]
+        ),
+        root_cause="Pytest reported failing tests.",
+        suggested_fix=SUGGESTED_FIX_TEMPLATES["pytest"],
+        file_regexes=_compile([r"(?P<path>[A-Za-z0-9_./-]+\.py):\d+:"]),
+        playbook_url="docs/INTEGRATION_GUIDE.md#scenario-1-tests-failing",
+    ),
+    TriagePattern(
+        error_type="coverage",
+        regexes=_compile(
+            [
+                r"coverage\s+failure",
+                r"TOTAL\s+\d+\s+\d+\s+\d+%",
+                r"required test coverage of \d+% not reached",
+            ]
+        ),
+        root_cause="Coverage enforcement failed.",
+        suggested_fix=SUGGESTED_FIX_TEMPLATES["coverage"],
+        playbook_url="docs/INTEGRATION_GUIDE.md#consumer-repo-setup-coverage-soft-gate",
+    ),
+    TriagePattern(
+        error_type="import_error",
+        regexes=_compile(
+            [
+                r"ModuleNotFoundError",
+                r"ImportError",
+                r"No module named",
+            ]
+        ),
+        root_cause="Python import failed during test or runtime.",
+        suggested_fix=SUGGESTED_FIX_TEMPLATES["import_error"],
+        file_regexes=_compile([r"File \"(?P<path>[A-Za-z0-9_./-]+\.py)\""]),
+        playbook_url="docs/llm-task-analysis.md#import-errors",
+    ),
+    TriagePattern(
+        error_type="syntax_error",
+        regexes=_compile(
+            [
+                r"SyntaxError",
+                r"IndentationError",
+                r"unexpected EOF while parsing",
+            ]
+        ),
+        root_cause="Python parser raised a syntax error.",
+        suggested_fix=SUGGESTED_FIX_TEMPLATES["syntax_error"],
+        file_regexes=_compile([r"File \"(?P<path>[A-Za-z0-9_./-]+\.py)\""]),
+        playbook_url="docs/fast-validation-ecosystem.md#error-handling",
+    ),
+)
+
+
+def triage_ci_failure(
+    log_text: str,
+    patterns: tuple[TriagePattern, ...] = DEFAULT_TRIAGE_PATTERNS,
+    use_llm: bool | None = None,
+) -> TriageReport:
+    lines = [line.rstrip() for line in log_text.splitlines() if line.strip()]
+    findings: list[TriageFinding] = []
+    failed_tests = extract_pytest_failures(log_text)
+
+    for pattern in patterns:
+        evidence = _collect_evidence(lines, pattern.regexes)
+        if not evidence:
+            continue
+        relevant_files = _extract_relevant_files(evidence, pattern.file_regexes)
+        suggested_fix = _format_suggested_fix(pattern.suggested_fix, relevant_files)
+        findings.append(
+            TriageFinding(
+                error_type=pattern.error_type,
+                root_cause=pattern.root_cause,
+                suggested_fix=suggested_fix,
+                relevant_files=relevant_files,
+                playbook_url=pattern.playbook_url,
+                evidence=evidence,
+            )
+        )
+
+    summary = _build_summary(findings, failed_tests)
+    report = TriageReport(findings=findings, summary=summary, failed_tests=failed_tests)
+    return _maybe_enhance_with_llm(report, log_text, use_llm)
+
+
+def _collect_evidence(lines: list[str], regexes: tuple[re.Pattern[str], ...]) -> list[str]:
+    evidence: list[str] = []
+    for line in lines:
+        if any(regex.search(line) for regex in regexes):
+            evidence.append(line)
+    return evidence
+
+
+def _extract_relevant_files(
+    evidence: list[str], file_regexes: tuple[re.Pattern[str], ...]
+) -> list[str]:
+    paths: list[str] = []
+
+    for line in evidence:
+        for regex in file_regexes:
+            match = regex.search(line)
+            if match:
+                path = match.groupdict().get("path")
+                if path:
+                    paths.append(path)
+        match = _DEFAULT_FILE_REGEX.search(line)
+        if match:
+            path = match.groupdict().get("path")
+            if path:
+                paths.append(path)
+
+    seen: set[str] = set()
+    unique_paths = []
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        unique_paths.append(path)
+    return unique_paths
+
+
+def _format_suggested_fix(template: str, relevant_files: list[str]) -> str:
+    if "{files}" not in template:
+        return template
+    files = ", ".join(relevant_files) if relevant_files else "the reported files"
+    return template.format(files=files)
+
+
+def _build_summary(findings: list[TriageFinding], failed_tests: list[str] | None = None) -> str:
+    if not findings:
+        if failed_tests:
+            return "Detected failing tests without a known failure pattern."
+        return "No known failure patterns detected."
+    types = ", ".join(finding.error_type for finding in findings)
+    if failed_tests:
+        return f"Detected failure types: {types}. Pytest failures: {len(failed_tests)}."
+    return f"Detected failure types: {types}."
+
+
+def extract_pytest_failures(log_text: str) -> list[str]:
+    failures: list[str] = []
+    for line in log_text.splitlines():
+        line = line.strip()
+        if not line.startswith("FAILED "):
+            continue
+        payload = line[len("FAILED ") :].strip()
+        if not payload:
+            continue
+        test_id = payload.split(" - ", 1)[0].strip()
+        if test_id and test_id not in failures:
+            failures.append(test_id)
+    return failures
+
+
+def _maybe_enhance_with_llm(
+    report: TriageReport, log_text: str, use_llm: bool | None
+) -> TriageReport:
+    if use_llm is None:
+        use_llm = _bool_env(os.environ.get("KEEPALIVE_USE_LLM_TRIAGE"))
+    if not use_llm:
+        return report
+
+    llm_findings = _run_llm_triage(log_text)
+    if not llm_findings:
+        return report
+
+    existing_types = {finding.error_type for finding in report.findings}
+    merged = list(report.findings)
+    for finding in llm_findings:
+        if finding.error_type in existing_types:
+            continue
+        merged.append(finding)
+        existing_types.add(finding.error_type)
+
+    summary = _build_summary(merged, report.failed_tests)
+    return TriageReport(findings=merged, summary=summary, failed_tests=report.failed_tests)
+
+
+def _bool_env(value: str | None) -> bool:
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    return normalized in {"1", "true", "yes", "on"}
+
+
+def _run_llm_triage(log_text: str) -> list[TriageFinding]:
+    client_info = _get_llm_client()
+    if not client_info:
+        return []
+    client, _ = client_info
+    prompt = _build_llm_prompt(log_text)
+    try:
+        response = client.invoke(prompt)
+    except Exception:
+        return []
+    content = getattr(response, "content", None) or str(response)
+    return _parse_llm_findings(content)
+
+
+def _get_llm_client() -> tuple[object, str] | None:
+    try:
+        from langchain_openai import ChatOpenAI
+    except ImportError:
+        return None
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    openai_token = os.environ.get("OPENAI_API_KEY")
+    if not github_token and not openai_token:
+        return None
+
+    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+
+    if github_token:
+        return (
+            ChatOpenAI(
+                model=DEFAULT_MODEL,
+                base_url=GITHUB_MODELS_BASE_URL,
+                api_key=github_token,
+                temperature=0.1,
+            ),
+            "github-models",
+        )
+    return (
+        ChatOpenAI(
+            model=DEFAULT_MODEL,
+            api_key=openai_token,
+            temperature=0.1,
+        ),
+        "openai",
+    )
+
+
+def _build_llm_prompt(log_text: str) -> str:
+    trimmed = log_text.strip()
+    if len(trimmed) > 8000:
+        trimmed = trimmed[:8000]
+    schema = {
+        "findings": [
+            {
+                "error_type": "string",
+                "root_cause": "string",
+                "suggested_fix": "string",
+                "relevant_files": ["string"],
+                "playbook_url": "string or null",
+            }
+        ]
+    }
+    return (
+        "You are a CI failure triage assistant. "
+        "Read the log snippet and return JSON only, matching this schema:\n"
+        f"{json.dumps(schema)}\n"
+        "Return an empty findings list if nothing is clear.\n"
+        "Log snippet:\n"
+        f"{trimmed}"
+    )
+
+
+def _parse_llm_findings(text: str) -> list[TriageFinding]:
+    payload = _extract_json_payload(text)
+    if not payload:
+        return []
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return []
+    findings_data = data.get("findings")
+    if not isinstance(findings_data, list):
+        return []
+    findings: list[TriageFinding] = []
+    for raw in findings_data:
+        if not isinstance(raw, dict):
+            continue
+        error_type = str(raw.get("error_type") or "").strip()
+        root_cause = str(raw.get("root_cause") or "").strip()
+        suggested_fix = str(raw.get("suggested_fix") or "").strip()
+        if not (error_type and root_cause and suggested_fix):
+            continue
+        relevant_files = [
+            str(item).strip()
+            for item in raw.get("relevant_files", [])
+            if isinstance(item, str) and item.strip()
+        ]
+        playbook_url = raw.get("playbook_url")
+        if playbook_url is not None:
+            playbook_url = str(playbook_url).strip() or None
+        findings.append(
+            TriageFinding(
+                error_type=error_type,
+                root_cause=root_cause,
+                suggested_fix=suggested_fix,
+                relevant_files=relevant_files,
+                playbook_url=playbook_url,
+            )
+        )
+    return findings
+
+
+def _extract_json_payload(text: str) -> str | None:
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return stripped
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    return stripped[start : end + 1]
+
+
+def _report_to_dict(report: TriageReport) -> dict[str, object]:
+    return {
+        "summary": report.summary,
+        "failed_tests": report.failed_tests,
+        "findings": [
+            {
+                "error_type": finding.error_type,
+                "root_cause": finding.root_cause,
+                "suggested_fix": finding.suggested_fix,
+                "relevant_files": finding.relevant_files,
+                "playbook_url": finding.playbook_url,
+                "evidence": finding.evidence,
+            }
+            for finding in report.findings
+        ],
+    }
+
+
+def _format_text_report(report: TriageReport) -> str:
+    if not report.findings:
+        if report.failed_tests:
+            failures = "\n".join(f"- {test_id}" for test_id in report.failed_tests)
+            return f"{report.summary}\nFailing tests:\n{failures}"
+        return report.summary
+
+    lines = [report.summary]
+    if report.failed_tests:
+        lines.append("Failing tests:")
+        lines.extend(f"- {test_id}" for test_id in report.failed_tests)
+    for finding in report.findings:
+        lines.append(f"- error_type: {finding.error_type}")
+        lines.append(f"  root_cause: {finding.root_cause}")
+        lines.append(f"  suggested_fix: {finding.suggested_fix}")
+        if finding.relevant_files:
+            files = ", ".join(finding.relevant_files)
+            lines.append(f"  relevant_files: {files}")
+        if finding.playbook_url:
+            lines.append(f"  playbook_url: {finding.playbook_url}")
+    return "\n".join(lines)
+
+
+def _read_log_text(path: str | None) -> str:
+    if path:
+        return Path(path).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CI failure triage helper.")
+    parser.add_argument("--log-file", help="Path to a log file; defaults to stdin.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    args = parser.parse_args(argv)
+
+    log_text = _read_log_text(args.log_file)
+    report = triage_ci_failure(log_text)
+
+    if args.json:
+        payload = _report_to_dict(report)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_text_report(report))
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 import re
-import xml.etree.ElementTree as ET
+from html import unescape
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -383,26 +383,68 @@ def _collect_junit_failures(artifacts_root: Path, limit: int) -> list[str]:
 
     for path in sorted(base.rglob("**/pytest-junit.xml")):
         try:
-            tree = ET.parse(path)
-        except ET.ParseError:
+            xml_text = path.read_text(encoding="utf-8")
+        except OSError:
             continue
-        root = tree.getroot()
-        for case in root.iter("testcase"):
-            file_attr = case.attrib.get("file")
-            line_attr = case.attrib.get("line")
+        for case in _iter_junit_testcase_blocks(xml_text):
+            case_attrs = _parse_xml_attributes(case["attrs"])
+            file_attr = case_attrs.get("file")
+            line_attr = case_attrs.get("line")
             if file_attr:
                 line_suffix = f", line {line_attr}" if line_attr else ""
                 _append_line(failures, f'File "{file_attr}"{line_suffix}', limit)
             for tag in ("failure", "error"):
-                for node in case.findall(tag):
-                    message = node.attrib.get("message")
+                for node in _iter_xml_tag_blocks(case["body"], tag):
+                    attrs = _parse_xml_attributes(node["attrs"])
+                    message = attrs.get("message")
                     if message:
                         _append_text(failures, message, limit)
-                    if node.text:
-                        _append_text(failures, node.text, limit)
+                    if node["body"]:
+                        _append_text(failures, _strip_xml_tags(node["body"]), limit)
             if len(failures) >= limit:
                 return failures
     return failures
+
+
+_TESTCASE_RE = re.compile(
+    r"<testcase\b(?P<attrs>[^>]*)>(?P<body>.*?)</testcase>",
+    re.IGNORECASE | re.DOTALL,
+)
+_XML_ATTR_RE = re.compile(
+    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*"
+    r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
+)
+_XML_TAG_RE_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _iter_junit_testcase_blocks(xml_text: str) -> Iterable[dict[str, str]]:
+    for match in _TESTCASE_RE.finditer(xml_text):
+        yield {"attrs": match.group("attrs"), "body": match.group("body")}
+
+
+def _iter_xml_tag_blocks(xml_text: str, tag: str) -> Iterable[dict[str, str]]:
+    pattern = _XML_TAG_RE_CACHE.get(tag)
+    if pattern is None:
+        escaped = re.escape(tag)
+        pattern = re.compile(
+            rf"<{escaped}\b(?P<attrs>[^>]*)>(?P<body>.*?)</{escaped}>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        _XML_TAG_RE_CACHE[tag] = pattern
+    for match in pattern.finditer(xml_text):
+        yield {"attrs": match.group("attrs"), "body": match.group("body")}
+
+
+def _parse_xml_attributes(raw_attrs: str) -> dict[str, str]:
+    return {
+        match.group("name"): unescape(match.group("value"))
+        for match in _XML_ATTR_RE.finditer(raw_attrs)
+    }
+
+
+def _strip_xml_tags(xml_text: str) -> str:
+    return unescape(re.sub(r"<[^>]+>", "", xml_text))
 
 
 def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> list[str]:

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import json
 import os
 import re
-from html import unescape
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from dataclasses import dataclass
+from html import unescape
 from pathlib import Path
 from typing import Any, TypedDict
 

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -1,0 +1,887 @@
+"""Helpers for building the consolidated post-CI run summary.
+
+Originally wired to the legacy post-CI follower, the helper now powers the
+inline `summary` job in `pr-00-gate.yml`. Unit tests keep coverage without
+requiring the full workflow to run on GitHub.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypedDict
+
+from tools.ci_failure_triage import triage_ci_failure
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    name: str
+    state: str | None
+    url: str | None
+    highlight: bool
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    key: str
+    display_name: str
+    present: bool
+    state: str | None
+    attempt: int | None
+    label: str
+    url: str | None
+
+
+class RequiredJobGroup(TypedDict):
+    label: str
+    patterns: list[str]
+
+
+DEFAULT_REQUIRED_JOB_GROUPS: list[RequiredJobGroup] = [
+    {
+        "label": "python ci (3.12)",
+        "patterns": [r"(python\s*ci|core\s*(tests?)?).*(3\.12|py\.?312)"],
+    },
+    {
+        "label": "python ci (3.13)",
+        "patterns": [r"(python\s*ci|core\s*(tests?)?).*(3\.13|py\.?313)"],
+    },
+    {"label": "docker smoke", "patterns": [r"docker.*smoke|smoke.*docker"]},
+    {"label": "gate", "patterns": [r"gate"]},
+]
+
+
+REQUIRED_CONTEXTS_PATH = Path(".github/config/required-contexts.json")
+
+
+def _copy_required_groups(
+    groups: Sequence[RequiredJobGroup],
+) -> list[RequiredJobGroup]:
+    return [{"label": group["label"], "patterns": list(group["patterns"])} for group in groups]
+
+
+def _badge(state: str | None) -> str:
+    if not state:
+        return "⏳"
+    normalized = state.lower()
+    if normalized == "success":
+        return "✅"
+    if normalized in {"failure", "cancelled", "timed_out", "action_required"}:
+        return "❌"
+    if normalized == "skipped":
+        return "⏭️"
+    if normalized in {"in_progress", "queued", "waiting", "requested"}:
+        return "⏳"
+    return "⏳"
+
+
+def _display_state(state: str | None) -> str:
+    if not state:
+        return "pending"
+    text = str(state).strip()
+    if not text:
+        return "pending"
+    return text.replace("_", " ").lower()
+
+
+def _priority(state: str | None) -> int:
+    normalized = (state or "").lower()
+    if normalized in {"failure", "cancelled", "timed_out", "action_required"}:
+        return 0
+    if normalized in {"in_progress", "queued", "waiting", "requested"}:
+        return 1
+    if normalized == "success":
+        return 2
+    if normalized == "skipped":
+        return 3
+    return 4
+
+
+def _combine_states(states: Iterable[str | None]) -> str:
+    lowered: list[str] = [s.lower() for s in states if isinstance(s, str) and s]
+    if not lowered:
+        return "missing"
+    for candidate in ("failure", "cancelled", "timed_out", "action_required"):
+        if candidate in lowered:
+            return candidate
+    for candidate in ("in_progress", "queued", "waiting", "requested"):
+        if candidate in lowered:
+            return candidate
+    if all(state == "skipped" for state in lowered):
+        return "skipped"
+    if "success" in lowered:
+        return "success"
+    return lowered[0]
+
+
+def _slugify(value: str) -> str:
+    collapsed = re.sub(r"[^a-z0-9]+", "-", value.casefold())
+    return re.sub(r"-+", "-", collapsed).strip("-")
+
+
+class RequiredJobRule(TypedDict):
+    key: str
+    label: str
+    slug_variants: list[list[str]]
+    fallback_patterns: list[str]
+
+
+REQUIRED_JOB_RULES: list[RequiredJobRule] = [
+    {
+        "key": "core312",
+        "label": "core tests (3.12)",
+        "slug_variants": [
+            ["core", "3-12"],
+            ["py312"],
+            ["3-12", "tests"],
+        ],
+        "fallback_patterns": [r"core\s*(tests?)?.*(3\.12|py\.?312)"],
+    },
+    {
+        "key": "core313",
+        "label": "core tests (3.13)",
+        "slug_variants": [
+            ["core", "3-13"],
+            ["core", "313"],
+            ["py313"],
+            ["3-13", "tests"],
+        ],
+        "fallback_patterns": [r"core\s*(tests?)?.*(3\.13|py\.?313)"],
+    },
+    {
+        "key": "docker",
+        "label": "docker smoke",
+        "slug_variants": [["docker", "smoke"], ["smoke", "docker"]],
+        "fallback_patterns": [r"docker.*smoke|smoke.*docker"],
+    },
+    {
+        "key": "gate",
+        "label": "gate",
+        "slug_variants": [["gate"], ["aggregator", "gate"]],
+        "fallback_patterns": [r"gate"],
+    },
+]
+
+
+DOC_ONLY_JOB_KEYS: tuple[str, ...] = ("core312", "core313", "docker")
+
+
+def _matches_slug(slug: str, variants: Sequence[Sequence[str]]) -> bool:
+    return any(all(token in slug for token in option) for option in variants)
+
+
+def _classify_job_key(name: str) -> str | None:
+    slug = _slugify(name)
+    for rule in REQUIRED_JOB_RULES:
+        if _matches_slug(slug, rule["slug_variants"]):
+            return rule["key"]
+    return None
+
+
+def _derive_required_groups_from_runs(
+    runs: Sequence[Mapping[str, object]],
+) -> list[RequiredJobGroup]:
+    job_names: list[tuple[str, str]] = []
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        jobs = run.get("jobs")
+        if not isinstance(jobs, Sequence):
+            continue
+        for job in jobs:
+            if not isinstance(job, Mapping):
+                continue
+            name_value = job.get("name")
+            if not isinstance(name_value, str):
+                continue
+            name = name_value.strip()
+            if not name:
+                continue
+            job_names.append((name, _slugify(name)))
+
+    groups: list[RequiredJobGroup] = []
+    used: set[str] = set()
+    for rule in REQUIRED_JOB_RULES:
+        matches: list[str] = []
+        for original, slug in job_names:
+            if _matches_slug(slug, rule["slug_variants"]):
+                lowered = original.casefold()
+                if lowered in used:
+                    continue
+                used.add(lowered)
+                matches.append(original)
+        if matches:
+            patterns = [rf"^{re.escape(match)}$" for match in matches]
+            groups.append({"label": matches[0], "patterns": patterns})
+        else:
+            groups.append(
+                {
+                    "label": rule["label"],
+                    "patterns": list(rule["fallback_patterns"]),
+                }
+            )
+    return groups
+
+
+def _collect_category_states(
+    runs: Sequence[Mapping[str, object]],
+) -> dict[str, tuple[str, str | None]]:
+    states: dict[str, tuple[str, str | None]] = {}
+    for run in runs:
+        if not isinstance(run, Mapping) or not run.get("present"):
+            continue
+        display = str(
+            run.get("displayName") or run.get("display_name") or run.get("key") or "workflow"
+        )
+        jobs = run.get("jobs")
+        if not isinstance(jobs, Sequence):
+            continue
+        for job in jobs:
+            if not isinstance(job, Mapping):
+                continue
+            name_value = job.get("name")
+            if not isinstance(name_value, str):
+                continue
+            name = name_value.strip()
+            if not name:
+                continue
+            key = _classify_job_key(name)
+            if not key:
+                continue
+            state_value = job.get("conclusion") or job.get("status")
+            state_str = str(state_value) if state_value is not None else None
+            label = f"{display} / {name}" if display else name
+            existing = states.get(key)
+            if existing is None or _priority(state_str) < _priority(existing[1]):
+                states[key] = (label, state_str)
+    return states
+
+
+def _is_docs_only_fast_pass(
+    category_states: Mapping[str, tuple[str, str | None]],
+) -> bool:
+    seen_skipped = False
+    for key in DOC_ONLY_JOB_KEYS:
+        record = category_states.get(key)
+        if record is None:
+            return False
+        state = record[1] or ""
+        normalized = state.lower()
+        if normalized != "skipped":
+            return False
+        seen_skipped = True
+    return seen_skipped
+
+
+def _load_required_groups(
+    env_value: str | None, runs: Sequence[Mapping[str, object]]
+) -> list[RequiredJobGroup]:
+    if not env_value:
+        derived = _derive_required_groups_from_runs(runs)
+        if derived:
+            return derived
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
+    try:
+        parsed = json.loads(env_value)
+    except json.JSONDecodeError:
+        derived = _derive_required_groups_from_runs(runs)
+        if derived:
+            return derived
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
+    if not isinstance(parsed, list):
+        derived = _derive_required_groups_from_runs(runs)
+        if derived:
+            return derived
+        return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
+    result: list[RequiredJobGroup] = []
+    for item in parsed:
+        if not isinstance(item, Mapping):
+            continue
+        label = str(item.get("label") or item.get("name") or "").strip()
+        patterns = item.get("patterns")
+        if not label or not isinstance(patterns, Sequence) or isinstance(patterns, (str, bytes)):
+            continue
+        cleaned: list[str] = [p for p in patterns if isinstance(p, str) and p]
+        if not cleaned:
+            continue
+        result.append({"label": label, "patterns": cleaned})
+    if result:
+        return result
+    derived = _derive_required_groups_from_runs(runs)
+    if derived:
+        return derived
+    return _copy_required_groups(DEFAULT_REQUIRED_JOB_GROUPS)
+
+
+def _load_required_contexts(
+    config_path: str | os.PathLike[str] | None = None,
+) -> list[str]:
+    candidate = Path(config_path or os.getenv("REQUIRED_CONTEXTS_FILE") or REQUIRED_CONTEXTS_PATH)
+    try:
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError:
+        return []
+
+    if isinstance(payload, Mapping):
+        contexts_value = payload.get("required_contexts") or payload.get("contexts")
+    else:
+        contexts_value = payload
+
+    contexts: list[str] = []
+    if isinstance(contexts_value, Iterable) and not isinstance(contexts_value, (str, bytes)):
+        for item in contexts_value:
+            if isinstance(item, str):
+                value = item.strip()
+                if value:
+                    contexts.append(value)
+    return contexts
+
+
+def _load_gate_summary_records(artifacts_root: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    base = artifacts_root / "downloads"
+    if not base.exists():
+        return records
+    for path in sorted(base.rglob("**/summary.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            records.append(data)
+    return records
+
+
+def _append_line(lines: list[str], line: str, limit: int) -> None:
+    if len(lines) >= limit:
+        return
+    cleaned = line.strip()
+    if cleaned:
+        lines.append(cleaned)
+
+
+def _append_text(lines: list[str], text: str, limit: int) -> None:
+    for raw in text.splitlines():
+        if len(lines) >= limit:
+            break
+        _append_line(lines, raw, limit)
+
+
+def _collect_junit_failures(artifacts_root: Path, limit: int) -> list[str]:
+    failures: list[str] = []
+    base = artifacts_root / "downloads"
+    if not base.exists():
+        return failures
+
+    for path in sorted(base.rglob("**/pytest-junit.xml")):
+        try:
+            tree = ET.parse(path)
+        except ET.ParseError:
+            continue
+        root = tree.getroot()
+        for case in root.iter("testcase"):
+            file_attr = case.attrib.get("file")
+            line_attr = case.attrib.get("line")
+            if file_attr:
+                line_suffix = f", line {line_attr}" if line_attr else ""
+                _append_line(failures, f'File "{file_attr}"{line_suffix}', limit)
+            for tag in ("failure", "error"):
+                for node in case.findall(tag):
+                    message = node.attrib.get("message")
+                    if message:
+                        _append_text(failures, message, limit)
+                    if node.text:
+                        _append_text(failures, node.text, limit)
+            if len(failures) >= limit:
+                return failures
+    return failures
+
+
+def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> list[str]:
+    lines: list[str] = []
+
+    def _outcome_is_failure(outcome: object) -> bool:
+        normalized = str(outcome or "").strip().lower()
+        return normalized in {"failure", "cancelled", "timed_out", "error", "action_required"}
+
+    for record in records:
+        checks = record.get("checks")
+        if not isinstance(checks, Mapping):
+            continue
+
+        type_check = checks.get("type_check") if isinstance(checks, Mapping) else None
+        if isinstance(type_check, Mapping) and _outcome_is_failure(type_check.get("outcome")):
+            lines.append("mypy: Found 1 errors in 1 files")
+
+        tests = checks.get("tests") if isinstance(checks, Mapping) else None
+        if isinstance(tests, Mapping) and _outcome_is_failure(tests.get("outcome")):
+            lines.append("= FAILURES =")
+
+        coverage_min = checks.get("coverage_minimum") if isinstance(checks, Mapping) else None
+        if isinstance(coverage_min, Mapping) and _outcome_is_failure(coverage_min.get("outcome")):
+            lines.append("coverage failure: required test coverage of 0% not reached")
+
+    return lines
+
+
+def _format_triage_block(log_text: str) -> list[str]:
+    report = triage_ci_failure(log_text)
+    if not report.findings:
+        return []
+
+    lines = ["### Failure triage", report.summary]
+    for finding in report.findings:
+        lines.append(f"- error_type: {finding.error_type}")
+        lines.append(f"  root_cause: {finding.root_cause}")
+        lines.append(f"  suggested_fix: {finding.suggested_fix}")
+        if finding.relevant_files:
+            files = ", ".join(finding.relevant_files)
+            lines.append(f"  relevant_files: {files}")
+        if finding.playbook_url:
+            lines.append(f"  playbook_url: {finding.playbook_url}")
+    return lines
+
+
+def _collect_triage_block(artifacts_root: Path) -> list[str]:
+    if not artifacts_root.exists():
+        return []
+
+    records = _load_gate_summary_records(artifacts_root)
+    lines: list[str] = []
+    limit = 200
+
+    lines.extend(_collect_check_failure_lines(records))
+    lines.extend(_collect_junit_failures(artifacts_root, limit))
+
+    if not lines:
+        return []
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        if line in seen:
+            continue
+        seen.add(line)
+        deduped.append(line)
+        if len(deduped) >= limit:
+            break
+
+    log_text = "\n".join(deduped)
+    return _format_triage_block(log_text)
+
+
+def _dedupe_runs(runs: Sequence[Mapping[str, object]]) -> list[Mapping[str, object]]:
+    deduped: list[Mapping[str, object]] = []
+    index_by_key: dict[str, int] = {}
+
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+
+        key_value = run.get("key")
+        key_str: str | None
+        if isinstance(key_value, str):
+            key_str = key_value.strip() or None
+        elif key_value is None:
+            key_str = None
+        else:
+            key_str = str(key_value)
+
+        if not key_str:
+            deduped.append(run)
+            continue
+
+        existing_index = index_by_key.get(key_str)
+        if existing_index is None:
+            index_by_key[key_str] = len(deduped)
+            deduped.append(run)
+            continue
+
+        existing = deduped[existing_index]
+        existing_present = bool(existing.get("present"))
+        candidate_present = bool(run.get("present"))
+
+        if candidate_present and not existing_present:
+            deduped[existing_index] = run
+            continue
+
+        if candidate_present == existing_present:
+            existing_state_value = existing.get("conclusion") or existing.get("status")
+            candidate_state_value = run.get("conclusion") or run.get("status")
+
+            existing_state = str(existing_state_value) if existing_state_value is not None else None
+            candidate_state = (
+                str(candidate_state_value) if candidate_state_value is not None else None
+            )
+
+            if (candidate_state and not existing_state) or (
+                _priority(candidate_state) < _priority(existing_state)
+            ):
+                deduped[existing_index] = run
+
+    return deduped
+
+
+def _build_job_rows(runs: Sequence[Mapping[str, object]]) -> list[JobRecord]:
+    rows: list[JobRecord] = []
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        present = bool(run.get("present"))
+        if not present:
+            continue
+        display = str(
+            run.get("displayName") or run.get("display_name") or run.get("key") or "workflow"
+        )
+        jobs = run.get("jobs")
+        if not isinstance(jobs, Sequence):
+            continue
+        for job in jobs:
+            if not isinstance(job, Mapping):
+                continue
+            name = str(job.get("name") or "").strip()
+            if not name:
+                continue
+            state = job.get("conclusion") or job.get("status")
+            state_str = str(state) if state is not None else None
+            highlight = bool(
+                state_str
+                and state_str.lower() in {"failure", "cancelled", "timed_out", "action_required"}
+            )
+            label = f"{display} / {name}"
+            if highlight:
+                label = f"**{label}**"
+            rows.append(
+                JobRecord(
+                    name=label,
+                    state=state_str,
+                    url=str(job.get("html_url")) if job.get("html_url") else None,
+                    highlight=highlight,
+                )
+            )
+    rows.sort(key=lambda record: (_priority(record.state), record.name))
+    return rows
+
+
+def _format_jobs_table(rows: Sequence[JobRecord]) -> list[str]:
+    header = [
+        "| Workflow / Job | Result | Logs |",
+        "|----------------|--------|------|",
+    ]
+    if not rows:
+        return header + ["| _(no jobs reported)_ | ⏳ pending | — |"]
+    body = []
+    for record in rows:
+        state_display = _display_state(record.state)
+        link = f"[logs]({record.url})" if record.url else "—"
+        body.append(f"| {record.name} | {_badge(record.state)} {state_display} | {link} |")
+    return header + body
+
+
+def _format_percent(value: Any) -> str | None:
+    try:
+        return f"{float(value):.2f}%"
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_delta_pp(value: Any, *, signed: bool = True) -> str | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not signed:
+        return f"{abs(number):.2f} pp"
+    sign = "+" if number > 0 else ""
+    return f"{sign}{number:.2f} pp"
+
+
+def _collect_required_segments(
+    runs: Sequence[Mapping[str, object]],
+    groups: Sequence[RequiredJobGroup],
+) -> list[str]:
+    import re
+
+    segments: list[str] = []
+    job_sources: list[Mapping[str, object]] = []
+    for run in runs:
+        if not isinstance(run, Mapping) or not run.get("present"):
+            continue
+        jobs = run.get("jobs")
+        if isinstance(jobs, Sequence):
+            job_sources.append(run)
+
+    for group in groups:
+        label = group.get("label", "").strip()
+        patterns = group.get("patterns", [])
+        if not label or not isinstance(patterns, Sequence):
+            continue
+
+        regexes = []
+        for pattern in patterns:
+            if not isinstance(pattern, str):
+                continue
+            try:
+                regexes.append(re.compile(pattern, re.IGNORECASE))
+            except re.error:
+                continue
+        if not regexes:
+            continue
+
+        matched_states: list[str | None] = []
+        matched_names: list[str] = []
+        for run in job_sources:
+            jobs = run.get("jobs")
+            if not isinstance(jobs, Sequence):
+                continue
+            for job in jobs:
+                if not isinstance(job, Mapping):
+                    continue
+                name = str(job.get("name") or "")
+                if not name:
+                    continue
+                if any(regex.search(name) for regex in regexes):
+                    matched_names.append(name)
+                    state_value = job.get("conclusion") or job.get("status")
+                    matched_states.append(str(state_value) if state_value is not None else None)
+
+        state = _combine_states(matched_states) if matched_states else None
+        canonical_name: str | None = None
+        if matched_names:
+            seen: set[str] = set()
+            for candidate in matched_names:
+                lowered = candidate.casefold()
+                if lowered in seen:
+                    continue
+                seen.add(lowered)
+                canonical_name = candidate
+                break
+        display_label = canonical_name or label or "Job group"
+        segments.append(f"{display_label}: {_badge(state)} {_display_state(state)}")
+
+    return segments
+
+
+def _format_latest_runs(runs: Sequence[Mapping[str, object]]) -> str:
+    parts: list[str] = []
+    for run in runs:
+        if not isinstance(run, Mapping):
+            continue
+        display = (
+            str(
+                run.get("displayName") or run.get("display_name") or run.get("key") or "workflow"
+            ).strip()
+            or "workflow"
+        )
+
+        state = run.get("conclusion") or run.get("status")
+        state_str = str(state) if state is not None else None
+        badge = _badge(state_str)
+        state_display = _display_state(state_str)
+
+        if not run.get("present"):
+            parts.append(f"{badge} {state_display} — {display}")
+            continue
+
+        run_id = run.get("id")
+        attempt = run.get("run_attempt")
+        attempt_suffix = f" (attempt {attempt})" if isinstance(attempt, int) and attempt > 1 else ""
+        label = f"{display} (#{run_id}{attempt_suffix})" if run_id else display
+        url = run.get("html_url")
+        if url:
+            label = f"[{label}]({url})"
+
+        parts.append(f"{badge} {state_display} — {label}")
+    return " · ".join(parts)
+
+
+def _format_coverage_lines(stats: Mapping[str, object] | None) -> list[str]:
+    if not isinstance(stats, Mapping):
+        return []
+
+    lines: list[str] = []
+    avg_latest = _format_percent(stats.get("avg_latest"))
+    avg_delta = _format_delta_pp(stats.get("avg_delta"))
+    avg_parts = [part for part in (avg_latest, f"Δ {avg_delta}" if avg_delta else None) if part]
+    if avg_parts:
+        lines.append(f"- Coverage (jobs): {' | '.join(avg_parts)}")
+
+    worst_latest = _format_percent(stats.get("worst_latest"))
+    worst_delta = _format_delta_pp(stats.get("worst_delta"))
+    worst_parts = [
+        part for part in (worst_latest, f"Δ {worst_delta}" if worst_delta else None) if part
+    ]
+    if worst_parts:
+        lines.append(f"- Coverage (worst job): {' | '.join(worst_parts)}")
+
+    history_len = stats.get("history_len")
+    if isinstance(history_len, int):
+        lines.append(f"- Coverage history entries: {history_len}")
+    return lines
+
+
+def _format_coverage_delta_lines(
+    delta: Mapping[str, object] | None,
+) -> list[str]:
+    if not isinstance(delta, Mapping):
+        return []
+
+    head_value = _format_percent(delta.get("current"))
+    baseline_value = _format_percent(delta.get("baseline"))
+    delta_value = _format_delta_pp(delta.get("delta"))
+    drop_value = _format_delta_pp(delta.get("drop"), signed=False)
+    threshold_value = _format_delta_pp(delta.get("threshold"), signed=False)
+
+    parts: list[str] = []
+    if head_value:
+        parts.append(f"head {head_value}")
+    if baseline_value:
+        parts.append(f"base {baseline_value}")
+    elif str(delta.get("status")) == "no-baseline":
+        parts.append("base — (no baseline)")
+    if delta_value:
+        parts.append(f"Δ {delta_value}")
+    if drop_value:
+        parts.append(f"drop {drop_value}")
+    if threshold_value:
+        parts.append(f"threshold {threshold_value}")
+
+    status = str(delta.get("status") or "").strip()
+    if status:
+        parts.append(f"status {status}")
+
+    return [f"- Coverage delta: {' | '.join(parts)}"] if parts else []
+
+
+def build_summary_comment(
+    *,
+    runs: Sequence[Mapping[str, object]],
+    head_sha: str | None,
+    coverage_stats: Mapping[str, object] | None,
+    coverage_section: str | None,
+    coverage_delta: Mapping[str, object] | None,
+    required_groups_env: str | None,
+    triage_block: Sequence[str] | None = None,
+) -> str:
+    deduped_runs = _dedupe_runs(runs)
+    category_states = _collect_category_states(deduped_runs)
+    docs_only_fast_pass = _is_docs_only_fast_pass(category_states)
+    rows = _build_job_rows(deduped_runs)
+    job_table_lines = _format_jobs_table(rows)
+    groups = _load_required_groups(required_groups_env, deduped_runs)
+    required_segments = _collect_required_segments(deduped_runs, groups)
+    contexts = _load_required_contexts(None)
+    latest_runs_line = _format_latest_runs(deduped_runs)
+    coverage_lines = _format_coverage_lines(coverage_stats)
+    coverage_delta_lines = _format_coverage_delta_lines(coverage_delta)
+    coverage_table = ""
+    if isinstance(coverage_stats, Mapping):
+        table_value = coverage_stats.get("coverage_table_markdown")
+        if isinstance(table_value, str):
+            coverage_table = table_value.strip()
+
+    coverage_block: list[str] = []
+    coverage_section_clean = (coverage_section or "").strip()
+    if coverage_lines or coverage_delta_lines:
+        coverage_block.append("### Coverage Overview")
+    if coverage_delta_lines:
+        coverage_block.append("\n".join(coverage_delta_lines))
+    if coverage_lines:
+        coverage_block.append("\n".join(coverage_lines))
+    if coverage_table:
+        if not coverage_block:
+            coverage_block.append("### Coverage Overview")
+        coverage_block.append(coverage_table)
+    if coverage_section_clean:
+        if not coverage_block:
+            coverage_block.append("### Coverage Overview")
+        coverage_block.append(coverage_section_clean)
+    if docs_only_fast_pass:
+        note = "Docs-only fast-pass: coverage artifacts were not refreshed for this run."
+        if coverage_block:
+            coverage_block.append(note)
+        else:
+            coverage_block.extend(["### Coverage Overview", note])
+
+    body_parts: MutableSequence[str] = ["## Automated Status Summary"]
+    if head_sha:
+        body_parts.append(f"**Head SHA:** {head_sha}")
+    if latest_runs_line:
+        body_parts.append(f"**Latest Runs:** {latest_runs_line}")
+    if contexts:
+        body_parts.append(f"**Required contexts:** {', '.join(contexts)}")
+    if required_segments:
+        body_parts.append(f"**Required:** {', '.join(required_segments)}")
+    body_parts.append("")
+    body_parts.extend(job_table_lines)
+    body_parts.append("")
+    if docs_only_fast_pass:
+        body_parts.append("Docs-only change detected; heavy checks skipped.")
+        body_parts.append("")
+    body_parts.extend(part for part in coverage_block if part)
+    if coverage_block:
+        body_parts.append("")
+    if triage_block:
+        body_parts.extend(triage_block)
+        body_parts.append("")
+    body_parts.append("_Updated automatically; will refresh on subsequent CI/Docker completions._")
+
+    return "\n".join(part for part in body_parts if part is not None)
+
+
+def _load_json_from_env(value: str | None) -> Mapping[str, object] | None:
+    if not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, Mapping) else None
+
+
+def main() -> None:
+    runs_value = os.environ.get("RUNS_JSON", "[]")
+    try:
+        runs = json.loads(runs_value)
+    except json.JSONDecodeError:
+        runs = []
+    if not isinstance(runs, list):
+        runs = []
+
+    head_sha = os.environ.get("HEAD_SHA") or None
+    coverage_stats = _load_json_from_env(os.environ.get("COVERAGE_STATS"))
+    coverage_section = os.environ.get("COVERAGE_SECTION")
+    coverage_delta = _load_json_from_env(os.environ.get("COVERAGE_DELTA"))
+    required_groups_env = os.environ.get("REQUIRED_JOB_GROUPS_JSON")
+    artifacts_root = Path(os.environ.get("GATE_ARTIFACTS_ROOT", "gate_artifacts"))
+    triage_block = _collect_triage_block(artifacts_root)
+
+    body = build_summary_comment(
+        runs=runs,
+        head_sha=head_sha,
+        coverage_stats=coverage_stats,
+        coverage_section=coverage_section,
+        coverage_delta=coverage_delta,
+        required_groups_env=required_groups_env,
+        triage_block=triage_block,
+    )
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        handle_path = Path(output_path)
+        with handle_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"body<<EOF\n{body}\nEOF\n")
+    else:
+        print(body)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -411,8 +411,7 @@ _TESTCASE_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _XML_ATTR_RE = re.compile(
-    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*"
-    r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*" r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
     re.DOTALL,
 )
 _XML_TAG_RE_CACHE: dict[str, re.Pattern[str]] = {}

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 import re
-import xml.etree.ElementTree as ET
+from html import unescape
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -383,26 +383,68 @@ def _collect_junit_failures(artifacts_root: Path, limit: int) -> list[str]:
 
     for path in sorted(base.rglob("**/pytest-junit.xml")):
         try:
-            tree = ET.parse(path)
-        except ET.ParseError:
+            xml_text = path.read_text(encoding="utf-8")
+        except OSError:
             continue
-        root = tree.getroot()
-        for case in root.iter("testcase"):
-            file_attr = case.attrib.get("file")
-            line_attr = case.attrib.get("line")
+        for case in _iter_junit_testcase_blocks(xml_text):
+            case_attrs = _parse_xml_attributes(case["attrs"])
+            file_attr = case_attrs.get("file")
+            line_attr = case_attrs.get("line")
             if file_attr:
                 line_suffix = f", line {line_attr}" if line_attr else ""
                 _append_line(failures, f'File "{file_attr}"{line_suffix}', limit)
             for tag in ("failure", "error"):
-                for node in case.findall(tag):
-                    message = node.attrib.get("message")
+                for node in _iter_xml_tag_blocks(case["body"], tag):
+                    attrs = _parse_xml_attributes(node["attrs"])
+                    message = attrs.get("message")
                     if message:
                         _append_text(failures, message, limit)
-                    if node.text:
-                        _append_text(failures, node.text, limit)
+                    if node["body"]:
+                        _append_text(failures, _strip_xml_tags(node["body"]), limit)
             if len(failures) >= limit:
                 return failures
     return failures
+
+
+_TESTCASE_RE = re.compile(
+    r"<testcase\b(?P<attrs>[^>]*)>(?P<body>.*?)</testcase>",
+    re.IGNORECASE | re.DOTALL,
+)
+_XML_ATTR_RE = re.compile(
+    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*"
+    r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
+)
+_XML_TAG_RE_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _iter_junit_testcase_blocks(xml_text: str) -> Iterable[dict[str, str]]:
+    for match in _TESTCASE_RE.finditer(xml_text):
+        yield {"attrs": match.group("attrs"), "body": match.group("body")}
+
+
+def _iter_xml_tag_blocks(xml_text: str, tag: str) -> Iterable[dict[str, str]]:
+    pattern = _XML_TAG_RE_CACHE.get(tag)
+    if pattern is None:
+        escaped = re.escape(tag)
+        pattern = re.compile(
+            rf"<{escaped}\b(?P<attrs>[^>]*)>(?P<body>.*?)</{escaped}>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        _XML_TAG_RE_CACHE[tag] = pattern
+    for match in pattern.finditer(xml_text):
+        yield {"attrs": match.group("attrs"), "body": match.group("body")}
+
+
+def _parse_xml_attributes(raw_attrs: str) -> dict[str, str]:
+    return {
+        match.group("name"): unescape(match.group("value"))
+        for match in _XML_ATTR_RE.finditer(raw_attrs)
+    }
+
+
+def _strip_xml_tags(xml_text: str) -> str:
+    return unescape(re.sub(r"<[^>]+>", "", xml_text))
 
 
 def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> list[str]:

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import json
 import os
 import re
-from html import unescape
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from dataclasses import dataclass
+from html import unescape
 from pathlib import Path
 from typing import Any, TypedDict
 

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -411,8 +411,7 @@ _TESTCASE_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _XML_ATTR_RE = re.compile(
-    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*"
-    r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    r"(?P<name>[A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*" r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
     re.DOTALL,
 )
 _XML_TAG_RE_CACHE: dict[str, re.Pattern[str]] = {}


### PR DESCRIPTION
## Summary
- add the Gate summary helper and CI triage dependency to the consumer template
- add the tools package marker for synced Python helpers
- declare the helpers in the sync manifest so Template and consumers receive them

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m pytest tests/test_post_ci_summary.py -q
- python -m py_compile templates/consumer-repo/tools/__init__.py templates/consumer-repo/tools/ci_failure_triage.py templates/consumer-repo/tools/post_ci_summary.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI failure log triage with deterministic regex-based categorization and optional LLM-based enrichment.
  * Added a consolidated post-CI run summary generator (job results, coverage overview/delta, required job badges, and optional triage details).
  * Enabled synchronization of new CI helper utilities into consumer repositories.
* **Refactor**
  * Improved pytest JUnit failure extraction for summary generation by switching to regex-based parsing of `pytest-junit.xml`, with better handling of extracted failure/error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->