### PR TITLE
fix(security): harden dependency bot actor checks

### DIFF
--- a/.github/workflows/maint-auto-label-dep-prs.yml
+++ b/.github/workflows/maint-auto-label-dep-prs.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   label:
     # Dependabot and Renovate both produce dependency PRs that should carry agents:allow-change.
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Add agents:allow-change label

--- a/.github/workflows/maint-auto-lock-deps.yml
+++ b/.github/workflows/maint-auto-lock-deps.yml
@@ -32,7 +32,7 @@ jobs:
   regenerate-lock:
     name: Regenerate requirements.lock
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2366 -->
> **Source:** Issue #2366

Closes #2366

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2365](https://github.com/stranske/Workflows/issues/2365)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `maint-dependabot-auto-label.yml:16` — gate on `github.event.pull_request.user.login == 'dependabot[bot]'` (reliable). If the trigger is not a PR event, use `github.triggering_actor` and document why.
- [ ] `maint-dependabot-auto-lock.yml:26` — same hardening; also verify the `github.head_ref` checkout is not a `pull_request_target` + untrusted-checkout footgun (if it is, note it for the dangerous-triggers follow-up).
- [ ] `templates/consumer-repo/.github/workflows/dependabot-automerge.yml:20` — drop the redundant `github.actor` term (keep `user.login`) OR add `# zizmor: ignore[bot-conditions]` with a one-line justification. Apply via the **template sync** mechanism, not a hand-patch to consumers.

#### Acceptance criteria
- [ ] Named gate: `pipx run zizmor --config .github/zizmor.yml .github/workflows/maint-dependabot-auto-label.yml .github/workflows/maint-dependabot-auto-lock.yml templates/consumer-repo/.github/workflows/dependabot-automerge.yml` reports **0 `bot-conditions`** findings.
- [ ] Deliberate-break → revert: re-introduce a bare `if: github.actor == 'dependabot[bot]'` on one file, confirm zizmor reports `bot-conditions` for it, then revert.

**Head SHA:** 9dd7ade5f2783a88e977a45612b63a8fff818626
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label dependency PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/27662969876) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969937) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/27662969892) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27662969848) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969854) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/27662969834) |
| Health 51 Actions SAST (zizmor) | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969888) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969881) |
| Health 73 Template Completeness | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969830) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969932) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969845) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969827) |
| Validate Sync Manifest | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/27662969852) |
<!-- auto-status-summary:end -->