### PR TITLE
fix: allow post ci summary path execution

### DIFF
--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -1,4 +1,7 @@
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from tools import post_ci_summary
@@ -143,6 +146,29 @@ def test_main_writes_github_output(tmp_path: Path, monkeypatch) -> None:
     output_text = output_path.read_text(encoding="utf-8")
     assert "body<<EOF" in output_text
     assert "Automated Status Summary" in output_text
+
+
+def test_main_runs_when_invoked_by_file_path(tmp_path: Path) -> None:
+    output_path = tmp_path / "output.txt"
+    contexts_path = tmp_path / "contexts.json"
+    _write_json(contexts_path, [])
+
+    result = subprocess.run(
+        [sys.executable, "tools/post_ci_summary.py"],
+        cwd=Path(__file__).resolve().parents[1],
+        env={
+            **os.environ,
+            "RUNS_JSON": "[]",
+            "REQUIRED_CONTEXTS_FILE": str(contexts_path),
+            "GITHUB_OUTPUT": str(output_path),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Automated Status Summary" in output_path.read_text(encoding="utf-8")
 
 
 def test_collect_triage_block_from_artifacts(tmp_path: Path) -> None:

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -16,7 +16,15 @@ from html import unescape
 from pathlib import Path
 from typing import Any, TypedDict
 
-from tools.ci_failure_triage import triage_ci_failure
+try:
+    from tools.ci_failure_triage import triage_ci_failure
+except ModuleNotFoundError as exc:
+    if exc.name != "tools":
+        raise
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from tools.ci_failure_triage import triage_ci_failure
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- add a fallback so `tools/post_ci_summary.py` can be invoked directly by file path
- cover the file-path invocation with a subprocess regression test

## Validation
- `python -m pytest tests/test_post_ci_summary.py -q`
- `RUNS_JSON=[] REQUIRED_CONTEXTS_FILE=/dev/null GITHUB_OUTPUT=$(mktemp) python tools/post_ci_summary.py`
- `python scripts/validate_template_sync.py`
- `python scripts/validate_template_completeness.py`
- `python -m py_compile tools/post_ci_summary.py tools/ci_failure_triage.py`
- `python -m ruff check tools/post_ci_summary.py tests/test_post_ci_summary.py`
- `python -m black --check tools/post_ci_summary.py tests/test_post_ci_summary.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import handling in the post CI summary tool for better resilience across different environment configurations.

* **Tests**
  * Added integration test verifying the post CI summary tool generates expected output when invoked as a subprocess with environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->