### PR TITLE
fix: harden synced post-ci helpers

### DIFF
--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -428,7 +428,10 @@ def _format_text_report(report: TriageReport) -> str:
 
 def _read_log_text(path: str | None) -> str:
     if path:
-        return Path(path).read_text(encoding="utf-8")
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.exit(f"Error reading log file: {exc}")
     return sys.stdin.read()
 
 

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -19,11 +19,13 @@ from typing import Any, TypedDict
 try:
     from tools.ci_failure_triage import triage_ci_failure
 except ModuleNotFoundError as exc:
-    if exc.name != "tools":
+    missing_name = exc.name or ""
+    if missing_name != "tools" and not missing_name.startswith("tools."):
         raise
     import sys
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.modules.pop("tools", None)
     from tools.ci_failure_triage import triage_ci_failure
 
 

--- a/templates/consumer-repo/tools/post_ci_summary.py
+++ b/templates/consumer-repo/tools/post_ci_summary.py
@@ -16,7 +16,15 @@ from html import unescape
 from pathlib import Path
 from typing import Any, TypedDict
 
-from tools.ci_failure_triage import triage_ci_failure
+try:
+    from tools.ci_failure_triage import triage_ci_failure
+except ModuleNotFoundError as exc:
+    if exc.name != "tools":
+        raise
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from tools.ci_failure_triage import triage_ci_failure
 
 
 @dataclass(frozen=True)
@@ -25,17 +33,6 @@ class JobRecord:
     state: str | None
     url: str | None
     highlight: bool
-
-
-@dataclass(frozen=True)
-class RunRecord:
-    key: str
-    display_name: str
-    present: bool
-    state: str | None
-    attempt: int | None
-    label: str
-    url: str | None
 
 
 class RequiredJobGroup(TypedDict):
@@ -173,7 +170,11 @@ DOC_ONLY_JOB_KEYS: tuple[str, ...] = ("core312", "core313", "docker")
 
 
 def _matches_slug(slug: str, variants: Sequence[Sequence[str]]) -> bool:
-    return any(all(token in slug for token in option) for option in variants)
+    segments = set(slug.split("-"))
+    return any(
+        all(part in segments for token in option for part in token.split("-"))
+        for option in variants
+    )
 
 
 def _classify_job_key(name: str) -> str | None:
@@ -350,7 +351,7 @@ def _load_gate_summary_records(artifacts_root: Path) -> list[dict[str, object]]:
     base = artifacts_root / "downloads"
     if not base.exists():
         return records
-    for path in sorted(base.rglob("**/summary.json")):
+    for path in sorted(base.rglob("summary.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
@@ -381,7 +382,7 @@ def _collect_junit_failures(artifacts_root: Path, limit: int) -> list[str]:
     if not base.exists():
         return failures
 
-    for path in sorted(base.rglob("**/pytest-junit.xml")):
+    for path in sorted(base.rglob("pytest-junit.xml")):
         try:
             xml_text = path.read_text(encoding="utf-8")
         except OSError:
@@ -460,7 +461,7 @@ def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> lis
 
         type_check = checks.get("type_check") if isinstance(checks, Mapping) else None
         if isinstance(type_check, Mapping) and _outcome_is_failure(type_check.get("outcome")):
-            lines.append("mypy: Found 1 errors in 1 files")
+            lines.append("mypy type check failed")
 
         tests = checks.get("tests") if isinstance(checks, Mapping) else None
         if isinstance(tests, Mapping) and _outcome_is_failure(tests.get("outcome")):
@@ -468,7 +469,7 @@ def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> lis
 
         coverage_min = checks.get("coverage_minimum") if isinstance(checks, Mapping) else None
         if isinstance(coverage_min, Mapping) and _outcome_is_failure(coverage_min.get("outcome")):
-            lines.append("coverage failure: required test coverage of 0% not reached")
+            lines.append("coverage failure: coverage minimum check failed")
 
     return lines
 
@@ -649,8 +650,6 @@ def _collect_required_segments(
     runs: Sequence[Mapping[str, object]],
     groups: Sequence[RequiredJobGroup],
 ) -> list[str]:
-    import re
-
     segments: list[str] = []
     job_sources: list[Mapping[str, object]] = []
     for run in runs:

--- a/tests/test_post_ci_summary.py
+++ b/tests/test_post_ci_summary.py
@@ -171,6 +171,34 @@ def test_main_runs_when_invoked_by_file_path(tmp_path: Path) -> None:
     assert "Automated Status Summary" in output_path.read_text(encoding="utf-8")
 
 
+def test_main_runs_by_file_path_when_tools_package_is_shadowed(tmp_path: Path) -> None:
+    output_path = tmp_path / "output.txt"
+    contexts_path = tmp_path / "contexts.json"
+    shadow_root = tmp_path / "shadow"
+    shadow_tools = shadow_root / "tools"
+    shadow_tools.mkdir(parents=True)
+    (shadow_tools / "__init__.py").write_text("# Shadow package without ci_failure_triage\n")
+    _write_json(contexts_path, [])
+
+    result = subprocess.run(
+        [sys.executable, "tools/post_ci_summary.py"],
+        cwd=Path(__file__).resolve().parents[1],
+        env={
+            **os.environ,
+            "PYTHONPATH": str(shadow_root),
+            "RUNS_JSON": "[]",
+            "REQUIRED_CONTEXTS_FILE": str(contexts_path),
+            "GITHUB_OUTPUT": str(output_path),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Automated Status Summary" in output_path.read_text(encoding="utf-8")
+
+
 def test_collect_triage_block_from_artifacts(tmp_path: Path) -> None:
     artifacts_root = tmp_path / "gate_artifacts"
     runtime_dir = artifacts_root / "downloads" / "coverage" / "runtimes" / "3.12"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,3 +1,3 @@
 """Utility helpers used by the CI infrastructure."""
 
-__all__ = ["post_ci_summary", "integration_repo"]
+__all__ = ["ci_failure_triage", "post_ci_summary", "resolve_mypy_pin"]

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -428,7 +428,10 @@ def _format_text_report(report: TriageReport) -> str:
 
 def _read_log_text(path: str | None) -> str:
     if path:
-        return Path(path).read_text(encoding="utf-8")
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError as exc:
+            sys.exit(f"Error reading log file: {exc}")
     return sys.stdin.read()
 
 

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -35,17 +35,6 @@ class JobRecord:
     highlight: bool
 
 
-@dataclass(frozen=True)
-class RunRecord:
-    key: str
-    display_name: str
-    present: bool
-    state: str | None
-    attempt: int | None
-    label: str
-    url: str | None
-
-
 class RequiredJobGroup(TypedDict):
     label: str
     patterns: list[str]
@@ -181,7 +170,11 @@ DOC_ONLY_JOB_KEYS: tuple[str, ...] = ("core312", "core313", "docker")
 
 
 def _matches_slug(slug: str, variants: Sequence[Sequence[str]]) -> bool:
-    return any(all(token in slug for token in option) for option in variants)
+    segments = set(slug.split("-"))
+    return any(
+        all(part in segments for token in option for part in token.split("-"))
+        for option in variants
+    )
 
 
 def _classify_job_key(name: str) -> str | None:
@@ -358,7 +351,7 @@ def _load_gate_summary_records(artifacts_root: Path) -> list[dict[str, object]]:
     base = artifacts_root / "downloads"
     if not base.exists():
         return records
-    for path in sorted(base.rglob("**/summary.json")):
+    for path in sorted(base.rglob("summary.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
@@ -389,7 +382,7 @@ def _collect_junit_failures(artifacts_root: Path, limit: int) -> list[str]:
     if not base.exists():
         return failures
 
-    for path in sorted(base.rglob("**/pytest-junit.xml")):
+    for path in sorted(base.rglob("pytest-junit.xml")):
         try:
             xml_text = path.read_text(encoding="utf-8")
         except OSError:
@@ -468,7 +461,7 @@ def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> lis
 
         type_check = checks.get("type_check") if isinstance(checks, Mapping) else None
         if isinstance(type_check, Mapping) and _outcome_is_failure(type_check.get("outcome")):
-            lines.append("mypy: Found 1 errors in 1 files")
+            lines.append("mypy type check failed")
 
         tests = checks.get("tests") if isinstance(checks, Mapping) else None
         if isinstance(tests, Mapping) and _outcome_is_failure(tests.get("outcome")):
@@ -476,7 +469,7 @@ def _collect_check_failure_lines(records: Sequence[Mapping[str, object]]) -> lis
 
         coverage_min = checks.get("coverage_minimum") if isinstance(checks, Mapping) else None
         if isinstance(coverage_min, Mapping) and _outcome_is_failure(coverage_min.get("outcome")):
-            lines.append("coverage failure: required test coverage of 0% not reached")
+            lines.append("coverage failure: coverage minimum check failed")
 
     return lines
 
@@ -657,8 +650,6 @@ def _collect_required_segments(
     runs: Sequence[Mapping[str, object]],
     groups: Sequence[RequiredJobGroup],
 ) -> list[str]:
-    import re
-
     segments: list[str] = []
     job_sources: list[Mapping[str, object]] = []
     for run in runs:

--- a/tools/post_ci_summary.py
+++ b/tools/post_ci_summary.py
@@ -19,11 +19,13 @@ from typing import Any, TypedDict
 try:
     from tools.ci_failure_triage import triage_ci_failure
 except ModuleNotFoundError as exc:
-    if exc.name != "tools":
+    missing_name = exc.name or ""
+    if missing_name != "tools" and not missing_name.startswith("tools."):
         raise
     import sys
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    sys.modules.pop("tools", None)
     from tools.ci_failure_triage import triage_ci_failure
 
 


### PR DESCRIPTION
## Summary
- make synced post_ci_summary runnable by file path in consumers
- align helper package exports with synced modules
- harden CI triage file reads and clean up post-CI summary matching/triage text

## Validation
- python -m pytest tests/test_post_ci_summary.py tests/tools/test_ci_failure_triage.py tests/workflows/test_maint46_post_ci_sparse_checkout.py -q
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m py_compile tools/post_ci_summary.py tools/ci_failure_triage.py templates/consumer-repo/tools/post_ci_summary.py templates/consumer-repo/tools/ci_failure_triage.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for CI log file reading; the triage tooling now exits gracefully with clear error messages when log files can’t be accessed.

* **Improvements**
  * Enhanced CI failure triage and summary generation with tighter artifact discovery, updated check failure wording, and more accurate job slug matching.
  * Improved robustness of CI summary script importing when the `tools` package is shadowed.

* **Tests**
  * Added coverage for running the CI summary script under a shadowed `tools` package scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- workflow-source:review_followup -->
