### PR TITLE
fix: sync integration dev tool pins

### DIFF
--- a/.github/workflows/maint-69-sync-integration-repo.yml
+++ b/.github/workflows/maint-69-sync-integration-repo.yml
@@ -47,6 +47,7 @@ jobs:
             templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
             .github/workflows/autofix-versions.env
             .github/scripts/sync_tracker_state
+            scripts/sync_dev_dependencies.py
           sparse-checkout-cone-mode: false
 
       - name: Prepare sync token
@@ -108,6 +109,16 @@ jobs:
             cp "../workflows/.github/workflows/autofix-versions.env" \
               .github/workflows/autofix-versions.env
             echo "✅ Updated autofix-versions.env"
+          fi
+
+          # Align integration repo dev-tool pins with the canonical env before
+          # regenerating the lock, otherwise reusable CI may install conflicting pins.
+          if [ -f "pyproject.toml" ]; then
+            python "../workflows/scripts/sync_dev_dependencies.py" \
+              --apply \
+              --pin-file ".github/workflows/autofix-versions.env" \
+              --pyproject "pyproject.toml"
+            echo "✅ Synced pyproject.toml dev tool pins"
           fi
 
           # Sync notify-workflows.yml (handles bidirectional sync)
@@ -186,7 +197,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add .github/workflows/ requirements.lock scripts/
+          git add .github/workflows/ pyproject.toml requirements.lock scripts/
           git commit \
             -m "sync: Update workflow templates from stranske/Workflows" \
             -m "" \

--- a/tests/workflows/test_integration_repo_sync_hubs.py
+++ b/tests/workflows/test_integration_repo_sync_hubs.py
@@ -46,6 +46,24 @@ def test_integration_repo_sync_delivers_consumer_agent_hubs_to_wit() -> None:
         assert hub in commit_script
 
 
+def test_integration_repo_sync_aligns_dev_tool_pins() -> None:
+    workflow = _workflow()
+    checkout = next(
+        step
+        for step in workflow["jobs"]["sync"]["steps"]
+        if step.get("name") == "Checkout Workflows repo"
+    )
+    sparse_checkout = str(checkout["with"]["sparse-checkout"])
+    apply_script = _step_run(workflow, "Apply template updates")
+    commit_script = _step_run(workflow, "Commit and push changes")
+
+    assert "scripts/sync_dev_dependencies.py" in sparse_checkout
+    assert 'python "../workflows/scripts/sync_dev_dependencies.py"' in apply_script
+    assert '--pin-file ".github/workflows/autofix-versions.env"' in apply_script
+    assert '--pyproject "pyproject.toml"' in apply_script
+    assert "git add .github/workflows/ pyproject.toml requirements.lock scripts/" in commit_script
+
+
 def test_sync_manifest_removes_stale_consumer_local_workflow_syncer() -> None:
     manifest = yaml.safe_load(SYNC_MANIFEST.read_text(encoding="utf-8")) or {}
     removal_targets = {


### PR DESCRIPTION
## Summary
- make Maint 69 sync Workflows-Integration-Tests pyproject dev-tool pins from canonical autofix-versions.env before regenerating requirements.lock
- stage pyproject.toml with the integration sync commit
- add workflow regression coverage for the sync helper and staged file

## Validation
- uv run pytest tests/workflows/test_integration_repo_sync_hubs.py tests/scripts/test_sync_dev_dependencies.py -q
- git diff --check