### PR TITLE
fix: type ci triage llm client

### DIFF
--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -13,6 +13,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Protocol, cast
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,10 @@ class TriageReport:
     findings: list[TriageFinding]
     summary: str
     failed_tests: list[str] = field(default_factory=list)
+
+
+class _LLMClient(Protocol):
+    def invoke(self, prompt: str) -> object: ...
 
 
 _DEFAULT_FILE_REGEX = re.compile(r"(?P<path>[A-Za-z0-9_./-]+\.(?:py|js|ts|tsx|json|ya?ml))")
@@ -276,7 +281,7 @@ def _run_llm_triage(log_text: str) -> list[TriageFinding]:
     return _parse_llm_findings(content)
 
 
-def _get_llm_client() -> tuple[object, str] | None:
+def _get_llm_client() -> tuple[_LLMClient, str] | None:
     try:
         from langchain_openai import ChatOpenAI
     except ImportError:
@@ -294,15 +299,17 @@ def _get_llm_client() -> tuple[object, str] | None:
             ChatOpenAI(
                 model=DEFAULT_MODEL,
                 base_url=GITHUB_MODELS_BASE_URL,
-                api_key=github_token,
+                api_key=cast(Any, github_token),
                 temperature=0.1,
             ),
             "github-models",
         )
+    if openai_token is None:
+        return None
     return (
         ChatOpenAI(
             model=DEFAULT_MODEL,
-            api_key=openai_token,
+            api_key=cast(Any, openai_token),
             temperature=0.1,
         ),
         "openai",

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -13,6 +13,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Protocol, cast
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,10 @@ class TriageReport:
     findings: list[TriageFinding]
     summary: str
     failed_tests: list[str] = field(default_factory=list)
+
+
+class _LLMClient(Protocol):
+    def invoke(self, prompt: str) -> object: ...
 
 
 _DEFAULT_FILE_REGEX = re.compile(r"(?P<path>[A-Za-z0-9_./-]+\.(?:py|js|ts|tsx|json|ya?ml))")
@@ -276,7 +281,7 @@ def _run_llm_triage(log_text: str) -> list[TriageFinding]:
     return _parse_llm_findings(content)
 
 
-def _get_llm_client() -> tuple[object, str] | None:
+def _get_llm_client() -> tuple[_LLMClient, str] | None:
     try:
         from langchain_openai import ChatOpenAI
     except ImportError:
@@ -294,15 +299,17 @@ def _get_llm_client() -> tuple[object, str] | None:
             ChatOpenAI(
                 model=DEFAULT_MODEL,
                 base_url=GITHUB_MODELS_BASE_URL,
-                api_key=github_token,
+                api_key=cast(Any, github_token),
                 temperature=0.1,
             ),
             "github-models",
         )
+    if openai_token is None:
+        return None
     return (
         ChatOpenAI(
             model=DEFAULT_MODEL,
-            api_key=openai_token,
+            api_key=cast(Any, openai_token),
             temperature=0.1,
         ),
         "openai",


### PR DESCRIPTION
## Summary
- add a narrow protocol for the optional LLM triage client
- cast LangChain API keys to the accepted dynamic type while preserving runtime behavior
- keep source and consumer template helper copies in sync

## Tests
- python -m py_compile tools/ci_failure_triage.py templates/consumer-repo/tools/ci_failure_triage.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m pytest tests/tools/test_ci_failure_triage.py tests/test_post_ci_summary.py -q
- python -m mypy tools/ci_failure_triage.py
- python -m mypy templates/consumer-repo/tools/ci_failure_triage.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code type safety for the LLM integration component through stronger type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->