### PR TITLE
fix: keep dev tool sync pins exact

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -184,8 +184,7 @@ jobs:
 
           # Run sync check first
           if python ../scripts/sync_dev_dependencies.py \
-            --check \
-            --use-minimum-pins 2>&1 \
+            --check 2>&1 \
             | tee /tmp/sync_output.txt; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
@@ -193,7 +192,7 @@ jobs:
 
             # Apply if not dry run
             if [ "${{ inputs.dry_run }}" != "true" ]; then
-              python ../scripts/sync_dev_dependencies.py --apply --use-minimum-pins
+              python ../scripts/sync_dev_dependencies.py --apply
             fi
           fi
 
@@ -218,7 +217,6 @@ jobs:
           # Use --create-if-missing to add dev deps
           if python ../scripts/sync_dev_dependencies.py \
             --apply \
-            --use-minimum-pins \
             --create-if-missing 2>&1 \
             | tee /tmp/sync_output.txt; then
             if grep -q "version updates" /tmp/sync_output.txt; then

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -352,6 +352,7 @@ def test_autofix_versions_env_is_not_general_template_synced():
     assert ".github/workflows/autofix-versions.env" in version_sync_text
     assert "pyproject.toml .github/workflows/autofix-versions.env" in version_sync_text
     assert "requirements.lock" in version_sync_text
+    assert "--use-minimum-pins" not in version_sync_text
 
 
 def test_consumer_sync_repo_exclusions_live_in_manifest():


### PR DESCRIPTION
## Summary
- remove Maint 52 `--use-minimum-pins` overrides so generated dev-tool-sync PRs keep exact pins from `.github/workflows/autofix-versions.env`
- add regression coverage that Maint 52 no longer opts into minimum pins

## Validation
- uv run pytest tests/workflows/test_workflow_agents_consolidation.py::test_autofix_versions_env_is_not_general_template_synced tests/scripts/test_sync_dev_dependencies.py -q
- git diff --check

## Context
This addresses active review debt on the current `deps: sync dev tool versions` wave, where generated PRs changed exact dev-tool pins to lower bounds.