### PR TITLE
fix: cast ci triage llm clients

### DIFF
--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -296,21 +296,27 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
 
     if github_token:
         return (
-            ChatOpenAI(
-                model=DEFAULT_MODEL,
-                base_url=GITHUB_MODELS_BASE_URL,
-                api_key=cast(Any, github_token),
-                temperature=0.1,
+            cast(
+                _LLMClient,
+                ChatOpenAI(
+                    model=DEFAULT_MODEL,
+                    base_url=GITHUB_MODELS_BASE_URL,
+                    api_key=cast(Any, github_token),
+                    temperature=0.1,
+                ),
             ),
             "github-models",
         )
     if openai_token is None:
         return None
     return (
-        ChatOpenAI(
-            model=DEFAULT_MODEL,
-            api_key=cast(Any, openai_token),
-            temperature=0.1,
+        cast(
+            _LLMClient,
+            ChatOpenAI(
+                model=DEFAULT_MODEL,
+                api_key=cast(Any, openai_token),
+                temperature=0.1,
+            ),
         ),
         "openai",
     )

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -296,21 +296,27 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
 
     if github_token:
         return (
-            ChatOpenAI(
-                model=DEFAULT_MODEL,
-                base_url=GITHUB_MODELS_BASE_URL,
-                api_key=cast(Any, github_token),
-                temperature=0.1,
+            cast(
+                _LLMClient,
+                ChatOpenAI(
+                    model=DEFAULT_MODEL,
+                    base_url=GITHUB_MODELS_BASE_URL,
+                    api_key=cast(Any, github_token),
+                    temperature=0.1,
+                ),
             ),
             "github-models",
         )
     if openai_token is None:
         return None
     return (
-        ChatOpenAI(
-            model=DEFAULT_MODEL,
-            api_key=cast(Any, openai_token),
-            temperature=0.1,
+        cast(
+            _LLMClient,
+            ChatOpenAI(
+                model=DEFAULT_MODEL,
+                api_key=cast(Any, openai_token),
+                temperature=0.1,
+            ),
         ),
         "openai",
     )


### PR DESCRIPTION
## Summary
- cast constructed ChatOpenAI clients to the local LLM protocol type
- keep source and consumer template ci_failure_triage helpers in sync

## Validation
- python -m py_compile tools/ci_failure_triage.py templates/consumer-repo/tools/ci_failure_triage.py
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- python -m pytest tests/tools/test_ci_failure_triage.py tests/test_post_ci_summary.py -q
- python -m mypy tools/ci_failure_triage.py
- python -m mypy templates/consumer-repo/tools/ci_failure_triage.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type annotations for CI failure triage tooling to improve code consistency and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->