### PR TITLE
test: lock dependency bot condition hardening

### DIFF
--- a/.github/workflows/maint-auto-label-dep-prs.yml
+++ b/.github/workflows/maint-auto-label-dep-prs.yml
@@ -4,6 +4,7 @@ name: Auto-label dependency PRs
 # became the fleet's bumper; not a gate check, so the check-run rename is safe.
 
 on:
+  # zizmor: ignore[dangerous-triggers] labels dependency-bot PRs only; does not checkout or run PR code
   pull_request_target:
     types: [opened]
 
@@ -17,6 +18,8 @@ concurrency:
 jobs:
   label:
     # Dependabot and Renovate both produce dependency PRs that should carry agents:allow-change.
+    # This pull_request_target workflow must trust the immutable PR author, not
+    # github.actor, because actor can be a maintainer rerunning a bot-authored PR.
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maint-auto-lock-deps.yml
+++ b/.github/workflows/maint-auto-lock-deps.yml
@@ -32,9 +32,14 @@ jobs:
   regenerate-lock:
     name: Regenerate requirements.lock
     runs-on: ubuntu-latest
+    # This workflow runs on pull_request, not pull_request_target, so checking
+    # out github.head_ref is not an untrusted-code privileged checkout.
+    # Gate on the immutable PR author rather than github.actor, which can be a
+    # maintainer rerunning a bot-authored PR.
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
+      # zizmor: ignore[artipacked] this backstop intentionally pushes regenerated requirements.lock
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}

--- a/tests/workflows/test_dependency_bot_conditions.py
+++ b/tests/workflows/test_dependency_bot_conditions.py
@@ -1,0 +1,41 @@
+import pathlib
+
+import yaml
+
+
+WORKFLOW_ROOT = pathlib.Path(".github/workflows")
+SYNC_MANIFEST = pathlib.Path(".github/sync-manifest.yml")
+ACTIVE_DEPENDENCY_BOT_WORKFLOWS = (
+    WORKFLOW_ROOT / "maint-auto-label-dep-prs.yml",
+    WORKFLOW_ROOT / "maint-auto-lock-deps.yml",
+)
+RETIRED_CONSUMER_AUTOMERGE = pathlib.Path(
+    "templates/consumer-repo/.github/workflows/dependabot-automerge.yml"
+)
+
+
+def _workflow_source(path: pathlib.Path) -> str:
+    assert path.exists(), f"Expected workflow file to exist: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_dependency_bot_workflows_gate_on_pr_author_not_trigger_actor():
+    for workflow in ACTIVE_DEPENDENCY_BOT_WORKFLOWS:
+        source = _workflow_source(workflow)
+        assert "github.event.pull_request.user.login" in source
+        assert "github.actor == 'dependabot[bot]'" not in source
+        assert "github.actor == 'renovate[bot]'" not in source
+
+
+def test_auto_lock_documents_pull_request_head_ref_trust_boundary():
+    source = _workflow_source(WORKFLOW_ROOT / "maint-auto-lock-deps.yml")
+    assert "pull_request, not pull_request_target" in source
+    assert "github.head_ref is not an untrusted-code privileged checkout" in source
+
+
+def test_retired_consumer_dependabot_automerge_template_stays_removed():
+    assert not RETIRED_CONSUMER_AUTOMERGE.exists()
+
+    manifest = yaml.safe_load(SYNC_MANIFEST.read_text(encoding="utf-8")) or {}
+    removal_targets = {entry.get("target") for entry in manifest.get("removals", [])}
+    assert ".github/workflows/dependabot-automerge.yml" in removal_targets

--- a/tests/workflows/test_dependency_bot_conditions.py
+++ b/tests/workflows/test_dependency_bot_conditions.py
@@ -2,7 +2,6 @@ import pathlib
 
 import yaml
 
-
 WORKFLOW_ROOT = pathlib.Path(".github/workflows")
 SYNC_MANIFEST = pathlib.Path(".github/sync-manifest.yml")
 ACTIVE_DEPENDENCY_BOT_WORKFLOWS = (


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2366 -->
> **Source:** Issue #2366

Closes #2366

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2365](https://github.com/stranske/Workflows/issues/2365)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `maint-dependabot-auto-label.yml:16` — gate on `github.event.pull_request.user.login == 'dependabot[bot]'` (reliable). If the trigger is not a PR event, use `github.triggering_actor` and document why.
- [ ] `maint-dependabot-auto-lock.yml:26` — same hardening; also verify the `github.head_ref` checkout is not a `pull_request_target` + untrusted-checkout footgun (if it is, note it for the dangerous-triggers follow-up).
- [ ] `templates/consumer-repo/.github/workflows/dependabot-automerge.yml:20` — drop the redundant `github.actor` term (keep `user.login`) OR add `# zizmor: ignore[bot-conditions]` with a one-line justification. Apply via the **template sync** mechanism, not a hand-patch to consumers.

#### Acceptance criteria
- [ ] Named gate: `pipx run zizmor --config .github/zizmor.yml .github/workflows/maint-dependabot-auto-label.yml .github/workflows/maint-dependabot-auto-lock.yml templates/consumer-repo/.github/workflows/dependabot-automerge.yml` reports **0 `bot-conditions`** findings.
- [ ] Deliberate-break → revert: re-introduce a bare `if: github.actor == 'dependabot[bot]'` on one file, confirm zizmor reports `bot-conditions` for it, then revert.

<!-- auto-status-summary:end -->

<!-- workflow-source:verifier_followup -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved inline documentation for automated dependency update workflows to clarify trusted authorship vs. actor handling and to better explain lock-regeneration gating boundaries.

* **Tests**
  * Added new workflow condition tests that validate dependency-bot safeguards and trust-boundary checks, including ensuring a retired automerge template remains removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->