### PR TITLE
Refresh registry-backed multi-agent routing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Issue created ──▶ Format ──▶ Optimize ──▶ Apply ──▶ Capa
 | **Format** | `issue_formatter.py` + `task_decomposer.py` restructure the issue into Why / Scope / Tasks / Acceptance Criteria |
 | **Optimize** | `issue_optimizer.py` analyzes the repo codebase and adds file paths, patterns, and conflict warnings |
 | **Apply** | Enriches issue tasks with optimizer suggestions |
-| **Capability Check** | Validates issue suitability for automation; assigns `agent:codex` label |
+| **Capability Check** | Validates issue suitability for automation; assigns the registry-backed `agent:<name>` label (default `agent:codex`, overridable via `runner:<name>`) |
 | **Create PR** | Creates `codex/issue-*` branch with issue context in PR body |
-| **Keepalive** | Event-driven loop (Gate completion → task appendix → Codex CLI dispatch → push → repeat) |
+| **Keepalive** | Event-driven loop (Gate completion → task appendix → registry-backed agent dispatch → push → repeat) |
 | **Verify** | LLM-based evaluation of PR against acceptance criteria (PASS / CONCERNS / FAIL) |
 | **Follow-up** | On CONCERNS/FAIL, creates a follow-up issue with verification gaps as tasks (target max depth 2; automated enforcement pending) |
 

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -20,7 +20,7 @@ Manual dispatch / 30-minute schedule ──▶ agents-70-orchestrator.yml
 Gate workflow_run (PRs) ───────────────▶ agents-keepalive-loop.yml
                                         │
                                         ├─ Evaluate PR keepalive guardrails
-                                        ├─ Run Codex CLI via reusable-codex-run.yml
+                                        ├─ Run the registry-backed agent via its reusable runner workflow
                                         └─ Loop on subsequent Gate completions
 ```
 
@@ -104,7 +104,7 @@ The `agents-auto-pilot.yml` workflow implements a complete end-to-end automation
 | **Format** | Structures issue into standard template | ✅ Inline: `issue_formatter.py` | `agents:formatted` |
 | **Optimize** | Analyzes and suggests improvements | ✅ Inline: `issue_optimizer.py` | (none - adds comment) |
 | **Apply** | Applies optimization suggestions | ✅ Inline: `apply_suggestions()` | `agents:apply-suggestions` |
-| **Capability Check** | Validates agent can handle task | 🏷️ Label: `agent:codex` (triggers capability workflow) | `agent:codex` |
+| **Capability Check** | Validates agent can handle task | 🏷️ Label: `agent:<name>` (registry default or runner override) | `agent:<name> (registry default or runner override)` |
 | **Create PR** | Creates branch and initial PR | ✅ Direct: GitHub API | (converts issue to PR) |
 | **Monitor** | Tracks PR progress via keepalive | 🏷️ Label: `agents:keepalive` (triggers keepalive) | `agents:keepalive` |
 | **Check Completion** | Verifies all tasks done, CI passes | ✅ Inline: Checks CI status directly | (checks state) |

--- a/docs/keepalive/Agents.md
+++ b/docs/keepalive/Agents.md
@@ -49,7 +49,7 @@ Auto-pilot pipeline:
 | Formats and enriches the issue | Drives the agent through PR tasks |
 | Creates the PR and branch | Evaluates Gate results and remaining work |
 | Dispatches the next pipeline step | Builds task appendix from PR body checkboxes |
-| Triggers verification post-merge | Dispatches Codex CLI with explicit task context |
+| Triggers verification post-merge | Dispatches the registry-backed agent with explicit task context |
 
 ### Critical Integration Points
 

--- a/docs/keepalive/GoalsAndPlumbing.md
+++ b/docs/keepalive/GoalsAndPlumbing.md
@@ -142,6 +142,8 @@ The keepalive loop routes to agent workflows through `.github/agents/registry.ym
 |-------|-------|----------|
 | `agent:codex` | Codex CLI (gpt-5.5; fallback gpt-5.4) | `reusable-codex-run.yml` |
 | `agent:claude` | Claude CLI | `reusable-claude-run.yml` |
+| `agent:cursor` | Cursor | `reusable-cursor-run.yml` |
+| `agent:gemini` | Gemini | `reusable-gemini-run.yml` |
 
 The table above is a snapshot of the current registry, not a second source of truth. See [`MULTI_AGENT_ROUTING.md`](MULTI_AGENT_ROUTING.md) and [`../guides/ADD_NEW_AGENT.md`](../guides/ADD_NEW_AGENT.md) for implementation details and how to add new agents.
 

--- a/docs/keepalive/MULTI_AGENT_ROUTING.md
+++ b/docs/keepalive/MULTI_AGENT_ROUTING.md
@@ -15,6 +15,8 @@ The keepalive system routes work to different agents based on the `agent:*` labe
 |-------|-------|----------|
 | `agent:codex` | Codex CLI (gpt-5.5; fallback gpt-5.4) | `reusable-codex-run.yml` |
 | `agent:claude` | Claude CLI | `reusable-claude-run.yml` |
+| `agent:cursor` | Cursor | `reusable-cursor-run.yml` |
+| `agent:gemini` | Gemini | `reusable-gemini-run.yml` |
 
 The authoritative list lives in `.github/agents/registry.yml`; update that registry and the matching runner workflow before adding labels to this table.
 

--- a/tests/docs/test_workflow_source_docs.py
+++ b/tests/docs/test_workflow_source_docs.py
@@ -71,6 +71,8 @@ def test_agent_routing_doc_covers_enabled_registry_agents() -> None:
         if config.get("runner_workflow") and config.get("enabled", True) is not False
     }
 
+    assert set(active_runners) == {"codex", "claude", "cursor", "gemini"}
+
     missing = [
         f"{agent} ({Path(workflow).name})"
         for agent, workflow in active_runners.items()

--- a/tests/docs/test_workflow_source_docs.py
+++ b/tests/docs/test_workflow_source_docs.py
@@ -77,7 +77,8 @@ def test_agent_routing_doc_covers_enabled_registry_agents() -> None:
         if f"agent:{agent}" not in routing_doc or Path(workflow).name not in routing_doc
     ]
 
-    assert not missing, (
-        "docs/keepalive/MULTI_AGENT_ROUTING.md is missing active registry agents: "
-        + ", ".join(missing)
+    assert (
+        not missing
+    ), "docs/keepalive/MULTI_AGENT_ROUTING.md is missing active registry agents: " + ", ".join(
+        missing
     )

--- a/tests/docs/test_workflow_source_docs.py
+++ b/tests/docs/test_workflow_source_docs.py
@@ -11,6 +11,8 @@ from tools import langchain_client
 README = Path("README.md")
 WORKFLOWS_DOC = Path("docs/ci/WORKFLOWS.md")
 WORKFLOWS_DIR = Path(".github/workflows")
+AGENT_REGISTRY = Path(".github/agents/registry.yml")
+MULTI_AGENT_ROUTING_DOC = Path("docs/keepalive/MULTI_AGENT_ROUTING.md")
 
 
 def _default_compare_models() -> tuple[str, str]:
@@ -57,3 +59,25 @@ def test_workflows_doc_names_gate_autofix_dispatch_path() -> None:
     )
     assert 'gate --> autofixDispatch["Autofix Dispatch' in doc
     assert 'autofixDispatch --> autofixLoop["Agents Autofix Loop' in doc
+
+
+def test_agent_routing_doc_covers_enabled_registry_agents() -> None:
+    registry = yaml.safe_load(AGENT_REGISTRY.read_text(encoding="utf-8"))
+    routing_doc = MULTI_AGENT_ROUTING_DOC.read_text(encoding="utf-8")
+
+    active_runners = {
+        agent: config["runner_workflow"]
+        for agent, config in registry["agents"].items()
+        if config.get("runner_workflow") and config.get("enabled", True) is not False
+    }
+
+    missing = [
+        f"{agent} ({Path(workflow).name})"
+        for agent, workflow in active_runners.items()
+        if f"agent:{agent}" not in routing_doc or Path(workflow).name not in routing_doc
+    ]
+
+    assert not missing, (
+        "docs/keepalive/MULTI_AGENT_ROUTING.md is missing active registry agents: "
+        + ", ".join(missing)
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2445 -->
> **Source:** Issue #2445

Closes #2445

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/keepalive/MULTI_AGENT_ROUTING.md:14–18` lists only `agent:codex → reusable-codex-run.yml` and `agent:claude → reusable-claude-run.yml`. The actual `.github/agents/registry.yml` has four agents with non-empty runner workflows: codex, claude, cursor (`runner_workflow: .github/workflows/reusable-cursor-run.yml`, `pr_keepalive: true`), and gemini (`enabled: true`, `runner_workflow: .github/workflows/reusable-gemini-run.yml`, `pr_keepalive: true`). The same two-agent snapshot is frozen in `docs/keepalive/GoalsAndPlumbing.md:141–145` (Section 7 Agent Routing). Five additional stale claims name Codex as the exclusive agent: `README.md:58` says Capability Check "assigns `agent:codex` label"; `README.md:60` says Keepalive does "Codex CLI dispatch"; `docs/agent-automation.md:23` says "Run Codex CLI via reusable-codex-run.yml"; `docs/agent-automation.md:107` hard-codes `agent:codex` in the Capability Check row; `docs/keepalive/Agents.md:52` says "Dispatches Codex CLI with explicit task context." This is **latent fragility, not a current break**: no CI guard catches when the routing docs fall behind the registry, so new agents silently become invisible to anyone reading these docs.

#### Tasks
- [ ] In `docs/keepalive/MULTI_AGENT_ROUTING.md:14–18`, add `| \`agent:cursor\` | Cursor | \`reusable-cursor-run.yml\` |` and `| \`agent:gemini\` | Gemini | \`reusable-gemini-run.yml\` |` rows. Preserve the line 19 note: "The authoritative list lives in `.github/agents/registry.yml`".
- [ ] In `docs/keepalive/GoalsAndPlumbing.md:141–145` (Section 7), add cursor and gemini rows or replace the table body with a note deferring to `MULTI_AGENT_ROUTING.md`. Preserve line 146 anchor text.
- [ ] In `README.md:58`, change "assigns `agent:codex` label" to "assigns the registry-backed `agent:<name>` label (default `agent:codex`, overridable via `runner:<name>`)."
- [ ] In `README.md:60`, change "Codex CLI dispatch" to "registry-backed agent dispatch."
- [ ] In `docs/agent-automation.md:23`, change "Run Codex CLI via reusable-codex-run.yml" to "Run the registry-backed agent via its reusable runner workflow."
- [ ] In `docs/agent-automation.md:107`, change the Capability Check label column from `agent:codex` to `agent:<name> (registry default or runner override)`.
- [ ] In `docs/keepalive/Agents.md:52`, change "Dispatches Codex CLI with explicit task context" to "Dispatches the registry-backed agent with explicit task context."
- [ ] Add `test_agent_routing_doc_covers_enabled_registry_agents()` to `tests/docs/test_workflow_source_docs.py`: load `registry.yml` with PyYAML, collect agents where `runner_workflow` is non-empty and `enabled != false`, read `docs/keepalive/MULTI_AGENT_ROUTING.md`, assert each agent key appears in the doc.

#### Acceptance criteria
- [ ] `rg "assigns .agent:codex. label" README.md` returns no matches.
- [ ] `rg "Codex CLI dispatch|Codex CLI via reusable-codex|Dispatches Codex CLI" README.md docs/agent-automation.md docs/keepalive/Agents.md` returns no matches.
- [ ] `rg "cursor|gemini" docs/keepalive/MULTI_AGENT_ROUTING.md` returns at least two matches (one row per new agent).
- [ ] **Deliberate-break gate:** add a fake registry entry `fakerobot` with a non-empty `runner_workflow` to `.github/agents/registry.yml`. Run `pytest tests/docs/test_workflow_source_docs.py::test_agent_routing_doc_covers_enabled_registry_agents -v` — it **must FAIL** naming `fakerobot`. Revert; test must pass. Capture failure output before reverting.
- [ ] `pytest tests/workflows/test_workflow_agents_consolidation.py -v` passes with no regressions from the doc edits.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the “Auto-Pilot Pipeline” stage descriptions and keepalive wording to reflect registry-backed agent dispatch with dynamic `agent:<name>` routing.
  * Refreshed keepalive and multi-agent routing docs, including expanded agent-to-workflow mappings for Cursor and Gemini.

* **Tests**
  * Added contract coverage to verify the multi-agent routing documentation stays in sync with the enabled agent registry (including required `agent:<name>` and workflow references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->