### PR TITLE
[codex] Add LangSmith fleet artifact upload

### DIFF
--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -2190,6 +2190,7 @@ jobs:
           echo "All checks passed!"
 
       - name: Resolve primary python version
+        if: ${{ always() }}
         run: |
           python - <<'PY'
           import json
@@ -2477,7 +2478,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: langsmith-fleet.ndjson
+          name: ${{ inputs['artifact-prefix'] }}langsmith-fleet
           path: ${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -2450,6 +2450,39 @@ jobs:
           retention-days: 7
           overwrite: true
 
+      - name: Check LangSmith fleet telemetry artifact
+        id: langsmith_fleet_artifact
+        if: >-
+          ${{
+          always()
+          && matrix.python-version == env.PRIMARY_PYTHON_VERSION
+          }}
+        run: |
+          set -euo pipefail
+          fleet_path="${PROJECT_ROOT}/artifacts/langsmith/langsmith-fleet.ndjson"
+          if [ -f "$fleet_path" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "path=$fleet_path" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload LangSmith fleet telemetry artifact
+        if: >-
+          ${{
+          always()
+          && matrix.python-version == env.PRIMARY_PYTHON_VERSION
+          && steps.langsmith_fleet_artifact.outputs.exists == 'true'
+          }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: langsmith-fleet.ndjson
+          path: ${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson
+          if-no-files-found: warn
+          retention-days: 90
+          overwrite: true
+
   logs_summary:
     name: logs summary
     needs:

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -217,8 +217,7 @@ def test_artifact_names_normalized() -> None:
     assert langsmith_upload_step["uses"] == "actions/upload-artifact@v7"
     assert langsmith_upload_step["continue-on-error"] is True
     assert (
-        langsmith_upload_step["with"]["name"]
-        == "${{ inputs['artifact-prefix'] }}langsmith-fleet"
+        langsmith_upload_step["with"]["name"] == "${{ inputs['artifact-prefix'] }}langsmith-fleet"
     )
     assert (
         langsmith_upload_step["with"]["path"]

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -205,6 +205,36 @@ def test_artifact_names_normalized() -> None:
     delta_step = _step("Upload coverage delta artifact")
     assert delta_step["with"]["name"] == "${{ inputs['artifact-prefix'] }}coverage-delta"
 
+    langsmith_check_step = _step("Check LangSmith fleet telemetry artifact")
+    assert langsmith_check_step["id"] == "langsmith_fleet_artifact"
+    assert "artifacts/langsmith/langsmith-fleet.ndjson" in langsmith_check_step["run"]
+    assert "exists=true" in langsmith_check_step["run"]
+
+    langsmith_upload_step = _step("Upload LangSmith fleet telemetry artifact")
+    assert langsmith_upload_step["uses"] == "actions/upload-artifact@v7"
+    assert langsmith_upload_step["continue-on-error"] is True
+    assert langsmith_upload_step["with"]["name"] == "langsmith-fleet.ndjson"
+    assert (
+        langsmith_upload_step["with"]["path"]
+        == "${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson"
+    )
+    assert langsmith_upload_step["with"]["if-no-files-found"] == "warn"
+    assert langsmith_upload_step["with"]["retention-days"] == 90
+    assert langsmith_upload_step["with"]["overwrite"] is True
+
+    upload_if = _normalize_expr(langsmith_upload_step["if"])
+    assert "always()" in upload_if
+    assert "matrix.python-version==env.PRIMARY_PYTHON_VERSION" in upload_if
+    assert "steps.langsmith_fleet_artifact.outputs.exists=='true'" in upload_if
+
+    step_names = [step.get("name") for step in steps]
+    assert step_names.index("Check LangSmith fleet telemetry artifact") > step_names.index(
+        "Upload coverage trend history artifact"
+    )
+    assert step_names.index("Upload LangSmith fleet telemetry artifact") == (
+        step_names.index("Check LangSmith fleet telemetry artifact") + 1
+    )
+
 
 def test_workflow_uses_shared_mypy_pin_helper() -> None:
     workflow = _load_workflow()

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -205,6 +205,9 @@ def test_artifact_names_normalized() -> None:
     delta_step = _step("Upload coverage delta artifact")
     assert delta_step["with"]["name"] == "${{ inputs['artifact-prefix'] }}coverage-delta"
 
+    primary_step = _step("Resolve primary python version")
+    assert _normalize_expr(primary_step["if"]) == "${{always()}}"
+
     langsmith_check_step = _step("Check LangSmith fleet telemetry artifact")
     assert langsmith_check_step["id"] == "langsmith_fleet_artifact"
     assert "artifacts/langsmith/langsmith-fleet.ndjson" in langsmith_check_step["run"]
@@ -213,7 +216,10 @@ def test_artifact_names_normalized() -> None:
     langsmith_upload_step = _step("Upload LangSmith fleet telemetry artifact")
     assert langsmith_upload_step["uses"] == "actions/upload-artifact@v7"
     assert langsmith_upload_step["continue-on-error"] is True
-    assert langsmith_upload_step["with"]["name"] == "langsmith-fleet.ndjson"
+    assert (
+        langsmith_upload_step["with"]["name"]
+        == "${{ inputs['artifact-prefix'] }}langsmith-fleet"
+    )
     assert (
         langsmith_upload_step["with"]["path"]
         == "${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson"


### PR DESCRIPTION
## Summary
- upload `artifacts/langsmith/langsmith-fleet.ndjson` from reusable Python CI when a consumer repo produces it
- restrict the upload to the primary Python matrix entry to avoid duplicate artifact names
- add workflow contract coverage for the LangSmith fleet telemetry artifact

## Validation
- `uv run pytest tests/workflows/test_reusable_ci_workflow.py tests/workflows/test_langsmith_metrics_dashboard.py tests/scripts/test_langsmith_fleet.py tests/scripts/test_langsmith_fleet_conformance.py`
- `scripts/sync_templates.sh`
- `python scripts/validate_template_completeness.py`

## Orchestrator context
This closes the producer side of the dry LangSmith execution plane. The local Orchestrator fetcher was also updated and mirror-synced so rollup fallback scans paginated artifact lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to always resolve the primary Python version, even if earlier steps fail.
  * Added conditional LangSmith “fleet telemetry” artifact collection and upload with safe missing-file handling and 90-day retention.
* **Tests**
  * Extended CI workflow validation to verify the new telemetry artifact steps’ configuration, gating behavior, and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- workflow-source:local_request -->
