### PR TITLE
feat(repo-review): surface dynamic run-evidence in the weekly evaluator

### DIFF
--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -43,6 +43,7 @@ Every active repo review uses the same dimensions:
 - `test_and_live_readiness`: determine whether tests or smoke paths prove the user journey required by the design.
 - `integration_and_state`: check cross-repo contracts, external providers, persistence, reload behavior, source authority, generated artifacts, and workflow handoffs.
 - `issue_generation`: convert verified gaps into issue drafts with evidence, non-goals, tasks, acceptance criteria, and tests that would fail before the fix.
+- `dynamic_run_evidence`: real run-outcome evidence the static review cannot see — reverted/abandoned agent PRs and recurring failure patterns from the week's runs. This dimension is **automated and locally sourced**: the evaluator shells to the Orchestrator feedback Brain (`keepalive_evidence.py`) and the dimension is present only when that local store is reachable. It degrades silently (the dimension is omitted, never an error) wherever the Brain is absent, e.g. CI. A reverted PR raises a `material` gap; an abandoned PR or recurring failure raises `needs human decision`; a candidate whose linked issue is still open is flagged as already-tracked rather than net-new.
 
 ## Weekly Run
 
@@ -153,7 +154,7 @@ If natural-language GitNexus query returns no processes and the repo map has `em
 
 `decision-brief.md` is the human review surface. It summarizes current progress against the design anchor, readiness for testing/live implementation, candidate issue set, and a compact feedback slot for approve/revise/defer/drop/deeper-review decisions.
 
-`review-execution.md` is the automated execution phase. It gathers evidence for each standard dimension and classifies obvious automated gaps such as missing design sources, missing implementation surfaces, missing tests/workflows, or absent smoke/live-readiness markers. Dimensions marked `needs human decision` still require semantic review before issue approval.
+`review-execution.md` is the automated execution phase. It gathers evidence for each standard dimension and classifies obvious automated gaps such as missing design sources, missing implementation surfaces, missing tests/workflows, or absent smoke/live-readiness markers. When the local Orchestrator feedback Brain is reachable it also adds the `dynamic_run_evidence` dimension — reverted/abandoned PRs and recurring failures observed in the week's runs — which the static design-vs-implementation pass structurally cannot detect. Dimensions marked `needs human decision` still require semantic review before issue approval.
 
 ## Archive Use
 

--- a/scripts/repo_review_evaluator.py
+++ b/scripts/repo_review_evaluator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -524,6 +525,107 @@ def gap_label(severity: str) -> str:
     return "no"
 
 
+def _resolve_orchestrator_cli(name: str = "keepalive_evidence.py") -> Path | None:
+    """Locate an Orchestrator Brain CLI. The repo-review runs locally and reaches the Brain via the
+    Dropbox canonical dir or the launchd-readable mirror; CI reaches neither (degrade silently)."""
+    candidates: list[Path] = []
+    env_dir = os.environ.get("ORCH_DIR")
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser() / name)
+    candidates.append(Path("~/.codex/orchestrator-mirror").expanduser() / name)
+    candidates.append(
+        Path("~/Library/CloudStorage/Dropbox/Learning/Code/Orchestrator").expanduser() / name
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def build_dynamic_run_evidence(state: dict[str, Any]) -> dict[str, Any] | None:
+    """Automated dimension fed by the local feedback Brain (keepalive_evidence.py): real run-outcome
+    evidence (reverted/abandoned PRs, recurring failures) the static design review cannot see. Returns
+    None — and the dimension is omitted — whenever the Brain/CLI is unavailable (e.g. CI), so the
+    evaluator never depends on local-only state for correctness."""
+    repo = state.get("repo")
+    cli = _resolve_orchestrator_cli()
+    if not repo or cli is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["python3", str(cli), "--repo", repo, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        data = json.loads(proc.stdout)
+    except ValueError:
+        return None
+    candidates = data.get("candidates") or []
+    signals = data.get("signals") or {}
+    # Net-new = the static review missed it; already-tracked = an open issue already covers it.
+    fresh = [c for c in candidates if not c.get("possible_duplicate")]
+    tracked = [c for c in candidates if c.get("possible_duplicate")]
+    high = [c for c in fresh if c.get("severity") == "HIGH"]
+    other = [c for c in fresh if c.get("severity") != "HIGH"]
+    tracked_high = [c for c in tracked if c.get("severity") == "HIGH"]
+    if high:
+        severity = "material"
+    elif other or tracked_high:
+        # A tracked reversal stays a human-decision nudge (confirm the open issue captures the revert).
+        severity = "needs human decision"
+    else:
+        severity = "none"
+    by_type: dict[str, int] = {}
+    for candidate in fresh:
+        by_type[candidate["type"]] = by_type.get(candidate["type"], 0) + 1
+    durable_rate = signals.get("durable_rate")
+    rate_text = f"{durable_rate:.2f}" if isinstance(durable_rate, (int, float)) else "n/a"
+    evidence = [
+        f"Source: local feedback Brain keepalive run outcomes ({data.get('lookback_days', 30)}d window).",
+        f"Net-new candidates: {len(fresh)} (by type: {by_type or 'none'}).",
+        f"Repo durable-rate: {rate_text}.",
+    ]
+    for candidate in (high + other)[:6]:
+        evidence.append(f"[{candidate.get('severity')}] {candidate.get('seed')}")
+    if tracked:
+        refs = ", ".join(
+            f"{c.get('type')} PR#{c.get('evidence', {}).get('pr', '?')}->#{c.get('dup_issue')}"
+            for c in tracked[:5]
+        )
+        evidence.append(
+            f"Already tracked by open issues (confirm each captures the run outcome, not net-new): {refs}"
+        )
+    finding_parts: list[str] = []
+    if fresh:
+        finding_parts.append(
+            f"{len(fresh)} net-new candidate(s) the static design review cannot see "
+            f"({len(high)} reverted/breaking, {len(other)} abandoned/recurring)"
+        )
+    if tracked:
+        finding_parts.append(f"{len(tracked)} already tracked by an open issue (confirm coverage)")
+    if finding_parts:
+        finding = "; ".join(finding_parts) + " — review for durable-fix or regression-test issues."
+    else:
+        finding = (
+            "No reverted, abandoned, or recurring-failure run evidence in the window; "
+            "nothing the static review missed."
+        )
+    return {
+        "id": "dynamic_run_evidence",
+        "label": "Dynamic Run Evidence",
+        "evidence": evidence,
+        "finding": finding,
+        "gap_severity": severity,
+        "issue_draft_needed": gap_label(severity),
+    }
+
+
 def build_review_execution(state: dict[str, Any]) -> dict[str, Any]:
     repo_path = Path(state["local_path"])
     tracked_files = tracked_repo_files(repo_path)
@@ -744,6 +846,10 @@ def build_review_execution(state: dict[str, Any]) -> dict[str, Any]:
             "issue_draft_needed": gap_label(issue_severity),
         }
     )
+
+    dynamic_dimension = build_dynamic_run_evidence(state)
+    if dynamic_dimension is not None:
+        dimensions.append(dynamic_dimension)
 
     gap_count = sum(
         1


### PR DESCRIPTION
## What

Adds a `dynamic_run_evidence` dimension to the weekly repo-review evaluator. It shells to the local Orchestrator feedback Brain (`keepalive_evidence.py`) and surfaces real run-outcome evidence the static design-vs-implementation review cannot see: reverted/abandoned agent PRs and recurring failure patterns from the week's runs.

## Why

The repo-review only compared design docs to code — it was blind to what actually broke or failed to hold when agents ran. The Brain now records per-PR keepalive outcomes (durable / pending / abandoned / reverted) for every active repo; this dimension turns that into candidate issue-seeds for the human-decision packet.

## Behavior

- **Severity:** reverted PR → `material`; abandoned PR or recurring failure → `needs human decision`; clean repo → `none`.
- A candidate whose **linked issue is still open** is shown as already-tracked context (not a net-new gap), so the automation doesn't re-file tracked work.
- **Degrades silently:** when the Brain/CLI is unreachable (e.g. CI), the dimension is omitted — never an error. The evaluator never depends on local-only state for correctness.

## Test (last 30 days, 10 active repos)

- 22 net-new candidates (19 abandoned PRs with closed linked issues, 3 recurring failures) + 1 already-tracked (the fleet's only reversal, whose linked issue is open → correctly flagged).
- Real recurring gotchas surfaced by name (Counter_Risk Black-vs-ruff mismatch; Trend ruff-format churn).
- Severity gradient verified on Trend (`material`→`needs human decision` after dedup), Counter_Risk (`needs human decision`), Pension-Data (`none`); degrade path returns `None`.

The evidence generator (`keepalive_evidence.py`) and the ingest live in the local Orchestrator and are *called*, not vendored into this repo. Docs updated in `docs/ops/REPO_REVIEW_PROCESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated repository review process documentation with details on the new dynamic run evidence dimension and its integration during the review execution phase.

* **New Features**
  * Introduced automated dynamic run evidence dimension that pulls feedback from local Orchestrator sources. Automatically categorizes PR outcomes and computes gap severity to identify issues requiring attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->