### PR TITLE
Issue #2475: Add opt-in deliberate-break Gate check

### DIFF
--- a/.github/scripts/gate_summary.py
+++ b/.github/scripts/gate_summary.py
@@ -21,6 +21,7 @@ class SummaryContext:
     output_path: Path | None
     python_required: bool = True
     docs_guard_result: str = "success"
+    test_quality_result: str = "skipped"
 
 
 @dataclass(slots=True)
@@ -243,6 +244,7 @@ def _append_job_table(
     job_results: Mapping[str, Iterable[str]],
     docs_guard_result: str,
     docker_result: str,
+    test_quality_result: str,
 ) -> None:
     lines.append("")
     lines.append("| Job | Result |")
@@ -252,6 +254,7 @@ def _append_job_table(
         lines.append(f"| {job_name} | {_friendly(result)} |")
     lines.append(f"| docs-guard | {_friendly(docs_guard_result)} |")
     lines.append(f"| docker-smoke | {_friendly(docker_result)} |")
+    lines.append(f"| test-quality | {_friendly(test_quality_result)} |")
 
 
 def _active_lines(
@@ -264,9 +267,10 @@ def _active_lines(
     job_results: Mapping[str, list[str]],
     docs_guard_result: str = "success",
     docker_result: str = "skipped",
+    test_quality_result: str = "skipped",
 ) -> list[str]:
     lines = ["### Gate status", *table]
-    _append_job_table(lines, job_results, docs_guard_result, docker_result)
+    _append_job_table(lines, job_results, docs_guard_result, docker_result, test_quality_result)
 
     lint_status, lint_detail = _aggregate(lint_entries)
     type_status, type_detail = _aggregate(type_entries)
@@ -334,6 +338,7 @@ def summarize(context: SummaryContext) -> SummaryResult:
         job_results,
         docs_guard_result,
         context.docker_result,
+        context.test_quality_result,
     )
 
     state = "success"
@@ -341,6 +346,7 @@ def summarize(context: SummaryContext) -> SummaryResult:
 
     python_result = _normalize(context.python_result or "success")
     docker_result_norm = _normalize(context.docker_result or "skipped")
+    test_quality_result = _normalize(context.test_quality_result or "skipped")
     cosmetic_failure = False
     failure_checks: tuple[str, ...] = ()
     format_failure = False
@@ -378,10 +384,20 @@ def summarize(context: SummaryContext) -> SummaryResult:
     elif not context.docker_changed:
         lines.append("- Docker smoke skipped: no Docker-related changes detected.")
 
+    if state == "success":
+        if test_quality_result == "cancelled":
+            state = "pending"
+            description = "Test-quality cancelled; waiting for rerun."
+        elif test_quality_result not in ("success", "skipped"):
+            state = "failure"
+            description = f"Test-quality result: {test_quality_result}."
+
     adjusted_lines = []
     for line in lines:
         if line.startswith("| docker-smoke"):
             adjusted_lines.append(f"| docker-smoke | {_friendly(docker_result_norm)} |")
+        elif line.startswith("| test-quality"):
+            adjusted_lines.append(f"| test-quality | {_friendly(test_quality_result)} |")
         else:
             adjusted_lines.append(line)
 
@@ -409,6 +425,7 @@ def build_context() -> SummaryContext:
     python_result = os.environ.get("PYTHON_RESULT") or "skipped"
     docs_guard_result = os.environ.get("DOCS_GUARD_RESULT") or "success"
     docker_result = os.environ.get("DOCKER_RESULT") or "skipped"
+    test_quality_result = os.environ.get("TEST_QUALITY_RESULT") or "skipped"
     docker_changed = _normalize(os.environ.get("DOCKER_CHANGED"), "false") == "true"
     python_required = _normalize(os.environ.get("PYTHON_REQUIRED"), "true") == "true"
     artifacts_root = Path(os.environ.get("GATE_ARTIFACTS_ROOT", "gate_artifacts"))
@@ -422,6 +439,7 @@ def build_context() -> SummaryContext:
         python_result=python_result,
         docs_guard_result=docs_guard_result,
         docker_result=docker_result,
+        test_quality_result=test_quality_result,
         docker_changed=docker_changed,
         artifacts_root=artifacts_root,
         summary_path=summary_path,

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -238,6 +238,9 @@ scripts:
   - source: scripts/state_fingerprint.py
     description: "Computes workflow state fingerprints for unchanged-state skip gates"
 
+  - source: scripts/check_deliberate_break.py
+    description: "Opt-in Gate helper that proves named deliberate-break acceptance tests fail against the base implementation"
+
   - source: scripts/reference_packs.py
     description: "Validates and resolves reference pack configuration for shared runner prompt assembly"
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -345,7 +345,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
       - name: Apply runtime acceptance-criteria label
         if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issue_number = context.payload.pull_request.number;

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -348,12 +348,23 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            await github.rest.issues.addLabels({
+            const issue_number = context.payload.pull_request.number;
+            const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['acceptance-criteria'],
+              issue_number,
             });
+            const labels = issue.labels.map((label) =>
+              typeof label === 'string' ? label : label.name
+            );
+            if (!labels.includes('acceptance-criteria')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: ['acceptance-criteria'],
+              });
+            }
 
   docker-smoke:
     name: docker smoke

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -307,6 +307,10 @@ jobs:
       - environment-gate
     if: ${{ github.event_name == 'pull_request' && needs.detect.outputs.doc_only != 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -324,11 +328,32 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
+      - name: Install test-quality dependencies
+        run: python -m pip install --upgrade pip pytest
       - name: Check test quality and secret diff
         run: >-
           python scripts/check_gate_diff_quality.py
           --base "refs/remotes/upstream/${{ github.event.pull_request.base.ref }}"
           --head HEAD
+      - name: Check deliberate-break acceptance criterion
+        id: deliberate_break
+        run: >-
+          python scripts/check_deliberate_break.py
+          --base "refs/remotes/upstream/${{ github.event.pull_request.base.ref }}"
+          --head HEAD
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+      - name: Apply runtime acceptance-criteria label
+        if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['acceptance-criteria'],
+            });
 
   docker-smoke:
     name: docker smoke

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -312,7 +312,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -628,6 +628,7 @@ jobs:
           DOCS_GUARD_RESULT: ${{ needs.docs-guard.result || 'success' }}
           PYTHON_REQUIRED: ${{ needs.detect.outputs.is_python_code || 'true' }}
           DOCKER_RESULT: ${{ needs.docker-smoke.result || 'skipped' }}
+          TEST_QUALITY_RESULT: ${{ needs.test-quality.result || 'skipped' }}
           DOCKER_CHANGED: ${{ needs.detect.outputs.docker_changed || 'false' }}
           COVERAGE_ENABLED: ${{ needs.detect.outputs.coverage || 'true' }}
         run: python .github/scripts/gate_summary.py

--- a/docs/keepalive/GoalsAndPlumbing.md
+++ b/docs/keepalive/GoalsAndPlumbing.md
@@ -226,6 +226,18 @@ Keepalive now has two ways to detect task completion and keep PR checkboxes in s
 - The reconciliation step uses the same task text from the Automated Status Summary to avoid accidental mismatch.
 - LLM analysis is optional; if unavailable, the commit/file matcher remains active.
 
+### Deliberate-Break Gate
+
+Gate runs an opt-in execution check when the PR body's Acceptance Criteria declares a deliberate-break marker:
+
+```markdown
+<!-- deliberate-break: test=tests/test_feature.py::test_runtime_contract test-file=tests/test_feature.py break-file=src/feature.py -->
+```
+
+When present, `scripts/check_deliberate_break.py` runs the named test on the PR head, archives the base ref, overlays only the named test file onto that base tree, and reruns the same test. The expected result is green on head and red on base; green on both is reported as `FAIL_HOLLOW`, and red on head is reported as `FAIL_BROKEN`. If no marker is present, the step logs `skipped: no deliberate-break marker` and exits successfully.
+
+The same Gate step applies the `acceptance-criteria` label when a marker is present. That label arms the runtime acceptance merge guard so non-CI-verifiable merge lanes defer to the local Orchestrator runtime acceptance path instead of merging on prose evidence alone.
+
 ---
 
 ## Appendix: Operator Checklist

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -30,6 +31,7 @@ SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+(.+?)\s*$", re.MULTILINE)
 ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
+DEFAULT_TIMEOUT_SECONDS = 120
 
 
 @dataclass(frozen=True)
@@ -128,7 +130,12 @@ def _pytest_command(test_id: str) -> tuple[str, ...]:
     return (sys.executable, "-m", "pytest", test_id, "-q")
 
 
-def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    command: tuple[str, ...],
+    cwd: Path,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     pythonpath = str(cwd)
     if env.get("PYTHONPATH"):
@@ -140,17 +147,33 @@ def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str
         text=True,
         capture_output=True,
         env=env,
+        timeout=timeout,
     )
 
 
-def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def _git(
+    args: list[str],
+    cwd: Path,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
         cwd=cwd,
         check=True,
         text=True,
         capture_output=True,
+        timeout=timeout,
     )
+
+
+def _assertion_diff_lines(diff_text: str) -> Iterator[str]:
+    """Yield removed assertion lines; adding a new assertion is valid test growth."""
+    for line in diff_text.splitlines():
+        if not line.startswith("-") or line.startswith("---"):
+            continue
+        if ASSERTION_DIFF_RE.search(line):
+            yield line[:240]
 
 
 def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list[str]:
@@ -161,15 +184,7 @@ def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list
         ["diff", "--no-ext-diff", "--unified=0", f"{base}...{head}", "--", test_file],
         cwd,
     )
-    hits: list[str] = []
-    for line in completed.stdout.splitlines():
-        if not (line.startswith("+") or line.startswith("-")):
-            continue
-        if line.startswith(("+++", "---")):
-            continue
-        if ASSERTION_DIFF_RE.search(line):
-            hits.append(line[:240])
-    return hits
+    return list(_assertion_diff_lines(completed.stdout))
 
 
 def _archive_ref(base: str, target: Path, cwd: Path) -> None:
@@ -178,9 +193,27 @@ def _archive_ref(base: str, target: Path, cwd: Path) -> None:
         cwd=cwd,
         check=True,
         capture_output=True,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
     )
+    target_root = target.resolve()
     with tarfile.open(fileobj=BytesIO(archive.stdout), mode="r:") as tar:
-        tar.extractall(target, filter="data")
+        for member in tar:
+            member_path = target_root / member.name
+            resolved = member_path.resolve()
+            if not resolved.is_relative_to(target_root):
+                raise ValueError(f"unsafe archive path: {member.name}")
+            if member.isdir():
+                resolved.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                continue
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            source = tar.extractfile(member)
+            if source is None:
+                continue
+            with source, resolved.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+            resolved.chmod(member.mode & 0o777)
 
 
 def verify_spec(
@@ -200,17 +233,26 @@ def verify_spec(
             test_file=spec.test_file,
         )
 
-    if enforce_tamper:
-        tampered = _changed_assertions(base, head, spec.test_file, repo)
-        if tampered:
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="test-assertion-tamper",
-                test_file=spec.test_file,
-                changed_assertions=tampered,
-            )
+    try:
+        if enforce_tamper:
+            tampered = _changed_assertions(base, head, spec.test_file, repo)
+            if tampered:
+                return _json_result(
+                    VERDICT_BROKEN,
+                    reason="test-assertion-tamper",
+                    test_file=spec.test_file,
+                    changed_assertions=tampered,
+                )
 
-    head_run = _run(spec.command, repo)
+        head_run = _run(spec.command, repo)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+
     if head_run.returncode != 0:
         return _json_result(
             VERDICT_BROKEN,
@@ -221,13 +263,27 @@ def verify_spec(
             stderr=head_run.stderr,
         )
 
-    with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
-        base_dir = Path(tmp)
-        _archive_ref(base, base_dir, repo)
-        base_test = base_dir / spec.test_file
-        base_test.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(test_path, base_test)
-        base_run = _run(spec.command, base_dir)
+    try:
+        with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
+            base_dir = Path(tmp)
+            _archive_ref(base, base_dir, repo)
+            base_test = base_dir / spec.test_file
+            base_test.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(test_path, base_test)
+            base_run = _run(spec.command, base_dir)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+    except ValueError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="archive-extract-failed",
+            detail=str(exc),
+        )
 
     if base_run.returncode == 0:
         return _json_result(

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -85,9 +85,7 @@ def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
         break_file = values.get("break-file") or values.get("revert-file")
         command_text = values.get("command")
         if not test_id or not test_file or not break_file:
-            raise ValueError(
-                "deliberate-break marker requires test, test-file, and break-file"
-            )
+            raise ValueError("deliberate-break marker requires test, test-file, and break-file")
         command = tuple(shlex.split(command_text)) if command_text else _pytest_command(test_id)
         return DeliberateBreakSpec(test_id, test_file, break_file, command)
     return None
@@ -102,8 +100,7 @@ def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
         (
             line
             for line in section.splitlines()
-            if "deliberate-break" in line.lower()
-            or "deliberate break" in line.lower()
+            if "deliberate-break" in line.lower() or "deliberate break" in line.lower()
         ),
         "",
     )

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Opt-in execution check for deliberate-break acceptance criteria."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+VERDICT_PASS = "PASS"
+VERDICT_HOLLOW = "FAIL_HOLLOW"
+VERDICT_BROKEN = "FAIL_BROKEN"
+VERDICT_SKIPPED = "SKIPPED"
+
+MARKER_RE = re.compile(
+    r"(?:<!--\s*)?deliberate-break:\s*(?P<body>.*?)(?:\s*-->)?$",
+    re.IGNORECASE,
+)
+SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+(.+?)\s*$", re.MULTILINE)
+ASSERTION_DIFF_RE = re.compile(
+    r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
+)
+
+
+@dataclass(frozen=True)
+class DeliberateBreakSpec:
+    test_id: str
+    test_file: str
+    break_file: str
+    command: tuple[str, ...]
+
+
+def _json_result(verdict: str, **fields: object) -> dict[str, object]:
+    return {"verdict": verdict, **fields}
+
+
+def _write_github_output(**fields: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        for key, value in fields.items():
+            handle.write(f"{key}={value}\n")
+
+
+def _acceptance_criteria(markdown: str) -> str:
+    headers = list(SECTION_HEADER_RE.finditer(markdown))
+    for index, match in enumerate(headers):
+        if match.group(1).strip().lower() != "acceptance criteria":
+            continue
+        start = match.end()
+        end = headers[index + 1].start() if index + 1 < len(headers) else len(markdown)
+        return markdown[start:end].strip()
+    return markdown
+
+
+def _parse_key_values(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for token in shlex.split(text):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        values[key.strip().replace("_", "-").lower()] = value.strip()
+    return values
+
+
+def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
+    for line in section.splitlines():
+        match = MARKER_RE.search(line.strip())
+        if not match:
+            continue
+        values = _parse_key_values(match.group("body"))
+        test_id = values.get("test") or values.get("test-id")
+        test_file = values.get("test-file") or values.get("file")
+        break_file = values.get("break-file") or values.get("revert-file")
+        command_text = values.get("command")
+        if not test_id or not test_file or not break_file:
+            raise ValueError(
+                "deliberate-break marker requires test, test-file, and break-file"
+            )
+        command = tuple(shlex.split(command_text)) if command_text else _pytest_command(test_id)
+        return DeliberateBreakSpec(test_id, test_file, break_file, command)
+    return None
+
+
+def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
+    named_line = next(
+        (line for line in section.splitlines() if "named test:" in line.lower()),
+        "",
+    )
+    break_line = next(
+        (
+            line
+            for line in section.splitlines()
+            if "deliberate-break" in line.lower()
+            or "deliberate break" in line.lower()
+        ),
+        "",
+    )
+    if not named_line or not break_line:
+        return None
+
+    test_file_match = re.search(r"`([^`]*(?:test|tests)[^`]*\.py)`", named_line)
+    test_name_match = re.search(r"\bwith\s+`?([A-Za-z_][A-Za-z0-9_]*)`?", named_line)
+    break_file_match = re.search(r"`([^`]+)`", break_line)
+    if not test_file_match or not test_name_match or not break_file_match:
+        return None
+
+    test_file = test_file_match.group(1)
+    test_id = f"{test_file}::{test_name_match.group(1)}"
+    break_file = break_file_match.group(1)
+    return DeliberateBreakSpec(test_id, test_file, break_file, _pytest_command(test_id))
+
+
+def parse_deliberate_break_spec(markdown: str) -> DeliberateBreakSpec | None:
+    section = _acceptance_criteria(markdown)
+    return _explicit_marker(section) or _fallback_marker(section)
+
+
+def _pytest_command(test_id: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", "pytest", test_id, "-q")
+
+
+def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    pythonpath = str(cwd)
+    if env.get("PYTHONPATH"):
+        pythonpath = pythonpath + os.pathsep + env["PYTHONPATH"]
+    env["PYTHONPATH"] = pythonpath
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list[str]:
+    status = _git(["diff", "--name-status", f"{base}...{head}", "--", test_file], cwd)
+    if any(line.split("\t", 1)[0] == "A" for line in status.stdout.splitlines()):
+        return []
+    completed = _git(
+        ["diff", "--no-ext-diff", "--unified=0", f"{base}...{head}", "--", test_file],
+        cwd,
+    )
+    hits: list[str] = []
+    for line in completed.stdout.splitlines():
+        if not (line.startswith("+") or line.startswith("-")):
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        if ASSERTION_DIFF_RE.search(line):
+            hits.append(line[:240])
+    return hits
+
+
+def _archive_ref(base: str, target: Path, cwd: Path) -> None:
+    archive = subprocess.run(
+        ["git", "archive", "--format=tar", base],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+    with tarfile.open(fileobj=BytesIO(archive.stdout), mode="r:") as tar:
+        tar.extractall(target, filter="data")
+
+
+def verify_spec(
+    spec: DeliberateBreakSpec,
+    *,
+    base: str,
+    head: str = "HEAD",
+    cwd: Path | None = None,
+    enforce_tamper: bool = True,
+) -> dict[str, object]:
+    repo = cwd or Path.cwd()
+    test_path = repo / spec.test_file
+    if not test_path.is_file():
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="test-file-missing",
+            test_file=spec.test_file,
+        )
+
+    if enforce_tamper:
+        tampered = _changed_assertions(base, head, spec.test_file, repo)
+        if tampered:
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="test-assertion-tamper",
+                test_file=spec.test_file,
+                changed_assertions=tampered,
+            )
+
+    head_run = _run(spec.command, repo)
+    if head_run.returncode != 0:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="head-test-failed",
+            test_id=spec.test_id,
+            command=list(spec.command),
+            stdout=head_run.stdout,
+            stderr=head_run.stderr,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
+        base_dir = Path(tmp)
+        _archive_ref(base, base_dir, repo)
+        base_test = base_dir / spec.test_file
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(test_path, base_test)
+        base_run = _run(spec.command, base_dir)
+
+    if base_run.returncode == 0:
+        return _json_result(
+            VERDICT_HOLLOW,
+            reason="test-passed-on-base-with-candidate-test",
+            test_id=spec.test_id,
+            test_file=spec.test_file,
+            break_file=spec.break_file,
+            command=list(spec.command),
+            stdout=base_run.stdout,
+            stderr=base_run.stderr,
+        )
+
+    return _json_result(
+        VERDICT_PASS,
+        reason="head-passed-base-failed",
+        test_id=spec.test_id,
+        test_file=spec.test_file,
+        break_file=spec.break_file,
+        command=list(spec.command),
+        base_stdout=base_run.stdout,
+        base_stderr=base_run.stderr,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-body-file")
+    parser.add_argument("--pr-body-env", default="PR_BODY")
+    parser.add_argument("--no-tamper-check", action="store_true")
+    args = parser.parse_args(argv)
+
+    body = ""
+    if args.pr_body_file:
+        body = Path(args.pr_body_file).read_text(encoding="utf-8")
+    else:
+        body = os.environ.get(args.pr_body_env, "")
+
+    spec = parse_deliberate_break_spec(body)
+    if spec is None:
+        _write_github_output(has_marker="false", verdict=VERDICT_SKIPPED)
+        print(json.dumps(_json_result(VERDICT_SKIPPED, reason="no deliberate-break marker")))
+        print("skipped: no deliberate-break marker")
+        return 0
+
+    _write_github_output(has_marker="true")
+    result = verify_spec(
+        spec,
+        base=args.base,
+        head=args.head,
+        enforce_tamper=not args.no_tamper_check,
+    )
+    _write_github_output(verdict=str(result["verdict"]))
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["verdict"] == VERDICT_PASS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/consumer-repo/.github/scripts/gate_summary.py
+++ b/templates/consumer-repo/.github/scripts/gate_summary.py
@@ -21,6 +21,7 @@ class SummaryContext:
     output_path: Path | None
     python_required: bool = True
     docs_guard_result: str = "success"
+    test_quality_result: str = "skipped"
 
 
 @dataclass(slots=True)
@@ -243,6 +244,7 @@ def _append_job_table(
     job_results: Mapping[str, Iterable[str]],
     docs_guard_result: str,
     docker_result: str,
+    test_quality_result: str,
 ) -> None:
     lines.append("")
     lines.append("| Job | Result |")
@@ -252,6 +254,7 @@ def _append_job_table(
         lines.append(f"| {job_name} | {_friendly(result)} |")
     lines.append(f"| docs-guard | {_friendly(docs_guard_result)} |")
     lines.append(f"| docker-smoke | {_friendly(docker_result)} |")
+    lines.append(f"| test-quality | {_friendly(test_quality_result)} |")
 
 
 def _active_lines(
@@ -264,9 +267,10 @@ def _active_lines(
     job_results: Mapping[str, list[str]],
     docs_guard_result: str = "success",
     docker_result: str = "skipped",
+    test_quality_result: str = "skipped",
 ) -> list[str]:
     lines = ["### Gate status", *table]
-    _append_job_table(lines, job_results, docs_guard_result, docker_result)
+    _append_job_table(lines, job_results, docs_guard_result, docker_result, test_quality_result)
 
     lint_status, lint_detail = _aggregate(lint_entries)
     type_status, type_detail = _aggregate(type_entries)
@@ -334,6 +338,7 @@ def summarize(context: SummaryContext) -> SummaryResult:
         job_results,
         docs_guard_result,
         context.docker_result,
+        context.test_quality_result,
     )
 
     state = "success"
@@ -341,6 +346,7 @@ def summarize(context: SummaryContext) -> SummaryResult:
 
     python_result = _normalize(context.python_result or "success")
     docker_result_norm = _normalize(context.docker_result or "skipped")
+    test_quality_result = _normalize(context.test_quality_result or "skipped")
     cosmetic_failure = False
     failure_checks: tuple[str, ...] = ()
     format_failure = False
@@ -378,10 +384,20 @@ def summarize(context: SummaryContext) -> SummaryResult:
     elif not context.docker_changed:
         lines.append("- Docker smoke skipped: no Docker-related changes detected.")
 
+    if state == "success":
+        if test_quality_result == "cancelled":
+            state = "pending"
+            description = "Test-quality cancelled; waiting for rerun."
+        elif test_quality_result not in ("success", "skipped"):
+            state = "failure"
+            description = f"Test-quality result: {test_quality_result}."
+
     adjusted_lines = []
     for line in lines:
         if line.startswith("| docker-smoke"):
             adjusted_lines.append(f"| docker-smoke | {_friendly(docker_result_norm)} |")
+        elif line.startswith("| test-quality"):
+            adjusted_lines.append(f"| test-quality | {_friendly(test_quality_result)} |")
         else:
             adjusted_lines.append(line)
 
@@ -409,6 +425,7 @@ def build_context() -> SummaryContext:
     python_result = os.environ.get("PYTHON_RESULT") or "skipped"
     docs_guard_result = os.environ.get("DOCS_GUARD_RESULT") or "success"
     docker_result = os.environ.get("DOCKER_RESULT") or "skipped"
+    test_quality_result = os.environ.get("TEST_QUALITY_RESULT") or "skipped"
     docker_changed = _normalize(os.environ.get("DOCKER_CHANGED"), "false") == "true"
     python_required = _normalize(os.environ.get("PYTHON_REQUIRED"), "true") == "true"
     artifacts_root = Path(os.environ.get("GATE_ARTIFACTS_ROOT", "gate_artifacts"))
@@ -422,6 +439,7 @@ def build_context() -> SummaryContext:
         python_result=python_result,
         docs_guard_result=docs_guard_result,
         docker_result=docker_result,
+        test_quality_result=test_quality_result,
         docker_changed=docker_changed,
         artifacts_root=artifacts_root,
         summary_path=summary_path,

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -362,12 +362,23 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            await github.rest.issues.addLabels({
+            const issue_number = context.payload.pull_request.number;
+            const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['acceptance-criteria'],
+              issue_number,
             });
+            const labels = issue.labels.map((label) =>
+              typeof label === 'string' ? label : label.name
+            );
+            if (!labels.includes('acceptance-criteria')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: ['acceptance-criteria'],
+              });
+            }
 
   docker-smoke:
     name: docker smoke

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -341,6 +341,8 @@ jobs:
           python-version: '3.14'
       - name: Install test-quality dependencies
         run: python -m pip install --upgrade pip pytest
+      # Consumer repos intentionally omit Workflows-specific
+      # check_gate_diff_quality.py; only check_deliberate_break.py is synced.
       - name: Check deliberate-break acceptance criterion
         id: deliberate_break
         if: ${{ hashFiles('scripts/check_deliberate_break.py') != '' }}
@@ -641,6 +643,7 @@ jobs:
           DOCS_GUARD_RESULT: ${{ needs.docs-guard.result || 'success' }}
           PYTHON_REQUIRED: ${{ needs.detect.outputs.is_python_code || 'true' }}
           DOCKER_RESULT: ${{ needs.docker-smoke.result || 'skipped' }}
+          TEST_QUALITY_RESULT: ${{ needs.test-quality.result || 'skipped' }}
           DOCKER_CHANGED: ${{ needs.detect.outputs.docker_changed || 'false' }}
           COVERAGE_ENABLED: ${{ needs.detect.outputs.coverage || 'true' }}
         run: python .github/scripts/gate_summary.py

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -311,6 +311,62 @@ jobs:
           echo "scripts/check_issue_consistency.py not present;
           skipping Workflows-specific issue consistency check."
 
+  test-quality:
+    name: test-quality
+    needs:
+      - detect
+      - environment-gate
+    if: ${{ github.event_name == 'pull_request' && needs.detect.outputs.doc_only != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - name: Fetch base ref
+        run: |
+          set -euo pipefail
+          upstream="https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git"
+          base_ref="${{ github.event.pull_request.base.ref }}"
+          git remote add upstream "$upstream"
+          git fetch --no-tags upstream \
+            "refs/heads/${base_ref}:refs/remotes/upstream/${base_ref}"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.14'
+      - name: Install test-quality dependencies
+        run: python -m pip install --upgrade pip pytest
+      - name: Check deliberate-break acceptance criterion
+        id: deliberate_break
+        if: ${{ hashFiles('scripts/check_deliberate_break.py') != '' }}
+        run: >-
+          python scripts/check_deliberate_break.py
+          --base "refs/remotes/upstream/${{ github.event.pull_request.base.ref }}"
+          --head HEAD
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+      - name: Skip deliberate-break check
+        if: ${{ hashFiles('scripts/check_deliberate_break.py') == '' }}
+        run: >-
+          echo "scripts/check_deliberate_break.py not present;
+          skipping opt-in deliberate-break check."
+      - name: Apply runtime acceptance-criteria label
+        if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['acceptance-criteria'],
+            });
+
   docker-smoke:
     name: docker smoke
     needs:
@@ -377,6 +433,7 @@ jobs:
       - docker-smoke
       - github-scripts-tests
       - issue-consistency
+      - test-quality
       - ledger-validation
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -30,6 +31,7 @@ SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+(.+?)\s*$", re.MULTILINE)
 ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
+DEFAULT_TIMEOUT_SECONDS = 120
 
 
 @dataclass(frozen=True)
@@ -128,7 +130,12 @@ def _pytest_command(test_id: str) -> tuple[str, ...]:
     return (sys.executable, "-m", "pytest", test_id, "-q")
 
 
-def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    command: tuple[str, ...],
+    cwd: Path,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     pythonpath = str(cwd)
     if env.get("PYTHONPATH"):
@@ -140,17 +147,33 @@ def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str
         text=True,
         capture_output=True,
         env=env,
+        timeout=timeout,
     )
 
 
-def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def _git(
+    args: list[str],
+    cwd: Path,
+    *,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
         cwd=cwd,
         check=True,
         text=True,
         capture_output=True,
+        timeout=timeout,
     )
+
+
+def _assertion_diff_lines(diff_text: str) -> Iterator[str]:
+    """Yield removed assertion lines; adding a new assertion is valid test growth."""
+    for line in diff_text.splitlines():
+        if not line.startswith("-") or line.startswith("---"):
+            continue
+        if ASSERTION_DIFF_RE.search(line):
+            yield line[:240]
 
 
 def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list[str]:
@@ -161,15 +184,7 @@ def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list
         ["diff", "--no-ext-diff", "--unified=0", f"{base}...{head}", "--", test_file],
         cwd,
     )
-    hits: list[str] = []
-    for line in completed.stdout.splitlines():
-        if not (line.startswith("+") or line.startswith("-")):
-            continue
-        if line.startswith(("+++", "---")):
-            continue
-        if ASSERTION_DIFF_RE.search(line):
-            hits.append(line[:240])
-    return hits
+    return list(_assertion_diff_lines(completed.stdout))
 
 
 def _archive_ref(base: str, target: Path, cwd: Path) -> None:
@@ -178,9 +193,27 @@ def _archive_ref(base: str, target: Path, cwd: Path) -> None:
         cwd=cwd,
         check=True,
         capture_output=True,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
     )
+    target_root = target.resolve()
     with tarfile.open(fileobj=BytesIO(archive.stdout), mode="r:") as tar:
-        tar.extractall(target, filter="data")
+        for member in tar:
+            member_path = target_root / member.name
+            resolved = member_path.resolve()
+            if not resolved.is_relative_to(target_root):
+                raise ValueError(f"unsafe archive path: {member.name}")
+            if member.isdir():
+                resolved.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                continue
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            source = tar.extractfile(member)
+            if source is None:
+                continue
+            with source, resolved.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+            resolved.chmod(member.mode & 0o777)
 
 
 def verify_spec(
@@ -200,17 +233,26 @@ def verify_spec(
             test_file=spec.test_file,
         )
 
-    if enforce_tamper:
-        tampered = _changed_assertions(base, head, spec.test_file, repo)
-        if tampered:
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="test-assertion-tamper",
-                test_file=spec.test_file,
-                changed_assertions=tampered,
-            )
+    try:
+        if enforce_tamper:
+            tampered = _changed_assertions(base, head, spec.test_file, repo)
+            if tampered:
+                return _json_result(
+                    VERDICT_BROKEN,
+                    reason="test-assertion-tamper",
+                    test_file=spec.test_file,
+                    changed_assertions=tampered,
+                )
 
-    head_run = _run(spec.command, repo)
+        head_run = _run(spec.command, repo)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+
     if head_run.returncode != 0:
         return _json_result(
             VERDICT_BROKEN,
@@ -221,13 +263,27 @@ def verify_spec(
             stderr=head_run.stderr,
         )
 
-    with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
-        base_dir = Path(tmp)
-        _archive_ref(base, base_dir, repo)
-        base_test = base_dir / spec.test_file
-        base_test.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(test_path, base_test)
-        base_run = _run(spec.command, base_dir)
+    try:
+        with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
+            base_dir = Path(tmp)
+            _archive_ref(base, base_dir, repo)
+            base_test = base_dir / spec.test_file
+            base_test.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(test_path, base_test)
+            base_run = _run(spec.command, base_dir)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+    except ValueError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="archive-extract-failed",
+            detail=str(exc),
+        )
 
     if base_run.returncode == 0:
         return _json_result(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -85,9 +85,7 @@ def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
         break_file = values.get("break-file") or values.get("revert-file")
         command_text = values.get("command")
         if not test_id or not test_file or not break_file:
-            raise ValueError(
-                "deliberate-break marker requires test, test-file, and break-file"
-            )
+            raise ValueError("deliberate-break marker requires test, test-file, and break-file")
         command = tuple(shlex.split(command_text)) if command_text else _pytest_command(test_id)
         return DeliberateBreakSpec(test_id, test_file, break_file, command)
     return None
@@ -102,8 +100,7 @@ def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
         (
             line
             for line in section.splitlines()
-            if "deliberate-break" in line.lower()
-            or "deliberate break" in line.lower()
+            if "deliberate-break" in line.lower() or "deliberate break" in line.lower()
         ),
         "",
     )

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Opt-in execution check for deliberate-break acceptance criteria."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+VERDICT_PASS = "PASS"
+VERDICT_HOLLOW = "FAIL_HOLLOW"
+VERDICT_BROKEN = "FAIL_BROKEN"
+VERDICT_SKIPPED = "SKIPPED"
+
+MARKER_RE = re.compile(
+    r"(?:<!--\s*)?deliberate-break:\s*(?P<body>.*?)(?:\s*-->)?$",
+    re.IGNORECASE,
+)
+SECTION_HEADER_RE = re.compile(r"^#{2,6}\s+(.+?)\s*$", re.MULTILINE)
+ASSERTION_DIFF_RE = re.compile(
+    r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
+)
+
+
+@dataclass(frozen=True)
+class DeliberateBreakSpec:
+    test_id: str
+    test_file: str
+    break_file: str
+    command: tuple[str, ...]
+
+
+def _json_result(verdict: str, **fields: object) -> dict[str, object]:
+    return {"verdict": verdict, **fields}
+
+
+def _write_github_output(**fields: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        for key, value in fields.items():
+            handle.write(f"{key}={value}\n")
+
+
+def _acceptance_criteria(markdown: str) -> str:
+    headers = list(SECTION_HEADER_RE.finditer(markdown))
+    for index, match in enumerate(headers):
+        if match.group(1).strip().lower() != "acceptance criteria":
+            continue
+        start = match.end()
+        end = headers[index + 1].start() if index + 1 < len(headers) else len(markdown)
+        return markdown[start:end].strip()
+    return markdown
+
+
+def _parse_key_values(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for token in shlex.split(text):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        values[key.strip().replace("_", "-").lower()] = value.strip()
+    return values
+
+
+def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
+    for line in section.splitlines():
+        match = MARKER_RE.search(line.strip())
+        if not match:
+            continue
+        values = _parse_key_values(match.group("body"))
+        test_id = values.get("test") or values.get("test-id")
+        test_file = values.get("test-file") or values.get("file")
+        break_file = values.get("break-file") or values.get("revert-file")
+        command_text = values.get("command")
+        if not test_id or not test_file or not break_file:
+            raise ValueError(
+                "deliberate-break marker requires test, test-file, and break-file"
+            )
+        command = tuple(shlex.split(command_text)) if command_text else _pytest_command(test_id)
+        return DeliberateBreakSpec(test_id, test_file, break_file, command)
+    return None
+
+
+def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
+    named_line = next(
+        (line for line in section.splitlines() if "named test:" in line.lower()),
+        "",
+    )
+    break_line = next(
+        (
+            line
+            for line in section.splitlines()
+            if "deliberate-break" in line.lower()
+            or "deliberate break" in line.lower()
+        ),
+        "",
+    )
+    if not named_line or not break_line:
+        return None
+
+    test_file_match = re.search(r"`([^`]*(?:test|tests)[^`]*\.py)`", named_line)
+    test_name_match = re.search(r"\bwith\s+`?([A-Za-z_][A-Za-z0-9_]*)`?", named_line)
+    break_file_match = re.search(r"`([^`]+)`", break_line)
+    if not test_file_match or not test_name_match or not break_file_match:
+        return None
+
+    test_file = test_file_match.group(1)
+    test_id = f"{test_file}::{test_name_match.group(1)}"
+    break_file = break_file_match.group(1)
+    return DeliberateBreakSpec(test_id, test_file, break_file, _pytest_command(test_id))
+
+
+def parse_deliberate_break_spec(markdown: str) -> DeliberateBreakSpec | None:
+    section = _acceptance_criteria(markdown)
+    return _explicit_marker(section) or _fallback_marker(section)
+
+
+def _pytest_command(test_id: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", "pytest", test_id, "-q")
+
+
+def _run(command: tuple[str, ...], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    pythonpath = str(cwd)
+    if env.get("PYTHONPATH"):
+        pythonpath = pythonpath + os.pathsep + env["PYTHONPATH"]
+    env["PYTHONPATH"] = pythonpath
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _changed_assertions(base: str, head: str, test_file: str, cwd: Path) -> list[str]:
+    status = _git(["diff", "--name-status", f"{base}...{head}", "--", test_file], cwd)
+    if any(line.split("\t", 1)[0] == "A" for line in status.stdout.splitlines()):
+        return []
+    completed = _git(
+        ["diff", "--no-ext-diff", "--unified=0", f"{base}...{head}", "--", test_file],
+        cwd,
+    )
+    hits: list[str] = []
+    for line in completed.stdout.splitlines():
+        if not (line.startswith("+") or line.startswith("-")):
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        if ASSERTION_DIFF_RE.search(line):
+            hits.append(line[:240])
+    return hits
+
+
+def _archive_ref(base: str, target: Path, cwd: Path) -> None:
+    archive = subprocess.run(
+        ["git", "archive", "--format=tar", base],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+    with tarfile.open(fileobj=BytesIO(archive.stdout), mode="r:") as tar:
+        tar.extractall(target, filter="data")
+
+
+def verify_spec(
+    spec: DeliberateBreakSpec,
+    *,
+    base: str,
+    head: str = "HEAD",
+    cwd: Path | None = None,
+    enforce_tamper: bool = True,
+) -> dict[str, object]:
+    repo = cwd or Path.cwd()
+    test_path = repo / spec.test_file
+    if not test_path.is_file():
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="test-file-missing",
+            test_file=spec.test_file,
+        )
+
+    if enforce_tamper:
+        tampered = _changed_assertions(base, head, spec.test_file, repo)
+        if tampered:
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="test-assertion-tamper",
+                test_file=spec.test_file,
+                changed_assertions=tampered,
+            )
+
+    head_run = _run(spec.command, repo)
+    if head_run.returncode != 0:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="head-test-failed",
+            test_id=spec.test_id,
+            command=list(spec.command),
+            stdout=head_run.stdout,
+            stderr=head_run.stderr,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="deliberate-break-base-") as tmp:
+        base_dir = Path(tmp)
+        _archive_ref(base, base_dir, repo)
+        base_test = base_dir / spec.test_file
+        base_test.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(test_path, base_test)
+        base_run = _run(spec.command, base_dir)
+
+    if base_run.returncode == 0:
+        return _json_result(
+            VERDICT_HOLLOW,
+            reason="test-passed-on-base-with-candidate-test",
+            test_id=spec.test_id,
+            test_file=spec.test_file,
+            break_file=spec.break_file,
+            command=list(spec.command),
+            stdout=base_run.stdout,
+            stderr=base_run.stderr,
+        )
+
+    return _json_result(
+        VERDICT_PASS,
+        reason="head-passed-base-failed",
+        test_id=spec.test_id,
+        test_file=spec.test_file,
+        break_file=spec.break_file,
+        command=list(spec.command),
+        base_stdout=base_run.stdout,
+        base_stderr=base_run.stderr,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--pr-body-file")
+    parser.add_argument("--pr-body-env", default="PR_BODY")
+    parser.add_argument("--no-tamper-check", action="store_true")
+    args = parser.parse_args(argv)
+
+    body = ""
+    if args.pr_body_file:
+        body = Path(args.pr_body_file).read_text(encoding="utf-8")
+    else:
+        body = os.environ.get(args.pr_body_env, "")
+
+    spec = parse_deliberate_break_spec(body)
+    if spec is None:
+        _write_github_output(has_marker="false", verdict=VERDICT_SKIPPED)
+        print(json.dumps(_json_result(VERDICT_SKIPPED, reason="no deliberate-break marker")))
+        print("skipped: no deliberate-break marker")
+        return 0
+
+    _write_github_output(has_marker="true")
+    result = verify_spec(
+        spec,
+        base=args.base,
+        head=args.head,
+        enforce_tamper=not args.no_tamper_check,
+    )
+    _write_github_output(verdict=str(result["verdict"]))
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["verdict"] == VERDICT_PASS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -43,7 +43,7 @@ def _write_test(repo: Path, expected: int) -> None:
     test_file = repo / "tests" / "test_app.py"
     test_file.parent.mkdir(exist_ok=True)
     test_file.write_text(
-        "import app\n\n\n" "def test_value():\n" f"    assert app.value() == {expected}\n",
+        f"import app\n\n\ndef test_value():\n    assert app.value() == {expected}\n",
         encoding="utf-8",
     )
 
@@ -138,6 +138,43 @@ def test_assertion_tamper_is_flagged(tmp_path, monkeypatch) -> None:
 
     assert result["verdict"] == VERDICT_BROKEN
     assert result["reason"] == "test-assertion-tamper"
+
+
+def test_new_assertion_in_existing_test_file_is_not_tamper(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write_app(repo, 0)
+    test_file = repo / "tests" / "test_app.py"
+    test_file.parent.mkdir(exist_ok=True)
+    test_file.write_text(
+        "def test_existing_value():\n    assert 1 + 1 == 2\n",
+        encoding="utf-8",
+    )
+    base = _commit(repo, "base test")
+    _write_app(repo, 1)
+    test_file.write_text(
+        "import app\n\n\n"
+        "def test_existing_value():\n"
+        "    assert 1 + 1 == 2\n\n\n"
+        "def test_value():\n"
+        "    assert app.value() == 1\n",
+        encoding="utf-8",
+    )
+    _commit(repo, "implementation and added assertion")
+    monkeypatch.chdir(repo)
+
+    spec = parse_deliberate_break_spec(
+        "<!-- deliberate-break: "
+        "test=tests/test_app.py::test_value "
+        "test-file=tests/test_app.py "
+        "break-file=app.py -->"
+    )
+    assert spec is not None
+
+    result = verify_spec(spec, base=base)
+
+    assert result["verdict"] == VERDICT_PASS
 
 
 def test_added_acceptance_test_is_not_tamper(tmp_path, monkeypatch) -> None:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -43,9 +43,7 @@ def _write_test(repo: Path, expected: int) -> None:
     test_file = repo / "tests" / "test_app.py"
     test_file.parent.mkdir(exist_ok=True)
     test_file.write_text(
-        "import app\n\n\n"
-        "def test_value():\n"
-        f"    assert app.value() == {expected}\n",
+        "import app\n\n\n" "def test_value():\n" f"    assert app.value() == {expected}\n",
         encoding="utf-8",
     )
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -1,0 +1,184 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_deliberate_break import (
+    VERDICT_BROKEN,
+    VERDICT_HOLLOW,
+    VERDICT_PASS,
+    parse_deliberate_break_spec,
+    verify_spec,
+)
+
+
+def _run(repo: Path, *args: str) -> None:
+    subprocess.run(args, cwd=repo, check=True, text=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _run(repo, "git", "init", "-q")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-qm", message)
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        text=True,
+    ).strip()
+
+
+def _write_app(repo: Path, value: int) -> None:
+    (repo / "app.py").write_text(
+        f"def value():\n    return {value}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_test(repo: Path, expected: int) -> None:
+    test_file = repo / "tests" / "test_app.py"
+    test_file.parent.mkdir(exist_ok=True)
+    test_file.write_text(
+        "import app\n\n\n"
+        "def test_value():\n"
+        f"    assert app.value() == {expected}\n",
+        encoding="utf-8",
+    )
+
+
+def test_hollow_detected(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write_app(repo, 1)
+    base = _commit(repo, "base behavior")
+    _write_test(repo, 1)
+    _commit(repo, "candidate test")
+    monkeypatch.chdir(repo)
+
+    spec = parse_deliberate_break_spec(
+        "<!-- deliberate-break: "
+        "test=tests/test_app.py::test_value "
+        "test-file=tests/test_app.py "
+        "break-file=app.py -->"
+    )
+    assert spec is not None
+
+    result = verify_spec(spec, base=base, enforce_tamper=False)
+
+    assert result["verdict"] == VERDICT_HOLLOW
+
+
+def test_sound_passes(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write_app(repo, 0)
+    base = _commit(repo, "base behavior")
+    _write_app(repo, 1)
+    _write_test(repo, 1)
+    _commit(repo, "implementation and test")
+    monkeypatch.chdir(repo)
+
+    spec = parse_deliberate_break_spec(
+        "<!-- deliberate-break: "
+        "test=tests/test_app.py::test_value "
+        "test-file=tests/test_app.py "
+        "break-file=app.py -->"
+    )
+    assert spec is not None
+
+    result = verify_spec(spec, base=base, enforce_tamper=False)
+
+    assert result["verdict"] == VERDICT_PASS
+
+
+def test_no_marker_returns_none() -> None:
+    assert parse_deliberate_break_spec("## Acceptance Criteria\n- [ ] normal check") is None
+
+
+def test_issue_acceptance_wording_is_supported() -> None:
+    spec = parse_deliberate_break_spec(
+        "## Acceptance Criteria\n\n"
+        "- [ ] Named test: add `tests/scripts/test_check_deliberate_break.py` "
+        "with `test_hollow_detected` (build a tmp git repo).\n"
+        "- [ ] **Deliberate-break gate:** temporarily edit "
+        "`scripts/check_deliberate_break.py` to skip the base-rerun.\n"
+    )
+
+    assert spec is not None
+    assert spec.test_id == "tests/scripts/test_check_deliberate_break.py::test_hollow_detected"
+    assert spec.test_file == "tests/scripts/test_check_deliberate_break.py"
+    assert spec.break_file == "scripts/check_deliberate_break.py"
+
+
+def test_assertion_tamper_is_flagged(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write_app(repo, 0)
+    _write_test(repo, 0)
+    base = _commit(repo, "base test")
+    _write_app(repo, 1)
+    _write_test(repo, 1)
+    _commit(repo, "tampered candidate")
+    monkeypatch.chdir(repo)
+
+    spec = parse_deliberate_break_spec(
+        "<!-- deliberate-break: "
+        "test=tests/test_app.py::test_value "
+        "test-file=tests/test_app.py "
+        "break-file=app.py -->"
+    )
+    assert spec is not None
+
+    result = verify_spec(spec, base=base)
+
+    assert result["verdict"] == VERDICT_BROKEN
+    assert result["reason"] == "test-assertion-tamper"
+
+
+def test_added_acceptance_test_is_not_tamper(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _write_app(repo, 0)
+    base = _commit(repo, "base behavior")
+    _write_app(repo, 1)
+    _write_test(repo, 1)
+    _commit(repo, "implementation and new test")
+    monkeypatch.chdir(repo)
+
+    spec = parse_deliberate_break_spec(
+        "<!-- deliberate-break: "
+        "test=tests/test_app.py::test_value "
+        "test-file=tests/test_app.py "
+        "break-file=app.py -->"
+    )
+    assert spec is not None
+
+    result = verify_spec(spec, base=base)
+
+    assert result["verdict"] == VERDICT_PASS
+
+
+def test_cli_skips_without_marker(tmp_path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parents[2] / "scripts" / "check_deliberate_break.py"),
+            "--base",
+            "HEAD",
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PR_BODY": "## Acceptance Criteria\n- [ ] normal"},
+    )
+
+    assert completed.returncode == 0
+    assert "skipped: no deliberate-break marker" in completed.stdout

--- a/tests/workflows/github_scripts/test_gate_summary.py
+++ b/tests/workflows/github_scripts/test_gate_summary.py
@@ -128,6 +128,29 @@ def test_active_summary_fails_when_docs_guard_fails(tmp_path: Path) -> None:
     assert "| docs-guard | failure |" in joined
 
 
+def test_active_summary_fails_when_test_quality_fails(tmp_path: Path) -> None:
+    write_summary(tmp_path, "3.12")
+
+    context = gate_summary.SummaryContext(
+        doc_only=False,
+        run_core=True,
+        reason="",
+        python_result="success",
+        docker_result="success",
+        docker_changed=False,
+        artifacts_root=tmp_path,
+        summary_path=None,
+        output_path=None,
+        test_quality_result="failure",
+    )
+
+    result = gate_summary.summarize(context)
+    joined = "\n".join(result.lines)
+    assert result.state == "failure"
+    assert result.description == "Test-quality result: failure."
+    assert "| test-quality | failure |" in joined
+
+
 @pytest.mark.parametrize(
     "python_outcome, expected_state",
     [("failure", "failure"), ("success", "success")],
@@ -403,6 +426,7 @@ def test_build_context_reads_environment(monkeypatch: pytest.MonkeyPatch, tmp_pa
     monkeypatch.setenv("PYTHON_REQUIRED", "FALSE")
     monkeypatch.setenv("DOCS_GUARD_RESULT", "FAILURE")
     monkeypatch.setenv("DOCKER_RESULT", "cancelled")
+    monkeypatch.setenv("TEST_QUALITY_RESULT", "failure")
     monkeypatch.setenv("DOCKER_CHANGED", "TRUE")
     artifacts_root = tmp_path / "gate_artifacts"
     monkeypatch.setenv("GATE_ARTIFACTS_ROOT", str(artifacts_root))
@@ -419,6 +443,7 @@ def test_build_context_reads_environment(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert context.python_required is False
     assert context.docs_guard_result == "FAILURE"
     assert context.docker_result == "cancelled"
+    assert context.test_quality_result == "failure"
     assert context.docker_changed is True
     assert context.artifacts_root == artifacts_root
     assert context.summary_path == summary_path


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2475 -->
> **Source:** Issue #2475

Closes #2475

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Repo-review issues are **required** by `templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md` (Definition of Ready, lines 171–215) to carry a deliberate-break acceptance criterion — "a named test must FAIL on the break and PASS after the fix" — but **nothing enforces it at PR or merge time** (verified). The only pre-merge gate, `.github/workflows/pr-00-gate.yml`, runs a *static* test-quality check: `scripts/check_gate_diff_quality.py` flags added test files lacking a literal-expected assertion (`LITERAL_ASSERTION_RE`, `check_gate_diff_quality.py:13`) but **cannot tell whether a test actually couples to the new implementation** — a test with `assert f(x) == 5` passes the static lint yet may also pass against the *unchanged* base. This is the "tests pass but nothing was implemented" hole that SWE-bench's FAIL_TO_PASS property is designed to close.

The local Orchestrator already implements the execution-based check — `Code/Orchestrator/local_verify.py` `verify()`: run the named test on HEAD (must pass), `git archive` the base ref, overlay only the candidate test file, rerun (must fail) → `PASS` / `FAIL_HOLLOW` / `FAIL_BROKEN` (selftested: `python3 local_verify.py --selftest`). It runs only in the local lanes; the GitHub-Actions pipeline has no equivalent.

This is **latent fragility, not a current break**: a plausible-but-hollow agent PR can merge green today, caught only weeks later (if ever).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2466](https://github.com/stranske/Workflows/issues/2466)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `scripts/check_deliberate_break.py` implementing the green-then-red algorithm from `Code/Orchestrator/local_verify.py` (`verify()`): run the named test on HEAD → must pass; `git archive` the base ref into a tempdir, overlay only the named test file, rerun → must fail; emit `PASS` / `FAIL_HOLLOW` / `FAIL_BROKEN` as JSON.
- [ ] Add a parser that extracts the deliberate-break marker (named test id + break/revert file) from the Acceptance Criteria block produced by `agents-pr-meta` (reuse the AC-extraction keepalive already uses); when no marker is present, the check is a no-op (opt-in).
- [ ] Wire the check into `.github/workflows/pr-00-gate.yml` `test-quality` job (which already fetches the base ref at lines 316–323 — reuse that checkout) as a step that runs **only the named test**, not the full suite.
- [ ] Add a **test-tamper tripwire**: fail the check if the PR diff modifies the named acceptance-test file's assertions (anti-reward-hacking; agents edit tests to force a pass when that is the only path — ImpossibleBench).
- [ ] Arm the dormant guard: when the AC declares a deliberate-break/runtime criterion, apply the `acceptance-criteria` label so `.github/scripts/runtime_ac_merge_guard.js` (already wired into all three merge lanes) defers non-CI-verifiable merges to the local `Code/Orchestrator/merge_guard.py`.
- [ ] Mirror the new script + Gate step into `templates/consumer-repo/` and update `.github/sync-manifest.yml` in the same PR.
- [ ] Update `docs/keepalive/GoalsAndPlumbing.md` §13 to document the new gate.
- [ ] Perform the deliberate-break verification (Acceptance Criteria), capture the FAIL output, then revert before requesting review.

#### Acceptance criteria
- [ ] Named test: add `tests/scripts/test_check_deliberate_break.py` with `test_hollow_detected` (build a tmp git repo where the candidate test passes on both base and head; assert verdict == `FAIL_HOLLOW`) and `test_sound_passes` (test fails on base, passes on head; assert `PASS`). Both pass via `pytest tests/scripts/test_check_deliberate_break.py -q` with a non-zero collected count.
- [ ] **Deliberate-break gate:** temporarily edit `scripts/check_deliberate_break.py` to skip the base-rerun (treat the head pass as success). With this change, `tests/scripts/test_check_deliberate_break.py::test_hollow_detected` **must FAIL** (a hollow test is no longer caught). Revert the edit and capture the failure output in the PR.
- [ ] A PR whose AC contains no deliberate-break marker leaves the new Gate step a no-op (run log shows a "skipped: no deliberate-break marker" line), demonstrated on a fixture or dry-run.
- [ ] A PR whose diff edits the named acceptance test's assertions is flagged by the tamper tripwire (run log shows the tamper failure), demonstrated on a fixture.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in “deliberate-break” gate driven by Acceptance Criteria markers, verifying a test on both the PR head and a base snapshot.
  * Gate workflows can automatically apply the `acceptance-criteria` label when the marker is present; gate summaries now include a `test-quality` result.
* **Documentation**
  * Added documentation for the Deliberate-Break Gate step, marker format, verdict meanings, and skip behavior.
* **Bug Fixes / Workflow Hardening**
  * Improved gate workflow permissions, checkout pinning, and test-quality result propagation.
* **Tests**
  * Added integration coverage for parsing, PASS/HOLLOW/BROKEN verdicts, tamper detection, and CLI skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->