### PR TITLE
[codex] fix consumer autofix workflow ref resolution

### DIFF
--- a/.github/workflows/reusable-18-autofix.yml
+++ b/.github/workflows/reusable-18-autofix.yml
@@ -243,7 +243,11 @@ jobs:
           WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
           set -euo pipefail
-          ref="${WORKFLOW_REF##*@}"
+          workflow_repo="${WORKFLOW_REF%%/.github/workflows/*}"
+          ref="main"
+          if [ "$workflow_repo" = "stranske/Workflows" ]; then
+            ref="${WORKFLOW_REF##*@}"
+          fi
           if [ -z "$ref" ] || [ "$ref" = "$WORKFLOW_REF" ]; then
             ref="main"
           fi

--- a/tests/workflows/test_workflow_autofix_guard.py
+++ b/tests/workflows/test_workflow_autofix_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+import subprocess
 from typing import Any
 
 import yaml
@@ -100,6 +101,40 @@ def test_reusable_autofix_splits_push_and_patch_paths() -> None:
     assert "env.AUTOFIX_CAN_PUSH == 'true'" in (commit_step.get("if") or "")
     # Patch fallback is for when push isn't possible (forks, dry-run, missing creds)
     assert "env.AUTOFIX_CAN_PUSH != 'true'" in (patch_step.get("if") or "")
+
+
+def _resolve_workflows_ref(workflow_ref: str, tmp_path: pathlib.Path) -> str:
+    data = _load_yaml("reusable-18-autofix.yml")
+    steps: list[dict[str, Any]] = data["jobs"]["autofix"]["steps"]
+    step = next(step for step in steps if step.get("name") == "Determine Workflows workflow ref")
+    output = tmp_path / "github-output.txt"
+    subprocess.run(
+        ["bash", "-c", step["run"]],
+        check=True,
+        env={"WORKFLOW_REF": workflow_ref, "GITHUB_OUTPUT": str(output)},
+    )
+    values = dict(
+        line.split("=", 1)
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    return values["ref"]
+
+
+def test_reusable_autofix_uses_main_for_consumer_workflow_refs(tmp_path: pathlib.Path) -> None:
+    ref = _resolve_workflows_ref(
+        "stranske/Workflows-Integration-Tests/.github/workflows/autofix.yml@refs/pull/34/merge",
+        tmp_path,
+    )
+    assert ref == "main"
+
+
+def test_reusable_autofix_preserves_workflows_repo_refs(tmp_path: pathlib.Path) -> None:
+    ref = _resolve_workflows_ref(
+        "stranske/Workflows/.github/workflows/autofix.yml@refs/pull/2470/merge",
+        tmp_path,
+    )
+    assert ref == "refs/pull/2470/merge"
 
 
 def _load_helper(name: str) -> str:


### PR DESCRIPTION
## Summary
- make `reusable-18-autofix.yml` fall back to Workflows `main` when invoked from consumer repository PR refs
- preserve PR refs only when `github.workflow_ref` actually belongs to `stranske/Workflows`
- add regression coverage that executes the workflow-ref resolution step for both consumer and source refs

## Context
The cross-repo consumer PR stranske/Workflows-Integration-Tests#34 exposed this source-side bug. The reusable autofix workflow was deriving its Workflows checkout ref from the caller workflow ref. For consumer PRs that value can be `refs/pull/<n>/merge` in the consumer repository, which does not exist in `stranske/Workflows`, causing the autofix job to fail before it can inspect the PR.

<!-- workflow-source:review_followup -->

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache-workflows2470 uv run --python 3.12 pytest tests/workflows/test_workflow_autofix_guard.py` (10 passed)
- `actionlint .github/workflows/reusable-18-autofix.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow configuration logic to handle repository references more precisely during automated fix operations.

* **Tests**
  * Added comprehensive test coverage for workflow reference resolution, validating behavior across different workflow sources and pull request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->