### PR TITLE
Issue #2480: Tighten keepalive stall and budget policy

### DIFF
--- a/.github/scripts/__tests__/agent-delegation-policy.test.js
+++ b/.github/scripts/__tests__/agent-delegation-policy.test.js
@@ -104,10 +104,10 @@ test('checkPrerequisites with mode=any returns available=false when no secrets p
   assert.equal(result.available, false);
 });
 
-test('calculateEffectiveness returns effective=true when commits made', () => {
+test('calculateEffectiveness returns effective=true when commits made with green gate', () => {
   const history = [
     { iteration: 16, commits: 0, tasks: 0, gate: 'fail' },
-    { iteration: 17, commits: 1, tasks: 0, gate: 'pending' },
+    { iteration: 17, commits: 1, tasks: 0, gate: 'pass' },
     { iteration: 18, commits: 0, tasks: 0, gate: 'pending' },
   ];
 
@@ -116,6 +116,21 @@ test('calculateEffectiveness returns effective=true when commits made', () => {
   assert.equal(result.effective, true);
   assert.equal(result.commits, 1);
   assert.ok(result.summary.includes('1 commits'));
+});
+
+test('churn without checkbox progress is not effective', () => {
+  const history = [
+    { iteration: 16, commits: 1, tasks: 0, gate: 'fail' },
+    { iteration: 17, commits: 1, tasks: 0, gate: 'pending' },
+    { iteration: 18, commits: 1, tasks: 0, gate: 'fail' },
+  ];
+
+  const result = calculateEffectiveness({ history, lookbackRounds: 3 });
+
+  assert.equal(result.effective, false);
+  assert.equal(result.commits, 3);
+  assert.equal(result.tasks, 0);
+  assert.equal(result.gatePassed, false);
 });
 
 test('calculateEffectiveness returns effective=true when tasks completed', () => {
@@ -180,6 +195,21 @@ test('detectStall returns isStalled=true when threshold exceeded', () => {
   assert.ok(result.reason.includes('3 rounds, no progress'));
 });
 
+test('stalls after two zero-progress rounds', () => {
+  const history = [
+    { iteration: 17, commits: 0, tasks: 0, gate: 'fail' },
+    { iteration: 18, commits: 0, tasks: 0, gate: 'fail' },
+  ];
+
+  const result = detectStall({ history });
+  const explicitResult = detectStall({ history, threshold: 2 });
+
+  assert.equal(result.isStalled, true);
+  assert.equal(result.consecutiveRounds, 2);
+  assert.equal(explicitResult.isStalled, true);
+  assert.equal(explicitResult.consecutiveRounds, 2);
+});
+
 // #2268 deliberate-break gate: a 3-round zero-commit green-gate history MUST
 // produce isStalled=true. Restoring the old `|| round.gate === 'pass'` progress
 // test in detectStall makes this case come back isStalled=false (the green gates
@@ -201,7 +231,7 @@ test('detectStall returns isStalled=false when progress in last round', () => {
   const history = [
     { iteration: 16, commits: 0, tasks: 0, gate: 'fail' },
     { iteration: 17, commits: 0, tasks: 0, gate: 'fail' },
-    { iteration: 18, commits: 1, tasks: 0, gate: 'fail' },
+    { iteration: 18, commits: 1, tasks: 0, gate: 'pass' },
   ];
 
   const result = detectStall({ history, threshold: 3 });

--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -350,6 +350,38 @@ test('evaluateKeepaliveLoop stops at max iterations even when productive with ta
   assert.equal(result.reason, 'round-budget-exhausted');
 });
 
+test('evaluateKeepaliveLoop stops at max iterations before fixable gate failures', async () => {
+  const pr = {
+    number: 407,
+    head: { ref: 'feature/budget-gate-fail', sha: 'sha-budget-fail' },
+    labels: [{ name: 'agent:codex' }],
+    body: '## Tasks\n- [ ] one\n## Acceptance Criteria\n- [ ] a',
+  };
+  const stateComment = formatStateComment({
+    trace: '',
+    iteration: 5,
+    max_iterations: 5,
+    last_files_changed: 2,
+    failure: {},
+  });
+  const github = buildGithubStub({
+    pr,
+    comments: [{ id: 25, body: stateComment, html_url: 'https://example.com/25' }],
+    workflowRuns: [{ id: 1007, head_sha: 'sha-budget-fail', conclusion: 'failure' }],
+  });
+  github.rest.actions.listJobsForWorkflowRun = async () => ({
+    data: { jobs: [{ name: 'test (3.12)', status: 'completed', conclusion: 'failure' }] },
+  });
+  const result = await evaluateKeepaliveLoop({
+    github,
+    context: buildContext(pr.number),
+    core: buildCore(),
+  });
+  assert.equal(result.action, 'stop');
+  assert.equal(result.reason, 'round-budget-exhausted');
+  assert.notEqual(result.reason, 'fix-test');
+});
+
 test('evaluateKeepaliveLoop triggers progress review without file changes', async () => {
   const pr = {
     number: 406,

--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -297,7 +297,7 @@ test('evaluateKeepaliveLoop stops when tasks are complete and verification is do
   assert.equal(result.reason, 'tasks-complete');
 });
 
-test('evaluateKeepaliveLoop stops when max iterations reached AND unproductive', async () => {
+test('evaluateKeepaliveLoop stops when round budget is exhausted', async () => {
   const pr = {
     number: 404,
     head: { ref: 'feature/four', sha: 'sha-4' },
@@ -315,10 +315,10 @@ test('evaluateKeepaliveLoop stops when max iterations reached AND unproductive',
     core: buildCore(),
   });
   assert.equal(result.action, 'stop');
-  assert.equal(result.reason, 'max-iterations-unproductive');
+  assert.equal(result.reason, 'round-budget-exhausted');
 });
 
-test('evaluateKeepaliveLoop continues past max iterations when productive with tasks remaining', async () => {
+test('evaluateKeepaliveLoop stops at max iterations even when productive with tasks remaining', async () => {
   const pr = {
     number: 405,
     head: { ref: 'feature/extended', sha: 'sha-ext' },
@@ -346,8 +346,8 @@ test('evaluateKeepaliveLoop continues past max iterations when productive with t
     context: buildContext(pr.number),
     core: buildCore(),
   });
-  assert.equal(result.action, 'run', 'Should continue past max iterations when productive');
-  assert.equal(result.reason, 'ready-extended', 'Should report ready-extended reason');
+  assert.equal(result.action, 'stop', 'Should stop once the per-PR round budget is exhausted');
+  assert.equal(result.reason, 'round-budget-exhausted');
 });
 
 test('evaluateKeepaliveLoop triggers progress review without file changes', async () => {

--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -382,6 +382,37 @@ test('evaluateKeepaliveLoop stops at max iterations before fixable gate failures
   assert.notEqual(result.reason, 'fix-test');
 });
 
+test('evaluateKeepaliveLoop falls back to default budget for invalid max iterations', async () => {
+  const pr = {
+    number: 408,
+    head: { ref: 'feature/invalid-budget', sha: 'sha-invalid-budget' },
+    labels: [{ name: 'agent:codex' }],
+    body: '<!-- keepalive-config: {"keepalive_enabled": true, "max_iterations": -3} -->\n## Tasks\n- [ ] one\n## Acceptance Criteria\n- [ ] a',
+  };
+  const stateComment = formatStateComment({
+    trace: '',
+    iteration: 12,
+    max_iterations: 0,
+    last_files_changed: 1,
+    failure: {},
+  });
+  const github = buildGithubStub({
+    pr,
+    comments: [{ id: 26, body: stateComment, html_url: 'https://example.com/26' }],
+    workflowRuns: [{ id: 1008, head_sha: 'sha-invalid-budget', conclusion: 'success' }],
+  });
+
+  const result = await evaluateKeepaliveLoop({
+    github,
+    context: buildContext(pr.number),
+    core: buildCore(),
+  });
+
+  assert.equal(result.action, 'stop');
+  assert.equal(result.reason, 'round-budget-exhausted');
+  assert.equal(result.maxIterations, 12);
+});
+
 test('evaluateKeepaliveLoop triggers progress review without file changes', async () => {
   const pr = {
     number: 406,

--- a/.github/scripts/__tests__/keepalive-loop.test.js
+++ b/.github/scripts/__tests__/keepalive-loop.test.js
@@ -383,34 +383,47 @@ test('evaluateKeepaliveLoop stops at max iterations before fixable gate failures
 });
 
 test('evaluateKeepaliveLoop falls back to default budget for invalid max iterations', async () => {
-  const pr = {
-    number: 408,
-    head: { ref: 'feature/invalid-budget', sha: 'sha-invalid-budget' },
-    labels: [{ name: 'agent:codex' }],
-    body: '<!-- keepalive-config: {"keepalive_enabled": true, "max_iterations": -3} -->\n## Tasks\n- [ ] one\n## Acceptance Criteria\n- [ ] a',
-  };
-  const stateComment = formatStateComment({
-    trace: '',
-    iteration: 12,
-    max_iterations: 0,
-    last_files_changed: 1,
-    failure: {},
-  });
-  const github = buildGithubStub({
-    pr,
-    comments: [{ id: 26, body: stateComment, html_url: 'https://example.com/26' }],
-    workflowRuns: [{ id: 1008, head_sha: 'sha-invalid-budget', conclusion: 'success' }],
-  });
+  const cases = [
+    { name: 'negative config', configValue: -3, stateValue: 0 },
+    { name: 'partial numeric string config', configValue: '3 rounds', stateValue: 0 },
+    { name: 'decimal config', configValue: 3.9, stateValue: 0 },
+    { name: 'partial numeric string state', configValue: 0, stateValue: '3 rounds' },
+    { name: 'decimal state', configValue: 0, stateValue: 3.9 },
+  ];
 
-  const result = await evaluateKeepaliveLoop({
-    github,
-    context: buildContext(pr.number),
-    core: buildCore(),
-  });
+  for (const testCase of cases) {
+    const pr = {
+      number: 408,
+      head: {
+        ref: `feature/invalid-budget-${testCase.name.replaceAll(' ', '-')}`,
+        sha: `sha-invalid-budget-${testCase.name}`,
+      },
+      labels: [{ name: 'agent:codex' }],
+      body: `<!-- keepalive-config: ${JSON.stringify({ keepalive_enabled: true, max_iterations: testCase.configValue })} -->\n## Tasks\n- [ ] one\n## Acceptance Criteria\n- [ ] a`,
+    };
+    const stateComment = formatStateComment({
+      trace: '',
+      iteration: 12,
+      max_iterations: testCase.stateValue,
+      last_files_changed: 1,
+      failure: {},
+    });
+    const github = buildGithubStub({
+      pr,
+      comments: [{ id: 26, body: stateComment, html_url: 'https://example.com/26' }],
+      workflowRuns: [{ id: 1008, head_sha: pr.head.sha, conclusion: 'success' }],
+    });
 
-  assert.equal(result.action, 'stop');
-  assert.equal(result.reason, 'round-budget-exhausted');
-  assert.equal(result.maxIterations, 12);
+    const result = await evaluateKeepaliveLoop({
+      github,
+      context: buildContext(pr.number),
+      core: buildCore(),
+    });
+
+    assert.equal(result.action, 'stop', testCase.name);
+    assert.equal(result.reason, 'round-budget-exhausted', testCase.name);
+    assert.equal(result.maxIterations, 12, testCase.name);
+  }
 });
 
 test('evaluateKeepaliveLoop triggers progress review without file changes', async () => {

--- a/.github/scripts/agent_delegation_policy.js
+++ b/.github/scripts/agent_delegation_policy.js
@@ -84,7 +84,7 @@ function decideNextAgent({ state = {}, labels = [], secrets = {}, registry = {},
 
   // Current agent exists - check if we should continue or switch
   const effectiveness = calculateEffectiveness({ history, lookbackRounds: 3, core });
-  const stall = detectStall({ history, threshold: 3, core });
+  const stall = detectStall({ history, threshold: 2, core });
   const roundsSinceSwitch = currentIteration - lastSwitchIteration;
   const inCooldown = roundsSinceSwitch < 5;
 
@@ -224,15 +224,13 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
   const tasks = recentRounds.reduce((sum, round) => sum + (round.tasks || 0), 0);
   const gatePassed = recentRounds.some((round) => round.gate === 'pass');
 
-  // Agent is effective only when it produced real forward motion:
-  // - Made at least 1 commit in lookback window, OR
-  // - Completed at least 1 task in lookback window.
-  // A green Gate with zero commits and zero tasks is NOT progress: a normal
-  // `run` dispatch only happens on a green Gate (Activation Guardrail §2), so a
-  // genuinely stuck agent records `gate: 'pass'` every round. Counting that as
-  // effective made the stall detector unable to ever fire (#2268). `gatePassed`
-  // is still returned/reported below, just not treated as progress.
-  const effective = commits >= 1 || tasks >= 1;
+  // Agent is effective only when it produced verified forward motion:
+  // - Completed at least 1 task in the lookback window, OR
+  // - Made commits and has a green Gate signal in the lookback window.
+  // Bare commits with no checkbox progress and a non-green Gate are churn, not
+  // progress; otherwise an agent can commit indefinitely without advancing
+  // acceptance criteria or CI and never trip delegation.
+  const effective = tasks >= 1 || (commits >= 1 && gatePassed);
 
   const summary = [
     commits > 0 ? `${commits} commits` : null,
@@ -262,7 +260,7 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
  * @param {Object} [options.core] - GitHub Actions core for logging
  * @returns {Object} - { isStalled, consecutiveRounds, reason }
  */
-function detectStall({ history = [], threshold = 3, core }) {
+function detectStall({ history = [], threshold = 2, core }) {
   if (history.length < threshold) {
     return {
       isStalled: false,
@@ -280,8 +278,8 @@ function detectStall({ history = [], threshold = 3, core }) {
     // keeps a green Gate while making zero commits never trips the stall
     // threshold and `agent:auto` delegation can never switch (#2268).
     const hasProgress =
-      (round.commits || 0) > 0 ||
-      (round.tasks || 0) > 0;
+      (round.tasks || 0) > 0 ||
+      ((round.commits || 0) > 0 && round.gate === 'pass');
 
     if (hasProgress) {
       break; // Found progress, stop counting

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1593,7 +1593,7 @@ function normaliseConfig(config = {}) {
     ),
     autofix_enabled: toBool(cfg.autofix_enabled ?? cfg.autofix, false),
     iteration: toNumber(cfg.iteration ?? cfg.keepalive_iteration, 0),
-    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 5),
+    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 0),
     failure_threshold: toNumber(cfg.failure_threshold ?? cfg.keepalive_failure_threshold, 3),
     trace,
     prompt_mode: promptMode,
@@ -2503,7 +2503,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // Prefer state iteration unless config explicitly sets it (0 from config is default, not explicit)
     const configHasExplicitIteration = config.iteration > 0;
     const iteration = configHasExplicitIteration ? config.iteration : toNumber(state.iteration, 0);
-    const maxIterations = toNumber(config.max_iterations ?? state.max_iterations, 5);
+    const maxIterations = toNumber(config.max_iterations || state.max_iterations || 12, 12);
     const failureThreshold = toNumber(config.failure_threshold ?? state.failure_threshold, 3);
     const progressReviewThreshold = toNumber(config.progress_review_threshold ?? state.progress_review_threshold, 4);
     // Default 3 rounds allows 2 fix attempts before stopping (round 1 = fix,
@@ -2595,14 +2595,11 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // An iteration is productive if it has a reasonable productivity score
     const isProductive = productivityScore >= 20 && !hasRecentFailures;
 
-    // max_iterations is a soft cap on agent runs.  Productive agents
-    // (recent file changes, no persistent failures) with remaining tasks
-    // continue in "extended mode" (reason: ready-extended) past the cap.
-    // Unproductive agents are hard-stopped to avoid wasting compute.
-    // Use the agent:retry label to force-continue regardless.
+    // max_iterations is a hard per-PR budget. Once reached, stop dispatching
+    // and require a human to raise the budget or remove the blocker.
     const hasMaxIterations = maxIterations > 0;
     const reachedMaxIterations = hasMaxIterations && iteration >= maxIterations;
-    const shouldStopForMaxIterations = reachedMaxIterations && !isProductive;
+    const shouldStopForMaxIterations = reachedMaxIterations;
 
     // Build task appendix for the agent prompt (after state load for reconciliation info)
     const taskAppendix = buildTaskAppendix(normalisedSections, checkboxCounts, state, { prBody: pr.body });
@@ -2768,13 +2765,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
           `Agent produced 0 file changes and 0 tasks completed for ${persistedConsecutiveZeroActivityRounds} consecutive rounds — likely infrastructure failure (auth, permissions, sandbox). Stopping.`,
         );
       }
-    } else if (shouldStopForMaxIterations && forceRetry && tasksRemaining) {
-      action = 'run';
-      reason = 'force-retry-max-iterations';
-      if (core) core.info('Force retry enabled: bypassing max-iterations stop');
     } else if (shouldStopForMaxIterations) {
       action = 'stop';
-      reason = isProductive ? 'max-iterations' : 'max-iterations-unproductive';
+      reason = 'round-budget-exhausted';
     } else if (needsProgressReview) {
       // Trigger LLM-based progress review when agent is active but not completing tasks
       // This allows legitimate prep work while catching scope drift early
@@ -2783,7 +2776,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       reason = `progress-review-${roundsWithoutTaskCompletion}`;
     } else if (tasksRemaining) {
       action = 'run';
-      reason = iteration >= maxIterations ? 'ready-extended' : 'ready';
+      reason = 'ready';
     }
 
     // Scope enforcement: if all tasks appear complete but there are scope

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -142,6 +142,11 @@ function toNumber(value, fallback = 0) {
   return Number.isFinite(fallback) ? Number(fallback) : 0;
 }
 
+function toPositiveInteger(value, fallback = 0) {
+  const parsed = toNumber(value, fallback);
+  return parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
 function toOptionalNumber(value) {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -2503,7 +2508,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // Prefer state iteration unless config explicitly sets it (0 from config is default, not explicit)
     const configHasExplicitIteration = config.iteration > 0;
     const iteration = configHasExplicitIteration ? config.iteration : toNumber(state.iteration, 0);
-    const maxIterations = toNumber(config.max_iterations || state.max_iterations || 12, 12);
+    const configMaxIterations = toPositiveInteger(config.max_iterations, 0);
+    const stateMaxIterations = toPositiveInteger(state.max_iterations, 0);
+    const maxIterations = configMaxIterations || stateMaxIterations || 12;
     const failureThreshold = toNumber(config.failure_threshold ?? state.failure_threshold, 3);
     const progressReviewThreshold = toNumber(config.progress_review_threshold ?? state.progress_review_threshold, 4);
     // Default 3 rounds allows 2 fix attempts before stopping (round 1 = fix,

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2660,6 +2660,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     } else if (!tasksPresent) {
       action = 'stop';
       reason = 'no-checklists';
+    } else if (shouldStopForMaxIterations) {
+      action = 'stop';
+      reason = 'round-budget-exhausted';
     } else if (gateNormalized !== 'success') {
       // Handle cancelled gate first (transient — should not consume fix budget)
       if (gateNormalized === 'cancelled') {
@@ -2765,9 +2768,6 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
           `Agent produced 0 file changes and 0 tasks completed for ${persistedConsecutiveZeroActivityRounds} consecutive rounds — likely infrastructure failure (auth, permissions, sandbox). Stopping.`,
         );
       }
-    } else if (shouldStopForMaxIterations) {
-      action = 'stop';
-      reason = 'round-budget-exhausted';
     } else if (needsProgressReview) {
       // Trigger LLM-based progress review when agent is active but not completing tasks
       // This allows legitimate prep work while catching scope drift early

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -143,8 +143,21 @@ function toNumber(value, fallback = 0) {
 }
 
 function toPositiveInteger(value, fallback = 0) {
-  const parsed = toNumber(value, fallback);
-  return parsed > 0 ? Math.floor(parsed) : fallback;
+  const fallbackValue = Number.isSafeInteger(fallback) && fallback > 0 ? fallback : 0;
+
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : fallbackValue;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^[1-9]\d*$/.test(trimmed)) {
+      const parsed = Number(trimmed);
+      return Number.isSafeInteger(parsed) ? parsed : fallbackValue;
+    }
+  }
+
+  return fallbackValue;
 }
 
 function toOptionalNumber(value) {
@@ -1598,7 +1611,7 @@ function normaliseConfig(config = {}) {
     ),
     autofix_enabled: toBool(cfg.autofix_enabled ?? cfg.autofix, false),
     iteration: toNumber(cfg.iteration ?? cfg.keepalive_iteration, 0),
-    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 0),
+    max_iterations: cfg.max_iterations ?? cfg.keepalive_max_iterations,
     failure_threshold: toNumber(cfg.failure_threshold ?? cfg.keepalive_failure_threshold, 3),
     trace,
     prompt_mode: promptMode,

--- a/docs/keepalive/GoalsAndPlumbing.md
+++ b/docs/keepalive/GoalsAndPlumbing.md
@@ -73,6 +73,8 @@ If any requirement fails, keepalive stays silent—no PR comments. Operators may
 - **Default limit:** Maximum of **1** concurrent agent run per PR.
 - **Label override:** Respect `agents:max-parallel:<K>` when present (integer 1–5).
 - **Enforcement:** Dispatch only when the count of in-progress runs is `< K`. If at cap, exit quietly after updating the run summary.
+- **Round budget:** The loop also enforces `max_iterations` as a hard per-PR round budget. The default is 12 rounds unless overridden by keepalive config.
+- **Budget exhaustion:** When the current iteration reaches `max_iterations`, keepalive stops dispatching and adds `needs-human` with reason `round-budget-exhausted`. Raise the configured budget only after reviewing the PR summary and deciding that more automated rounds are warranted.
 
 ---
 
@@ -81,6 +83,7 @@ If any requirement fails, keepalive stays silent—no PR comments. Operators may
 - Removing the `agent:*` label halts new dispatches until a label is re-applied and all guardrails pass again.
 - Respect the `agents:paused` label, which blocks *all* keepalive activity.
 - After repeated failures (default: 3), the loop pauses and adds `needs-human` label.
+- Agent delegation treats two consecutive zero-progress rounds as stalled. Commit churn is not progress unless it advances checklist state or reaches a green Gate.
 
 **To resume after failure:**
 1. Investigate the failure reason in the keepalive summary comment

--- a/templates/consumer-repo/.github/scripts/agent_delegation_policy.js
+++ b/templates/consumer-repo/.github/scripts/agent_delegation_policy.js
@@ -84,7 +84,7 @@ function decideNextAgent({ state = {}, labels = [], secrets = {}, registry = {},
 
   // Current agent exists - check if we should continue or switch
   const effectiveness = calculateEffectiveness({ history, lookbackRounds: 3, core });
-  const stall = detectStall({ history, threshold: 3, core });
+  const stall = detectStall({ history, threshold: 2, core });
   const roundsSinceSwitch = currentIteration - lastSwitchIteration;
   const inCooldown = roundsSinceSwitch < 5;
 
@@ -224,15 +224,13 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
   const tasks = recentRounds.reduce((sum, round) => sum + (round.tasks || 0), 0);
   const gatePassed = recentRounds.some((round) => round.gate === 'pass');
 
-  // Agent is effective only when it produced real forward motion:
-  // - Made at least 1 commit in lookback window, OR
-  // - Completed at least 1 task in lookback window.
-  // A green Gate with zero commits and zero tasks is NOT progress: a normal
-  // `run` dispatch only happens on a green Gate (Activation Guardrail §2), so a
-  // genuinely stuck agent records `gate: 'pass'` every round. Counting that as
-  // effective made the stall detector unable to ever fire (#2268). `gatePassed`
-  // is still returned/reported below, just not treated as progress.
-  const effective = commits >= 1 || tasks >= 1;
+  // Agent is effective only when it produced verified forward motion:
+  // - Completed at least 1 task in the lookback window, OR
+  // - Made commits and has a green Gate signal in the lookback window.
+  // Bare commits with no checkbox progress and a non-green Gate are churn, not
+  // progress; otherwise an agent can commit indefinitely without advancing
+  // acceptance criteria or CI and never trip delegation.
+  const effective = tasks >= 1 || (commits >= 1 && gatePassed);
 
   const summary = [
     commits > 0 ? `${commits} commits` : null,
@@ -262,7 +260,7 @@ function calculateEffectiveness({ history = [], lookbackRounds = 3, core }) {
  * @param {Object} [options.core] - GitHub Actions core for logging
  * @returns {Object} - { isStalled, consecutiveRounds, reason }
  */
-function detectStall({ history = [], threshold = 3, core }) {
+function detectStall({ history = [], threshold = 2, core }) {
   if (history.length < threshold) {
     return {
       isStalled: false,
@@ -280,8 +278,8 @@ function detectStall({ history = [], threshold = 3, core }) {
     // keeps a green Gate while making zero commits never trips the stall
     // threshold and `agent:auto` delegation can never switch (#2268).
     const hasProgress =
-      (round.commits || 0) > 0 ||
-      (round.tasks || 0) > 0;
+      (round.tasks || 0) > 0 ||
+      ((round.commits || 0) > 0 && round.gate === 'pass');
 
     if (hasProgress) {
       break; // Found progress, stop counting

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -1593,7 +1593,7 @@ function normaliseConfig(config = {}) {
     ),
     autofix_enabled: toBool(cfg.autofix_enabled ?? cfg.autofix, false),
     iteration: toNumber(cfg.iteration ?? cfg.keepalive_iteration, 0),
-    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 5),
+    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 0),
     failure_threshold: toNumber(cfg.failure_threshold ?? cfg.keepalive_failure_threshold, 3),
     trace,
     prompt_mode: promptMode,
@@ -2503,7 +2503,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // Prefer state iteration unless config explicitly sets it (0 from config is default, not explicit)
     const configHasExplicitIteration = config.iteration > 0;
     const iteration = configHasExplicitIteration ? config.iteration : toNumber(state.iteration, 0);
-    const maxIterations = toNumber(config.max_iterations ?? state.max_iterations, 5);
+    const maxIterations = toNumber(config.max_iterations || state.max_iterations || 12, 12);
     const failureThreshold = toNumber(config.failure_threshold ?? state.failure_threshold, 3);
     const progressReviewThreshold = toNumber(config.progress_review_threshold ?? state.progress_review_threshold, 4);
     // Default 3 rounds allows 2 fix attempts before stopping (round 1 = fix,
@@ -2595,14 +2595,11 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // An iteration is productive if it has a reasonable productivity score
     const isProductive = productivityScore >= 20 && !hasRecentFailures;
 
-    // max_iterations is a soft cap on agent runs.  Productive agents
-    // (recent file changes, no persistent failures) with remaining tasks
-    // continue in "extended mode" (reason: ready-extended) past the cap.
-    // Unproductive agents are hard-stopped to avoid wasting compute.
-    // Use the agent:retry label to force-continue regardless.
+    // max_iterations is a hard per-PR budget. Once reached, stop dispatching
+    // and require a human to raise the budget or remove the blocker.
     const hasMaxIterations = maxIterations > 0;
     const reachedMaxIterations = hasMaxIterations && iteration >= maxIterations;
-    const shouldStopForMaxIterations = reachedMaxIterations && !isProductive;
+    const shouldStopForMaxIterations = reachedMaxIterations;
 
     // Build task appendix for the agent prompt (after state load for reconciliation info)
     const taskAppendix = buildTaskAppendix(normalisedSections, checkboxCounts, state, { prBody: pr.body });
@@ -2768,13 +2765,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
           `Agent produced 0 file changes and 0 tasks completed for ${persistedConsecutiveZeroActivityRounds} consecutive rounds — likely infrastructure failure (auth, permissions, sandbox). Stopping.`,
         );
       }
-    } else if (shouldStopForMaxIterations && forceRetry && tasksRemaining) {
-      action = 'run';
-      reason = 'force-retry-max-iterations';
-      if (core) core.info('Force retry enabled: bypassing max-iterations stop');
     } else if (shouldStopForMaxIterations) {
       action = 'stop';
-      reason = isProductive ? 'max-iterations' : 'max-iterations-unproductive';
+      reason = 'round-budget-exhausted';
     } else if (needsProgressReview) {
       // Trigger LLM-based progress review when agent is active but not completing tasks
       // This allows legitimate prep work while catching scope drift early
@@ -2783,7 +2776,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       reason = `progress-review-${roundsWithoutTaskCompletion}`;
     } else if (tasksRemaining) {
       action = 'run';
-      reason = iteration >= maxIterations ? 'ready-extended' : 'ready';
+      reason = 'ready';
     }
 
     // Scope enforcement: if all tasks appear complete but there are scope

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -142,6 +142,11 @@ function toNumber(value, fallback = 0) {
   return Number.isFinite(fallback) ? Number(fallback) : 0;
 }
 
+function toPositiveInteger(value, fallback = 0) {
+  const parsed = toNumber(value, fallback);
+  return parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
 function toOptionalNumber(value) {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -2503,7 +2508,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     // Prefer state iteration unless config explicitly sets it (0 from config is default, not explicit)
     const configHasExplicitIteration = config.iteration > 0;
     const iteration = configHasExplicitIteration ? config.iteration : toNumber(state.iteration, 0);
-    const maxIterations = toNumber(config.max_iterations || state.max_iterations || 12, 12);
+    const configMaxIterations = toPositiveInteger(config.max_iterations, 0);
+    const stateMaxIterations = toPositiveInteger(state.max_iterations, 0);
+    const maxIterations = configMaxIterations || stateMaxIterations || 12;
     const failureThreshold = toNumber(config.failure_threshold ?? state.failure_threshold, 3);
     const progressReviewThreshold = toNumber(config.progress_review_threshold ?? state.progress_review_threshold, 4);
     // Default 3 rounds allows 2 fix attempts before stopping (round 1 = fix,

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -2660,6 +2660,9 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     } else if (!tasksPresent) {
       action = 'stop';
       reason = 'no-checklists';
+    } else if (shouldStopForMaxIterations) {
+      action = 'stop';
+      reason = 'round-budget-exhausted';
     } else if (gateNormalized !== 'success') {
       // Handle cancelled gate first (transient — should not consume fix budget)
       if (gateNormalized === 'cancelled') {
@@ -2765,9 +2768,6 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
           `Agent produced 0 file changes and 0 tasks completed for ${persistedConsecutiveZeroActivityRounds} consecutive rounds — likely infrastructure failure (auth, permissions, sandbox). Stopping.`,
         );
       }
-    } else if (shouldStopForMaxIterations) {
-      action = 'stop';
-      reason = 'round-budget-exhausted';
     } else if (needsProgressReview) {
       // Trigger LLM-based progress review when agent is active but not completing tasks
       // This allows legitimate prep work while catching scope drift early

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -143,8 +143,21 @@ function toNumber(value, fallback = 0) {
 }
 
 function toPositiveInteger(value, fallback = 0) {
-  const parsed = toNumber(value, fallback);
-  return parsed > 0 ? Math.floor(parsed) : fallback;
+  const fallbackValue = Number.isSafeInteger(fallback) && fallback > 0 ? fallback : 0;
+
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : fallbackValue;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^[1-9]\d*$/.test(trimmed)) {
+      const parsed = Number(trimmed);
+      return Number.isSafeInteger(parsed) ? parsed : fallbackValue;
+    }
+  }
+
+  return fallbackValue;
 }
 
 function toOptionalNumber(value) {
@@ -1598,7 +1611,7 @@ function normaliseConfig(config = {}) {
     ),
     autofix_enabled: toBool(cfg.autofix_enabled ?? cfg.autofix, false),
     iteration: toNumber(cfg.iteration ?? cfg.keepalive_iteration, 0),
-    max_iterations: toNumber(cfg.max_iterations ?? cfg.keepalive_max_iterations, 0),
+    max_iterations: cfg.max_iterations ?? cfg.keepalive_max_iterations,
     failure_threshold: toNumber(cfg.failure_threshold ?? cfg.keepalive_failure_threshold, 3),
     trace,
     prompt_mode: promptMode,


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2480 -->
> **Source:** Issue #2480

Closes #2480

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
keepalive's stall/effectiveness handling is blunt and lets two cheap failure modes burn rounds (and flat-rate agent capacity):

1. `detectStall` only switches the agent after **3** consecutive zero-progress rounds — `detectStall({ history, threshold: 3, core })` at `.github/scripts/agent_delegation_policy.js:87` (default `:265`).
2. `calculateEffectiveness` counts a round as effective on **bare commits** — `const effective = commits >= 1 || tasks >= 1;` at `agent_delegation_policy.js:235` (commits summed at `:223`) — so an agent that commits every round **without advancing any acceptance/task checkbox** is "effective" indefinitely and never escalates (churn-without-verification).

There is also no hard per-PR round budget: `keepalive_state.js` tracks `iteration` and `max_iterations` (`:102`, `:155`) but nothing forces a stop when the budget is reached.

External-early-stop research (BAGEN: agents are not budget-aware, so an *external* cap saves 28–64% of wasted tokens at ~2–4% success cost) and self-repair research (cap retries at ~2 rounds; sharply diminishing returns after) both point the same way: stop doomed/churning loops sooner. This is **latent waste, not a current break** — runs still complete, they just burn rounds on doomed or churning PRs.

#### Tasks
- [ ] Lower the stall threshold 3→2 at `.github/scripts/agent_delegation_policy.js:87` (`detectStall({ history, threshold: 2, core })`), or make it overridable via an `agents:stall-threshold:<n>` label defaulting to 2; keep the existing 5-round cooldown anti-thrash.
- [ ] Fix churn-without-verification in `calculateEffectiveness` (`agent_delegation_policy.js:235`): a round with `commits >= 1` but **zero** task-checkbox progress (`tasks_completed_delta === 0`, already tracked at `.github/scripts/keepalive_loop.js:218`) and a non-green Gate must NOT count as effective. Require `tasks >= 1` (a checkbox advanced) or a Gate-green signal; bare commits for ≥2 rounds → not effective → escalate.
- [ ] Enforce a per-PR round budget: when `state.iteration` reaches `state.max_iterations` (`.github/scripts/keepalive_state.js:102,155`), stop dispatching and add `needs-human` with a "round budget exhausted" reason. Default the cap to a small finite number (e.g. 12) overridable via the existing `max_iterations`.
- [ ] Mirror any consumer-facing change into `templates/consumer-repo/` + update `.github/sync-manifest.yml`; update `docs/keepalive/GoalsAndPlumbing.md` §3/§4.

#### Acceptance criteria
- [ ] Named test: extend `.github/scripts/__tests__/agent-delegation-policy.test.js` with `stalls after two zero-progress rounds` (asserts `detectStall({ history: [two zero-progress rounds], threshold: 2 })` reports stalled) and `churn without checkbox progress is not effective` (asserts a 3-round history of `commits>0, tasks_completed_delta:0` yields `effective === false`). Both pass via the repo's JS test runner (`npm test` / the github-scripts test job) with a non-zero collected count.
- [ ] **Deliberate-break gate:** temporarily revert the threshold to 3 (`detectStall({ ..., threshold: 3 })`). The `stalls after two zero-progress rounds` test **must FAIL** (two rounds no longer trip the stall). Revert and capture the failure output in the PR.
- [ ] A keepalive PR that reaches `max_iterations` stops dispatching and is labeled `needs-human` with a "round budget exhausted" reason, demonstrated on the keepalive-loop test harness / a fixture.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a hard per-PR round budget: when `max_iterations` is reached, the loop stops unconditionally (default 12) with `round-budget-exhausted`.
  * Simplified the boundary behavior so dispatch uses `ready` (no extended-ready variant).
  * Updated delegation heuristics: stall detection triggers after 2 consecutive zero-progress rounds, and effectiveness counts progress only when checklist tasks advance or commits occur with a passing gate.
* **Documentation**
  * Updated keepalive contract for the new round budget and stall/progress semantics.
* **Tests**
  * Expanded coverage for budget exhaustion and the revised delegation effectiveness/stall rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->