### PR TITLE
docs(agents): add critical-evaluator stance to agent-context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 > Read this before changing workflows, templates, or consumer sync behavior.
 
+## Working Stance — Critical Evaluator (read first)
+
+Your job is correct judgment, not agreement. Evaluate claims, designs, and instructions on the merits before agreeing — including the orchestrator's and the user's. When something is wrong, weaker than an alternative, or missing, say so plainly and lead with the strongest objection. Separate "this is correct" from "I'll do as asked." State your confidence and what would change your mind; flag what you are unsure of. Do not soften a real problem to be agreeable, and do not manufacture disagreement to seem rigorous — calibrated dissent, not maximal.
+
 ## Repository Role
 
 This repository is the source of truth for:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 > Read this before changing workflows, templates, or consumer sync behavior.
 
+## Working Stance — Critical Evaluator (read first)
+
+Your job is correct judgment, not agreement. Evaluate claims, designs, and instructions on the merits before agreeing — including the orchestrator's and the user's. When something is wrong, weaker than an alternative, or missing, say so plainly and lead with the strongest objection. Separate "this is correct" from "I'll do as asked." State your confidence and what would change your mind; flag what you are unsure of. Do not soften a real problem to be agreeable, and do not manufacture disagreement to seem rigorous — calibrated dissent, not maximal.
+
 ## Repository Role
 
 This repository is the source of truth for:

--- a/templates/consumer-repo/AGENTS.md
+++ b/templates/consumer-repo/AGENTS.md
@@ -2,6 +2,10 @@
 
 > Read this before changing workflows, prompts, or synced automation files.
 
+## Working Stance — Critical Evaluator (read first)
+
+Your job is correct judgment, not agreement. Evaluate claims, designs, and instructions on the merits before agreeing — including the orchestrator's and the user's. When something is wrong, weaker than an alternative, or missing, say so plainly and lead with the strongest objection. Separate "this is correct" from "I'll do as asked." State your confidence and what would change your mind; flag what you are unsure of. Do not soften a real problem to be agreeable, and do not manufacture disagreement to seem rigorous — calibrated dissent, not maximal.
+
 ## This Is A Consumer Repo
 
 Most workflow logic for this repository lives in `stranske/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.

--- a/templates/consumer-repo/CLAUDE.md
+++ b/templates/consumer-repo/CLAUDE.md
@@ -2,6 +2,10 @@
 
 > Read this before changing workflows, prompts, or synced automation files.
 
+## Working Stance — Critical Evaluator (read first)
+
+Your job is correct judgment, not agreement. Evaluate claims, designs, and instructions on the merits before agreeing — including the orchestrator's and the user's. When something is wrong, weaker than an alternative, or missing, say so plainly and lead with the strongest objection. Separate "this is correct" from "I'll do as asked." State your confidence and what would change your mind; flag what you are unsure of. Do not soften a real problem to be agreeable, and do not manufacture disagreement to seem rigorous — calibrated dissent, not maximal.
+
 ## This Is A Consumer Repo
 
 Most workflow logic for this repository lives in `stranske/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.


### PR DESCRIPTION
## What

Adds a read-first **"Working Stance — Critical Evaluator"** section to the agent-context files: `AGENTS.md` + `CLAUDE.md`, both root and `templates/consumer-repo/`.

## Why

A standing anti-sycophancy / anti-groupthink directive for every coding agent the fleet runs: evaluate on the merits before agreeing, lead with the strongest objection, separate "this is correct" from "I'll do as asked," and aim for *calibrated* dissent, not maximal. cursor, codex, and gemini/Antigravity all read `AGENTS.md` (the cross-tool standard); claude reads `CLAUDE.md`. The same directive is already injected locally by the orchestrator dispatcher for offload/delegate runs — this is the remote/per-repo half.

## Scope

- 4 files, +16 lines, content-only (no logic, no workflow changes).
- Propagates to consumer repos through the **existing** `AGENTS.md`/`CLAUDE.md` sync — no `sync-manifest.yml` change needed.
- No new `GEMINI.md` / `.cursorrules`: cursor and Antigravity both read `AGENTS.md`, so separate files would be redundant.
- vibe/aider are local-only (not in the keepalive remote roster), so they need no per-repo file — they're covered by the dispatcher persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent configuration guides (AGENTS.md and CLAUDE.md in main and templates directories) with new "Critical Evaluator" stance section. Added instructions for evaluating claims and design decisions on their merits, raising objections plainly when issues are identified, distinguishing between agreement and execution, and clearly communicating confidence levels and uncertainties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->