### PR TITLE
Issue #2476: warn on stale managed AGENTS playbook refs

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -212,6 +212,9 @@ scripts:
   # Dev dependency sync script
   - source: scripts/sync_dev_dependencies.py
     description: "Syncs dev dependency versions from autofix-versions.env to pyproject.toml"
+  - source: scripts/check_agents_md_freshness.py
+    description: "Warns when the generated Orchestrator AGENTS.md playbook section cites stale repo paths or commands"
+    template_sync: exact
   - source: tools/resolve_mypy_pin.py
     description: "Resolves mypy version pinning - required by reusable CI workflow"
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -220,6 +220,11 @@ jobs:
           fi
           python -m pip install --upgrade pip pytest pyyaml
           python -m pytest "${tests[@]}" -q
+      - name: Warn on stale managed AGENTS.md playbook refs
+        run: >-
+          python scripts/check_agents_md_freshness.py
+          --repo-root .
+          --github-annotations
 
   github-scripts-tests:
     name: github scripts tests
@@ -343,11 +348,6 @@ jobs:
           --head HEAD
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-      - name: Warn on stale managed AGENTS.md playbook refs
-        run: >-
-          python scripts/check_agents_md_freshness.py
-          --repo-root .
-          --github-annotations
       - name: Apply runtime acceptance-criteria label
         if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -343,6 +343,11 @@ jobs:
           --head HEAD
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
+      - name: Warn on stale managed AGENTS.md playbook refs
+        run: >-
+          python scripts/check_agents_md_freshness.py
+          --repo-root .
+          --github-annotations
       - name: Apply runtime acceptance-criteria label
         if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/docs/keepalive/Agents.md
+++ b/docs/keepalive/Agents.md
@@ -61,6 +61,8 @@ Auto-pilot pipeline:
 
 4. **Self-dispatch**: Auto-pilot uses `force_step` re-dispatch, not label changes, to sequence its stages. The keepalive loop is triggered independently by Gate completion, not by auto-pilot dispatch.
 
+5. **Repo playbook context**: The Orchestrator registry is the single editable owner for curated per-repo definition-of-done and gotcha rules. `repo_knowledge.py --export-agents-md <owner/repo> --repo-path <checkout> --apply` may write a small generated section in a repo's `AGENTS.md` between `<!-- BEGIN orch-playbook -->` and `<!-- END orch-playbook -->`; humans should edit the registry, not the generated block. Keepalive owns freshness validation: Gate runs `scripts/check_agents_md_freshness.py` in warning-only mode so stale cited paths or commands surface without wedging unrelated PRs while the registry is seeded.
+
 ## Key Principles
 
 1. **Task Focus**: Agents must work on PR tasks, not unrelated improvements. Tasks are explicitly injected via the task appendix.

--- a/scripts/check_agents_md_freshness.py
+++ b/scripts/check_agents_md_freshness.py
@@ -40,7 +40,7 @@ class Finding:
 
 def managed_section(text: str) -> str | None:
     start = text.find(MANAGED_START)
-    end = text.find(MANAGED_END)
+    end = text.find(MANAGED_END, start + len(MANAGED_START)) if start >= 0 else -1
     if start < 0 or end < 0 or end < start:
         return None
     return text[start : end + len(MANAGED_END)]
@@ -79,6 +79,9 @@ def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
         findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
     for arg in ref.split()[1:]:
         arg = _clean_ref(arg)
+        if "=" in arg:
+            _, arg = arg.split("=", 1)
+            arg = _clean_ref(arg)
         if _looks_like_path(arg) and not _path_exists(repo_root, arg):
             findings.append(Finding("path", arg, f"referenced path not found: {arg}"))
     return findings

--- a/scripts/check_agents_md_freshness.py
+++ b/scripts/check_agents_md_freshness.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Warn when the managed Orchestrator AGENTS.md section cites stale repo facts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MANAGED_START = "<!-- BEGIN orch-playbook -->"
+MANAGED_END = "<!-- END orch-playbook -->"
+PATH_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    value: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "value": self.value, "message": self.message}
+
+
+def managed_section(text: str) -> str | None:
+    start = text.find(MANAGED_START)
+    end = text.find(MANAGED_END)
+    if start < 0 or end < 0 or end < start:
+        return None
+    return text[start : end + len(MANAGED_END)]
+
+
+def _clean_ref(value: str) -> str:
+    value = value.strip().strip("\"'")
+    value = re.sub(r"[:#]L?\d+(?:-L?\d+)?$", "", value)
+    return value
+
+
+def _looks_like_path(value: str) -> bool:
+    if value.startswith(("./", "../", ".github/", "docs/", "scripts/", "templates/", "tools/")):
+        return True
+    path = Path(value)
+    return "/" in value or path.suffix.lower() in PATH_SUFFIXES
+
+
+def _path_exists(repo_root: Path, ref: str) -> bool:
+    return (repo_root / ref).exists()
+
+
+def _command_exists(repo_root: Path, ref: str) -> bool:
+    parts = ref.split()
+    if not parts:
+        return True
+    command = parts[0]
+    if command.startswith(("./", "../")) or "/" in command:
+        return (repo_root / command).exists()
+    return shutil.which(command) is not None
+
+
+def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
+    findings: list[Finding] = []
+    if not _command_exists(repo_root, ref):
+        findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
+    for arg in ref.split()[1:]:
+        arg = _clean_ref(arg)
+        if _looks_like_path(arg) and not _path_exists(repo_root, arg):
+            findings.append(Finding("path", arg, f"referenced path not found: {arg}"))
+    return findings
+
+
+def cited_refs(section: str) -> list[str]:
+    refs: list[str] = []
+    for raw in re.findall(r"`([^`]+)`", section):
+        value = _clean_ref(raw)
+        if not value or value.startswith(("http://", "https://")):
+            continue
+        refs.append(value)
+    return refs
+
+
+def check_agents_md(repo_root: Path, agents_md: Path | None = None) -> list[Finding]:
+    agents_path = agents_md or repo_root / "AGENTS.md"
+    if not agents_path.exists():
+        return []
+    section = managed_section(agents_path.read_text(encoding="utf-8"))
+    if section is None:
+        return []
+
+    findings: list[Finding] = []
+    seen: set[tuple[str, str]] = set()
+    for ref in cited_refs(section):
+        if " " in ref:
+            for finding in _check_command_ref(repo_root, ref):
+                key = (finding.kind, finding.value)
+                if key not in seen:
+                    findings.append(finding)
+                seen.add(key)
+        elif _looks_like_path(ref):
+            key = ("path", ref)
+            if key not in seen and not _path_exists(repo_root, ref):
+                findings.append(Finding("path", ref, f"referenced path not found: {ref}"))
+            seen.add(key)
+    return findings
+
+
+def _emit_github_warnings(findings: list[Finding]) -> None:
+    for finding in findings:
+        message = finding.message.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+        print(f"::warning title=AGENTS.md freshness::{message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--agents-md", type=Path)
+    parser.add_argument("--github-annotations", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--strict", action="store_true", help="Exit non-zero when findings are present."
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    agents_md = args.agents_md.resolve() if args.agents_md else None
+    findings = check_agents_md(repo_root, agents_md)
+
+    if args.as_json:
+        print(json.dumps({"findings": [finding.as_dict() for finding in findings]}, indent=2))
+    elif findings:
+        for finding in findings:
+            print(finding.message)
+    else:
+        print("AGENTS.md managed section freshness check passed.")
+
+    if args.github_annotations and findings:
+        _emit_github_warnings(findings)
+
+    return 1 if args.strict and findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -230,6 +230,11 @@ jobs:
           fi
           python -m pip install --upgrade pip pytest pyyaml
           python -m pytest "${tests[@]}" -q
+      - name: Warn on stale managed AGENTS.md playbook refs
+        run: >-
+          python scripts/check_agents_md_freshness.py
+          --repo-root .
+          --github-annotations
 
   github-scripts-tests:
     name: github scripts tests
@@ -357,11 +362,6 @@ jobs:
         run: >-
           echo "scripts/check_deliberate_break.py not present;
           skipping opt-in deliberate-break check."
-      - name: Warn on stale managed AGENTS.md playbook refs
-        run: >-
-          python scripts/check_agents_md_freshness.py
-          --repo-root .
-          --github-annotations
       - name: Apply runtime acceptance-criteria label
         if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -358,7 +358,6 @@ jobs:
           echo "scripts/check_deliberate_break.py not present;
           skipping opt-in deliberate-break check."
       - name: Warn on stale managed AGENTS.md playbook refs
-        if: ${{ hashFiles('scripts/check_agents_md_freshness.py') != '' }}
         run: >-
           python scripts/check_agents_md_freshness.py
           --repo-root .

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -357,6 +357,12 @@ jobs:
         run: >-
           echo "scripts/check_deliberate_break.py not present;
           skipping opt-in deliberate-break check."
+      - name: Warn on stale managed AGENTS.md playbook refs
+        if: ${{ hashFiles('scripts/check_agents_md_freshness.py') != '' }}
+        run: >-
+          python scripts/check_agents_md_freshness.py
+          --repo-root .
+          --github-annotations
       - name: Apply runtime acceptance-criteria label
         if: ${{ steps.deliberate_break.outputs.has_marker == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/templates/consumer-repo/scripts/check_agents_md_freshness.py
+++ b/templates/consumer-repo/scripts/check_agents_md_freshness.py
@@ -40,7 +40,7 @@ class Finding:
 
 def managed_section(text: str) -> str | None:
     start = text.find(MANAGED_START)
-    end = text.find(MANAGED_END)
+    end = text.find(MANAGED_END, start + len(MANAGED_START)) if start >= 0 else -1
     if start < 0 or end < 0 or end < start:
         return None
     return text[start : end + len(MANAGED_END)]
@@ -79,6 +79,9 @@ def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
         findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
     for arg in ref.split()[1:]:
         arg = _clean_ref(arg)
+        if "=" in arg:
+            _, arg = arg.split("=", 1)
+            arg = _clean_ref(arg)
         if _looks_like_path(arg) and not _path_exists(repo_root, arg):
             findings.append(Finding("path", arg, f"referenced path not found: {arg}"))
     return findings

--- a/templates/consumer-repo/scripts/check_agents_md_freshness.py
+++ b/templates/consumer-repo/scripts/check_agents_md_freshness.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Warn when the managed Orchestrator AGENTS.md section cites stale repo facts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MANAGED_START = "<!-- BEGIN orch-playbook -->"
+MANAGED_END = "<!-- END orch-playbook -->"
+PATH_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    value: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "value": self.value, "message": self.message}
+
+
+def managed_section(text: str) -> str | None:
+    start = text.find(MANAGED_START)
+    end = text.find(MANAGED_END)
+    if start < 0 or end < 0 or end < start:
+        return None
+    return text[start : end + len(MANAGED_END)]
+
+
+def _clean_ref(value: str) -> str:
+    value = value.strip().strip("\"'")
+    value = re.sub(r"[:#]L?\d+(?:-L?\d+)?$", "", value)
+    return value
+
+
+def _looks_like_path(value: str) -> bool:
+    if value.startswith(("./", "../", ".github/", "docs/", "scripts/", "templates/", "tools/")):
+        return True
+    path = Path(value)
+    return "/" in value or path.suffix.lower() in PATH_SUFFIXES
+
+
+def _path_exists(repo_root: Path, ref: str) -> bool:
+    return (repo_root / ref).exists()
+
+
+def _command_exists(repo_root: Path, ref: str) -> bool:
+    parts = ref.split()
+    if not parts:
+        return True
+    command = parts[0]
+    if command.startswith(("./", "../")) or "/" in command:
+        return (repo_root / command).exists()
+    return shutil.which(command) is not None
+
+
+def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
+    findings: list[Finding] = []
+    if not _command_exists(repo_root, ref):
+        findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
+    for arg in ref.split()[1:]:
+        arg = _clean_ref(arg)
+        if _looks_like_path(arg) and not _path_exists(repo_root, arg):
+            findings.append(Finding("path", arg, f"referenced path not found: {arg}"))
+    return findings
+
+
+def cited_refs(section: str) -> list[str]:
+    refs: list[str] = []
+    for raw in re.findall(r"`([^`]+)`", section):
+        value = _clean_ref(raw)
+        if not value or value.startswith(("http://", "https://")):
+            continue
+        refs.append(value)
+    return refs
+
+
+def check_agents_md(repo_root: Path, agents_md: Path | None = None) -> list[Finding]:
+    agents_path = agents_md or repo_root / "AGENTS.md"
+    if not agents_path.exists():
+        return []
+    section = managed_section(agents_path.read_text(encoding="utf-8"))
+    if section is None:
+        return []
+
+    findings: list[Finding] = []
+    seen: set[tuple[str, str]] = set()
+    for ref in cited_refs(section):
+        if " " in ref:
+            for finding in _check_command_ref(repo_root, ref):
+                key = (finding.kind, finding.value)
+                if key not in seen:
+                    findings.append(finding)
+                seen.add(key)
+        elif _looks_like_path(ref):
+            key = ("path", ref)
+            if key not in seen and not _path_exists(repo_root, ref):
+                findings.append(Finding("path", ref, f"referenced path not found: {ref}"))
+            seen.add(key)
+    return findings
+
+
+def _emit_github_warnings(findings: list[Finding]) -> None:
+    for finding in findings:
+        message = finding.message.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+        print(f"::warning title=AGENTS.md freshness::{message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--agents-md", type=Path)
+    parser.add_argument("--github-annotations", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--strict", action="store_true", help="Exit non-zero when findings are present."
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    agents_md = args.agents_md.resolve() if args.agents_md else None
+    findings = check_agents_md(repo_root, agents_md)
+
+    if args.as_json:
+        print(json.dumps({"findings": [finding.as_dict() for finding in findings]}, indent=2))
+    elif findings:
+        for finding in findings:
+            print(finding.message)
+    else:
+        print("AGENTS.md managed section freshness check passed.")
+
+    if args.github_annotations and findings:
+        _emit_github_warnings(findings)
+
+    return 1 if args.strict and findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_agents_md_freshness.py
+++ b/tests/scripts/test_check_agents_md_freshness.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from scripts.check_agents_md_freshness import check_agents_md
+
+
+def _agents_md(*refs: str) -> str:
+    lines = [
+        "# AGENTS.md",
+        "<!-- BEGIN orch-playbook -->",
+        "<!-- exported by repo_knowledge.py; owner: Orchestrator; freshness owner: keepalive -->",
+        "## Orchestrator Repo Playbook (stranske/Example)",
+    ]
+    lines.extend(f"- Keep `{ref}` fresh." for ref in refs)
+    lines.append("<!-- END orch-playbook -->")
+    return "\n".join(lines) + "\n"
+
+
+def test_dead_path_flagged(tmp_path):
+    (tmp_path / "AGENTS.md").write_text(_agents_md("docs/missing.md"), encoding="utf-8")
+
+    findings = check_agents_md(tmp_path)
+
+    assert [finding.as_dict() for finding in findings] == [
+        {
+            "kind": "path",
+            "value": "docs/missing.md",
+            "message": "referenced path not found: docs/missing.md",
+        }
+    ]
+
+
+def test_existing_path_passes(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("ok\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text(_agents_md("docs/guide.md"), encoding="utf-8")
+
+    assert check_agents_md(tmp_path) == []

--- a/tests/scripts/test_check_agents_md_freshness.py
+++ b/tests/scripts/test_check_agents_md_freshness.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from scripts.check_agents_md_freshness import check_agents_md
 
 
-def _agents_md(*refs: str) -> str:
+def _agents_md(*refs: str, prefix: str = "") -> str:
     lines = [
         "# AGENTS.md",
         "<!-- BEGIN orch-playbook -->",
@@ -12,7 +12,7 @@ def _agents_md(*refs: str) -> str:
     ]
     lines.extend(f"- Keep `{ref}` fresh." for ref in refs)
     lines.append("<!-- END orch-playbook -->")
-    return "\n".join(lines) + "\n"
+    return prefix + "\n".join(lines) + "\n"
 
 
 def test_dead_path_flagged(tmp_path):
@@ -33,5 +33,35 @@ def test_existing_path_passes(tmp_path):
     (tmp_path / "docs").mkdir()
     (tmp_path / "docs" / "guide.md").write_text("ok\n", encoding="utf-8")
     (tmp_path / "AGENTS.md").write_text(_agents_md("docs/guide.md"), encoding="utf-8")
+
+    assert check_agents_md(tmp_path) == []
+
+
+def test_command_ref_with_equals_path_arg_is_checked(tmp_path):
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "x.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text(
+        _agents_md("python tools/x.py --config=docs/missing.md"),
+        encoding="utf-8",
+    )
+
+    findings = check_agents_md(tmp_path)
+
+    assert [finding.as_dict() for finding in findings] == [
+        {
+            "kind": "path",
+            "value": "docs/missing.md",
+            "message": "referenced path not found: docs/missing.md",
+        }
+    ]
+
+
+def test_managed_section_ignores_stray_end_marker_before_start(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("ok\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text(
+        _agents_md("docs/guide.md", prefix="<!-- END orch-playbook -->\n"),
+        encoding="utf-8",
+    )
 
     assert check_agents_md(tmp_path) == []


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2476 -->
> **Source:** Issue #2476

Closes #2476

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The keepalive prompt injects only the PR's own Scope/Tasks/Acceptance Criteria — `.github/scripts/keepalive_prompt_composer.js` assembles prompt segments from PR-body context with **no per-repo knowledge** (verified). Recurring per-repo gotchas are therefore re-hit every cycle: Counter_Risk uses black-not-ruff, Trend bases opener work on `phase-3` not `main`, LMS is Postgres-only. The local Orchestrator already curates exactly these in `Code/Orchestrator/experiments/repo_knowledge.json` and injects them into its LOCAL lane prompts via `repo_knowledge.append_context()` (`Code/Orchestrator/repo_knowledge.py`), but the GitHub-Actions agents get none of it. Missing behavior: the CI-driven agents start cold on per-repo conventions, lowering first-try completion and causing avoidable rework.

This is **latent fragility, not a current break** (no red main); it is a first-try-success / rework-churn cost.

#### Tasks
- [ ] Add `export_agents_md(repo)` to `Code/Orchestrator/repo_knowledge.py` emitting a ≤30-line section between managed markers (`<!-- BEGIN orch-playbook -->` … `<!-- END orch-playbook -->`) built from `context_for(repo)` for that repo's registry entry.
- [ ] Add a Workflows-side freshness checker `scripts/check_agents_md_freshness.py` that parses the managed `AGENTS.md` section and reports any cited path/command that no longer resolves in the checkout.
- [ ] Wire the freshness checker into `.github/workflows/pr-00-gate.yml` `test-quality` job as a **non-blocking warning first** (annotation, not a hard fail) so it cannot wedge unrelated PRs while the registry is seeded.
- [ ] Document the contract (single owner = registry; `AGENTS.md` block is generated; keepalive validates freshness) in `docs/keepalive/Agents.md`.
- [ ] Mirror any consumer-facing file and update `.github/sync-manifest.yml` in the same PR.

#### Acceptance criteria
- [ ] Named test: `tests/scripts/test_check_agents_md_freshness.py::test_dead_path_flagged` builds a fixture `AGENTS.md` whose managed section cites a non-existent path and asserts the checker reports it; passes via `pytest tests/scripts/test_check_agents_md_freshness.py -q` with a non-zero collected count.
- [ ] **Deliberate-break gate:** temporarily change the freshness checker's path-existence test to always return True. `tests/scripts/test_check_agents_md_freshness.py::test_dead_path_flagged` **must FAIL** (a dead path is no longer flagged). Revert and capture the failure output in the PR.
- [ ] `export_agents_md("stranske/Counter_Risk")` produces a managed section that contains the black-not-ruff gotcha and is ≤30 lines; asserted in `repo_knowledge.py`'s selftest so `python3 Code/Orchestrator/repo_knowledge.py --selftest` stays green.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI freshness gate that scans the managed `AGENTS.md` playbook section for stale or missing command/path references and surfaces findings as non-blocking warnings.
  * Updated consumer repo and PR gate templates to run the check with GitHub annotations.
* **Documentation**
  * Clarified that the Orchestrator registry is the single editable source for curated per-repo playbook rules, including how managed sections are generated.
* **Tests**
  * Expanded coverage for the freshness checker, including missing vs existing paths, `--config=...`-style argument handling, and managed-block parsing robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->