### PR TITLE
Add docs drift fix agent

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,7 +35,7 @@ The CI stack now routes every pull request through a single Gate workflow that o
 Legacy wrappers (`pr-10-ci-python.yml`, `pr-12-docker-smoke.yml`) have been removed now that branch protection enforces the Gate job directly.
 
 ### 1.2 Naming policy & archive status (Issue #1669)
-- Active workflows **must** use one of the WFv1 prefixes: `pr-*`, `maint-*`, `agents-*`, or `reusable-*`. Guard tests (`tests/test_workflow_naming.py`) enforce this policy.
+- Active workflows **must** use one of the WFv1 prefixes: `pr-*`, `maint-*`, `agents-*`, or `reusable-*`. Guard tests (`tests/workflows/test_workflow_naming.py`) enforce this policy.
 - Historical directories `Old/.github/workflows/` and `.github/workflows/archive/` were removed. Reference [ARCHIVE_WORKFLOWS.md](../../ARCHIVE_WORKFLOWS.md) when you need the legacy slugs.
 - New workflows should document their purpose in this README and in [WORKFLOW_AUDIT_TEMP.md](../../WORKFLOW_AUDIT_TEMP.md) so future audits inherit a complete inventory.
 
@@ -189,7 +189,7 @@ Key traits:
 4. Uses the same cosmetic repair helper consumed by the autofix follower, ensuring identical formatting rules across automated and manual flows.
 5. Captures repair summaries and emits outputs that downstream tooling (like Gate summary jobs) can render in job summaries.
 
-Guardrails: `tests/test_workflow_naming.py` asserts the workflow remains in the inventory, and the repair helper’s behaviour is covered by tests for `scripts/ci_cosmetic_repair.py`.
+Guardrails: `tests/workflows/test_workflow_naming.py` asserts the workflow remains in the inventory, and the repair helper’s behaviour is covered by tests for `scripts/ci_cosmetic_repair.py`.
 
 ---
 ## 6. Onboarding Checklist (~7m)

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -32,7 +32,7 @@ operational detail for the kept set.
 4. Update this guide, `docs/ci/WORKFLOWS.md`, and the overview in `docs/ci/WORKFLOW_SYSTEM.md` whenever workflows are added,
    renamed, or removed.
 
-Tests under `tests/test_workflow_naming.py` enforce the naming policy and inventory parity.
+Tests under `tests/workflows/test_workflow_naming.py` enforce the naming policy and inventory parity.
 
 ## Final Workflow Set
 

--- a/docs/ops/REPO_REVIEW_PROCESS.md
+++ b/docs/ops/REPO_REVIEW_PROCESS.md
@@ -85,6 +85,26 @@ available. Use `--no-refresh-stale-gitnexus` to report stale maps without
 refreshing, or `--skip-gitnexus-preflight` only when GitNexus is deliberately
 out of scope for that run.
 
+### Docs-drift fix-agent
+
+The weekly semantic docs-drift scanner and monthly `maint-48-docs-drift-audit`
+issue find stale operational claims, but they do not repair the docs directly.
+Use the deterministic fix-agent to turn drift findings into bounded PR-ready
+repair briefs:
+
+```bash
+python scripts/docs_drift_fix_agent.py \
+    --repo-root . \
+    --scan-json docs/reports/repo-review/docs-drift-scan.json \
+    --out-dir docs/reports/docs-drift-fix-agent
+```
+
+The command is read-only by default. It writes `plan.json`, one repair prompt,
+one issue body, and one PR plan per bounded batch. Give the repair prompt to an
+agent lane to open a docs-only fix PR, or pass `--apply` only when you want the
+tool to create one GitHub issue per batch. The fix-agent composes existing scan
+outputs; it does not launch a new Claude review and it does not edit files.
+
 ### Phase-4 Components
 
 The coordinator orchestrates five Phase-4 scripts under `scripts/`:

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -18,7 +18,7 @@ DriftRecord = dict[str, str]
 DEFAULT_DOCS = ("docs/ci/WORKFLOWS.md",)
 WORKFLOWS_DOC = Path("docs/ci/WORKFLOWS.md")
 WORKFLOW_SUFFIXES = (".yml", ".yaml")
-REPO_PATH_PREFIXES = ("scripts/", ".github/workflows/", "tests/", "docs/")
+REPO_PATH_PREFIXES = ("scripts/", "tests/", "docs/")
 
 WORKFLOW_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])([A-Za-z0-9_./-]+\.ya?ml)(?![A-Za-z0-9_])")
 INLINE_CODE_RE = re.compile(r"(?<!`)`(?!`)([^`\n]+?)(?<!`)`(?!`)")
@@ -80,6 +80,9 @@ def _mentioned_workflow_filenames(text: str, root_workflows: set[str] | None = N
         token = match.group(1)
         if "/" in token:
             if not _is_root_workflow_path(token):
+                continue
+            context = _workflow_token_context(text, match.start(1), match.end(1))
+            if NON_ROOT_WORKFLOW_CONTEXT_RE.search(context):
                 continue
         elif not _is_bare_workflow_reference(text, match, root_workflows):
             continue

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -81,8 +81,10 @@ def _mentioned_workflow_filenames(text: str, root_workflows: set[str] | None = N
         if "/" in token:
             if not _is_root_workflow_path(token):
                 continue
-            context = _workflow_token_context(text, match.start(1), match.end(1))
-            if NON_ROOT_WORKFLOW_CONTEXT_RE.search(context):
+            filename = PurePosixPath(token).name
+            if filename not in (root_workflows or set()) and NON_ROOT_WORKFLOW_CONTEXT_RE.search(
+                _workflow_token_context(text, match.start(1), match.end(1))
+            ):
                 continue
         elif not _is_bare_workflow_reference(text, match, root_workflows):
             continue
@@ -111,7 +113,7 @@ def check_workflow_inventory(root: Path) -> list[DriftRecord]:
                 "type": "undocumented_workflow",
                 "path": filename,
                 "detail": (
-                    "Exists in .github/workflows/ but is not mentioned in " "docs/ci/WORKFLOWS.md"
+                    "Exists in .github/workflows/ but is not mentioned in docs/ci/WORKFLOWS.md"
                 ),
             }
         )

--- a/scripts/docs_drift_fix_agent.py
+++ b/scripts/docs_drift_fix_agent.py
@@ -37,7 +37,6 @@ from scripts import check_docs_drift  # noqa: E402
 DEFAULT_REPO = "stranske/Workflows"
 DEFAULT_MAX_PER_BATCH = 8
 DEFAULT_DOCS_CONFIG = Path("config/source_of_truth_docs.yml")
-DEFAULT_OUTPUT_DIR = Path("docs/reports/docs-drift-fix-agent")
 WORKFLOW_INVENTORY_TEST = (
     "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q"
 )
@@ -183,13 +182,18 @@ def _docs_arg(docs: Sequence[str] | None) -> str:
 
 
 def verification_commands(docs: Sequence[str] | None = None) -> tuple[str, ...]:
-    """Commands that validate the same deterministic docs scope as discovery."""
+    """Commands that must pass after a single repair batch."""
     docs_arg = _docs_arg(docs)
     return (
-        f"python3 scripts/docs_drift_fix_agent.py --repo-root . --json{docs_arg}",
         f"python3 scripts/check_docs_drift.py --json{docs_arg}",
         WORKFLOW_INVENTORY_TEST,
     )
+
+
+def informational_commands(docs: Sequence[str] | None = None) -> tuple[str, ...]:
+    """Commands that refresh full-plan context but may still report other batches."""
+    docs_arg = _docs_arg(docs)
+    return (f"python3 scripts/docs_drift_fix_agent.py --repo-root . --json{docs_arg}",)
 
 
 def _finding_line(finding: Finding) -> str:
@@ -209,6 +213,7 @@ def build_repair_prompt(
 ) -> str:
     finding_lines = "\n".join(_finding_line(finding) for finding in batch.findings)
     check_lines = "\n".join(f"- `{cmd}`" for cmd in (checks or verification_commands()))
+    info_lines = "\n".join(f"- `{cmd}`" for cmd in informational_commands())
     return f"""You are repairing documentation drift in {repo}.
 
 Goal: open one focused docs-only fix PR for repair batch `{batch.batch_id}`.
@@ -224,6 +229,9 @@ Rules:
 
 Required verification before opening the PR:
 {check_lines}
+
+Informational full-plan refresh:
+{info_lines}
 
 Deliverable:
 - Commit the docs-only changes.
@@ -264,6 +272,10 @@ def build_issue_body(
     check_items = "\n".join(
         f"- [ ] `{cmd}` passes after the repair." for cmd in (checks or verification_commands())
     )
+    info_items = "\n".join(
+        f"- [ ] `{cmd}` was reviewed for remaining non-batch findings."
+        for cmd in informational_commands()
+    )
     evidence = "\n".join(
         f"- `{finding.doc_path}` -> `{finding.target}` ({finding.source}/{finding.kind})"
         for finding in batch.findings
@@ -286,11 +298,17 @@ Repair only the docs named in this issue for batch `{batch.batch_id}`:
 - [ ] Keep each edit tied to one listed finding and preserve unrelated wording.
 - [ ] Include the relevant before/after claim in the pull request body.
 - [ ] Run the docs-drift and workflow-inventory verification commands.
+- [ ] Refresh the full fix-agent plan as informational context.
 
 ## Acceptance Criteria
 {check_items}
 - [ ] The pull request changes only documentation files for this batch.
 - [ ] The PR body lists each repaired finding and the source used to verify it.
+
+## Informational Checks
+These commands may still report findings for other batches and should not block this batch once the required checks pass:
+
+{info_items}
 
 ## Implementation Notes
 Use `scripts/docs_drift_fix_agent.py` output for the repair prompt and plan. Evidence trace:

--- a/scripts/docs_drift_fix_agent.py
+++ b/scripts/docs_drift_fix_agent.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Build bounded docs-drift repair plans from existing drift detectors.
+
+This is the missing "fix-agent" layer for docs drift: it does not perform a
+new semantic scan and it does not edit files. It composes the deterministic
+docs-drift check plus an optional weekly ``docs-drift-scan.json`` export into
+small repair batches with:
+
+- an agent prompt for opening a focused fix PR
+- an agent-ready GitHub issue body
+- a local verification checklist
+
+Default mode is read-only. ``--apply`` creates one issue per repair batch and
+never edits repository files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import check_docs_drift  # noqa: E402
+
+DEFAULT_REPO = "stranske/Workflows"
+DEFAULT_MAX_PER_BATCH = 8
+DEFAULT_DOCS_CONFIG = Path("config/source_of_truth_docs.yml")
+DEFAULT_OUTPUT_DIR = Path("docs/reports/docs-drift-fix-agent")
+WORKFLOW_INVENTORY_TEST = (
+    "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    source: str
+    kind: str
+    doc_path: str
+    target: str
+    detail: str
+    classification: str = ""
+    authoritative_source: str = ""
+
+
+@dataclass(frozen=True)
+class RepairBatch:
+    batch_id: str
+    findings: tuple[Finding, ...]
+
+
+def detect_repo_root(cwd: Path | None = None) -> Path:
+    """Find the git root, falling back to the current directory."""
+    probe = cwd or Path.cwd()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=False,
+            cwd=probe,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        result = None
+    if result and result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip()).resolve()
+    return probe.resolve()
+
+
+def _doc_from_detail(detail: str) -> str:
+    match = re.search(r"Referenced in ([^`]+)$", detail or "")
+    if match:
+        return match.group(1).strip()
+    return "docs/ci/WORKFLOWS.md"
+
+
+def findings_from_deterministic_report(report: dict[str, Any]) -> list[Finding]:
+    """Map ``check_docs_drift.build_report`` output into repair findings."""
+    findings: list[Finding] = []
+    for row in report.get("drift") or []:
+        if not isinstance(row, dict):
+            continue
+        kind = str(row.get("type") or "")
+        path = str(row.get("path") or "")
+        detail = str(row.get("detail") or "")
+        doc_path = _doc_from_detail(detail) if kind == "dangling_reference" else "docs/ci/WORKFLOWS.md"
+        findings.append(
+            Finding(
+                source="deterministic",
+                kind=kind,
+                doc_path=doc_path,
+                target=path,
+                detail=detail,
+                classification=kind,
+                authoritative_source=path,
+            )
+        )
+    return findings
+
+
+def findings_from_scan_json(payload: dict[str, Any], *, repo: str) -> list[Finding]:
+    """Extract stale/contradictory semantic drift from docs-drift-scan JSON."""
+    findings: list[Finding] = []
+    for bucket in payload.get("by_repo") or []:
+        if not isinstance(bucket, dict) or bucket.get("repo") != repo:
+            continue
+        for row in bucket.get("drift_instances") or []:
+            if not isinstance(row, dict):
+                continue
+            classification = str(row.get("classification") or "")
+            if classification not in {"stale", "contradictory"}:
+                continue
+            claim = str(row.get("claim") or "").strip()
+            doc_path = str(row.get("doc_path") or "").strip() or "<unknown-doc>"
+            findings.append(
+                Finding(
+                    source="semantic-scan",
+                    kind="semantic_drift",
+                    doc_path=doc_path,
+                    target=claim[:160] or doc_path,
+                    detail=claim,
+                    classification=classification,
+                    authoritative_source=str(row.get("authoritative_source") or "").strip(),
+                )
+            )
+    return findings
+
+
+def dedupe_findings(findings: Sequence[Finding]) -> list[Finding]:
+    """Collapse obvious duplicates while preferring deterministic findings."""
+    priority = {"deterministic": 0, "semantic-scan": 1}
+    ordered = sorted(findings, key=lambda f: (priority.get(f.source, 9), f.doc_path, f.kind, f.target))
+    seen: set[tuple[str, str, str]] = set()
+    out: list[Finding] = []
+    for finding in ordered:
+        key = (
+            finding.doc_path.strip().lower(),
+            finding.kind.strip().lower(),
+            finding.target.strip().lower(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return sorted(out, key=lambda f: (f.doc_path, f.source, f.kind, f.target))
+
+
+def batch_findings(
+    findings: Sequence[Finding],
+    *,
+    max_per_batch: int = DEFAULT_MAX_PER_BATCH,
+) -> list[RepairBatch]:
+    if max_per_batch <= 0:
+        raise ValueError("max_per_batch must be positive")
+    unique = dedupe_findings(findings)
+    batches: list[RepairBatch] = []
+    for index in range(0, len(unique), max_per_batch):
+        chunk = tuple(unique[index : index + max_per_batch])
+        batches.append(RepairBatch(batch_id=f"docs-drift-{len(batches) + 1:02d}", findings=chunk))
+    return batches
+
+
+def _docs_arg(docs: Sequence[str] | None) -> str:
+    if not docs:
+        return ""
+    return " --docs " + " ".join(docs)
+
+
+def verification_commands(docs: Sequence[str] | None = None) -> tuple[str, ...]:
+    """Commands that validate the same deterministic docs scope as discovery."""
+    docs_arg = _docs_arg(docs)
+    return (
+        f"python3 scripts/docs_drift_fix_agent.py --repo-root . --json{docs_arg}",
+        f"python3 scripts/check_docs_drift.py --json{docs_arg}",
+        WORKFLOW_INVENTORY_TEST,
+    )
+
+
+def _finding_line(finding: Finding) -> str:
+    suffix = f" ({finding.classification})" if finding.classification else ""
+    source = f"; source={finding.authoritative_source}" if finding.authoritative_source else ""
+    return (
+        f"- `{finding.doc_path}`: {finding.kind}{suffix}; target `{finding.target}`; "
+        f"{finding.detail}{source}"
+    )
+
+
+def build_repair_prompt(
+    batch: RepairBatch,
+    *,
+    repo: str = DEFAULT_REPO,
+    checks: Sequence[str] | None = None,
+) -> str:
+    finding_lines = "\n".join(_finding_line(finding) for finding in batch.findings)
+    check_lines = "\n".join(f"- `{cmd}`" for cmd in (checks or verification_commands()))
+    return f"""You are repairing documentation drift in {repo}.
+
+Goal: open one focused docs-only fix PR for repair batch `{batch.batch_id}`.
+
+Findings to repair:
+{finding_lines}
+
+Rules:
+- Fix the documentation to match the current repository tree unless the finding names a stronger source of truth.
+- Keep edits narrow. Do not rewrite whole documents or introduce new design content.
+- Do not change workflows, scripts, templates, generated files, or consumer repositories in this batch.
+- Cite exact file paths in the PR body and include the verification commands you ran.
+
+Required verification before opening the PR:
+{check_lines}
+
+Deliverable:
+- Commit the docs-only changes.
+- Push a branch.
+- Open a PR titled `[Docs Drift] Repair {batch.batch_id}`.
+"""
+
+
+def build_pr_plan(batch: RepairBatch, *, checks: Sequence[str] | None = None) -> str:
+    doc_paths = sorted({finding.doc_path for finding in batch.findings})
+    check_lines = "\n".join(f"- [ ] `{cmd}`" for cmd in (checks or verification_commands()))
+    findings = "\n".join(_finding_line(finding) for finding in batch.findings)
+    docs = "\n".join(f"- [ ] `{doc}`" for doc in doc_paths)
+    return f"""# Docs Drift Repair Plan: {batch.batch_id}
+
+## Scope
+{docs}
+
+## Findings
+{findings}
+
+## Verification
+{check_lines}
+"""
+
+
+def build_issue_body(
+    batch: RepairBatch,
+    *,
+    repo: str = DEFAULT_REPO,
+    checks: Sequence[str] | None = None,
+) -> str:
+    findings = "\n".join(_finding_line(finding) for finding in batch.findings)
+    docs = sorted({finding.doc_path for finding in batch.findings})
+    docs_tasks = "\n".join(f"- [ ] Update `{doc}` so its cited claims match the current tree." for doc in docs)
+    check_items = "\n".join(
+        f"- [ ] `{cmd}` passes after the repair." for cmd in (checks or verification_commands())
+    )
+    evidence = "\n".join(
+        f"- `{finding.doc_path}` -> `{finding.target}` ({finding.source}/{finding.kind})"
+        for finding in batch.findings
+    )
+    return f"""## Why
+The docs-drift fix-agent found source-of-truth documentation claims that no longer match current repository state in `{repo}`. Stale operational docs mislead agents and humans during workflow maintenance.
+
+## Scope
+Repair only the docs named in this issue for batch `{batch.batch_id}`:
+
+{findings}
+
+## Non-Goals
+- Do not change workflow YAML, scripts, templates, generated artifacts, or consumer repositories.
+- Do not broaden the docs or rewrite unrelated sections.
+- Do not resolve findings outside this batch.
+
+## Tasks
+{docs_tasks}
+- [ ] Keep each edit tied to one listed finding and preserve unrelated wording.
+- [ ] Include the relevant before/after claim in the pull request body.
+- [ ] Run the docs-drift and workflow-inventory verification commands.
+
+## Acceptance Criteria
+{check_items}
+- [ ] The pull request changes only documentation files for this batch.
+- [ ] The PR body lists each repaired finding and the source used to verify it.
+
+## Implementation Notes
+Use `scripts/docs_drift_fix_agent.py` output for the repair prompt and plan. Evidence trace:
+
+{evidence}
+"""
+
+
+def load_scan_json(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {"by_repo": []}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def default_docs_from_config(repo_root: Path, *, repo: str = DEFAULT_REPO) -> list[str]:
+    config_path = repo_root / DEFAULT_DOCS_CONFIG
+    if not config_path.is_file():
+        return list(check_docs_drift.DEFAULT_DOCS)
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    repo_config = (data.get("repos") or {}).get(repo) or {}
+    docs = [
+        str(item.get("path"))
+        for item in repo_config.get("docs") or []
+        if isinstance(item, dict) and item.get("path")
+    ]
+    return docs or list(check_docs_drift.DEFAULT_DOCS)
+
+
+def collect_findings(
+    *,
+    repo_root: Path,
+    repo: str,
+    docs: Sequence[str] | None = None,
+    scan_json: Path | None = None,
+) -> list[Finding]:
+    docs_to_scan = list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
+    deterministic = check_docs_drift.build_report(check_docs_drift.check_docs_drift(repo_root, docs_to_scan))
+    findings = findings_from_deterministic_report(deterministic)
+    if scan_json is not None:
+        findings.extend(findings_from_scan_json(load_scan_json(scan_json), repo=repo))
+    return dedupe_findings(findings)
+
+
+def build_plan(
+    *,
+    repo_root: Path,
+    repo: str,
+    docs: Sequence[str] | None = None,
+    scan_json: Path | None = None,
+    max_per_batch: int = DEFAULT_MAX_PER_BATCH,
+) -> dict[str, Any]:
+    docs_to_scan = list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
+    checks = verification_commands(docs_to_scan)
+    findings = collect_findings(repo_root=repo_root, repo=repo, docs=docs_to_scan, scan_json=scan_json)
+    batches = batch_findings(findings, max_per_batch=max_per_batch)
+    return {
+        "repo": repo,
+        "repo_root": str(repo_root),
+        "finding_count": len(findings),
+        "batch_count": len(batches),
+        "checks": list(checks),
+        "findings": [asdict(finding) for finding in findings],
+        "batches": [
+            {
+                "batch_id": batch.batch_id,
+                "findings": [asdict(finding) for finding in batch.findings],
+                "repair_prompt": build_repair_prompt(batch, repo=repo, checks=checks),
+                "issue_title": f"[Docs Drift] Repair {batch.batch_id}",
+                "issue_body": build_issue_body(batch, repo=repo, checks=checks),
+                "pr_plan": build_pr_plan(batch, checks=checks),
+            }
+            for batch in batches
+        ],
+    }
+
+
+def write_plan_outputs(plan: dict[str, Any], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "plan.json").write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    for batch in plan["batches"]:
+        batch_id = batch["batch_id"]
+        (out_dir / f"{batch_id}-repair-prompt.md").write_text(
+            batch["repair_prompt"], encoding="utf-8"
+        )
+        (out_dir / f"{batch_id}-issue-body.md").write_text(batch["issue_body"], encoding="utf-8")
+        (out_dir / f"{batch_id}-pr-plan.md").write_text(batch["pr_plan"], encoding="utf-8")
+
+
+def apply_issues(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    created: list[dict[str, Any]] = []
+    for batch in plan["batches"]:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                plan["repo"],
+                "--title",
+                batch["issue_title"],
+                "--body",
+                batch["issue_body"],
+                "--label",
+                "documentation",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+        created.append(
+            {
+                "batch_id": batch["batch_id"],
+                "returncode": result.returncode,
+                "stdout": result.stdout.strip(),
+                "stderr": result.stderr.strip(),
+            }
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue create failed for {batch['batch_id']}: {result.stderr.strip()}")
+    return created
+
+
+def format_summary(plan: dict[str, Any], out_dir: Path | None = None) -> str:
+    lines = [
+        f"Docs drift fix-agent: {plan['finding_count']} finding(s) in {plan['batch_count']} batch(es)"
+    ]
+    by_source: dict[str, int] = {}
+    for finding in plan["findings"]:
+        by_source[finding["source"]] = by_source.get(finding["source"], 0) + 1
+    if by_source:
+        lines.append("  " + " ".join(f"{key}={by_source[key]}" for key in sorted(by_source)))
+    for batch in plan["batches"]:
+        docs = sorted({finding["doc_path"] for finding in batch["findings"]})
+        lines.append(f"  {batch['batch_id']}: {', '.join(docs)}")
+    if out_dir is not None:
+        lines.append(f"Outputs: {out_dir}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build bounded docs-drift repair prompts and issue bodies."
+    )
+    parser.add_argument("--repo-root", type=Path, help="repository root to scan")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo name for issue/prompt output")
+    parser.add_argument("--docs", nargs="+", help="repo-relative docs to scan for dangling refs")
+    parser.add_argument("--scan-json", type=Path, help="optional repo_review docs-drift-scan.json")
+    parser.add_argument("--out-dir", type=Path, help="write plan and per-batch prompt files")
+    parser.add_argument("--max-per-batch", type=int, default=DEFAULT_MAX_PER_BATCH)
+    parser.add_argument("--json", action="store_true", help="print plan JSON")
+    parser.add_argument("--apply", action="store_true", help="create one GitHub issue per repair batch")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        repo_root = (args.repo_root or detect_repo_root()).expanduser().resolve()
+        if not repo_root.is_dir():
+            raise FileNotFoundError(f"repo root not found: {repo_root}")
+        scan_json = args.scan_json.expanduser().resolve() if args.scan_json else None
+        if scan_json is not None and not scan_json.is_file():
+            raise FileNotFoundError(f"scan json not found: {scan_json}")
+        plan = build_plan(
+            repo_root=repo_root,
+            repo=args.repo,
+            docs=args.docs,
+            scan_json=scan_json,
+            max_per_batch=args.max_per_batch,
+        )
+        out_dir = args.out_dir.expanduser().resolve() if args.out_dir else None
+        if out_dir is not None:
+            write_plan_outputs(plan, out_dir)
+        if args.apply:
+            plan["created_issues"] = apply_issues(plan)
+        if args.json:
+            print(json.dumps(plan, indent=2))
+        else:
+            print(format_summary(plan, out_dir))
+        return 1 if plan["finding_count"] else 0
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/docs_drift_fix_agent.py
+++ b/scripts/docs_drift_fix_agent.py
@@ -95,7 +95,9 @@ def findings_from_deterministic_report(report: dict[str, Any]) -> list[Finding]:
         kind = str(row.get("type") or "")
         path = str(row.get("path") or "")
         detail = str(row.get("detail") or "")
-        doc_path = _doc_from_detail(detail) if kind == "dangling_reference" else "docs/ci/WORKFLOWS.md"
+        doc_path = (
+            _doc_from_detail(detail) if kind == "dangling_reference" else "docs/ci/WORKFLOWS.md"
+        )
         findings.append(
             Finding(
                 source="deterministic",
@@ -141,7 +143,9 @@ def findings_from_scan_json(payload: dict[str, Any], *, repo: str) -> list[Findi
 def dedupe_findings(findings: Sequence[Finding]) -> list[Finding]:
     """Collapse obvious duplicates while preferring deterministic findings."""
     priority = {"deterministic": 0, "semantic-scan": 1}
-    ordered = sorted(findings, key=lambda f: (priority.get(f.source, 9), f.doc_path, f.kind, f.target))
+    ordered = sorted(
+        findings, key=lambda f: (priority.get(f.source, 9), f.doc_path, f.kind, f.target)
+    )
     seen: set[tuple[str, str, str]] = set()
     out: list[Finding] = []
     for finding in ordered:
@@ -254,7 +258,9 @@ def build_issue_body(
 ) -> str:
     findings = "\n".join(_finding_line(finding) for finding in batch.findings)
     docs = sorted({finding.doc_path for finding in batch.findings})
-    docs_tasks = "\n".join(f"- [ ] Update `{doc}` so its cited claims match the current tree." for doc in docs)
+    docs_tasks = "\n".join(
+        f"- [ ] Update `{doc}` so its cited claims match the current tree." for doc in docs
+    )
     check_items = "\n".join(
         f"- [ ] `{cmd}` passes after the repair." for cmd in (checks or verification_commands())
     )
@@ -320,8 +326,12 @@ def collect_findings(
     docs: Sequence[str] | None = None,
     scan_json: Path | None = None,
 ) -> list[Finding]:
-    docs_to_scan = list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
-    deterministic = check_docs_drift.build_report(check_docs_drift.check_docs_drift(repo_root, docs_to_scan))
+    docs_to_scan = (
+        list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
+    )
+    deterministic = check_docs_drift.build_report(
+        check_docs_drift.check_docs_drift(repo_root, docs_to_scan)
+    )
     findings = findings_from_deterministic_report(deterministic)
     if scan_json is not None:
         findings.extend(findings_from_scan_json(load_scan_json(scan_json), repo=repo))
@@ -336,9 +346,13 @@ def build_plan(
     scan_json: Path | None = None,
     max_per_batch: int = DEFAULT_MAX_PER_BATCH,
 ) -> dict[str, Any]:
-    docs_to_scan = list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
+    docs_to_scan = (
+        list(docs) if docs is not None else default_docs_from_config(repo_root, repo=repo)
+    )
     checks = verification_commands(docs_to_scan)
-    findings = collect_findings(repo_root=repo_root, repo=repo, docs=docs_to_scan, scan_json=scan_json)
+    findings = collect_findings(
+        repo_root=repo_root, repo=repo, docs=docs_to_scan, scan_json=scan_json
+    )
     batches = batch_findings(findings, max_per_batch=max_per_batch)
     return {
         "repo": repo,
@@ -404,7 +418,9 @@ def apply_issues(plan: dict[str, Any]) -> list[dict[str, Any]]:
             }
         )
         if result.returncode != 0:
-            raise RuntimeError(f"gh issue create failed for {batch['batch_id']}: {result.stderr.strip()}")
+            raise RuntimeError(
+                f"gh issue create failed for {batch['batch_id']}: {result.stderr.strip()}"
+            )
     return created
 
 
@@ -430,13 +446,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         description="Build bounded docs-drift repair prompts and issue bodies."
     )
     parser.add_argument("--repo-root", type=Path, help="repository root to scan")
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repo name for issue/prompt output")
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help="GitHub repo name for issue/prompt output"
+    )
     parser.add_argument("--docs", nargs="+", help="repo-relative docs to scan for dangling refs")
     parser.add_argument("--scan-json", type=Path, help="optional repo_review docs-drift-scan.json")
     parser.add_argument("--out-dir", type=Path, help="write plan and per-batch prompt files")
     parser.add_argument("--max-per-batch", type=int, default=DEFAULT_MAX_PER_BATCH)
     parser.add_argument("--json", action="store_true", help="print plan JSON")
-    parser.add_argument("--apply", action="store_true", help="create one GitHub issue per repair batch")
+    parser.add_argument(
+        "--apply", action="store_true", help="create one GitHub issue per repair batch"
+    )
     return parser.parse_args(argv)
 
 

--- a/tests/scripts/test_docs_drift_fix_agent.py
+++ b/tests/scripts/test_docs_drift_fix_agent.py
@@ -109,6 +109,8 @@ def test_issue_body_is_agent_ready() -> None:
     assert issue_body_is_agent_ready(body)
     assert "## Why" in body
     assert "python3 scripts/check_docs_drift.py --json" in body
+    assert "## Informational Checks" in body
+    assert "was reviewed for remaining non-batch findings" in body
 
 
 def test_repair_prompt_includes_required_verification() -> None:
@@ -132,6 +134,7 @@ def test_repair_prompt_includes_required_verification() -> None:
         "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q"
         in prompt
     )
+    assert "Informational full-plan refresh" in prompt
     assert "Do not change workflows" in prompt
 
 

--- a/tests/scripts/test_docs_drift_fix_agent.py
+++ b/tests/scripts/test_docs_drift_fix_agent.py
@@ -111,6 +111,7 @@ def test_issue_body_is_agent_ready() -> None:
     assert "python3 scripts/check_docs_drift.py --json" in body
     assert "## Informational Checks" in body
     assert "was reviewed for remaining non-batch findings" in body
+    assert "python3 scripts/docs_drift_fix_agent.py --repo-root . --json" in body
 
 
 def test_repair_prompt_includes_required_verification() -> None:
@@ -135,6 +136,7 @@ def test_repair_prompt_includes_required_verification() -> None:
         in prompt
     )
     assert "Informational full-plan refresh" in prompt
+    assert "python3 scripts/docs_drift_fix_agent.py --repo-root . --json" in prompt
     assert "Do not change workflows" in prompt
 
 

--- a/tests/scripts/test_docs_drift_fix_agent.py
+++ b/tests/scripts/test_docs_drift_fix_agent.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import docs_drift_fix_agent as fix_agent  # noqa: E402
+from scripts.repo_review_issue_quality import issue_body_is_agent_ready  # noqa: E402
+
+
+def _write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _repo(root: Path, *, workflows: tuple[str, ...], workflows_doc: str) -> Path:
+    _write(root / "docs/ci/WORKFLOWS.md", workflows_doc)
+    for workflow in workflows:
+        _write(root / ".github/workflows" / workflow, "name: test\n")
+    return root
+
+
+def test_findings_from_scan_json_filters_accurate_instances() -> None:
+    payload = {
+        "by_repo": [
+            {
+                "repo": "stranske/Workflows",
+                "drift_instances": [
+                    {
+                        "doc_path": "README.md",
+                        "claim": "Old command",
+                        "authoritative_source": "scripts/new.py:1",
+                        "classification": "stale",
+                    },
+                    {
+                        "doc_path": "README.md",
+                        "claim": "Verified",
+                        "classification": "accurate-no-drift",
+                    },
+                ],
+            }
+        ]
+    }
+
+    findings = fix_agent.findings_from_scan_json(payload, repo="stranske/Workflows")
+
+    assert len(findings) == 1
+    assert findings[0].source == "semantic-scan"
+    assert findings[0].classification == "stale"
+
+
+def test_batch_findings_respects_max_per_batch() -> None:
+    findings = [
+        fix_agent.Finding(
+            source="deterministic",
+            kind="dangling_reference",
+            doc_path=f"docs/{index}.md",
+            target=f"scripts/missing_{index}.py",
+            detail="missing",
+        )
+        for index in range(10)
+    ]
+
+    batches = fix_agent.batch_findings(findings, max_per_batch=8)
+
+    assert [len(batch.findings) for batch in batches] == [8, 2]
+    assert [batch.batch_id for batch in batches] == ["docs-drift-01", "docs-drift-02"]
+
+
+def test_dedupe_prefers_deterministic_finding() -> None:
+    semantic = fix_agent.Finding(
+        source="semantic-scan",
+        kind="dangling_reference",
+        doc_path="docs/ci/WORKFLOWS.md",
+        target="scripts/missing.py",
+        detail="semantic",
+    )
+    deterministic = fix_agent.Finding(
+        source="deterministic",
+        kind="dangling_reference",
+        doc_path="docs/ci/WORKFLOWS.md",
+        target="scripts/missing.py",
+        detail="deterministic",
+    )
+
+    assert fix_agent.dedupe_findings([semantic, deterministic]) == [deterministic]
+
+
+def test_issue_body_is_agent_ready() -> None:
+    batch = fix_agent.RepairBatch(
+        batch_id="docs-drift-01",
+        findings=(
+            fix_agent.Finding(
+                source="deterministic",
+                kind="undocumented_workflow",
+                doc_path="docs/ci/WORKFLOWS.md",
+                target="new.yml",
+                detail="Exists in .github/workflows/ but is not mentioned",
+            ),
+        ),
+    )
+
+    body = fix_agent.build_issue_body(batch)
+
+    assert issue_body_is_agent_ready(body)
+    assert "## Why" in body
+    assert "python3 scripts/check_docs_drift.py --json" in body
+
+
+def test_repair_prompt_includes_required_verification() -> None:
+    batch = fix_agent.RepairBatch(
+        batch_id="docs-drift-01",
+        findings=(
+            fix_agent.Finding(
+                source="deterministic",
+                kind="documented_but_missing",
+                doc_path="docs/ci/WORKFLOWS.md",
+                target="old.yml",
+                detail="missing from .github/workflows",
+            ),
+        ),
+    )
+
+    prompt = fix_agent.build_repair_prompt(batch)
+
+    assert "open one focused docs-only fix PR" in prompt
+    assert "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q" in prompt
+    assert "Do not change workflows" in prompt
+
+
+def test_cli_clean_repo_exit_zero(tmp_path: Path, capsys) -> None:
+    root = _repo(
+        tmp_path / "repo",
+        workflows=("build.yml",),
+        workflows_doc="Active workflows: `build.yml`.\n",
+    )
+
+    exit_code = fix_agent.main(["--repo-root", str(root), "--docs", "docs/ci/WORKFLOWS.md"])
+
+    assert exit_code == 0
+    assert "0 finding(s)" in capsys.readouterr().out
+
+
+def test_cli_drift_fixture_exit_one_and_writes_outputs(tmp_path: Path, capsys) -> None:
+    root = _repo(
+        tmp_path / "repo",
+        workflows=("build.yml", "new.yml"),
+        workflows_doc="Active workflows: `build.yml`.\nMissing path: `scripts/missing.py`.\n",
+    )
+    out_dir = tmp_path / "out"
+
+    exit_code = fix_agent.main(
+        [
+            "--repo-root",
+            str(root),
+            "--docs",
+            "docs/ci/WORKFLOWS.md",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert exit_code == 1
+    stdout = capsys.readouterr().out
+    assert "2 finding(s)" in stdout
+    plan = json.loads((out_dir / "plan.json").read_text(encoding="utf-8"))
+    assert plan["finding_count"] == 2
+    assert (out_dir / "docs-drift-01-repair-prompt.md").is_file()
+    assert (out_dir / "docs-drift-01-issue-body.md").is_file()
+    assert (out_dir / "docs-drift-01-pr-plan.md").is_file()
+
+
+def test_cli_apply_creates_one_issue_per_batch(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    root = _repo(
+        tmp_path / "repo",
+        workflows=("a.yml", "b.yml"),
+        workflows_doc="No workflows listed.\n",
+    )
+    calls: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = "https://github.com/stranske/Workflows/issues/1\n"
+        stderr = ""
+
+    def fake_run(args, **kwargs):  # noqa: ANN001
+        calls.append(list(args))
+        return Result()
+
+    monkeypatch.setattr(fix_agent.subprocess, "run", fake_run)
+
+    exit_code = fix_agent.main(
+        [
+            "--repo-root",
+            str(root),
+            "--docs",
+            "docs/ci/WORKFLOWS.md",
+            "--max-per-batch",
+            "1",
+            "--apply",
+        ]
+    )
+
+    assert exit_code == 1
+    capsys.readouterr()
+    issue_calls = [call for call in calls if call[:3] == ["gh", "issue", "create"]]
+    assert len(issue_calls) == 2

--- a/tests/scripts/test_docs_drift_fix_agent.py
+++ b/tests/scripts/test_docs_drift_fix_agent.py
@@ -128,7 +128,10 @@ def test_repair_prompt_includes_required_verification() -> None:
     prompt = fix_agent.build_repair_prompt(batch)
 
     assert "open one focused docs-only fix PR" in prompt
-    assert "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q" in prompt
+    assert (
+        "pytest tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q"
+        in prompt
+    )
     assert "Do not change workflows" in prompt
 
 
@@ -174,9 +177,7 @@ def test_cli_drift_fixture_exit_one_and_writes_outputs(tmp_path: Path, capsys) -
     assert (out_dir / "docs-drift-01-pr-plan.md").is_file()
 
 
-def test_cli_apply_creates_one_issue_per_batch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_cli_apply_creates_one_issue_per_batch(tmp_path: Path, monkeypatch, capsys) -> None:
     root = _repo(
         tmp_path / "repo",
         workflows=("a.yml", "b.yml"),

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -167,7 +167,9 @@ def test_consumer_workflow_destination_path_is_not_dangling_reference(tmp_path: 
     assert check_docs_drift(root) == []
 
 
-def test_root_workflow_link_counts_before_consumer_context_suppression(tmp_path: Path) -> None:
+def test_consumer_context_does_not_suppress_known_root_workflow_mention(
+    tmp_path: Path,
+) -> None:
     root = _repo(
         tmp_path,
         workflows=("health-68-consumer-sync-drift.yml",),

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -167,6 +167,20 @@ def test_consumer_workflow_destination_path_is_not_dangling_reference(tmp_path: 
     assert check_docs_drift(root) == []
 
 
+def test_root_workflow_link_counts_before_consumer_context_suppression(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("health-68-consumer-sync-drift.yml",),
+        workflows_doc=(
+            "Consumer sync drift is covered by "
+            "[Health 68 Consumer Sync Drift](../../.github/workflows/"
+            "health-68-consumer-sync-drift.yml).\n"
+        ),
+    )
+
+    assert check_workflow_inventory(root) == []
+
+
 def test_repo_path_glob_tokens_are_ignored(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,

--- a/tests/test_check_docs_drift.py
+++ b/tests/test_check_docs_drift.py
@@ -152,6 +152,21 @@ def test_missing_backtick_repo_path_is_dangling_reference(tmp_path: Path) -> Non
     assert "docs/ci/WORKFLOWS.md" in drift[0]["detail"]
 
 
+def test_consumer_workflow_destination_path_is_not_dangling_reference(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        workflows=("build.yml",),
+        workflows_doc=(
+            "Install the consumer workflow at `.github/workflows/ci.yml`, "
+            "using the template source `templates/consumer-repo/.github/workflows/ci.yml`.\n"
+            "The Workflows inventory still lists `build.yml`.\n"
+        ),
+    )
+
+    assert check_dangling_references(root) == []
+    assert check_docs_drift(root) == []
+
+
 def test_repo_path_glob_tokens_are_ignored(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- add a read-only-by-default docs_drift_fix_agent CLI that composes deterministic drift checks plus optional docs-drift-scan.json into bounded repair prompts, issue bodies, and PR plans
- tighten docs drift detection to avoid treating consumer .github/workflows destination paths as missing Workflows repo files
- refresh active docs references to the workflow naming test path and document the fix-agent in the repo-review process

## Validation
- python3 -m pytest tests/scripts/test_docs_drift_fix_agent.py tests/test_check_docs_drift.py tests/workflows/test_workflow_naming.py::test_inventory_docs_list_all_workflows -q
- uv run ruff check scripts/docs_drift_fix_agent.py scripts/check_docs_drift.py tests/scripts/test_docs_drift_fix_agent.py tests/test_check_docs_drift.py
- python3 scripts/check_docs_drift.py --json
- python3 scripts/docs_drift_fix_agent.py --repo-root . --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a CLI tool to turn documentation drift scan results into bounded repair batches, including PR prompts, checklists, and ready-to-file issue descriptions, with optional issue creation.

* **Bug Fixes**
  * Reduced documentation-drift false positives by ignoring workflow inline tokens under the workflows directory and excluding non-root template/consumer references from drift counting.

* **Documentation**
  * Updated workflow and repo review docs to reference the relocated workflow naming guard test.

* **Tests**
  * Added coverage for the new repair-plan CLI and expanded drift/inventory checks for consumer workflow template links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->