### PR TITLE
Cover Renovate fleet distribution contracts

### DIFF
--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -21,13 +21,12 @@ def _manifest_entries() -> dict[str, dict]:
 def test_consumer_create_only_files_are_manifested() -> None:
     entries = _manifest_entries()
 
-    # .github/dependabot.yml was intentionally dropped from the template and the
-    # manifest in #2401 (P3b of the Renovate fleet migration): create_only sync
-    # would otherwise resurrect Dependabot on every re-sync. It must no longer be
-    # manifested.
+    # Consumer-specific bootstrap files must be seeded without clobbering repos
+    # that already customized their local configuration.
     for source in (
         ".github/workflows/pr-00-gate.yml",
         ".github/workflows/ci.yml",
+        ".github/renovate.json",
     ):
         assert source in entries
         assert entries[source]["sync_mode"] == "create_only"
@@ -38,9 +37,19 @@ def test_consumer_create_only_files_are_manifested() -> None:
     ):
         assert entries[source]["overwrite_repos"] == ["stranske/Template"]
 
-    # Guard against re-adding the Dependabot config to the manifest (would
-    # resurrect Dependabot on consumers via create_only sync). See #2401.
+    # .github/dependabot.yml was intentionally dropped from the template and the
+    # manifest in #2401 (P3b of the Renovate fleet migration): create_only sync
+    # would otherwise resurrect Dependabot on every re-sync. It must no longer be
+    # manifested.
     assert ".github/dependabot.yml" not in entries
+
+
+def test_consumer_renovate_template_extends_fleet_preset() -> None:
+    template = yaml.safe_load(
+        (REPO_ROOT / "templates/consumer-repo/.github/renovate.json").read_text(encoding="utf-8")
+    )
+
+    assert template["extends"] == ["github>stranske/Workflows//renovate-presets/fleet"]
 
 
 def test_gate_manifest_entry_documents_fresh_consumer_bootstrap_risk() -> None:

--- a/tests/workflows/test_maint82_sync_campaign_contract.py
+++ b/tests/workflows/test_maint82_sync_campaign_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 WORKFLOW = Path(".github/workflows/maint-82-sync-dependency-campaign.yml")
+CAMPAIGN_SCRIPT = Path(".github/scripts/sync_dependency_campaign.js")
 
 
 def _refresh_script() -> str:
@@ -35,3 +36,11 @@ def test_campaign_workflow_bot_agnostic_identity():
     assert data["name"] == "Sync/Dependency Campaign"
     # Loads the renamed campaign script.
     assert "sync_dependency_campaign.js" in _refresh_script()
+
+
+def test_campaign_tracks_renovate_as_dependency_bot():
+    script = CAMPAIGN_SCRIPT.read_text(encoding="utf-8")
+
+    assert "renovate[bot]" in script
+    assert "app/renovate" in script
+    assert "headRef.startsWith('renovate/')" in script


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## Summary
- Adds contract coverage that the consumer Renovate config stays create-only in the sync manifest
- Asserts the consumer Renovate template extends the shared fleet preset
- Adds a maint-82 contract guard that Renovate bot identities and branches stay classified as dependency-bot work

## Validation
- python3 -m pytest tests/workflows/test_maint82_sync_campaign_contract.py tests/workflows/test_consumer_sync_create_only_evidence.py tests/workflows/test_dependency_bot_conditions.py -q
- node --test .github/scripts/__tests__/sync_dependency_campaign.test.js
- uv run ruff check tests/workflows/test_maint82_sync_campaign_contract.py tests/workflows/test_consumer_sync_create_only_evidence.py
- uv run black --check --line-length 100 tests/workflows/test_maint82_sync_campaign_contract.py tests/workflows/test_consumer_sync_create_only_evidence.py
- python3 scripts/validate_template_completeness.py --strict --source sync-manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Renovate configuration synchronization and preset inheritance validation
  * Added test to verify Renovate bot is properly tracked in dependency management automation scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->