### PR TITLE
fix: harden orchestrator skill materialization

### DIFF
--- a/.github/actions/agent-reference-packs/action.yml
+++ b/.github/actions/agent-reference-packs/action.yml
@@ -172,4 +172,8 @@ runs:
             print("Orchestrator skill context not materialized.")
         else:
             print(f"Generated {summary}")
+            env_path = os.environ.get("GITHUB_ENV")
+            if env_path:
+                with open(env_path, "a", encoding="utf-8") as env_file:
+                    env_file.write(f"ORCHESTRATOR_SKILL_SUMMARY_PATH={summary}\n")
         ORCHSKILL_EOF

--- a/scripts/orchestrator_skill.py
+++ b/scripts/orchestrator_skill.py
@@ -80,7 +80,8 @@ def _require_nonempty_string(value: Any, field_name: str) -> str:
 
 
 def _validate_repo(repo: str) -> str:
-    if "/" not in repo or repo.startswith("/") or repo.endswith("/"):
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
         raise OrchestratorSkillConfigError("repo must use owner/name format")
     return repo
 

--- a/scripts/reference_packs.py
+++ b/scripts/reference_packs.py
@@ -83,7 +83,8 @@ def _require_nonempty_string(value: Any, field_name: str) -> str:
 
 
 def _validate_repo(repo: str) -> str:
-    if "/" not in repo or repo.startswith("/") or repo.endswith("/"):
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
         raise ReferencePackConfigError("repo must use owner/name format")
     return repo
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -421,7 +421,12 @@ def assemble_prompt(
             token=token,
         )
     else:
-        orchestrator_summary_path = None
+        orchestrator_summary_raw = context.get("orchestrator_skill_summary_path")
+        orchestrator_summary_path = (
+            Path(str(orchestrator_summary_raw)) if orchestrator_summary_raw else None
+        )
+        if orchestrator_summary_path and not orchestrator_summary_path.is_absolute():
+            orchestrator_summary_path = workspace / orchestrator_summary_path
 
     output_file = str(
         context.get("output_file") or _prompt_output_name(provider, context.get("pr_number"))
@@ -945,6 +950,7 @@ def _cmd_assemble(args: argparse.Namespace) -> int:
         "materialize_orchestrator_skill": args.materialize_orchestrator_skill,
         "orchestrator_skill_pack": args.orchestrator_skill_pack or None,
         "orchestrator_skill_enabled": _parse_optional_bool(args.orchestrator_skill_enabled),
+        "orchestrator_skill_summary_path": os.environ.get("ORCHESTRATOR_SKILL_SUMMARY_PATH"),
         "github_token": os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
     }
     prompt = assemble_prompt(args.reference_pack_name, context, args.provider)

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import contextlib
 import dataclasses
 import datetime as dt
 import hashlib
@@ -366,7 +367,8 @@ def materialize_orchestrator_skill(
         if not matching:
             raise ValueError(f"orchestrator skill reference pack not found: {plan.pack}")
         checkout_path = workspace_path / matching[0].checkout_path
-        shutil.rmtree(checkout_path, ignore_errors=True)
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(checkout_path)
         materialize_reference_packs(
             workspace_path,
             reference_pack_name=plan.pack,

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -356,11 +356,6 @@ def materialize_orchestrator_skill(
         return None
 
     if plan.pack:
-        materialize_reference_packs(
-            workspace_path,
-            reference_pack_name=plan.pack,
-            token=token,
-        )
         reference_packs = _load_reference_packs_module()
         snapshot = reference_packs.load_reference_packs(workspace_path)
         matching = [
@@ -371,6 +366,12 @@ def materialize_orchestrator_skill(
         if not matching:
             raise ValueError(f"orchestrator skill reference pack not found: {plan.pack}")
         checkout_path = workspace_path / matching[0].checkout_path
+        shutil.rmtree(checkout_path, ignore_errors=True)
+        materialize_reference_packs(
+            workspace_path,
+            reference_pack_name=plan.pack,
+            token=token,
+        )
     else:
         checkout_path = _materialize_single_checkout_plan(
             workspace_path,
@@ -413,12 +414,14 @@ def assemble_prompt(
         )
 
     if context.get("materialize_orchestrator_skill"):
-        materialize_orchestrator_skill(
+        orchestrator_summary_path = materialize_orchestrator_skill(
             workspace,
             pack_override=context.get("orchestrator_skill_pack") or None,
             enabled_override=context.get("orchestrator_skill_enabled"),
             token=token,
         )
+    else:
+        orchestrator_summary_path = None
 
     output_file = str(
         context.get("output_file") or _prompt_output_name(provider, context.get("pr_number"))
@@ -448,12 +451,11 @@ def assemble_prompt(
     if reference_summary.is_file():
         parts.extend(["\n\n## Reference Packs\n", _read_text(reference_summary).rstrip()])
 
-    orchestrator_summary = workspace / ".reference" / "ORCHESTRATOR_SKILL.md"
-    if orchestrator_summary.is_file():
+    if orchestrator_summary_path and orchestrator_summary_path.is_file():
         parts.extend(
             [
                 "\n\n## Orchestrator Skill Context\n",
-                _read_text(orchestrator_summary).rstrip(),
+                _read_text(orchestrator_summary_path).rstrip(),
             ]
         )
 

--- a/tests/scripts/test_orchestrator_skill.py
+++ b/tests/scripts/test_orchestrator_skill.py
@@ -82,6 +82,18 @@ def test_parse_rejects_local_runtime_paths() -> None:
         )
 
 
+def test_parse_rejects_nested_repo_names() -> None:
+    with pytest.raises(OrchestratorSkillConfigError, match="repo must use owner/name format"):
+        parse_orchestrator_skill_config(
+            {
+                "enabled": True,
+                "repo": "owner/repo/extra",
+                "ref": "main",
+                "paths": ["docs/exports/orchestrator-skill/SKILL.md"],
+            }
+        )
+
+
 def test_enabled_override_can_enable_pack_without_repo_config(tmp_path: Path) -> None:
     plan = resolve_orchestrator_skill_plan(
         tmp_path,

--- a/tests/scripts/test_reference_packs.py
+++ b/tests/scripts/test_reference_packs.py
@@ -160,6 +160,22 @@ def test_parse_reference_packs_list_format() -> None:
     assert packs[0].name == "trend-streamlit"
 
 
+def test_parse_reference_packs_rejects_nested_repo_names() -> None:
+    with pytest.raises(ReferencePackConfigError, match="repo must use owner/name format"):
+        parse_reference_packs(
+            {
+                "packs": [
+                    {
+                        "name": "trend-streamlit",
+                        "repo": "trend/research/extra",
+                        "ref": "main",
+                        "paths": ["apps/streamlit"],
+                    }
+                ]
+            }
+        )
+
+
 def test_build_checkout_plan_sets_reference_paths() -> None:
     packs = parse_reference_packs(
         {

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -455,6 +455,36 @@ def test_materialize_orchestrator_skill_clears_stale_pack_checkout(
     assert "`SKILL.md`" in summary.read_text(encoding="utf-8")
 
 
+def test_materialize_orchestrator_skill_surfaces_stale_checkout_cleanup_errors(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    plan = types.SimpleNamespace(name="orchestrator", checkout_path=".reference/orchestrator")
+    fake_reference_packs = types.SimpleNamespace(
+        load_reference_packs=lambda _workspace: types.SimpleNamespace(packs=[plan]),
+        build_checkout_plan=lambda _packs: [plan],
+    )
+
+    def fake_load_reference_packs_module() -> Any:
+        return fake_reference_packs
+
+    def fake_rmtree(_path: Path) -> None:
+        raise PermissionError("locked checkout")
+
+    monkeypatch.setattr(
+        runner_core,
+        "_load_reference_packs_module",
+        fake_load_reference_packs_module,
+    )
+    monkeypatch.setattr(runner_core.shutil, "rmtree", fake_rmtree)
+
+    with pytest.raises(PermissionError, match="locked checkout"):
+        runner_core.materialize_orchestrator_skill(
+            tmp_path,
+            pack_override="orchestrator",
+            enabled_override=True,
+        )
+
+
 def test_pr_comment_marker_round_trips_nested_result_payload() -> None:
     result = parse_runner_output("claude", "Done")
     record = {

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -74,7 +74,7 @@ def test_assemble_prompt_formats_codex_prompt(tmp_path: Path) -> None:
     assert (tmp_path / "codex-prompt-123.md").read_text(encoding="utf-8") == prompt.text
 
 
-def test_assemble_prompt_includes_orchestrator_skill_section_when_summary_exists(
+def test_assemble_prompt_skips_stale_orchestrator_skill_section_when_summary_exists(
     tmp_path: Path,
 ) -> None:
     _write_prompt_fixture(tmp_path)
@@ -89,6 +89,39 @@ def test_assemble_prompt_includes_orchestrator_skill_section_when_summary_exists
         {
             "workspace": tmp_path,
             "base_prompt_file": ".github/codex/prompts/task.md",
+        },
+        "codex",
+    )
+
+    assert "## Orchestrator Skill Context" not in prompt.text
+    assert "Read and apply the materialized Orchestrator skill files" not in prompt.text
+
+
+def test_assemble_prompt_includes_orchestrator_skill_section_when_materialized(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    _write_prompt_fixture(tmp_path)
+
+    def fake_materialize_orchestrator_skill(*_args: Any, **_kwargs: Any) -> Path:
+        orchestrator_summary = tmp_path / ".reference" / "ORCHESTRATOR_SKILL.md"
+        orchestrator_summary.write_text(
+            "Read and apply the materialized Orchestrator skill files before coordinating work.\n",
+            encoding="utf-8",
+        )
+        return orchestrator_summary
+
+    monkeypatch.setattr(
+        runner_core,
+        "materialize_orchestrator_skill",
+        fake_materialize_orchestrator_skill,
+    )
+
+    prompt = assemble_prompt(
+        None,
+        {
+            "workspace": tmp_path,
+            "base_prompt_file": ".github/codex/prompts/task.md",
+            "materialize_orchestrator_skill": True,
         },
         "codex",
     )
@@ -374,6 +407,52 @@ def test_materialize_reference_packs_keeps_token_out_of_git_argv(
     assert (tmp_path / ".reference" / "baseline" / "README.md").is_file()
     assert calls
     assert all(env.get("GIT_ASKPASS_PASSWORD") == "secret-token" for _cmd, env in calls)
+
+
+def test_materialize_orchestrator_skill_clears_stale_pack_checkout(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    checkout = tmp_path / ".reference" / "orchestrator"
+    checkout.mkdir(parents=True)
+    stale_file = checkout / "removed-upstream.md"
+    stale_file.write_text("stale\n", encoding="utf-8")
+
+    plan = types.SimpleNamespace(name="orchestrator", checkout_path=".reference/orchestrator")
+    fake_reference_packs = types.SimpleNamespace(
+        load_reference_packs=lambda _workspace: types.SimpleNamespace(packs=[plan]),
+        build_checkout_plan=lambda _packs: [plan],
+    )
+
+    def fake_load_reference_packs_module() -> Any:
+        return fake_reference_packs
+
+    def fake_materialize_reference_packs(*_args: Any, **_kwargs: Any) -> Path:
+        assert not stale_file.exists()
+        checkout.mkdir(parents=True, exist_ok=True)
+        (checkout / "SKILL.md").write_text("# Fresh skill\n", encoding="utf-8")
+        return tmp_path / ".reference" / "REFERENCE_PACKS.md"
+
+    monkeypatch.setattr(
+        runner_core,
+        "_load_reference_packs_module",
+        fake_load_reference_packs_module,
+    )
+    monkeypatch.setattr(
+        runner_core,
+        "materialize_reference_packs",
+        fake_materialize_reference_packs,
+    )
+
+    summary = runner_core.materialize_orchestrator_skill(
+        tmp_path,
+        pack_override="orchestrator",
+        enabled_override=True,
+    )
+
+    assert summary == tmp_path / ".reference" / "ORCHESTRATOR_SKILL.md"
+    assert not stale_file.exists()
+    assert (checkout / "SKILL.md").read_text(encoding="utf-8") == "# Fresh skill\n"
+    assert "`SKILL.md`" in summary.read_text(encoding="utf-8")
 
 
 def test_pr_comment_marker_round_trips_nested_result_payload() -> None:

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -139,6 +139,7 @@ def _render_prompt_with_assemble_step(
     appendix: str = "",
     mode: str = "autofix",
     pr_number: str = "",
+    orchestrator_skill_summary_path: str = "",
 ) -> str:
     assemble_step = _find_step_by_name(workflow, "Assemble prompt")
     run_script = str(assemble_step.get("run", ""))
@@ -156,6 +157,7 @@ def _render_prompt_with_assemble_step(
             "MODE": mode,
             "GITHUB_OUTPUT": str(github_output),
             "GITHUB_WORKSPACE": str(Path.cwd()),
+            "ORCHESTRATOR_SKILL_SUMMARY_PATH": orchestrator_skill_summary_path,
         }
     )
 
@@ -418,7 +420,7 @@ def test_reusable_codex_prompt_step_skips_reference_pack_section_when_file_missi
     assert "## Reference Packs\n" not in rendered
 
 
-def test_reusable_codex_prompt_step_includes_orchestrator_skill_section_when_file_exists(
+def test_reusable_codex_prompt_step_skips_stale_orchestrator_skill_section_when_file_exists(
     tmp_path: Path,
 ) -> None:
     workflow = _load_workflow(REUSABLE_CODEX_RUN)
@@ -433,6 +435,28 @@ def test_reusable_codex_prompt_step_includes_orchestrator_skill_section_when_fil
         tmp_path,
         workflow,
         base_prompt_text="Base prompt content\n",
+    )
+
+    assert "## Orchestrator Skill Context\n" not in rendered
+    assert "Read and apply the materialized Orchestrator skill files" not in rendered
+
+
+def test_reusable_codex_prompt_step_includes_active_orchestrator_skill_section(
+    tmp_path: Path,
+) -> None:
+    workflow = _load_workflow(REUSABLE_CODEX_RUN)
+    orchestrator_text = (
+        "Read and apply the materialized Orchestrator skill files before coordinating work.\n"
+    )
+    orchestrator_path = tmp_path / ".reference" / "ORCHESTRATOR_SKILL.md"
+    orchestrator_path.parent.mkdir(parents=True, exist_ok=True)
+    orchestrator_path.write_text(orchestrator_text, encoding="utf-8")
+
+    rendered = _render_prompt_with_assemble_step(
+        tmp_path,
+        workflow,
+        base_prompt_text="Base prompt content\n",
+        orchestrator_skill_summary_path=str(orchestrator_path),
     )
 
     assert "## Orchestrator Skill Context\n" in rendered


### PR DESCRIPTION
## Summary

- tighten reference pack and orchestrator skill repo validation to exactly `owner/name`
- clear stale orchestrator reference-pack material before re-materializing the selected pack
- include `ORCHESTRATOR_SKILL.md` in runner prompts only when it was materialized during the current run

## Campaign context

This is the Workflows source fix for active review debt on generated sync PR `stranske/learning-management-system#336`. The comments target synced/shared runner helper behavior, so the fix belongs in Workflows source rather than in the consumer branch.

One consumer comment references `scripts/check_agents_md_freshness.py`, which is not present on current Workflows `main`; that part appears stale relative to the latest source tree.

## Validation

- `python -m pytest tests/scripts/test_runner_lib.py tests/scripts/test_reference_packs.py tests/scripts/test_orchestrator_skill.py -q`
- `python -m py_compile scripts/reference_packs.py scripts/orchestrator_skill.py scripts/runner_lib/core.py`
- `git diff --check origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced strict `owner/name` repository format validation for orchestrator skills and reference packs, rejecting nested/malformed values.
  * Updated orchestrator skill prompt context to use the active provided summary file when available, avoiding stale content.
  * Improved orchestrator skill materialization by clearing any existing checkout directory before refreshing.
  * Updated the composite workflow to export `ORCHESTRATOR_SKILL_SUMMARY_PATH` to `GITHUB_ENV` for downstream steps.
* **Tests**
  * Added coverage for rejecting nested repo names and for orchestrator-skill prompt/context and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->