### PR TITLE
fix: consume blocked llm override before fallback

### DIFF
--- a/templates/consumer-repo/tools/langchain_client.py
+++ b/templates/consumer-repo/tools/langchain_client.py
@@ -280,6 +280,14 @@ def build_chat_client(
     model_override = model or os.environ.get(ENV_MODEL)
     used_override = False
     for slot in slots:
+        slot_model = model_override if model_override and not used_override else slot.model
+        if model_override and not used_override and _is_model_blocked(slot.provider, slot_model):
+            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
+            used_override = True
+            slot_model = slot.model
+        if _is_model_blocked(slot.provider, slot_model):
+            logger.warning("Skipping blocked LLM model: %s/%s", slot.provider, slot_model)
+            continue
         slot_available = any(
             (
                 slot.provider == PROVIDER_OPENAI and openai_token,
@@ -289,16 +297,6 @@ def build_chat_client(
         )
         if not slot_available:
             continue
-        slot_model = model_override if model_override and not used_override else slot.model
-        if _is_model_blocked(slot.provider, slot_model):
-            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
-            if model_override and not used_override:
-                used_override = True
-                slot_model = slot.model
-                if _is_model_blocked(slot.provider, slot_model):
-                    continue
-            else:
-                continue
         if slot.provider == PROVIDER_OPENAI and openai_token:
             with contextlib.suppress(Exception):
                 client = _build_openai_client(

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -126,6 +126,7 @@ def test_build_chat_client_env_model_override(monkeypatch: pytest.MonkeyPatch) -
     FakeChatOpenAI = _install_fake_langchain_openai(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "gh-token")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(langchain_client.ENV_MODEL_REGISTRY_CONFIG, "/tmp/missing-registry.json")
     monkeypatch.setenv(langchain_client.ENV_MODEL, "gpt-4o-mini")
     monkeypatch.delenv(langchain_client.ENV_PROVIDER, raising=False)
 
@@ -172,6 +173,44 @@ def test_build_chat_client_blocked_model_override_does_not_shift_provider(
     assert resolved.model == "gpt-5.4"
     assert isinstance(resolved.client, FakeChatOpenAI)
     assert not isinstance(resolved.client, FakeChatAnthropic)
+
+
+def test_build_chat_client_blocked_override_consumed_when_first_provider_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A blocked first-slot override must not shift to the next available provider."""
+    _install_fake_langchain_openai(monkeypatch)
+    FakeChatAnthropic = _install_fake_langchain_anthropic(monkeypatch)
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "provider": "openai",
+                        "model_id": "gpt-blocked",
+                        "blocked": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(langchain_client.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv(langchain_client.ENV_ANTHROPIC_KEY, "claude-token")
+    monkeypatch.setenv(langchain_client.ENV_MODEL, "gpt-blocked")
+    monkeypatch.delenv(langchain_client.ENV_PROVIDER, raising=False)
+
+    resolved = langchain_client.build_chat_client()
+
+    assert resolved is not None
+    assert resolved.provider == langchain_client.PROVIDER_ANTHROPIC
+    assert resolved.model == "claude-sonnet-4-6"
+    assert isinstance(resolved.client, FakeChatAnthropic)
+    assert resolved.client.kwargs["model"] == "claude-sonnet-4-6"
 
 
 def test_load_model_registry_ignores_malformed_nested_values(

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -280,6 +280,14 @@ def build_chat_client(
     model_override = model or os.environ.get(ENV_MODEL)
     used_override = False
     for slot in slots:
+        slot_model = model_override if model_override and not used_override else slot.model
+        if model_override and not used_override and _is_model_blocked(slot.provider, slot_model):
+            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
+            used_override = True
+            slot_model = slot.model
+        if _is_model_blocked(slot.provider, slot_model):
+            logger.warning("Skipping blocked LLM model: %s/%s", slot.provider, slot_model)
+            continue
         slot_available = any(
             (
                 slot.provider == PROVIDER_OPENAI and openai_token,
@@ -289,16 +297,6 @@ def build_chat_client(
         )
         if not slot_available:
             continue
-        slot_model = model_override if model_override and not used_override else slot.model
-        if _is_model_blocked(slot.provider, slot_model):
-            logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)
-            if model_override and not used_override:
-                used_override = True
-                slot_model = slot.model
-                if _is_model_blocked(slot.provider, slot_model):
-                    continue
-            else:
-                continue
         if slot.provider == PROVIDER_OPENAI and openai_token:
             with contextlib.suppress(Exception):
                 client = _build_openai_client(


### PR DESCRIPTION
## Summary
- consume blocked global LLM overrides before moving to fallback providers
- add regression coverage for missing first-provider credentials
- keep the consumer template LangChain client copy aligned

## Validation
- UV_CACHE_DIR=/tmp/uv-cache-workflows-sync-fix uv run pytest tests/tools/test_langchain_client.py tests/scripts/test_runner_lib.py tests/scripts/test_check_agents_md_freshness.py -q
- UV_CACHE_DIR=/tmp/uv-cache-workflows-sync-fix uv run ruff check tools/langchain_client.py templates/consumer-repo/tools/langchain_client.py tests/tools/test_langchain_client.py
- UV_CACHE_DIR=/tmp/uv-cache-workflows-sync-fix uv run black --check tools/langchain_client.py templates/consumer-repo/tools/langchain_client.py tests/tools/test_langchain_client.py
- UV_CACHE_DIR=/tmp/uv-cache-workflows-sync-fix uv run --extra dev python scripts/validate_template_sync.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection logic to properly fall back to default models when overrides are unavailable or blocked.
  
* **Refactor**
  * Streamlined provider availability detection for more efficient chat client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->