### PR TITLE
fix: restore shared llm client resolution

### DIFF
--- a/scripts/langchain/progress_reviewer.py
+++ b/scripts/langchain/progress_reviewer.py
@@ -427,11 +427,11 @@ def review_progress_with_llm(
         rounds_without_completion,
     )
     try:
-        from tools.langchain_client import build_chat_client
+        from scripts.langchain._llm_client import build_client
     except ImportError:
-        build_chat_client = None
+        build_client = None
 
-    resolved = build_chat_client(model=model) if build_chat_client else None
+    resolved = build_client(model=model) if build_client else None
     if not resolved:
         score, aligned, unaligned = heuristic_alignment_check(
             acceptance_criteria, recent_commits, files_changed

--- a/templates/consumer-repo/tools/llm_provider.py
+++ b/templates/consumer-repo/tools/llm_provider.py
@@ -42,6 +42,14 @@ ANTHROPIC_API_KEY_ENV = "CLAUDE_API_STRANSKE"
 SHORT_ANALYSIS_CONFIDENCE_CAP = 0.4
 
 
+def _configured_langchain_model(provider: str, *, fallback: str) -> str:
+    try:
+        from tools.llm_registry import configured_model_for_provider
+    except ImportError:
+        return fallback
+    return configured_model_for_provider(provider, fallback=fallback) or fallback
+
+
 def _setup_langsmith_tracing() -> bool:
     """
     Configure LangSmith tracing if API key is available.
@@ -573,16 +581,17 @@ class OpenAIProvider(LLMProvider):
     def _get_client(self):
         """Get LangChain ChatOpenAI client."""
         try:
-            from langchain_openai import ChatOpenAI
+            from tools.langchain_client import build_chat_client
         except ImportError:
-            logger.warning("langchain_openai not installed")
+            logger.warning("LangChain client helper not available")
             return None
 
-        return ChatOpenAI(
-            model="gpt-5.1-codex",  # Purpose-built for analyzing Codex coding sessions
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            temperature=0.1,
-        )
+        model_name = _configured_langchain_model("openai", fallback="gpt-5.1-codex")
+        resolved = build_chat_client(provider="openai", model=model_name)
+        if resolved:
+            self._model_name = resolved.model
+            return resolved.client
+        return None
 
     def analyze_completion(
         self,
@@ -614,7 +623,11 @@ class OpenAIProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="gpt-5.1-codex",  # Actual model used by OpenAIProvider
+                model_name=getattr(
+                    self,
+                    "_model_name",
+                    _configured_langchain_model("openai", fallback="gpt-5.1-codex"),
+                ),
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,
@@ -639,16 +652,17 @@ class AnthropicProvider(LLMProvider):
 
     def _get_client(self):
         try:
-            from langchain_anthropic import ChatAnthropic
+            from tools.langchain_client import build_chat_client
         except ImportError:
-            logger.warning("langchain_anthropic not installed")
+            logger.warning("LangChain client helper not available")
             return None
 
-        return ChatAnthropic(
-            model="claude-sonnet-4-5-20250929",
-            anthropic_api_key=os.environ.get(ANTHROPIC_API_KEY_ENV),
-            temperature=0.1,
-        )
+        model_name = _configured_langchain_model("anthropic", fallback="claude-sonnet-4-5-20250929")
+        resolved = build_chat_client(provider="anthropic", model=model_name)
+        if resolved:
+            self._model_name = resolved.model
+            return resolved.client
+        return None
 
     def analyze_completion(
         self,
@@ -690,7 +704,11 @@ class AnthropicProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="claude-sonnet-4-5-20250929",
+                model_name=getattr(
+                    self,
+                    "_model_name",
+                    _configured_langchain_model("anthropic", fallback="claude-sonnet-4-5-20250929"),
+                ),
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,

--- a/tests/scripts/test_progress_reviewer.py
+++ b/tests/scripts/test_progress_reviewer.py
@@ -217,7 +217,7 @@ def test_review_progress_langsmith_trace_capture():
     mock_resolved.model = "test-model"
 
     with (
-        mock.patch("tools.langchain_client.build_chat_client", return_value=mock_resolved),
+        mock.patch("scripts.langchain._llm_client.build_client", return_value=mock_resolved),
         mock.patch.dict("os.environ", {"LANGSMITH_API_KEY": "test-key"}),
     ):
         result = review_progress_with_llm(

--- a/tests/tools/test_llm_provider.py
+++ b/tests/tools/test_llm_provider.py
@@ -2,6 +2,7 @@
 
 import inspect
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -556,6 +557,64 @@ class TestProviderLegacyBehavior:
 
         assert result.provider_used == "regex-fallback"
         assert result.completed_tasks == ["task1"]
+
+
+class TestProviderSharedClientResolution:
+    """Provider-specific clients should still use the shared model resolver."""
+
+    def test_openai_provider_reports_configured_client_model(self):
+        provider = OpenAIProvider()
+        mock_client = MagicMock()
+        mock_client.invoke.return_value = MagicMock(content="""
+{
+    "completed": ["task1"],
+    "in_progress": [],
+    "blocked": [],
+    "confidence": 0.85,
+    "reasoning": "Configured call."
+}
+""")
+        resolved = SimpleNamespace(client=mock_client, model="gpt-configured")
+
+        with (
+            patch(
+                "tools.llm_registry.configured_model_for_provider",
+                return_value="gpt-configured",
+            ) as mock_configured,
+            patch("tools.langchain_client.build_chat_client", return_value=resolved) as mock_build,
+        ):
+            result = provider.analyze_completion("output", ["task1"])
+
+        mock_configured.assert_called_with("openai", fallback="gpt-5.1-codex")
+        mock_build.assert_called_once_with(provider="openai", model="gpt-configured")
+        assert result.model_name == "gpt-configured"
+
+    def test_anthropic_provider_reports_configured_client_model(self):
+        provider = AnthropicProvider()
+        mock_client = MagicMock()
+        mock_client.invoke.return_value = MagicMock(content="""
+{
+    "completed": ["task1"],
+    "in_progress": [],
+    "blocked": [],
+    "confidence": 0.88,
+    "reasoning": "Configured call."
+}
+""")
+        resolved = SimpleNamespace(client=mock_client, model="claude-configured")
+
+        with (
+            patch(
+                "tools.llm_registry.configured_model_for_provider",
+                return_value="claude-configured",
+            ) as mock_configured,
+            patch("tools.langchain_client.build_chat_client", return_value=resolved) as mock_build,
+        ):
+            result = provider.analyze_completion("output", ["task1"])
+
+        mock_configured.assert_called_with("anthropic", fallback="claude-sonnet-4-5-20250929")
+        mock_build.assert_called_once_with(provider="anthropic", model="claude-configured")
+        assert result.model_name == "claude-configured"
 
 
 class TestRegexFallbackProvider:

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -42,6 +42,14 @@ ANTHROPIC_API_KEY_ENV = "CLAUDE_API_STRANSKE"
 SHORT_ANALYSIS_CONFIDENCE_CAP = 0.4
 
 
+def _configured_langchain_model(provider: str, *, fallback: str) -> str:
+    try:
+        from tools.llm_registry import configured_model_for_provider
+    except ImportError:
+        return fallback
+    return configured_model_for_provider(provider, fallback=fallback) or fallback
+
+
 def _setup_langsmith_tracing() -> bool:
     """
     Configure LangSmith tracing if API key is available.
@@ -585,16 +593,17 @@ class OpenAIProvider(LLMProvider):
     def _get_client(self):
         """Get LangChain ChatOpenAI client."""
         try:
-            from langchain_openai import ChatOpenAI
+            from tools.langchain_client import build_chat_client
         except ImportError:
-            logger.warning("langchain_openai not installed")
+            logger.warning("LangChain client helper not available")
             return None
 
-        return ChatOpenAI(
-            model="gpt-5.1-codex",  # Purpose-built for analyzing Codex coding sessions
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            temperature=0.1,
-        )
+        model_name = _configured_langchain_model("openai", fallback="gpt-5.1-codex")
+        resolved = build_chat_client(provider="openai", model=model_name)
+        if resolved:
+            self._model_name = resolved.model
+            return resolved.client
+        return None
 
     def analyze_completion(
         self,
@@ -626,7 +635,11 @@ class OpenAIProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="gpt-5.1-codex",  # Actual model used by OpenAIProvider
+                model_name=getattr(
+                    self,
+                    "_model_name",
+                    _configured_langchain_model("openai", fallback="gpt-5.1-codex"),
+                ),
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,
@@ -651,16 +664,17 @@ class AnthropicProvider(LLMProvider):
 
     def _get_client(self):
         try:
-            from langchain_anthropic import ChatAnthropic
+            from tools.langchain_client import build_chat_client
         except ImportError:
-            logger.warning("langchain_anthropic not installed")
+            logger.warning("LangChain client helper not available")
             return None
 
-        return ChatAnthropic(
-            model="claude-sonnet-4-5-20250929",
-            anthropic_api_key=os.environ.get(ANTHROPIC_API_KEY_ENV),
-            temperature=0.1,
-        )
+        model_name = _configured_langchain_model("anthropic", fallback="claude-sonnet-4-5-20250929")
+        resolved = build_chat_client(provider="anthropic", model=model_name)
+        if resolved:
+            self._model_name = resolved.model
+            return resolved.client
+        return None
 
     def analyze_completion(
         self,
@@ -702,7 +716,11 @@ class AnthropicProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="claude-sonnet-4-5-20250929",
+                model_name=getattr(
+                    self,
+                    "_model_name",
+                    _configured_langchain_model("anthropic", fallback="claude-sonnet-4-5-20250929"),
+                ),
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,


### PR DESCRIPTION
## Summary
- restore OpenAI/Anthropic completion analysis to resolve models through `tools.llm_registry` and `tools.langchain_client`
- route `progress_reviewer.py` through `scripts.langchain._llm_client` so scripts do not bypass the shared adapter
- add focused regression coverage for provider-reported model names and update the progress-review test hook

## Validation
- `uv run pytest tests/tools/test_llm_provider.py tests/tools/test_langchain_client.py tests/scripts/test_progress_reviewer.py tests/scripts/test_llm_client_shared.py -q`
- `uv run --with pyyaml python scripts/validate_template_sync.py`
- `uv run black --fast --check tools/llm_provider.py templates/consumer-repo/tools/llm_provider.py scripts/langchain/progress_reviewer.py tests/tools/test_llm_provider.py tests/scripts/test_progress_reviewer.py`
- `uv run ruff check tools/llm_provider.py templates/consumer-repo/tools/llm_provider.py scripts/langchain/progress_reviewer.py tests/tools/test_llm_provider.py tests/scripts/test_progress_reviewer.py`
- `git diff --check`

Related to sync/dependency cleanup campaign; unblocks `stranske/Inv-Man-Intake#624` replacement sync path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal LLM client construction for improved model configuration
  * Centralized model name resolution for OpenAI and Anthropic providers

* **Tests**
  * Enhanced test coverage for provider client initialization and model resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->