### PR TITLE
chore: update claude review action digest

### DIFF
--- a/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
+++ b/templates/consumer-repo/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@2fee15510437d71399d9139ed60433470484a8fb # v1
+        uses: anthropics/claude-code-action@30544b674398ee15c84819bd87caf8a87e8c7b55 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Summary
- update the template-managed Claude Code review workflow to anthropics/claude-code-action digest 30544b6
- keep the change in Workflows so Maint 68 can propagate it to consumers instead of merging consumer-only digest PRs

## Validation
- python scripts/validate_template_sync.py
- python scripts/validate_template_completeness.py
- git diff --check

Related to the sync/dependency cleanup campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation workflow dependencies to use the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->