### PR TITLE
Fix reusable runner reference-pack action path

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -420,7 +420,7 @@ jobs:
 
       - name: Validate and materialize reference packs
         id: reference_packs
-        uses: ./.github/actions/agent-reference-packs
+        uses: ./.workflows-lib/.github/actions/agent-reference-packs
         with:
           checkout_token: ${{ steps.run_base.outputs.checkout_token }}
 

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -450,7 +450,7 @@ jobs:
 
       - name: Validate and materialize reference packs
         id: reference_packs
-        uses: ./.github/actions/agent-reference-packs
+        uses: ./.workflows-lib/.github/actions/agent-reference-packs
         with:
           checkout_token: ${{ steps.run_base.outputs.checkout_token }}
           orchestrator_skill_pack: ${{ inputs.orchestrator_skill_pack }}

--- a/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
+++ b/tests/workflows/test_reusable_run_refpack_heredoc_compiles.py
@@ -36,6 +36,7 @@ REUSABLE_RUN_WORKFLOWS = [
     ".github/workflows/reusable-claude-run.yml",
 ]
 REFPACK_ACTION = ".github/actions/agent-reference-packs/action.yml"
+REFPACK_RUNNER_USES = "uses: ./.workflows-lib/.github/actions/agent-reference-packs"
 
 
 def _extract_yaml_run_block(path: Path, step_name: str) -> str:
@@ -120,8 +121,8 @@ def test_reusable_runners_use_shared_refpack_action(workflow_rel: str) -> None:
     assert path.exists(), f"missing workflow file: {workflow_rel}"
 
     src = path.read_text()
-    assert src.count("uses: ./.github/actions/agent-reference-packs") == 1
-    assert "uses: ./.github/actions/agent-reference-packs" in src
+    assert src.count(REFPACK_RUNNER_USES) == 1
+    assert REFPACK_RUNNER_USES in src
     assert (
         "REFPACK_EOF" not in src
     ), f"{workflow_rel}: reference-pack heredoc should live only in {REFPACK_ACTION}"

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -15,8 +15,10 @@ WORKFLOWS_DIR = Path(".github/workflows")
 AUTO_PILOT = WORKFLOWS_DIR / "agents-auto-pilot.yml"
 VERIFIER = WORKFLOWS_DIR / "reusable-agents-verifier.yml"
 REUSABLE_CODEX_RUN = WORKFLOWS_DIR / "reusable-codex-run.yml"
+REUSABLE_CLAUDE_RUN = WORKFLOWS_DIR / "reusable-claude-run.yml"
 NEEDS_HUMAN_COMMENT = Path("agents/codex-1447.md")
 REFERENCE_PACK_ACTION = Path(".github/actions/agent-reference-packs/action.yml")
+REFERENCE_PACK_RUNNER_USES = "./.workflows-lib/.github/actions/agent-reference-packs"
 REFERENCE_PACK_FIXTURES = Path("tests/workflows/fixtures/reference_packs")
 MIN_CODEX_CLI_BY_RUN_MODEL = {
     "gpt-5.5": (0, 125, 0),
@@ -481,7 +483,7 @@ def test_reusable_codex_workflow_passes_orchestrator_skill_overrides_to_referenc
 ):
     workflow = _load_workflow(REUSABLE_CODEX_RUN)
     step = _find_step_by_name(workflow, "Validate and materialize reference packs")
-    assert step.get("uses") == "./.github/actions/agent-reference-packs"
+    assert step.get("uses") == REFERENCE_PACK_RUNNER_USES
     with_block = step.get("with") or {}
     assert with_block.get("orchestrator_skill_pack") == "${{ inputs.orchestrator_skill_pack }}"
     assert (
@@ -489,10 +491,13 @@ def test_reusable_codex_workflow_passes_orchestrator_skill_overrides_to_referenc
     )
 
 
-def test_reusable_codex_workflow_has_reference_pack_validation_step() -> None:
-    workflow = _load_workflow(REUSABLE_CODEX_RUN)
+@pytest.mark.parametrize("workflow_path", [REUSABLE_CODEX_RUN, REUSABLE_CLAUDE_RUN])
+def test_reusable_runner_workflow_has_reference_pack_validation_step(
+    workflow_path: Path,
+) -> None:
+    workflow = _load_workflow(workflow_path)
     step = _find_step_by_name(workflow, "Validate and materialize reference packs")
-    assert step.get("uses") == "./.github/actions/agent-reference-packs"
+    assert step.get("uses") == REFERENCE_PACK_RUNNER_USES
     run_script = _reference_pack_action_script()
     # Shared action must validate config with reference_packs.py
     assert "reference_packs.py" in run_script
@@ -503,10 +508,11 @@ def test_reusable_codex_workflow_has_reference_pack_validation_step() -> None:
     step_names = [s.get("name", "") for s in steps]
     ref_idx = step_names.index("Validate and materialize reference packs")
     prompt_idx = step_names.index("Assemble prompt")
-    codex_idx = step_names.index("Run Codex")
+    run_step_name = "Run Codex" if workflow_path == REUSABLE_CODEX_RUN else "Run Claude"
+    run_idx = step_names.index(run_step_name)
     assert (
-        ref_idx < prompt_idx < codex_idx
-    ), "Reference pack validation must come before Assemble prompt and Run Codex"
+        ref_idx < prompt_idx < run_idx
+    ), "Reference pack validation must come before Assemble prompt and the runner"
 
 
 def test_reusable_codex_reference_pack_step_handles_sha_refs() -> None:


### PR DESCRIPTION
## Summary
- load the shared `agent-reference-packs` action from `.workflows-lib` in both reusable Codex and Claude runners
- extend runner workflow tests so Claude and Codex both guard the Workflows-checkout action path

## Why
Two opener-owned PRs are stuck with `agent:needs-attention` after Claude keepalive failed before prompt assembly. The failed runs show `Can't find action.yml` under the consumer repo path `.github/actions/agent-reference-packs`, then `Run Claude` masks the root cause as a missing prompt file.

Affected evidence:
- stranske/Manager-Database#1233 run 28035471665
- stranske/Trend_Model_Project#5655 run 28035473929

## Validation
- `python -m pytest tests/workflows/test_workflow_llm_installs.py -q`
- `git diff --check`

<!-- workflow-source:local_request -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated reusable workflow steps to reference the shared reference-pack action from the centralized workflows library instead of a local copy.

* **Tests**
  * Expanded workflow validation to cover both reusable Codex and reusable Claude runners.
  * Strengthened assertions that the reference-pack validation step runs before prompt assembly and that the required orchestrator inputs are passed through correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->