### PR TITLE
Follow up #2528: upload LangSmith fleet artifact under registry name

### DIFF
--- a/.github/workflows/maint-81-langsmith-fleet-conformance.yml
+++ b/.github/workflows/maint-81-langsmith-fleet-conformance.yml
@@ -62,13 +62,13 @@ jobs:
               fs.mkdirSync(outDir, { recursive: true });
 
               const artifacts = await withRetry(() =>
-                github.rest.actions.listArtifactsForRepo({
+                github.paginate(github.rest.actions.listArtifactsForRepo, {
                   owner,
                   repo: repoName,
                   per_page: 100,
                 })
               );
-              const candidates = artifacts.data.artifacts.filter((item) =>
+              const candidates = artifacts.filter((item) =>
                 !item.expired &&
                 (item.name === entry.artifact_name || item.name.endsWith(entry.artifact_name))
               );

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -2537,7 +2537,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs['artifact-prefix'] }}langsmith-fleet.ndjson
+          name: langsmith-fleet.ndjson
           path: ${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson
           if-no-files-found: warn
           retention-days: 90

--- a/tests/workflows/test_langsmith_fleet_conformance_workflow.py
+++ b/tests/workflows/test_langsmith_fleet_conformance_workflow.py
@@ -6,8 +6,9 @@ WORKFLOW = Path(".github/workflows/maint-81-langsmith-fleet-conformance.yml")
 def test_conformance_download_accepts_prefixed_fleet_artifacts() -> None:
     source = WORKFLOW.read_text(encoding="utf-8")
 
-    assert source.count("listArtifactsForRepo") == 1
+    assert source.count("github.paginate(github.rest.actions.listArtifactsForRepo") == 1
     assert source.count("name: entry.artifact_name") == 0
+    assert source.count("const candidates = artifacts.filter") == 1
     assert (
         source.count("item.name === entry.artifact_name || item.name.endsWith(entry.artifact_name)")
         == 1

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -255,10 +255,7 @@ def test_artifact_names_normalized() -> None:
     langsmith_upload_step = _step("Upload LangSmith fleet telemetry artifact")
     assert langsmith_upload_step["uses"] == "actions/upload-artifact@v7"
     assert langsmith_upload_step["continue-on-error"] is True
-    assert (
-        langsmith_upload_step["with"]["name"]
-        == "${{ inputs['artifact-prefix'] }}langsmith-fleet.ndjson"
-    )
+    assert langsmith_upload_step["with"]["name"] == "langsmith-fleet.ndjson"
     assert (
         langsmith_upload_step["with"]["path"]
         == "${{ env.PROJECT_ROOT }}/artifacts/langsmith/langsmith-fleet.ndjson"


### PR DESCRIPTION
## Summary
- Follow up merged PR #2528 by uploading the fallback LangSmith fleet telemetry artifact as the exact registry artifact name langsmith-fleet.ndjson.
- Update the reusable CI workflow contract test to prevent reintroducing the caller artifact prefix.

## Validation
- python -m pytest tests/workflows/test_reusable_ci_workflow.py -q -> 9 passed
- git diff --check -> passed

This preserves the review-fix commit that was pushed after #2528 merged at its previous head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the uploaded fleet telemetry artifact name to a fixed value, improving consistency and reducing naming mismatches during CI uploads.
  * Improved fleet artifact download in CI by updating the artifact listing approach to use a pagination helper, while keeping the existing artifact selection behavior.

* **Tests**
  * Updated workflow tests to reflect the new fixed artifact naming and the adjusted CI implementation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- workflow-source:review_followup -->