### PR TITLE
fix: constrain Fine-Art jsonschema renovate updates

### DIFF
--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -29,6 +29,9 @@ Some repos cannot use the template `pr-00-gate.yml` because:
 - **trip-planner**: Installs `.github/scripts` dependencies from
   `.github/scripts/package-lock.json` with `npm ci` and has an explicit hygiene
   check that forbids tracked `node_modules/` anywhere in the repo.
+- **Fine-Art-Archive**: Keeps a fleet-preset Renovate exception for
+  `jsonschema<4.23.0` because newer non-major releases currently violate the
+  repo's supported dependency range and fail Gate.
 
 For these repos:
 - The Gate workflow (`pr-00-gate.yml`) is maintained locally and excluded from sync.
@@ -37,6 +40,9 @@ For these repos:
 - `trip-planner` skips the synced `.github/scripts/package.json` and vendored
   `.github/scripts/node_modules/` entries so its lockfile-based dependency
   policy remains intact.
+- `Fine-Art-Archive` still receives the managed `.github/renovate.json`; its
+  dependency exception is centralized in `renovate-presets/fleet.json` with a
+  repository-scoped package rule, not patched directly in the consumer repo.
 - Other files listed in the sync manifest continue to sync normally.
 
 Maint 68 currently implements this by keeping an internal `custom_gate_repos` list in

--- a/renovate-presets/fleet.json
+++ b/renovate-presets/fleet.json
@@ -14,6 +14,12 @@
       "enabled": false
     },
     {
+      "description": "Fine-Art-Archive currently supports jsonschema below 4.23.0; do not reopen incompatible non-major bumps",
+      "matchRepositories": ["stranske/Fine-Art-Archive"],
+      "matchPackageNames": ["jsonschema"],
+      "allowedVersions": "<4.23.0"
+    },
+    {
       "description": "Runtime/test-support minor+patch: group + automerge on green (majors stay separate for review)",
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major updates",

--- a/tests/workflows/test_consumer_sync_create_only_evidence.py
+++ b/tests/workflows/test_consumer_sync_create_only_evidence.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import yaml
@@ -50,6 +51,26 @@ def test_consumer_renovate_template_extends_fleet_preset() -> None:
     )
 
     assert template["extends"] == ["github>stranske/Workflows//renovate-presets/fleet"]
+
+
+def test_fine_art_archive_jsonschema_renovate_exception_is_repo_scoped() -> None:
+    preset = json.loads((REPO_ROOT / "renovate-presets/fleet.json").read_text(encoding="utf-8"))
+
+    matching_rules = [
+        rule
+        for rule in preset["packageRules"]
+        if rule.get("matchRepositories") == ["stranske/Fine-Art-Archive"]
+        and rule.get("matchPackageNames") == ["jsonschema"]
+    ]
+
+    assert matching_rules == [
+        {
+            "description": "Fine-Art-Archive currently supports jsonschema below 4.23.0; do not reopen incompatible non-major bumps",
+            "matchRepositories": ["stranske/Fine-Art-Archive"],
+            "matchPackageNames": ["jsonschema"],
+            "allowedVersions": "<4.23.0",
+        }
+    ]
 
 
 def test_gate_manifest_entry_documents_fresh_consumer_bootstrap_risk() -> None:


### PR DESCRIPTION
## Summary
- add a repository-scoped Renovate preset rule for `stranske/Fine-Art-Archive` so `jsonschema` updates stay below `4.23.0`
- document the Fine-Art exception in consumer maintenance guidance
- add a regression test that keeps the exception repo-scoped

## Validation
- `python3 -m json.tool renovate-presets/fleet.json`
- `python3 -m pytest tests/workflows/test_consumer_sync_create_only_evidence.py -q`
- `ruff check tests/workflows/test_consumer_sync_create_only_evidence.py`
- `black --check tests/workflows/test_consumer_sync_create_only_evidence.py`
- `git diff --check`