### PR TITLE
chore: update shared ruff pin

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.19
+RUFF_VERSION=0.15.20
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ app = []
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.15.19",
+    "ruff==0.15.20",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.1.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -296,7 +296,7 @@ rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.19
+ruff==0.15.20
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.19
+RUFF_VERSION=0.15.20
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.19
+RUFF_VERSION=0.15.20
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0


### PR DESCRIPTION
## Summary
- update the canonical shared Ruff pin to 0.15.20
- sync the matching pyproject, requirements.lock, consumer template, and integration template pins

## Validation
- python3 scripts/sync_tool_versions.py --check
- python3 scripts/validate_version_pins.py --check-all-templates
- python3 scripts/validate_template_sync.py
- python3 scripts/validate_template_completeness.py
- git diff --check
- /opt/anaconda3/bin/python3.12 -m pytest tests/scripts/test_sync_tool_versions.py tests/scripts/test_validate_version_pins.py

## Campaign Context
Supersedes integration-only Renovate PR stranske/Workflows-Integration-Tests#40, which only bumped pyproject.toml and caused reusable CI to install conflicting Ruff pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Ruff version to `0.15.20` across development and workflow configuration.
  * Aligned template repository settings with the latest Ruff release for consistent formatting and linting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->