### PR TITLE
fix: align agents guard fallback pin

### DIFF
--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -100,7 +100,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09"
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -170,7 +170,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09"
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -86,9 +86,9 @@ reason = Intentional divergence (re-baselined 2026-06-14): consumer template SHA
 [pair.10]
 main = .github/workflows/agents-guard.yml
 template = templates/consumer-repo/.github/workflows/agents-guard.yml
-main_sha256 = 0f8534a819ab769499c129ae5473d6785d8fa9c01d52efab7613b168ec6ce1f2
+main_sha256 = 8990b52e05bb29e332adecc61f14e10cdff7cc514d8d53c416b5744fec3ccde3
 template_sha256 = 52247fc561df900e13122f4cb51b9949341e397c5d0ce2d4aea75d57e8273daf
-reason = Intentional divergence re-baselined 2026-06-26: root and consumer guard workflows differ for pinned consumer actions/App-token setup; consumer setup-api-client pins were refreshed to the Workflows a525e6e digest.
+reason = Intentional divergence re-baselined 2026-06-26: root and consumer guard workflows differ for pinned consumer actions/App-token setup; setup-api-client fallback pins now both point at the Workflows a525e6e digest.
 
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml


### PR DESCRIPTION
## Summary
- align the Workflows root agents-guard setup-api-client fallback pin with the current consumer template pin
- refresh the agents-guard template drift allowlist fingerprint and reason

## Validation
- python3 scripts/validate_template_sync.py
- python3 scripts/validate_template_completeness.py
- python3 scripts/check_template_drift.py --allowlist config/template-drift-allowlist.txt
- git diff --check

Part of the sync/dependency cleanup campaign; unblocks generated sync PR review debt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an automation workflow reference to a newer, fixed version for more consistent runs.
  * Refreshed the related allowlist entry to match the latest approved workflow state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->