### PR TITLE
[codex] test gate detect output parsing edges

### DIFF
--- a/tests/scripts/test_gate_detect_output_diff.py
+++ b/tests/scripts/test_gate_detect_output_diff.py
@@ -129,6 +129,101 @@ def test_compare_detect_outputs_reports_removed_keys_and_counts(tmp_path: Path) 
     assert report["added_outputs_vs_baseline"] == []
 
 
+def test_compare_detect_outputs_treats_missing_and_non_mapping_outputs_as_empty(
+    tmp_path: Path,
+) -> None:
+    baseline = _write(
+        tmp_path / "baseline.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      run_core: ${{ steps.classify.outputs.run_core }}
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+    missing_outputs = _write(
+        tmp_path / "missing-outputs.yml",
+        """
+jobs:
+  detect:
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+    non_mapping_outputs = _write(
+        tmp_path / "non-mapping-outputs.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      - doc_only
+      - run_core
+    steps:
+      - id: classify
+        run: echo ok
+""",
+    )
+
+    missing_report = diff.compare_gate_detect_outputs(missing_outputs, baseline)
+    non_mapping_report = diff.compare_gate_detect_outputs(non_mapping_outputs, baseline)
+
+    for report in (missing_report, non_mapping_report):
+        assert report["candidate_output_count"] == 0
+        assert report["baseline_output_count"] == 2
+        assert report["removed_outputs_vs_baseline"] == ["doc_only", "run_core"]
+        assert report["added_outputs_vs_baseline"] == []
+        assert report["invalid_step_output_references"] == {}
+
+
+def test_compare_detect_outputs_accepts_underscore_and_hyphen_step_ids(
+    tmp_path: Path,
+) -> None:
+    baseline = _write(
+        tmp_path / "baseline.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      affected_consumers: ${{ steps.path-classifier.outputs.affected_consumers }}
+    steps:
+      - id: path-classifier
+        run: echo ok
+""",
+    )
+    candidate = _write(
+        tmp_path / "candidate.yml",
+        """
+jobs:
+  detect:
+    outputs:
+      affected_consumers: ${{ steps.path-classifier.outputs.affected_consumers }}
+      classification_rationale: ${{ steps.classify_paths.outputs.classification-rationale }}
+      stale_output: ${{ steps.missing-step.outputs.value }}
+    steps:
+      - id: path-classifier
+        run: echo ok
+      - id: classify_paths
+        run: echo ok
+""",
+    )
+
+    report = diff.compare_gate_detect_outputs(candidate, baseline)
+
+    assert report["candidate_output_count"] == 3
+    assert report["baseline_output_count"] == 1
+    assert report["candidate_step_ids"] == ["classify_paths", "path-classifier"]
+    assert report["added_outputs_vs_baseline"] == [
+        "classification_rationale",
+        "stale_output",
+    ]
+    assert report["invalid_step_output_references"] == {"stale_output": ["missing-step"]}
+
+
 @pytest.mark.parametrize(
     ("candidate_body", "message"),
     [


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2558 -->
> **Source:** Issue #2558

Closes #2558

<!-- pr-preamble:end -->

## Summary
- Adds focused pytest coverage for `scripts/gate_detect_output_diff.py` when `jobs.detect.outputs` is missing or not a mapping.
- Adds coverage for step-output expressions that reference step IDs with underscores and hyphens, while still asserting invalid references are reported.
- Keeps the change tests-only: no production workflow or script files changed.

## Validation
- `uv run --python 3.12 pytest tests/scripts/test_gate_detect_output_diff.py -q` -> PASS (`5 passed in 0.21s`).
- `uv run --python 3.12 --extra dev ruff check tests/scripts/test_gate_detect_output_diff.py` -> PASS (`All checks passed!`).
- `git diff --check` -> PASS.
- Remote PR check after push: Gate -> success; Health 45 Agents Guard -> success; PR 11 Minimal invariant CI -> success; Selftest CI -> success; Health 40 Sweep reported `startup_failure` in the non-required sweep lane.

## Orchestrator Testgen Gate
Command:
```bash
uv run --python 3.12 --extra dev python /Users/teacher/.codex/orchestrator-mirror/testgen_gate.py --repo . --source scripts/gate_detect_output_diff.py --baseline-pytest-args 'tests/scripts/test_gate_detect_output_diff.py::test_compare_detect_outputs_reports_added_keys_without_invalid_refs tests/scripts/test_gate_detect_output_diff.py::test_compare_detect_outputs_flags_missing_step_ids tests/scripts/test_gate_detect_output_diff.py::test_template_gate_detect_outputs_expand_known_green_minimal_baseline' --candidate-pytest-args 'tests/scripts/test_gate_detect_output_diff.py' --reliability-pytest-args 'tests/scripts/test_gate_detect_output_diff.py::test_compare_detect_outputs_treats_missing_and_non_mapping_outputs_as_empty tests/scripts/test_gate_detect_output_diff.py::test_compare_detect_outputs_accepts_underscore_and_hyphen_step_ids' --runs 5 --min-covered-lines-delta 1 --timeout 120
```
Result: PASS. All gate checks passed, including `candidate_reliability` over 5 runs and `coverage_delta` (`covered-lines delta 1 >= required 1`).

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add focused tests around scripts/gate_detect_output_diff.py output parsing and YAML handling.

#### Tasks
- [x] Cover workflows where jobs.detect.outputs is missing or not a mapping.
- [x] Cover step ids with underscores and hyphens referenced from output expressions.
- [x] Keep tests isolated with temporary YAML files.

#### Acceptance criteria
- [x] pytest tests/scripts/test_gate_detect_output_diff.py passes.
- [x] Tests assert concrete report fields for output counts and invalid references.
- [x] No production workflow files are changed.

**Head SHA:** 51ef082d3b57b3a8f8888a8c48d32602057bd574
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367045) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28309367078) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28309367017) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367022) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367026) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367004) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367015) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367012) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309367008) |
<!-- auto-status-summary:end -->