### PR TITLE
[codex] Refactor autofix PR comment metadata helpers

### DIFF
--- a/scripts/build_autofix_pr_comment.py
+++ b/scripts/build_autofix_pr_comment.py
@@ -97,11 +97,21 @@ def extract_diagnostics_counts(report: dict | None) -> tuple[int | None, int | N
     return diagnostics_count, diagnostics_fixed
 
 
-def should_emit_comment(report: dict | None) -> bool:
+def extract_report_metadata(report: dict | None) -> dict[str, bool | int | None]:
     diagnostics_count, diagnostics_fixed = extract_diagnostics_counts(report)
     if diagnostics_count is None and diagnostics_fixed is None:
-        return False
-    return (diagnostics_count or 0) > 0 or (diagnostics_fixed or 0) > 0
+        should_post = False
+    else:
+        should_post = (diagnostics_count or 0) > 0 or (diagnostics_fixed or 0) > 0
+    return {
+        "diagnostics_count": diagnostics_count,
+        "diagnostics_fixed": diagnostics_fixed,
+        "should_post": should_post,
+    }
+
+
+def should_emit_comment(report: dict | None) -> bool:
+    return bool(extract_report_metadata(report)["should_post"])
 
 
 def _top_code_lines(codes: dict | None) -> tuple[str, ...]:
@@ -123,8 +133,10 @@ def _snapshot_code_lines(snapshot: dict | None) -> tuple[str, ...]:
     return tuple(lines)
 
 
-def _status_line(report: dict | None) -> str:
+def render_status_line(report: dict | None) -> str:
     classification = (report or {}).get("classification", {}) if isinstance(report, dict) else {}
+    if not isinstance(classification, dict):
+        classification = {}
     new_count = coerce_int(classification.get("new"), 0)
     changed = coerce_bool((report or {}).get("changed"), False)
     if changed:
@@ -132,6 +144,10 @@ def _status_line(report: dict | None) -> str:
     if new_count > 0:
         return "Status | ⚠️ new diagnostics detected"
     return "Status | ✅ no new diagnostics"
+
+
+def _status_line(report: dict | None) -> str:
+    return render_status_line(report)
 
 
 def build_comment(
@@ -147,11 +163,13 @@ def build_comment(
 
     lines = [
         MARKER,
-        _status_line(report),
+        render_status_line(report),
         f"History points | {len(history) if isinstance(history, list) else 0}",
     ]
 
     classification = report.get("classification", {}) if isinstance(report, dict) else {}
+    if not isinstance(classification, dict):
+        classification = {}
     timestamp = classification.get("timestamp")
     lines.append(f"Timestamp | {format_timestamp(timestamp)}")
 
@@ -177,12 +195,7 @@ def build_comment(
 
 
 def build_metadata(report: dict | None) -> dict:
-    diagnostics_count, diagnostics_fixed = extract_diagnostics_counts(report)
-    return {
-        "diagnostics_count": diagnostics_count,
-        "diagnostics_fixed": diagnostics_fixed,
-        "should_post": should_emit_comment(report),
-    }
+    return extract_report_metadata(report)
 
 
 def main(args: list[str] | None = None) -> int:

--- a/tests/scripts/test_build_autofix_pr_comment.py
+++ b/tests/scripts/test_build_autofix_pr_comment.py
@@ -1,0 +1,168 @@
+"""Focused tests for :mod:`scripts.build_autofix_pr_comment`."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from scripts import build_autofix_pr_comment as autofix_comment
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_extract_report_metadata_handles_missing_and_malformed_reports() -> None:
+    assert autofix_comment.extract_report_metadata(None) == {
+        "diagnostics_count": None,
+        "diagnostics_fixed": None,
+        "should_post": False,
+    }
+    assert autofix_comment.extract_report_metadata(
+        {
+            "diagnostics": {"count": "many"},
+            "diagnostics_fixed": "none",
+            "classification": "invalid",
+        }
+    ) == {
+        "diagnostics_count": None,
+        "diagnostics_fixed": None,
+        "should_post": False,
+    }
+    assert (
+        autofix_comment.render_status_line(
+            {"changed": "off", "classification": "not-a-dict"}
+        )
+        == "Status | \u2705 no new diagnostics"
+    )
+
+
+def test_extract_report_metadata_handles_populated_report_shapes() -> None:
+    report = {
+        "diagnostics": {"items": [{"code": "E001"}, {"code": "W002"}]},
+        "diagnostics_fixed_count": "1",
+        "classification": {"new": "2"},
+    }
+
+    assert autofix_comment.extract_report_metadata(report) == {
+        "diagnostics_count": 2,
+        "diagnostics_fixed": 1,
+        "should_post": True,
+    }
+    assert (
+        autofix_comment.render_status_line(report)
+        == "Status | \u26a0\ufe0f new diagnostics detected"
+    )
+    assert (
+        autofix_comment.render_status_line({"changed": "true", "classification": {"new": 2}})
+        == "Status | \u2705 autofix updates applied"
+    )
+
+
+def test_build_comment_handles_missing_report_and_trend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:
+            return datetime(2026, 1, 2, 3, 4, 5, tzinfo=tz or UTC)
+
+    monkeypatch.setattr(autofix_comment, "datetime", FrozenDateTime)
+
+    comment = autofix_comment.build_comment(
+        report_path=tmp_path / "missing-report.json",
+        trend_path=tmp_path / "missing-trend.json",
+    )
+
+    assert comment == "\n".join(
+        [
+            autofix_comment.MARKER,
+            "Status | \u2705 no new diagnostics",
+            "History points | 0",
+            "Timestamp | 2026-01-02 03:04:05 UTC",
+            "Report artifact | `autofix-report-pr-manual`",
+            "Remaining | \u2205",
+            "New | \u2205",
+            "No additional artifacts",
+            autofix_comment.MARKER,
+        ]
+    )
+
+
+def test_build_comment_handles_malformed_report_classification(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.json"
+    trend_path = tmp_path / "trend.json"
+    _write_json(report_path, {"changed": False, "classification": ["invalid"]})
+    _write_json(trend_path, {"remaining_latest": 0, "new_latest": 0})
+
+    comment = autofix_comment.build_comment(report_path=report_path, trend_path=trend_path)
+
+    lines = comment.splitlines()
+    assert lines[1] == "Status | \u2705 no new diagnostics"
+    assert lines[4] == "Report artifact | `autofix-report-pr-manual`"
+    assert lines[5:] == [
+        "Remaining | 0",
+        "New | 0",
+        "No additional artifacts",
+        autofix_comment.MARKER,
+    ]
+
+
+def test_build_comment_preserves_populated_markdown_line_order(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.json"
+    trend_path = tmp_path / "trend.json"
+    history_path = tmp_path / "history.json"
+    _write_json(
+        report_path,
+        {
+            "changed": False,
+            "classification": {
+                "total": 4,
+                "new": 2,
+                "timestamp": "2025-02-02T10:11:12+00:00",
+                "by_code": {"W002": 1, "E001": 3},
+            },
+        },
+    )
+    _write_json(
+        trend_path,
+        {
+            "remaining_latest": 4,
+            "new_latest": 2,
+            "codes": {"W002": {"latest": 1}, "E001": {"latest": 4}},
+        },
+    )
+    _write_json(history_path, [{"remaining": 5}, {"remaining": 4}])
+
+    comment = autofix_comment.build_comment(
+        report_path=report_path,
+        trend_path=trend_path,
+        history_path=history_path,
+        pr_number="101",
+    )
+
+    assert comment == "\n".join(
+        [
+            autofix_comment.MARKER,
+            "Status | \u26a0\ufe0f new diagnostics detected",
+            "History points | 2",
+            "Timestamp | 2025-02-02 10:11:12 UTC",
+            "Report artifact | `autofix-report-pr-101`",
+            "Remaining | 4",
+            "New | 2",
+            "",
+            "Top residual codes",
+            "",
+            "- `E001`: 4",
+            "- `W002`: 1",
+            "",
+            "Current per-code counts",
+            "",
+            "- `E001`: 3",
+            "- `W002`: 1",
+            autofix_comment.MARKER,
+        ]
+    )

--- a/tests/scripts/test_build_autofix_pr_comment.py
+++ b/tests/scripts/test_build_autofix_pr_comment.py
@@ -33,9 +33,7 @@ def test_extract_report_metadata_handles_missing_and_malformed_reports() -> None
         "should_post": False,
     }
     assert (
-        autofix_comment.render_status_line(
-            {"changed": "off", "classification": "not-a-dict"}
-        )
+        autofix_comment.render_status_line({"changed": "off", "classification": "not-a-dict"})
         == "Status | \u2705 no new diagnostics"
     )
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2579 -->
> **Source:** Issue #2579

Closes #2579

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Refactor `scripts/build_autofix_pr_comment.py` so metadata extraction and status-line rendering are easier to test independently while preserving generated Markdown.

#### Tasks
- [ ] Keep `build_comment()` output unchanged for existing report/trend inputs.
- [ ] Extract one or two small pure helpers around metadata/status rendering where that reduces duplication.
- [ ] Add or update focused tests in `tests/scripts/test_build_autofix_pr_comment.py` for missing, malformed, and populated report data.

#### Acceptance criteria
- [ ] `pytest tests/scripts/test_build_autofix_pr_comment.py -q` passes.
- [ ] Existing marker text and Markdown line order remain compatible.
- [ ] No workflow, artifact, or report schema changes.

**Head SHA:** 10b401ef23a5a93fcdea381106b2d834d697fbf8
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307975146) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28307969085) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28307975092) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307975085) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28307969029) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307969030) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307969044) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307969019) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28307969027) |
<!-- auto-status-summary:end -->