### PR TITLE
[codex] Add workflow YAML validator edge-case tests

### DIFF
--- a/tests/scripts/test_validate_workflow_yaml.py
+++ b/tests/scripts/test_validate_workflow_yaml.py
@@ -1,0 +1,104 @@
+import sys
+from pathlib import Path
+
+import pytest
+from scripts import validate_workflow_yaml as validator
+
+
+def _write_workflow(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_line_length_allows_pinned_setup_api_client_reference(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path / "line-length.yml",
+        [
+            "name: Line length",
+            ("      uses: stranske/Workflows/.github/actions/setup-api-client@" + "a" * 80),
+            "      run: echo " + "x" * 110,
+        ],
+    )
+
+    issues = validator.check_line_length(workflow)
+
+    assert issues == [(3, "Line exceeds 100 characters")]
+
+
+def test_runs_on_placement_flags_inline_mapping(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path / "bad-runs-on.yml",
+        [
+            "jobs:",
+            "  build: { runs-on: ubuntu-latest, steps: [] }",
+        ],
+    )
+
+    issues = validator.check_runs_on_placement(workflow)
+
+    assert issues == [
+        (2, "runs-on should be on its own line (found text before it)"),
+    ]
+
+
+def test_long_single_line_if_requires_multiline_condition(tmp_path: Path) -> None:
+    workflow = _write_workflow(
+        tmp_path / "long-if.yml",
+        [
+            "jobs:",
+            "  build:",
+            (
+                "    if: ${{ github.event_name == 'pull_request' && "
+                "github.actor != 'dependabot[bot]' && "
+                "contains(github.event.pull_request.labels.*.name, 'agent:codex') }}"
+            ),
+            "    runs-on: ubuntu-latest",
+        ],
+    )
+
+    issues = validator.check_multiline_conditions(workflow)
+
+    assert issues == [
+        (3, "Very long 'if' condition should use multiline format (| or >)"),
+    ]
+
+
+def test_legacy_workflow_is_skipped_unless_no_skip_is_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workflow = _write_workflow(
+        tmp_path / "agents-71-codex-belt-dispatcher.yml",
+        [
+            "name: Legacy",
+            "on: push",
+            "jobs:",
+            "  build:",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+            "      - run: echo " + "x" * 120,
+        ],
+    )
+
+    monkeypatch.setattr(sys, "argv", ["validate_workflow_yaml.py", str(workflow), "--verbose"])
+    with pytest.raises(SystemExit) as skipped:
+        validator.main()
+
+    assert skipped.value.code == 0
+    skipped_output = capsys.readouterr().out
+    assert "Skipped (known legacy workflow)" in skipped_output
+    assert "legacy workflow(s) skipped" in skipped_output
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["validate_workflow_yaml.py", str(workflow), "--verbose", "--no-skip"],
+    )
+    with pytest.raises(SystemExit) as failed:
+        validator.main()
+
+    assert failed.value.code == 1
+    failed_output = capsys.readouterr().out
+    assert "Length: Line exceeds 100 characters" in failed_output
+    assert "Validation failed" in failed_output


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2576 -->
> **Source:** Issue #2576

Closes #2576

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add tests for `scripts/validate_workflow_yaml.py` edge cases that are currently easy to regress.

#### Tasks
- [x] Cover line-length exemptions for pinned setup-api-client references.
- [x] Cover malformed `runs-on:` placement and long single-line `if:` conditions.
- [x] Cover legacy workflow skip behavior versus `--no-skip`.
- [x] Use temporary workflow files and call helper functions or `main()` with monkeypatched argv.

#### Acceptance criteria
- [x] `pytest tests/scripts/test_validate_workflow_yaml.py -q` passes.
- [x] Tests are deterministic and do not require GitHub Actions.
- [x] Existing validation messages and exit behavior remain compatible.

**Head SHA:** 9c3a830401dc7c869eb2324ad9cd3e53d7daa68d
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28308229776) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28308204580) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28308229749) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308229799) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308204549) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308204550) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308204554) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308204544) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308204551) |
<!-- auto-status-summary:end -->

## Summary
- Adds focused pytest coverage for `scripts/validate_workflow_yaml.py` edge cases from #2576.
- Covers setup-api-client line-length exemption behavior, malformed inline `runs-on:` placement, long single-line `if:` conditions, and legacy workflow skip behavior versus `--no-skip`.
- Keeps the change test-only; no production workflow or validator behavior changed.

## Validation
- PASS: `PATH=/opt/anaconda3/bin:$PATH python -m pytest tests/scripts/test_validate_workflow_yaml.py -q` (`4 passed`)
- PASS: `PATH=/opt/anaconda3/bin:$PATH python testgen_gate.py` (gate result: PASS)
- PASS: `git diff --check`

## Notes / Risks
- `testgen_gate.py` is stale for this branch: it prints `stranske/Workflows#2561` and validates `tests/scripts/test_pr_verifier_compare.py`, not the #2576 validator tests. I ran it as required and separately ran the issue acceptance pytest command above.
- Plain `python` currently resolves to `/Users/teacher/anaconda/bin/python` in this shell and returned an empty tool-level `-1`; validation used `/opt/anaconda3/bin` first on `PATH`.