### PR TITLE
test: add subprocess CLI acceptance for gate detect output diff

### DIFF
--- a/tests/scripts/test_gate_detect_output_diff.py
+++ b/tests/scripts/test_gate_detect_output_diff.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -147,6 +149,41 @@ def test_compare_detect_outputs_rejects_malformed_workflow_shapes(
 
     with pytest.raises(ValueError, match=message):
         diff.compare_gate_detect_outputs(candidate, baseline)
+
+
+def test_cli_exits_nonzero_and_reports_invalid_step_output_references(tmp_path: Path) -> None:
+    baseline = _write(
+        tmp_path / "baseline.yml",
+        _minimal_detect_workflow("""
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+"""),
+    )
+    candidate = _write(
+        tmp_path / "candidate.yml",
+        _minimal_detect_workflow("""
+      doc_only: ${{ steps.classify.outputs.doc_only }}
+      affected_consumers: ${{ steps.path_classifier.outputs.affected_consumers }}
+"""),
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/gate_detect_output_diff.py",
+            "--candidate",
+            str(candidate),
+            "--baseline",
+            str(baseline),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["invalid_step_output_references"] == {"affected_consumers": ["path_classifier"]}
 
 
 def test_main_preserves_json_report_shape_for_invalid_refs(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2557 -->
> **Source:** Issue #2557

Closes #2557

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add runtime acceptance coverage proving scripts/gate_detect_output_diff.py exits non-zero and reports invalid detect output references when a candidate workflow points to a missing step id.

#### Tasks
- [ ] Exercise the CLI through subprocess or an equivalent main-path test.
- [ ] Use temporary workflow YAML fixtures, not repository workflow mutation.
- [ ] Verify JSON output includes invalid_step_output_references for the missing step.

#### Acceptance criteria
- [ ] pytest tests/scripts/test_gate_detect_output_diff.py passes.
- [ ] The acceptance test covers the actual CLI exit code, not only compare_gate_detect_outputs.
- [ ] No production workflow behavior changes.

**Head SHA:** 9cc3aa4c8d4938716f8ba5c2ab7771a20a2ccfb3
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label dependency PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/28308319138) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319492) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28308319466) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319424) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319421) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319420) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319428) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319415) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319413) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308319422) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for CLI behavior when invalid step output references are detected.
  * Verified the command exits with a non-zero status and returns the expected JSON error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->