### PR TITLE
test: cover unsafe raw payload field rejection

### DIFF
--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -423,6 +423,7 @@ def _self_smoke(schema_dir: Path, registry_path: Path) -> int:
         for inv in (
             "missing_cost.json",
             "unsafe_rows_inline.json",
+            "unsafe_prompt_inline.json",
             "artifact_not_in_manifest.json",
             "bad_identity_ref.json",
         ):

--- a/scripts/validate_run_contract.py
+++ b/scripts/validate_run_contract.py
@@ -420,6 +420,7 @@ def _self_smoke(schema_dir: Path, registry_path: Path) -> int:
                     True,
                 )
             )
+        # Unsafe raw payload fixtures must fail without echoing sensitive values.
         for inv in (
             "missing_cost.json",
             "unsafe_rows_inline.json",

--- a/tests/contracts/test_validate_run_contract.py
+++ b/tests/contracts/test_validate_run_contract.py
@@ -340,7 +340,7 @@ def test_unsafe_raw_payload_fields_rejected_via_cli(tmp_path, capsys) -> None:
     assert rc == 1, f"Expected exit 1 in strict mode, got {rc}"
     captured = capsys.readouterr()
     assert "unsafe raw payload field 'prompt' inlined" in captured.err
-    # Ensure the raw payload content is NOT echoed in the violation message
+    # Report only the unsafe field name; raw prompt content must not leak.
     assert "sensitive data that should not be inlined" not in captured.err
 
     # Test warn-only mode: same unsafe envelope should exit 0
@@ -359,7 +359,7 @@ def test_unsafe_raw_payload_fields_rejected_via_cli(tmp_path, capsys) -> None:
     assert rc == 0, f"Expected exit 0 in warn-only mode, got {rc}"
     captured = capsys.readouterr()
     assert "unsafe raw payload field 'prompt' inlined" in captured.err
-    # Ensure the raw payload content is NOT echoed in the violation message
+    # Report only the unsafe field name; raw prompt content must not leak.
     assert "sensitive data that should not be inlined" not in captured.err
 
 

--- a/tests/contracts/test_validate_run_contract.py
+++ b/tests/contracts/test_validate_run_contract.py
@@ -299,6 +299,121 @@ def test_consumer_reports_closest_schema_errors_when_no_ingest_matches() -> None
     assert "not-a-valid-method" in report.violations[0].message
 
 
+def test_unsafe_raw_payload_fields_rejected_via_cli(tmp_path, capsys) -> None:
+    """Acceptance: CLI main path rejects unsafe raw payload fields in strict mode (exit 1) and warns in warn-only mode (exit 0)."""
+    mod = _import_validator()
+
+    # Create a temporary run envelope with an unsafe raw payload field (prompt)
+    unsafe_envelope = {
+        "schema_version": "run-contract/v1",
+        "repo": "stranske/Pension-Data",
+        "tool": "test-tool",
+        "run_id": "sha256:test123",
+        "status": "success",
+        "actor": {"kind": "ci", "id": "test", "intent": "test"},
+        "inputs": {"prompt": "sensitive data that should not be inlined"},
+        "outputs": {"manifest_ref": "artifact:manifest.json", "summary": {}, "artifact_ids": []},
+        "provenance": {"tool_version": "0.1.0"},
+        "cost": {"usd": None, "input_tokens": 0, "output_tokens": 0},
+        "latency": {"wall_ms": 12.0},
+        "warnings": [],
+        "data_quality": {"overall_status": "ok"},
+        "evidence_refs": [],
+        "identity_refs": [],
+    }
+
+    run_json = tmp_path / "unsafe_run.json"
+    run_json.write_text(json.dumps(unsafe_envelope))
+
+    # Test strict mode: should exit 1 and report unsafe field
+    rc = mod.main(
+        [
+            str(run_json),
+            "--registry",
+            str(REGISTRY),
+            "--schema-dir",
+            str(SCHEMA_DIR),
+            "--repo",
+            PRODUCER_REPO,
+        ]
+    )
+    assert rc == 1, f"Expected exit 1 in strict mode, got {rc}"
+    captured = capsys.readouterr()
+    assert "unsafe raw payload field 'prompt' inlined" in captured.err
+    # Ensure the raw payload content is NOT echoed in the violation message
+    assert "sensitive data that should not be inlined" not in captured.err
+
+    # Test warn-only mode: same unsafe envelope should exit 0
+    rc = mod.main(
+        [
+            str(run_json),
+            "--registry",
+            str(REGISTRY),
+            "--schema-dir",
+            str(SCHEMA_DIR),
+            "--repo",
+            PRODUCER_REPO,
+            "--warn-only",
+        ]
+    )
+    assert rc == 0, f"Expected exit 0 in warn-only mode, got {rc}"
+    captured = capsys.readouterr()
+    assert "unsafe raw payload field 'prompt' inlined" in captured.err
+    # Ensure the raw payload content is NOT echoed in the violation message
+    assert "sensitive data that should not be inlined" not in captured.err
+
+
+def test_unsafe_raw_payload_validation_direct() -> None:
+    """Acceptance: validate_envelope rejects multiple unsafe raw payload fields and identifies them by name only."""
+    mod = _import_validator()
+
+    # Test envelope with multiple unsafe fields
+    unsafe_envelope = {
+        "schema_version": "run-contract/v1",
+        "repo": "stranske/Pension-Data",
+        "tool": "test-tool",
+        "run_id": "sha256:test456",
+        "status": "success",
+        "actor": {"kind": "ci", "id": "test", "intent": "test"},
+        "inputs": {"prompt": "sensitive prompt data"},
+        "outputs": {
+            "manifest_ref": "artifact:manifest.json",
+            "summary": {"model_output": "sensitive model output"},
+            "artifact_ids": [],
+        },
+        "provenance": {"tool_version": "0.1.0"},
+        "cost": {"usd": None, "input_tokens": 0, "output_tokens": 0},
+        "latency": {"wall_ms": 12.0},
+        "warnings": [],
+        "data_quality": {"overall_status": "ok"},
+        "evidence_refs": [],
+        "identity_refs": [],
+    }
+
+    report = mod.validate_envelope(
+        envelope=unsafe_envelope,
+        schema_dir=SCHEMA_DIR,
+        registry=_registry(),
+        repo=PRODUCER_REPO,
+        manifest=None,
+    )
+
+    assert not report.conformant
+    assert not report.skipped
+
+    # Check that both unsafe fields are identified by name
+    violation_messages = [v.message for v in report.violations]
+    assert any("unsafe raw payload field 'prompt' inlined" in msg for msg in violation_messages)
+    assert any(
+        "unsafe raw payload field 'model_output' inlined" in msg for msg in violation_messages
+    )
+
+    # Ensure raw payload content is not echoed in any violation message
+    for msg in violation_messages:
+        assert "sensitive prompt data" not in msg
+        assert "sensitive model output" not in msg
+
+
 def test_consumer_mixed_unknown_ingest_token_fails() -> None:
     """Unknown ingest tokens are invalid even when another declared token matches."""
     mod = _import_validator()

--- a/tests/fixtures/backplane/unsafe_prompt_inline.json
+++ b/tests/fixtures/backplane/unsafe_prompt_inline.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "run-contract/v1",
+  "repo": "stranske/Pension-Data",
+  "tool": "test-tool",
+  "run_id": "sha256:0f0e0d0c0b0a09080706050403020100ffeeddccbbaa99887766554433221100",
+  "status": "success",
+  "github_issue": "stranske/Workflows#TBD-P0",
+  "actor": {
+    "kind": "ci",
+    "id": "test-fixture",
+    "intent": "INVALID: inlines raw prompt in inputs"
+  },
+  "inputs": {
+    "validated": true,
+    "prompt": "This is a sensitive user prompt that should not be inlined"
+  },
+  "outputs": {
+    "manifest_ref": "artifact:manifest.json",
+    "summary": {
+      "result": "test completed"
+    },
+    "artifact_ids": []
+  },
+  "provenance": {
+    "tool_version": "0.1.0"
+  },
+  "cost": {
+    "usd": null,
+    "input_tokens": 0,
+    "output_tokens": 0
+  },
+  "latency": {
+    "wall_ms": 12.0
+  },
+  "warnings": [],
+  "data_quality": {
+    "overall_status": "ok"
+  },
+  "evidence_refs": [],
+  "identity_refs": []
+}


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2556 -->
> **Source:** Issue #2556

Closes #2556

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add runtime acceptance coverage that validates scripts/validate_run_contract.py rejects unsafe raw payload fields while preserving warn-only exit behavior.

#### Tasks
- [ ] Exercise the CLI main path with a temporary run envelope containing a blocked raw field.
- [ ] Verify strict mode exits 1 and warn-only exits 0 for the same envelope.
- [ ] Assert the violation message identifies the unsafe field without echoing raw payload contents.

#### Acceptance criteria
- [ ] pytest tests/contracts/test_validate_run_contract.py passes.
- [ ] The new coverage runs without cloud credentials or network access.
- [ ] Registry and schema files remain unchanged unless a test fixture requires a local temporary copy.

**Head SHA:** b1942eb184038d3c0c53522662848f073a3449cf
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Backplane Contract Integrity | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781560) |
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781622) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28308781604) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28308781586) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781549) |
| Health 50 Security Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28308781574) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781567) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781569) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781551) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28308781587) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened run contract validation to reject unsafe inlined raw payloads in run records (including prompt and model output fields).
  * Improved violation reporting to reference the specific unsafe field names without echoing any sensitive raw payload content.
  * Ensured consistent outcomes between strict and warn-only command-line modes for these unsafe inline cases.
* **Tests**
  * Added new regression/acceptance coverage for unsafe inline prompt scenarios via both CLI and direct validation.
  * Included a new fixture to exercise the unsafe inline payload rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->