### PR TITLE
test: cover round2 schema edge validation

### DIFF
--- a/tests/scripts/test_repo_review_round2_schema.py
+++ b/tests/scripts/test_repo_review_round2_schema.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import pytest
+from scripts import repo_review_round2_schema as schema
+
+LONG_REASON = "This reason is long enough to satisfy the schema validator minimum length."
+
+
+def _valid_mark(**overrides: object) -> dict[str, object]:
+    mark: dict[str, object] = {
+        "source_agent": "codex",
+        "candidate_index": 1,
+        "mark": "agree-keep",
+        "reason": LONG_REASON,
+    }
+    mark.update(overrides)
+    return mark
+
+
+def _valid_meta_candidate(**overrides: object) -> dict[str, object]:
+    meta: dict[str, object] = {
+        "proposed": True,
+        "pattern": "Repeated stale repo-review guardrails",
+        "title": "Audit stale repo-review guardrails across the codebase",
+        "rationale": "Multiple concrete findings point at the same audit class.",
+        "supporting_candidate_indexes": [
+            {"agent": "codex", "candidate_index": 1},
+            {"agent": "claude", "candidate_index": 2},
+        ],
+        "scope": "audit",
+        "tasks": [
+            "Enumerate every matching guardrail with file references.",
+            "Classify each instance by risk and owner.",
+            "File per-instance follow-up issues for fixes.",
+        ],
+        "acceptance_criteria": [
+            "An audit report artifact lists every reviewed instance.",
+            "Per-instance follow-up issues are filed for concrete fixes.",
+            "The report records any intentionally deferred cases.",
+        ],
+        "non_goals": [
+            "Do not bundle per-instance fixes into a single PR.",
+        ],
+        "priority": "normal",
+        "confidence": "medium",
+    }
+    meta.update(overrides)
+    return meta
+
+
+def _valid_turn_output(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "agent": "codex",
+        "repo": "stranske/Workflows",
+        "turn": 1,
+        "marks": [_valid_mark()],
+        "own_candidates_revisions": [],
+        "meta_candidate_proposal": {"proposed": False},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _valid_converged_set(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "v1",
+        "repo": "stranske/Workflows",
+        "turns_completed": 2,
+        "round1_sources": [{"agent": "codex", "path": "/tmp/codex.json", "candidate_count": 1}],
+        "converged_candidates": [
+            {
+                "title": "Add focused repo-review tests",
+                "scope": "fix",
+            }
+        ],
+        "deadlocked_candidates": [],
+        "dropped_candidates": [],
+        "meta_candidate": {"title": "Audit related repo-review gaps", "scope": "audit"},
+        "negotiation_log": ["/tmp/round2/turn-1/codex.json"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _assert_error(errors: list[str], substring: str) -> None:
+    assert any(substring in error for error in errors), errors
+
+
+@pytest.mark.parametrize("agent", ["codex", "claude", "pilot-testgen"])
+def test_validate_mark_accepts_allowed_agents(agent: str) -> None:
+    assert schema.validate_mark(_valid_mark(source_agent=agent), 0) == []
+
+
+def test_validate_mark_rejects_unknown_agent() -> None:
+    errors = schema.validate_mark(_valid_mark(source_agent="gemini"), 0)
+
+    _assert_error(errors, "marks[0].source_agent: must be one of")
+
+
+@pytest.mark.parametrize(
+    ("mark_value", "missing_field", "expected_error"),
+    [
+        ("agree-merge", "merge_proposal", "marks[0].merge_proposal: required"),
+        ("disagree-revise", "revision_proposal", "marks[0].revision_proposal: required"),
+    ],
+)
+def test_validate_mark_requires_proposals_for_merge_and_revision(
+    mark_value: str,
+    missing_field: str,
+    expected_error: str,
+) -> None:
+    errors = schema.validate_mark(_valid_mark(mark=mark_value), 0)
+
+    assert missing_field not in _valid_mark(mark=mark_value)
+    _assert_error(errors, expected_error)
+
+
+def test_validate_mark_rejects_short_reason() -> None:
+    errors = schema.validate_mark(_valid_mark(reason="Too short."), 0)
+
+    _assert_error(errors, "marks[0].reason: must be \u226530 chars")
+
+
+def test_validate_mark_disagree_drop_requires_citation() -> None:
+    bare_prose = "This looks redundant based on general reviewer judgment but cites no evidence."
+    errors = schema.validate_mark(_valid_mark(mark="disagree-drop", reason=bare_prose), 0)
+
+    _assert_error(errors, "'disagree-drop' must cite a file ref")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Drop because scripts/repo_review_round2_schema.py already covers it.",
+        "Drop because tests/scripts/test_existing.py already exercises the case.",
+        "Drop because #2621 already tracks the remaining follow-up.",
+        "Drop because the merged PR already shipped the same validation.",
+    ],
+)
+def test_validate_mark_disagree_drop_accepts_concrete_citations(reason: str) -> None:
+    assert schema.validate_mark(_valid_mark(mark="disagree-drop", reason=reason), 0) == []
+
+
+def test_validate_meta_candidate_proposed_false_has_no_extra_requirements() -> None:
+    assert schema.validate_meta_candidate({"proposed": False}) == []
+
+
+def test_validate_meta_candidate_requires_proposed_boolean() -> None:
+    errors = schema.validate_meta_candidate({"pattern": "Missing proposed flag"})
+
+    _assert_error(errors, "meta_candidate_proposal.proposed: must be a boolean")
+
+
+def test_validate_meta_candidate_enforces_audit_scope() -> None:
+    errors = schema.validate_meta_candidate(_valid_meta_candidate(scope="fix"))
+
+    _assert_error(errors, "meta_candidate_proposal.scope: must be exactly 'audit'")
+
+
+def test_validate_meta_candidate_requires_two_supporting_candidates() -> None:
+    errors = schema.validate_meta_candidate(
+        _valid_meta_candidate(
+            supporting_candidate_indexes=[
+                {"agent": "codex", "candidate_index": 1},
+            ],
+        )
+    )
+
+    _assert_error(errors, "supporting_candidate_indexes: must list \u22652 anchoring candidates")
+
+
+def test_validate_meta_candidate_acceptance_must_reference_audit_or_report_token() -> None:
+    errors = schema.validate_meta_candidate(
+        _valid_meta_candidate(
+            acceptance_criteria=[
+                "Every reviewed instance has a clear owner.",
+                "Every reviewed instance has an explicit risk class.",
+                "Every reviewed instance has a concrete disposition.",
+            ],
+        )
+    )
+
+    _assert_error(errors, "acceptance_criteria: at least one criterion must reference")
+
+
+def test_validate_meta_candidate_non_goals_must_forbid_bundling() -> None:
+    errors = schema.validate_meta_candidate(
+        _valid_meta_candidate(non_goals=["Do not change unrelated CI workflows."])
+    )
+
+    _assert_error(errors, "non_goals: must explicitly forbid bundling")
+
+
+def test_validate_meta_candidate_high_confidence_requires_four_supports() -> None:
+    errors = schema.validate_meta_candidate(_valid_meta_candidate(confidence="high"))
+
+    _assert_error(errors, "confidence: 'high' requires \u22654 supporting")
+
+
+def test_validate_meta_candidate_valid_payload_passes() -> None:
+    assert schema.validate_meta_candidate(_valid_meta_candidate()) == []
+
+
+def test_validate_turn_output_rejects_expected_repo_mismatch() -> None:
+    errors = schema.validate_turn_output(
+        _valid_turn_output(repo="stranske/Other"),
+        expected_repo="stranske/Workflows",
+    )
+
+    _assert_error(errors, "repo: expected 'stranske/Workflows' got 'stranske/Other'")
+
+
+def test_validate_turn_output_rejects_empty_marks() -> None:
+    errors = schema.validate_turn_output(_valid_turn_output(marks=[]))
+
+    _assert_error(errors, "marks: must be non-empty")
+
+
+def test_validate_turn_output_rejects_invalid_turn() -> None:
+    errors = schema.validate_turn_output(_valid_turn_output(turn=4))
+
+    _assert_error(errors, "turn: must be 1, 2, or 3")
+
+
+def test_validate_turn_output_accepts_valid_payload() -> None:
+    assert schema.validate_turn_output(_valid_turn_output()) == []
+
+
+def test_validate_converged_set_rejects_expected_repo_mismatch() -> None:
+    errors = schema.validate_converged_set(
+        _valid_converged_set(repo="stranske/Other"),
+        expected_repo="stranske/Workflows",
+    )
+
+    _assert_error(errors, "repo: expected 'stranske/Workflows' got 'stranske/Other'")
+
+
+def test_validate_converged_set_rejects_invalid_candidate_scope() -> None:
+    errors = schema.validate_converged_set(
+        _valid_converged_set(converged_candidates=[{"title": "Bad scope", "scope": "cleanup"}])
+    )
+
+    _assert_error(errors, "converged_candidates[0].scope: must be one of")
+
+
+def test_validate_converged_set_rejects_non_object_meta_candidate() -> None:
+    errors = schema.validate_converged_set(_valid_converged_set(meta_candidate="audit"))
+
+    _assert_error(errors, "meta_candidate: must be null or an object")
+
+
+def test_validate_converged_set_accepts_compact_payload_with_meta_candidate() -> None:
+    assert schema.validate_converged_set(_valid_converged_set()) == []


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2621 -->
> **Source:** Issue #2621

Closes #2621

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/repo_review_round2_schema.py` validates round-2 negotiation outputs and converged sets. Its meta-candidate and mark validation rules are high-leverage guardrails, but edge behavior needs focused tests. This is a safe Route-Weight `testgen` opener because it is pure JSON validation.

#### Tasks
- [ ] Add focused tests for `scripts/repo_review_round2_schema.py`.
- [ ] Cover `validate_mark()` for allowed agents, required merge/revision proposal fields, short reasons, and `disagree-drop` citation requirements.
- [ ] Cover `validate_meta_candidate()` for `proposed=false`, missing proposed boolean, audit-scope enforcement, supporting candidate minimums, audit/report acceptance tokens, anti-bundling non-goals, and high-confidence support threshold.
- [ ] Cover `validate_turn_output()` for expected repo mismatch, empty marks, invalid turn, and a valid payload.
- [ ] Cover `validate_converged_set()` for expected repo mismatch and meta/per-instance validation paths that can be exercised with a compact payload.

#### Acceptance criteria
- [ ] Tests use in-memory payload dictionaries only.
- [ ] Tests assert precise error substrings for the critical gate failures.
- [ ] Existing schema contract remains strict.

**Head SHA:** cdd09120ad5f4148d23db894bdd8273fc60a30af
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label dependency PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/28309583989) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28309612110) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28309584009) |
| Health 44 Gate Branch Protection | ⏳ pending | [View run](https://github.com/stranske/Workflows/actions/runs/28309612024) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309612067) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309583972) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309583960) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309583982) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309583973) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28309583965) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation coverage for review-related schema inputs and outputs.
  * Expanded checks for accepted values, required fields, length constraints, repository consistency, turn range limits, and valid candidate payload shapes.
  * Added scenarios confirming that valid compact and full payloads are accepted while malformed data is rejected with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->