### PR TITLE
[codex] Add startup diagnostic error-path tests

### DIFF
--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from scripts import workflow_startup_failure_diagnostic as diag
 
 
@@ -27,6 +28,53 @@ def test_collect_startup_failures_filters_by_run_and_conclusion() -> None:
     }
     matches = diag._collect_startup_failures(payload, run_id=123)
     assert [m["id"] for m in matches] == [2]
+
+
+def test_collect_startup_failures_ignores_malformed_payloads() -> None:
+    assert diag._collect_startup_failures({"check_runs": {"id": 1}}, run_id=123) == []
+    assert diag._collect_startup_failures({"check_runs": None}, run_id=123) == []
+
+
+def test_collect_startup_failures_ignores_non_dict_entries() -> None:
+    payload = {
+        "check_runs": [
+            None,
+            "not-a-check-run",
+            42,
+            {
+                "id": 7,
+                "conclusion": "startup_failure",
+                "details_url": "https://github.com/o/r/actions/runs/123/job/1",
+            },
+        ]
+    }
+
+    matches = diag._collect_startup_failures(payload, run_id=123)
+
+    assert [m["id"] for m in matches] == [7]
+
+
+def test_gh_api_rejects_non_object_response(monkeypatch) -> None:
+    def fail_if_token_requested() -> str:
+        raise AssertionError("gh auth token should not be called when token is supplied")
+
+    def fake_request_json(
+        method: str,
+        url: str,
+        token: str,
+        payload: object | None = None,
+    ) -> list[str]:
+        assert method == "GET"
+        assert url.endswith("/repos/owner/repo/actions/runs/123")
+        assert token == "test-token"
+        assert payload is None
+        return ["not", "an", "object"]
+
+    monkeypatch.setattr(diag, "_github_token", fail_if_token_requested)
+    monkeypatch.setattr(diag.api_client, "_request_json", fake_request_json)
+
+    with pytest.raises(ValueError, match="Expected JSON object"):
+        diag._gh_api("repos/owner/repo/actions/runs/123", token="test-token")
 
 
 def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
@@ -75,6 +123,29 @@ def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
     assert finding["suspected_root_cause"] == "invalid_expression_context_reference"
 
 
+def test_diagnose_startup_failure_rejects_missing_head_sha(monkeypatch) -> None:
+    responses = [
+        {"name": "Gate", "conclusion": "startup_failure", "status": "completed"},
+        {"jobs": []},
+    ]
+    requested_paths: list[str] = []
+
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        assert token is None
+        requested_paths.append(path)
+        return responses.pop(0)
+
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
+
+    with pytest.raises(ValueError, match="missing head_sha"):
+        diag.diagnose_startup_failure("owner/repo", 555)
+
+    assert requested_paths == [
+        "repos/owner/repo/actions/runs/555",
+        "repos/owner/repo/actions/runs/555/jobs",
+    ]
+
+
 def test_classify_startup_failure_action_resolution() -> None:
     phase, root = diag._classify_startup_failure(
         summary="Unable to resolve action `owner/repo@main`",
@@ -83,6 +154,35 @@ def test_classify_startup_failure_action_resolution() -> None:
     )
     assert phase == "action_resolution"
     assert root == "action_reference_or_access"
+
+
+@pytest.mark.parametrize(
+    ("summary", "title", "text", "expected_root"),
+    [
+        (
+            "Unexpected value 'uses'",
+            "The workflow is not valid",
+            "Line 14, Col 9",
+            "yaml_structure_or_syntax",
+        ),
+        (
+            "The template is not valid. fromJson received invalid JSON input.",
+            "The workflow is not valid",
+            "Line 22, Col 17",
+            "expression_type_or_json_coercion",
+        ),
+    ],
+)
+def test_classify_startup_failure_parse_causes(
+    summary: str,
+    title: str,
+    text: str,
+    expected_root: str,
+) -> None:
+    phase, root = diag._classify_startup_failure(summary=summary, title=title, text=text)
+
+    assert phase == "workflow_parse_or_graph"
+    assert root == expected_root
 
 
 def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:
@@ -100,3 +200,20 @@ def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:
 
     assert exit_code == 2
     assert "No matching startup_failure check-runs found" in capsys.readouterr().err
+
+
+def test_main_returns_1_when_diagnosis_raises(monkeypatch, capsys) -> None:
+    def fake_diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
+        assert repo == "owner/repo"
+        assert run_id == 111
+        raise ValueError("Run 111 in owner/repo is missing head_sha")
+
+    monkeypatch.setattr(diag, "diagnose_startup_failure", fake_diagnose_startup_failure)
+
+    exit_code = diag.main(["--repo", "owner/repo", "--run-id", "111"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "workflow_startup_failure_diagnostic:" in captured.err
+    assert "missing head_sha" in captured.err


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2650 -->
> **Source:** Issue #2650

Closes #2650

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/workflow_startup_failure_diagnostic.py` has happy-path startup failure coverage, but its API validation and CLI error paths still need focused tests. Those paths matter when diagnosing failed GitHub Actions runs with malformed or incomplete API payloads.

#### Tasks
- [ ] Cover `_gh_api()` raising when the API response is not a JSON object.
- [ ] Cover `diagnose_startup_failure()` raising when the run payload lacks `head_sha`.
- [ ] Cover `_collect_startup_failures()` ignoring malformed `check_runs` payloads and non-dict entries.
- [ ] Cover `main()` returning `1` and writing stderr when diagnosis raises.
- [ ] Add classifier assertions for YAML structure and `fromJson` coercion parse causes.

#### Acceptance criteria
- [ ] Add focused pytest coverage in `tests/scripts/test_workflow_startup_failure_diagnostic.py` for the error/classifier paths in `scripts/workflow_startup_failure_diagnostic.py`.
- [ ] Tests monkeypatch API helpers and never call live GitHub or `gh auth token`.
- [ ] Keep production-code changes out unless a tiny, clearly explained testability fix is unavoidable.

**Head SHA:** 5589ae59bf7a60d889ecd331978adf6838e7e35e
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label dependency PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/28311643058) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28311731391) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28311643083) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28311731356) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311731354) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311643038) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311643042) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311643066) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311643033) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28311643049) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader coverage for workflow startup failure diagnostics.
  * Verified malformed API payloads are handled safely and only valid failure data is processed.
  * Added checks for missing required workflow metadata and unexpected API responses.
  * Expanded classification coverage for parsing-related failure messages.
  * Confirmed the CLI reports errors clearly and exits with a failure status when diagnosis cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->