### PR TITLE
[Route Weight][testgen] Add mypy version resolver tests

### DIFF
--- a/tests/tools/test_resolve_mypy_pin.py
+++ b/tests/tools/test_resolve_mypy_pin.py
@@ -64,6 +64,36 @@ python_version = "3.10"
     assert resolve_mypy_pin.get_mypy_python_version() == "3.10"
 
 
+def test_get_mypy_python_version_returns_none_with_no_mypy_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path / "pyproject.toml",
+        """
+[tool.other]
+some_key = "value"
+""",
+    )
+
+    assert resolve_mypy_pin.get_mypy_python_version() is None
+
+
+def test_get_mypy_python_version_returns_none_with_mypy_section_no_python_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_pyproject(
+        tmp_path / "pyproject.toml",
+        """
+[tool.mypy]
+other_key = "value"
+""",
+    )
+
+    assert resolve_mypy_pin.get_mypy_python_version() is None
+
+
 def test_main_writes_github_output_from_pyproject(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -95,3 +125,29 @@ def test_main_defaults_to_matrix_or_fallback(
 
     assert resolve_mypy_pin.main() == 0
     assert output_path.read_text(encoding="utf-8") == "python-version=3.9\n"
+
+
+def test_main_local_print_fallback_with_matrix_python_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("MATRIX_PYTHON_VERSION", "3.11")
+
+    assert resolve_mypy_pin.main() == 0
+    captured = capsys.readouterr()
+    assert "python-version=3.11" in captured.out
+
+
+def test_main_local_print_fallback_without_matrix_python_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.delenv("MATRIX_PYTHON_VERSION", raising=False)
+
+    assert resolve_mypy_pin.main() == 0
+    captured = capsys.readouterr()
+    assert "python-version=3.12" in captured.out


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2673 -->
> **Source:** Issue #2673

Closes #2673

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`tools/resolve_mypy_pin.py` determines which Python version should run mypy and writes GitHub output, but it lacks focused tests for TOML parsing, regex fallback, and environment output behavior. This is a safe Route-Weight `testgen` opener using temporary pyproject files.

#### Tasks
- [ ] Add tests for `get_mypy_python_version()` with a `[tool.mypy]` value, no file, and no mypy section.
- [ ] Cover regex fallback behavior by monkeypatching `tomlkit` import availability if needed.
- [ ] Cover `main()` writing `python-version=` to `GITHUB_OUTPUT` when set.
- [ ] Cover local print fallback when `GITHUB_OUTPUT` is absent and `MATRIX_PYTHON_VERSION` is set/unset.

#### Acceptance criteria
- [ ] Tests use `tmp_path` and `monkeypatch.chdir()`.
- [ ] Tests do not depend on the repository's real `pyproject.toml`.
- [ ] Existing output key name remains `python-version`.

**Head SHA:** 5b577b14b563afc2071c6576b98cc7b702a4c118
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Auto-label dependency PRs | ⏭️ skipped | [View run](https://github.com/stranske/Workflows/actions/runs/28312753656) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28312753756) |
| Health 40 Sweep | ❔ startup failure | [View run](https://github.com/stranske/Workflows/actions/runs/28312753725) |
| Health 44 Gate Branch Protection | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28312753661) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28312753670) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28312753663) |
| Health 52 Semgrep Scan | ❔ in progress | [View run](https://github.com/stranske/Workflows/actions/runs/28312753667) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28312753654) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28312753723) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28312753675) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Python version resolution when configuration is missing or incomplete.
  * Added coverage for fallback output behavior in local runs, including defaulting to `3.12` when no version is provided.
  * Improved confidence in version-handling behavior across different execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->