### PR TITLE
Ensure agent prompts include repo playbook guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,24 @@ Start with the current docs instead of inferring behavior from old comments:
 ## Agent-Specific Note
 
 This file is the agent-generic contract. Keep it materially aligned with `CLAUDE.md`; differences between the two should only be agent-specific execution notes, not different repository rules.
+
+<!-- BEGIN orch-playbook -->
+<!-- exported by repo_knowledge.py; owner: Orchestrator; freshness owner: keepalive -->
+
+## Orchestrator Repo Playbook (stranske/Workflows)
+
+- Summary: Shared automation source for the fleet; workflow changes usually need docs and registry surfaces.
+
+### Definition Of Done
+
+- Workflow additions or renames must update docs/ci/WORKFLOWS.md, docs/ci/WORKFLOW_SYSTEM.md, and the workflow naming tests. (tasks: implement, mechanical, testgen)
+- Consumer-facing files usually need sync-manifest/template coverage, not just the root copy. (tasks: implement, mechanical)
+- Route-weight codemod/refactor issues must produce the requested code or test change for the closer lane to validate; campaign plans, backfill plans, or analysis artifacts are not completion unless the issue explicitly asks for them. (tasks: codemod)
+- Epic or cross-repo documentation issues must create the named Markdown artifact at the requested path; dry-run rollout JSON or execution plans alone do not satisfy documentation acceptance criteria. (tasks: epic, cross_repo)
+
+### Validation
+
+- Run the narrow workflow/template tests named by the touched surface; include the command/result in the PR body.
+- For testgen issues, target the issue's named test file and source surface first; adjacent helper tests or generated gate artifacts are not a substitute for the requested coverage. (tasks: testgen)
+
+<!-- END orch-playbook -->

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -130,6 +130,10 @@ def _provider_instruction_path(workspace: Path, provider: str) -> Path:
     return workspace / ".github" / "claude" / "AGENT_INSTRUCTIONS.md"
 
 
+def _repository_guidance_path(workspace: Path) -> Path:
+    return workspace / "AGENTS.md"
+
+
 def _prompt_output_name(provider: str, pr_number: str | int | None) -> str:
     suffix = f"-{pr_number}" if pr_number not in (None, "") else ""
     return f"{provider}-prompt{suffix}.md"
@@ -488,6 +492,10 @@ def assemble_prompt(
 
     if appendix:
         parts.extend(["\n\n## Run context\n", appendix.rstrip()])
+
+    repository_guidance = _repository_guidance_path(workspace)
+    if repository_guidance.is_file():
+        parts.extend(["\n\n## Repository Guidance\n", _read_text(repository_guidance).rstrip()])
 
     reference_summary = workspace / ".reference" / "REFERENCE_PACKS.md"
     if reference_summary.is_file():

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -143,11 +143,14 @@ def _render_prompt_with_assemble_step(
     mode: str = "autofix",
     pr_number: str = "",
     orchestrator_skill_summary_path: str = "",
+    agents_text: str | None = None,
 ) -> str:
     assemble_step = _find_step_by_name(workflow, "Assemble prompt")
     run_script = str(assemble_step.get("run", ""))
     base_prompt = tmp_path / "base_prompt.md"
     base_prompt.write_text(base_prompt_text, encoding="utf-8")
+    if agents_text is not None:
+        (tmp_path / "AGENTS.md").write_text(agents_text, encoding="utf-8")
     github_output = tmp_path / "github_output.txt"
     github_output.write_text("", encoding="utf-8")
 
@@ -421,6 +424,45 @@ def test_reusable_codex_prompt_step_skips_reference_pack_section_when_file_missi
 
     # Missing file should not error and should not add a reference section.
     assert "## Reference Packs\n" not in rendered
+
+
+def test_reusable_codex_prompt_step_includes_repository_guidance_when_agents_md_exists(
+    tmp_path: Path,
+) -> None:
+    workflow = _load_workflow(REUSABLE_CODEX_RUN)
+    agents_text = (
+        "# AGENTS.md - Workflows Repository Context\n\n"
+        "<!-- BEGIN orch-playbook -->\n"
+        "## Orchestrator Repo Playbook (stranske/Workflows)\n\n"
+        "- Route-weight codemod/refactor issues must produce the requested code or "
+        "test change for the closer lane to validate.\n"
+        "<!-- END orch-playbook -->\n"
+    )
+
+    rendered = _render_prompt_with_assemble_step(
+        tmp_path,
+        workflow,
+        base_prompt_text="Base prompt content\n",
+        agents_text=agents_text,
+    )
+
+    assert "## Repository Guidance\n" in rendered
+    assert "<!-- BEGIN orch-playbook -->" in rendered
+    assert "Route-weight codemod/refactor issues" in rendered
+    assert "closer lane to validate" in rendered
+
+
+def test_reusable_codex_prompt_step_skips_repository_guidance_when_agents_md_missing(
+    tmp_path: Path,
+) -> None:
+    workflow = _load_workflow(REUSABLE_CODEX_RUN)
+    rendered = _render_prompt_with_assemble_step(
+        tmp_path,
+        workflow,
+        base_prompt_text="Base prompt content\n",
+    )
+
+    assert "## Repository Guidance\n" not in rendered
 
 
 def test_reusable_codex_prompt_step_skips_stale_orchestrator_skill_section_when_file_exists(


### PR DESCRIPTION
## Summary
- export the current Orchestrator Workflows playbook into `AGENTS.md`
- include root `AGENTS.md` in shared runner prompt assembly as `Repository Guidance`
- cover the reusable Codex assemble-prompt step with present/missing `AGENTS.md` tests

## Validation
- `python3 -m pytest tests/workflows/test_workflow_llm_installs.py -q` -> 20 passed, 2 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt assembly now conditionally adds a “Repository Guidance” section by reading `AGENTS.md` from the workspace root when it exists.
* **Documentation**
  * `AGENTS.md` now includes an Orchestrator Repo Playbook contract with workflow “Definition Of Done” acceptance criteria and validation requirements for changes.
* **Tests**
  * Added assertions that repository guidance is included in rendered prompts only when `AGENTS.md` is present, and excluded when it is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->