### PR TITLE
Pin Scorecard action to published version

### DIFF
--- a/.github/workflows/health-53-scorecard.yml
+++ b/.github/workflows/health-53-scorecard.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2
+      - uses: ossf/scorecard-action@v2.4.3
         continue-on-error: true  # advisory/report-only; a transient Scorecard
                                  # failure must not fail the whole workflow
         with:

--- a/tests/workflows/test_workflow_naming.py
+++ b/tests/workflows/test_workflow_naming.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 import yaml
 
@@ -123,6 +124,16 @@ def test_health_44_pull_requests_do_not_use_repo_variable_fingerprints():
     assert "pull-request-no-repo-variable" in source
     assert "--storage repo-variable" in source
     assert source.index("pull-request-no-repo-variable") < source.index("--storage repo-variable")
+
+
+def test_health_53_scorecard_uses_existing_semver_action_ref():
+    workflow = WORKFLOW_DIR / "health-53-scorecard.yml"
+    data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    uses = [step["uses"] for step in data["jobs"]["scorecard"]["steps"] if "uses" in step]
+    scorecard_refs = [action for action in uses if action.startswith("ossf/scorecard-action@")]
+
+    assert len(scorecard_refs) == 1
+    assert re.fullmatch(r"ossf/scorecard-action@v\d+\.\d+\.\d+", scorecard_refs[0])
 
 
 def test_maint_83_bootstrap_uses_published_action_versions():


### PR DESCRIPTION
## Summary
- pin `ossf/scorecard-action` to the existing `v2.4.3` tag instead of the missing `v2` major tag
- add a workflow guard test requiring the Scorecard action ref to use a concrete semantic version tag

## Validation
- `python3 -m pytest tests/workflows/test_workflow_naming.py tests/workflows/test_workflow_llm_installs.py -q` -> 32 passed, 2 skipped

## Context
- Follow-up to post-merge main verification after #2696: `Health 53 Scorecard` failed because GitHub could not resolve `ossf/scorecard-action@v2`.