### PR TITLE
Fix Health 40 reusable workflow permissions

### DIFF
--- a/.github/workflows/health-40-sweep.yml
+++ b/.github/workflows/health-40-sweep.yml
@@ -97,5 +97,9 @@ jobs:
     if: >-
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.detect.outputs.run_branch_protection != 'false'
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
     uses: ./.github/workflows/health-44-gate-branch-protection.yml
     secrets: inherit

--- a/tests/workflows/test_workflow_naming.py
+++ b/tests/workflows/test_workflow_naming.py
@@ -126,6 +126,24 @@ def test_health_44_pull_requests_do_not_use_repo_variable_fingerprints():
     assert source.index("pull-request-no-repo-variable") < source.index("--storage repo-variable")
 
 
+def test_health_40_sweep_permissions_cover_called_branch_protection_workflow():
+    sweep = yaml.safe_load((WORKFLOW_DIR / "health-40-sweep.yml").read_text(encoding="utf-8"))
+    branch_protection = yaml.safe_load(
+        (WORKFLOW_DIR / "health-44-gate-branch-protection.yml").read_text(encoding="utf-8")
+    )
+    permission_levels = {"none": 0, "read": 1, "write": 2}
+    branch_protection_job = sweep["jobs"]["branch-protection-verify"]
+    caller_permissions = branch_protection_job.get("permissions") or sweep.get("permissions") or {}
+    called_permissions = branch_protection.get("permissions") or {}
+
+    for scope, requested in called_permissions.items():
+        available = caller_permissions.get(scope, "none")
+        assert permission_levels[available] >= permission_levels[requested], (
+            "Health 40 Sweep calls Health 44 as a reusable workflow, so its effective "
+            f"`{scope}` permission must be at least `{requested}`; found `{available}`."
+        )
+
+
 def test_health_53_scorecard_uses_existing_semver_action_ref():
     workflow = WORKFLOW_DIR / "health-53-scorecard.yml"
     data = yaml.safe_load(workflow.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- grant `actions: write` to `Health 40 Sweep` so its reusable Health 44 branch-protection call cannot exceed the caller token permission ceiling
- add a regression test comparing Health 40's caller permissions against the permissions requested by `health-44-gate-branch-protection.yml`

## Root Cause
`Health 40 Sweep` calls `health-44-gate-branch-protection.yml` as a reusable workflow. The called workflow requests `actions: write`, but the caller only granted `contents`, `pull-requests`, and `checks`, so GitHub could reject the workflow at startup before scheduling any jobs.

## Validation
- `python3 -m pytest tests/workflows/test_workflow_naming.py tests/workflows/test_workflow_agents_consolidation.py tests/workflows/test_workflow_on_triggers_valid.py -q` -> 218 passed
- `DEV_CHECK_ACTIONLINT_ONLY=true DEV_CHECK_ACTIONLINT_FILE_LIST=.github/workflows/health-40-sweep.yml scripts/dev_check.sh` -> passed