### PR TITLE
test: cover LangChain version updater (#2665)

### DIFF
--- a/tests/scripts/test_update_langchain_versions.py
+++ b/tests/scripts/test_update_langchain_versions.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from scripts import update_langchain_versions as updater
+
+
+def test_get_major_minor_parses_valid_versions() -> None:
+    assert updater.get_major_minor("0.3.27") == (0, 3)
+    assert updater.get_major_minor("1.12.0rc1") == (1, 12)
+    assert updater.get_major_minor("42.7") == (42, 7)
+
+
+@pytest.mark.parametrize("version", ["", "v1.2.3", "1", "latest"])
+def test_get_major_minor_rejects_invalid_versions(version: str) -> None:
+    with pytest.raises(ValueError, match=f"Cannot parse version: {version}"):
+        updater.get_major_minor(version)
+
+
+def test_get_latest_pypi_version_uses_subprocess_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        assert capture_output is True
+        assert text is True
+        assert check is True
+        return subprocess.CompletedProcess(command, 0, '{"info": {"version": "0.3.27"}}', "")
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    assert updater.get_latest_pypi_version("langchain-core") == "0.3.27"
+    assert calls == [["curl", "-s", "https://pypi.org/pypi/langchain-core/json"]]
+
+
+def test_main_prints_recommended_major_minor_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    versions = {
+        "langchain": "0.3.27",
+        "langchain-core": "0.3.72",
+        "langchain-community": "0.3.26",
+        "langchain-openai": "0.3.28",
+    }
+
+    monkeypatch.setattr(updater, "get_latest_pypi_version", versions.__getitem__)
+
+    assert updater.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "Fetching latest versions from PyPI..." in captured.out
+    for package, version in versions.items():
+        major, minor = updater.get_major_minor(version)
+        assert f"  {package}: {version} (^{major}.{minor})" in captured.out
+        assert f'    "{package}>={major}.{minor},<{major}.{minor + 1}",' in captured.out
+
+
+def test_main_returns_nonzero_and_writes_stderr_on_fetch_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_fetch(package: str) -> str:
+        raise RuntimeError(f"{package} unavailable")
+
+    monkeypatch.setattr(updater, "get_latest_pypi_version", fail_fetch)
+
+    assert updater.main() == 1
+
+    captured = capsys.readouterr()
+    assert "Fetching latest versions from PyPI..." in captured.out
+    assert "ERROR fetching langchain: langchain unavailable" in captured.err
+    assert "Recommended pyproject.toml entries" not in captured.out


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2665 -->
> **Source:** Issue #2665

Closes #2665

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/update_langchain_versions.py` fetches package versions and prints recommended constraints, but it lacks deterministic tests for version parsing, subprocess JSON handling, and error paths. This is a safe Route-Weight `testgen` opener using monkeypatched subprocess calls.

#### Tasks
- [ ] Add tests for `get_major_minor()` with valid and invalid version strings.
- [ ] Add tests for `get_latest_pypi_version()` using a monkeypatched `subprocess.run` result.
- [ ] Cover `main()` printing recommended constraints for all packages with mocked versions.
- [ ] Cover a fetch error returning non-zero and writing an error to stderr.

#### Acceptance criteria
- [ ] Tests do not call PyPI or `curl` for real.
- [ ] Tests assert the printed constraint format for major/minor pins.
- [ ] Existing CLI behavior remains compatible.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for version parsing and error handling.
  * Verified latest-version fetching behavior and subprocess command usage.
  * Confirmed command-line output for both successful runs and fetch failures, including exit codes and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->