### PR TITLE
chore(coderabbit): skip maintenance-bot PRs fleet-wide via synced .coderabbit.yaml

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -847,6 +847,8 @@ user_docs:
 git_config:
   - source: .gitattributes
     description: "Git attributes - merge strategies to prevent pr_body.md conflicts"
+  - source: .coderabbit.yaml
+    description: "CodeRabbit auto-review config - skips maintenance-bot PRs (renovate/dependabot/github-actions/keepalive) and generated sync/draft PRs, while keeping substantial agent-authored PR reviews enabled. Advisory/non-gating per fleet rule."
 
 
 # Workflows-owned runtime-fetched scripts (issue #2347)

--- a/templates/consumer-repo/.coderabbit.yaml
+++ b/templates/consumer-repo/.coderabbit.yaml
@@ -1,0 +1,48 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Fleet default, synced from stranske/Workflows (templates/consumer-repo/.coderabbit.yaml).
+# Tuned for the stranske autonomous-agent fleet:
+#   - assertive review of substantial agent-authored PRs
+#   - advisory / non-gating, matching the fleet rule that review never blocks a merge
+#   - maintenance-bot PRs and generated sync/draft PRs do not spend review budget
+#   - a workflow-injection guard, since workflow YAML is synced across consumer repos
+language: en-US
+reviews:
+  profile: assertive
+  request_changes_workflow: false      # advisory: never auto-block a merge (fleet rule)
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false                      # opener creates drafts; review when marked ready
+    # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
+    # syncs). agents-workflows-bot is intentionally NOT listed — it authors substantial
+    # agent code PRs (e.g. "Agent belt for #N") that should still be reviewed.
+    ignore_usernames:
+      - "renovate[bot]"
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+      - "stranske-keepalive[bot]"
+    # Also skip generated maintenance / sync PRs by title and by negative label.
+    ignore_title_keywords:
+      - "chore: sync workflow templates"
+      - "sync workflow templates"
+    labels:
+      - "!sync"
+      - "!workflow:source-sync"
+      - "!workflow:source-maintenance"
+      - "!consumer-sync"
+      - "!integration-sync"
+      - "!workflows-sync"
+      - "!template-sync"
+  path_filters:
+    - "!**/*.lock"
+    - "!**/vendor/**"
+    - "!**/.workflows-lib/**"
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Flag template-injection, unpinned third-party actions, and spoofable bot-actor
+        checks — this workflow YAML is synced across consumer repos, so one bug
+        replicates fleet-wide.
+chat:
+  auto_reply: true


### PR DESCRIPTION
## What

Adds a fleet **consumer-template** `.coderabbit.yaml` and registers it in the sync manifest so CodeRabbit review config rolls out to all registered consumer repos via the existing `maint-68` sync.

The headline behavior: **maintenance-bot PRs no longer spend CodeRabbit's automatic-review budget**, while substantial agent-authored PRs keep getting reviewed.

## Why

CodeRabbit (Pro, 1 seat) bills per human PR-author and rate-limits reviews per developer. ~430 PRs/month across the fleet are Renovate/Dependabot/CI-maintenance noise that were eligible for auto-review. Excluding them concentrates the review budget on PRs that warrant substantial review.

## The bot classification (deliberate)

`ignore_usernames` covers only **pure-maintenance** bots:

- `renovate[bot]`, `dependabot[bot]` — dependency bumps
- `github-actions[bot]` — e.g. "chore: update dev tool versions from PyPI"
- `stranske-keepalive[bot]` — e.g. "ci(deps): sync action versions to templates"

**`agents-workflows-bot[bot]` is intentionally NOT ignored** — it authors substantial agent code (e.g. "Agent belt for #N", "Add integration repo renderer tests"), which should still be reviewed. Its release-please/sync chores are already filtered by `ignore_title_keywords` + negative labels.

## Mechanics

- File registered under the **`git_config`** manifest category (a processed copy-sync section, same as `.gitattributes`) — not a new `review_config:` category, which the sync engine in `maint-68` does **not** iterate (it would be inert).
- Default `sync_mode` (`sync` = overwrite) keeps consumers byte-aligned with the template.
- Config is advisory / non-gating per the fleet rule (`request_changes_workflow: false`).

## Not covered by this PR (follow-ups)

- **CodeRabbit isn't installed** on some active-dev consumers (Trend_Model_Project, Travel-Plan-Permission, trip-planner) — the synced config is dormant there until they're added in the CodeRabbit dashboard.
- **Collab-Deliverables** has CodeRabbit installed but is **not** a registered consumer, so it won't receive this template (would need a direct file or consumer registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated review settings for consumer repositories, including support for non-draft PRs, smarter exclusions for maintenance/sync-related PRs, and automatic chat replies.
  * Enabled stronger workflow-file checks to help catch risky action usage and spoofable bot activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->