### PR TITLE
feat(pdf-extract): scaffold single-source stranske-pdf-extract library (#2711)

### DIFF
--- a/packages/stranske_pdf_extract/README.md
+++ b/packages/stranske_pdf_extract/README.md
@@ -49,4 +49,5 @@ PYTHONPATH=src python -m pytest        # core suite is deterministic and dep-fre
 ```
 
 The Docling conformance test (`tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol`)
-passes with or without the `[docling]` extra; the extract path skips cleanly when absent.
+passes with or without the `[docling]` extra; when absent, `extract_modalities()` raises
+`DoclingUnavailableError`, and the test skips only if Docling is already installed.

--- a/packages/stranske_pdf_extract/README.md
+++ b/packages/stranske_pdf_extract/README.md
@@ -1,0 +1,52 @@
+# stranske-pdf-extract
+
+Single-source PDF text-extraction for the `stranske/*` fleet — replacing four
+independent, diverging implementations (Counter_Risk, Pension-Data, Inv-Man-Intake,
+Manager-Database) with one installable library.
+
+> **Design, distribution decision, and migration plan: [`docs/DESIGN.md`](docs/DESIGN.md).**
+> Grounding audits: `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` and
+> `…-methodology.md`.
+
+## What it owns (and what it does not)
+
+Owns the shared surface: the **text-extraction ladder** (pdfplumber → pypdf → OCR, with
+Docling as the real local extractor), a **page-level-provenance result contract**, a
+**fallback-orchestration primitive**, and a **reliability layer** (arithmetic/business-rule
+validation + cross-check + calibrated confidence routing).
+
+Does **not** own domain field-parsing — that stays in each consumer (repo-cash regex,
+funded/actuarial metrics, …). The library never learns a consumer's schema.
+
+## Modules
+
+| Module | Role | Provenance |
+|--------|------|-----------|
+| `contract` | the one result + page-level-provenance contract | generalizes Pension-Data + Inv-Man-Intake |
+| `provider` | `ExtractionProvider` / `MultiModalExtractionProvider` Protocols, OCR seam, registry | Inv-Man-Intake + Pension-Data |
+| `orchestration` | `run_fallback_chain` ladder primitive | Pension-Data (already generic) |
+| `reliability` | foot/cross-foot, weights, dates, cross-check, ECE, confidence routing | **greenfield** (absent fleet-wide) |
+| `providers.docling_provider` | real local extractor behind the Protocol (optional `[docling]`) | new — IMI #713 consumes this |
+| `providers.text_baseline` | pure-python ladder; runs with no native deps | Counter_Risk ladder, generalized |
+| `eval.harness` | golden-set scorer: normalize-then-compare, macro-F1, regression gate | methodology §6 |
+
+## Install
+
+```bash
+# core (pure-python, no native deps)
+pip install "git+https://github.com/stranske/Workflows@pdf-extract-v0.1.0#subdirectory=packages/stranske_pdf_extract"
+# with the real local extractor / OCR / eval gate
+pip install "stranske-pdf-extract[docling,ocr,eval]"   # extras: baseline, docling, ocr, textract, schema, eval
+```
+
+Distribution is **pip**, not Workflows copy-sync — see `docs/DESIGN.md` §2 for the call.
+
+## Test
+
+```bash
+cd packages/stranske_pdf_extract
+PYTHONPATH=src python -m pytest        # core suite is deterministic and dep-free
+```
+
+The Docling conformance test (`tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol`)
+passes with or without the `[docling]` extra; the extract path skips cleanly when absent.

--- a/packages/stranske_pdf_extract/docs/DESIGN.md
+++ b/packages/stranske_pdf_extract/docs/DESIGN.md
@@ -1,0 +1,221 @@
+# `stranske-pdf-extract` — design, distribution decision, and migration plan
+
+Status: **proposed / scaffolded** · Owner: fleet platform · Date: 2026-06-28
+
+Grounding docs (read these first; this design does not restate them):
+- `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` — who does PDF work, every disparate attempt.
+- `Code/Audits/2026-06-28-pdf-extraction-methodology.md` — how the field does extraction; recommended stack.
+
+This document is deliverables **2 (design)**, **3 (distribution decision)**, and **4 (migration plan)** of the
+single-source PDF-extraction initiative. The library skeleton in this package is deliverable **5 (scaffold)**.
+
+---
+
+## 0. What we are replacing (verified by reading source, 2026-06-28)
+
+Four repos independently reimplement the same shape — text-extraction ladder + OCR fallback + orchestration +
+a result/provenance contract — with four divergent contracts and three OCR strategies:
+
+| Repo | File | Library/ladder | OCR | Result contract | Maturity |
+|------|------|----------------|-----|-----------------|----------|
+| **Pension-Data** | `src/pension_data/parser/pdf_pipeline.py` + `extract/orchestration/fallback.py` + `db/models/provenance.py` | pypdf + injectable OCR + **staged fallback chain** | injectable callable (`ocr_extract`) | `PDFParserResult` + page-level evidence + `EvidenceReference`/`MetricEvidenceLink` | **Most mature contract** (page-level evidence, `method` enum, stable ids, per-link confidence) |
+| **Inv-Man-Intake** | `src/inv_man_intake/extraction/providers/base.py` + `orchestrator.py` | dependency-free regex (fixture-grade, **not real**) | none (escalates) | `ExtractionProvider` Protocol + `ProviderExtractionOutput` + `SourceLocation`(**bbox**)/`SnippetMetadata` | **Most mature seam** (runtime-checkable Protocol, bbox + char-offset provenance, validators) |
+| **Counter_Risk** | `src/counter_risk/parsers/daily_holdings_pdf.py` | **pdfplumber → pypdf → OCR** ladder, all import-guarded | **bundled** pytesseract + pdf2image | `dict[str,float]` (domain rows) | Best **OCR ladder** (graceful degradation per stage) |
+| **Manager-Database** | `utils/extract.py` | pdfplumber only | none | raw `str` | Trivial — easiest migration |
+
+Separate concern (PDF **generation**, out of scope): PAEM `pa_core/viz/pdf_report.py`, TPP
+`approval_packet.py`/`prompt_flow.py`. **Not** part of this initiative.
+
+The shared surface is items 1–4 (text extraction, OCR fallback, orchestration, result/provenance contract).
+**Item 5, domain field-parsing, stays in each consumer** (Counter_Risk's repo-cash regex, Pension-Data's
+funded/actuarial metric extraction, etc.). The library never learns a consumer's domain schema.
+
+The single biggest gap: **none of the four has a reliability layer** (arithmetic/business-rule validation,
+cross-check, calibrated confidence). The methodology doc rates this the highest-leverage and it is absent
+fleet-wide. We design it in from day one.
+
+---
+
+## 1. The shared core — what the library owns
+
+```
+stranske_pdf_extract/
+  contract.py        # the one result + page-level-provenance contract (generalizes PD + IMI)
+  provider.py        # ExtractionProvider / MultiModalExtractionProvider Protocols + registry + OCR seam
+  orchestration.py   # run_fallback_chain primitive (lifted from Pension-Data, already generic)
+  reliability.py     # arithmetic/business-rule validation + cross-check + calibration  (GREENFIELD)
+  providers/
+    docling_provider.py    # one REAL extractor behind the Protocol (Docling, MIT, local) — optional dep
+    text_baseline.py       # pure-python pdfplumber/pypdf baseline so the ladder + tests run with no native deps
+  eval/
+    harness.py       # shared golden-set eval harness (normalize-then-compare, per-field F1) — optional deps
+```
+
+### 1.1 Contract (`contract.py`) — generalize the two mature ones, do not invent a third
+
+The merge rule: **take IMI's modality-grouped raw output + bbox provenance** (strictly richer locator than
+PD's string refs) and **take PD's evidence-ref canonicalization + `method` enum + stable ids + per-link
+confidence** (richer linkage semantics). Concretely:
+
+- `SourceLocation(doc_id, page, bbox, table_index, image_index)` — from IMI. `bbox` is the superset locator;
+  PD's `p.40#table` string is derivable from it (`EvidenceRef.canonical`), so both consumers serialize losslessly.
+- `SnippetMetadata(kind, char_start, char_end)` — from IMI; the replayable excerpt offsets.
+- `ExtractionMethod` = `text | table | ocr | fallback | llm | vision` — from PD's `method` enum, extended for
+  the methodology's vision-table path.
+- `EvidenceRef` — PD's canonical string form (`doc#page=n`, `doc#anchor=…`, `p.40#table`) **plus** a stable
+  `ref_id` (content hash, excludes enrichment fields exactly as PD does — enrichment never changes identity).
+- `ExtractedTextBlock / ExtractedTableCell / ExtractedTable / ExtractedImage / ProviderExtractionOutput` — the
+  raw modality output, from IMI. This is what a layout extractor (Docling) naturally emits.
+- `ExtractedField(key, value, confidence, location, snippet, snippet_metadata, method)` — from IMI.
+- `ExtractedDocumentResult(doc_id, provider_name, fields, stage_name, stage_confidence, attempts, escalation,
+  escalation_required, flags, provenance_refs)` — IMI's result **fused with** PD's `PDFParserResult` outcome
+  metadata (stage/attempts/escalation/flags). One result type both consumers can adopt.
+- Validators (`validate_provider_output`, `validate_extracted_document_result`) — from IMI, extended with PD's
+  strict-mode rule (high-impact fields must carry an evidence ref).
+
+Why generalize rather than pick one: PD's provenance is string-ref based (loses bbox); IMI's is bbox-based but
+lacks the `method` enum, stable ids, and per-link confidence PD added for citation export. Each consumer needs
+the other's strengths. Generalizing once is the whole point of the initiative.
+
+### 1.2 Provider Protocol + OCR seam (`provider.py`)
+
+Lift IMI's two `@runtime_checkable` Protocols verbatim (they are already the right seam):
+- `ExtractionProvider.extract(doc_id, content: bytes) -> ExtractedDocumentResult` (field-level).
+- `MultiModalExtractionProvider.extract_modalities(doc_id, content: bytes) -> ProviderExtractionOutput` (raw).
+
+Plus PD's OCR-as-injection idea, promoted to a named type: `OcrExtract = Callable[[bytes], Sequence[str]]`.
+A repo can **bundle** Tesseract (Counter_Risk's pattern) or **inject** its own (Pension-Data's pattern) — the
+library never hard-codes an OCR engine. Docling/pdfplumber/pypdf/OCR/Textract are all just providers behind
+the same Protocol; a registry resolves them by name.
+
+### 1.3 Orchestration (`orchestration.py`)
+
+Lift Pension-Data's `run_fallback_chain[TResult]` — it is **already generic** (`ParserStage[TResult]`,
+completeness predicate, `EscalationEvent`, best-partial selection, structured `ParserAttempt` records). This is
+the canonical fallback ladder: try stages in order, accept first that satisfies `is_complete`, escalate with a
+structured event on exhaustion, keep the best partial. IMI's `ExtractionOrchestrator` (tracing/retry/metrics)
+becomes an optional richer driver layered on top, not the primitive.
+
+### 1.4 Reliability (`reliability.py`) — greenfield, highest leverage
+
+Per the methodology doc §5 (cheapest + most trustworthy first):
+1. **Arithmetic / business-rule validation** — foot/cross-foot subtotals→totals, weights sum to 100%,
+   sign/currency sanity, date-in-period. Deterministic, dependency-free. Violations localized to page+row via
+   the evidence ref (arXiv 2511.10659: 84% of fiscal-doc errors localize this way). **LLM says *what*,
+   deterministic code does the arithmetic** — never let the model do the sum.
+2. **Cross-check** — two structurally different providers → agree=auto-accept, disagree=flag the *specific*
+   field for review (label-free correctness signal).
+3. **Calibration + confidence routing** — ECE measurement, a `ConfidenceCalibrator` seam
+   (temperature/Platt/isotonic), and a double-threshold router (auto-accept high / auto-reject low /
+   human-review the ambiguous middle, ~85% gate). LLMs are systematically overconfident; never route on raw
+   confidence without measuring ECE on real data first.
+
+### 1.5 Eval harness (`eval/harness.py`)
+
+Golden-set runner: **normalize-then-compare** (numbers as parsed numerics, dates canonical — not raw
+exact-match), per-field precision/recall/F1 **macro-averaged** (rare-but-critical fields count). Optional
+DeepEval pytest gate and LangSmith dataset hooks (LangSmith is already wired in some fleet repos). Shipped in
+the shared library so every consumer inherits the same scorer and CI gate.
+
+---
+
+## 2. Distribution decision (deliverable 3) — **installable package, not copy-sync**
+
+**Decision: ship `stranske-pdf-extract` as an installable, semver-tagged Python package, pip/uv-installed from
+git source. Home it as a subdirectory package inside the Workflows repo** (`Workflows/packages/stranske_pdf_extract/`),
+installed via `pip install "git+https://github.com/stranske/Workflows@pdf-extract-vX.Y.Z#subdirectory=packages/stranske_pdf_extract"`,
+released under a dedicated tag prefix `pdf-extract-v*`. Confidence: **high** for package-over-copy-sync;
+**medium** for subdir-of-Workflows over a dedicated repo (see upgrade path).
+
+### Why a package beats the Workflows `tools/*` copy-sync
+
+The `tools/*` precedent (`.github/sync-manifest.yml`, ~231 entries, copied by `maint-68-sync-consumer-repos.yml`)
+exists for **single-file Python helpers that the reusable CI workflows themselves import** (`ci_failure_triage.py`,
+`coverage_guard.py`, `llm_provider.py`). This tool is a different animal on every axis:
+
+1. **Layer.** `tools/*` are imported by *workflow YAML / CI*. This is imported by consumer *application* code
+   (domain parsers). Different dependency layer → different distribution.
+2. **Optional native deps.** Docling, Tesseract, pdf2image are heavy/native. A package expresses these as
+   **extras** (`[docling]`, `[ocr]`, `[textract]`, `[eval]`); copy-sync copies files and cannot declare or gate
+   dependencies at all. Vendored loose files would force every consumer to hand-maintain the dep set.
+3. **Opt-in vs forced.** Only **4 of 13** consumer repos do extraction. Copy-sync pushes files to *all*
+   consumers; `pip install` is opt-in by exactly the repos that need it.
+4. **Semver / independent migration.** A package lets each consumer **pin** (`stranske-pdf-extract==0.3.1`) and
+   migrate on its own cadence — the explicit requirement that *no consumer's tests break*. Copy-sync couples
+   every consumer to "latest synced": a library fix forces a fleet-wide sync, and there is no pin to hold a
+   consumer on a known-good version during migration.
+5. **It's a package, not a script.** A multi-module tree (contract/provider/orchestration/reliability/eval)
+   vendored as loose files in `tools/` is awkward and breaks `import stranske_pdf_extract`.
+
+The pure-Python core has **no** heavy deps (the ladder degrades gracefully; Docling/OCR are extras), so
+"package vs copy-sync" is not about dep weight — it is about **versioning, opt-in, and layer**. On all three,
+the package wins.
+
+### Why subdirectory-of-Workflows (and the upgrade path)
+
+- Honors the fleet's "single source of truth = Workflows; distributed from one place" principle — no new repo to
+  onboard into keepalive, lanes, branch protection, CI bootstrap.
+- Real pip-installability + extras + independent semver (dedicated `pd-extract-v*` tag prefix keeps it out of
+  Workflows' moving tag namespace).
+- Reuses Workflows CI for the library's own tests.
+- **It is NOT added to `sync-manifest.yml`** — distribution is `pip`, not copy. (The only sync-manifest touch is
+  documentation: note the package exists and is pip-installed, so a future audit doesn't "fix" the absence.)
+
+**Upgrade path to a dedicated repo** (`stranske/pdf-extract`): warranted only if the library's release cadence
+diverges enough from Workflows that sharing the repo causes friction (e.g., frequent library releases vs. slow
+Workflows churn, or external consumers). Until then, subdir keeps operational overhead at zero. The package is
+self-contained (own `pyproject.toml`), so extraction to its own repo later is a `git filter-repo` move, not a
+rewrite.
+
+> Open operational question for the owner: confirm subdir-of-Workflows vs. a dedicated `stranske/pdf-extract`
+> repo. The scaffold is written to be home-agnostic so either choice is cheap.
+
+---
+
+## 3. Migration plan (deliverable 4) — dependency order, tests as the gate
+
+Phased, never big-bang. **Each repo keeps its domain parser and its existing tests; those tests are the
+migration gate — green before and after, no break permitted.** A consumer adopts the library by replacing its
+private *extraction + orchestration + provenance* internals with calls into `stranske_pdf_extract`, leaving its
+domain field-parsing untouched.
+
+**Phase 0 — build the library (this package).** Land contract + provider + orchestration + reliability +
+Docling provider + conformance test + eval harness skeleton. Tag `pdf-extract-v0.1.0`. (Issue: *Build*.)
+
+**Phase 1 — Pension-Data (start here — most mature contract).** PD already has the closest shape (staged
+fallback, page-level evidence). Migration = prove the generalized `contract.py` is a superset of
+`PDFParserResult` + `EvidenceReference`, then re-point `pdf_pipeline.py`'s stage machinery at
+`orchestration.run_fallback_chain` from the library and map PD's evidence model onto `EvidenceRef`. Lowest risk,
+highest validation value: if the generalized contract can carry PD's page-level evidence losslessly, the
+generalization is proven. Gate: PD's existing parser + provenance tests stay green.
+
+**Phase 2 — Inv-Man-Intake (#713 consumes this, does not re-implement).** IMI's Protocol/provenance is already
+the seam we lifted; migration = re-export the library's Protocols/contract from
+`inv_man_intake/extraction/providers/base.py` (or alias) and implement **#713's Docling provider as a thin
+adapter over `stranske_pdf_extract.providers.docling_provider`** rather than a 5th private extractor. Gate: IMI's
+extraction + orchestrator tests stay green; #713's named conformance test points at the shared provider.
+
+**Phase 3 — Counter_Risk (fold in the OCR ladder).** Replace `_extract_text_with_pdfplumber/_with_pypdf/_with_ocr`
+with the library's `text_baseline` provider + injected Tesseract OCR seam, behind `run_fallback_chain`. CR keeps
+`_extract_repo_cash_values` (domain). Gate: CR's daily-holdings parser tests stay green (including the
+sanitized-`.pdf`-fixture fallback path).
+
+**Phase 4 — Manager-Database (trivial).** Replace `utils/extract.py::_extract_pdf` with a one-line call into the
+library's baseline provider, returning text. Smallest change; do it last as a confidence-builder. Gate: MD's
+extract tests stay green.
+
+Reliability + eval are **available from Phase 0** but adopted opportunistically per repo (PD's funded/actuarial
+footing checks are the natural first real consumer of the arithmetic validators).
+
+---
+
+## 4. Constraints honored
+
+- **Local-first / confidentiality.** Docling (MIT, local) is the primary real extractor; managed APIs
+  (Textract/Azure DI) are optional sanity-check fallbacks only. Proprietary manager/holdings docs never have to
+  leave the building.
+- **Browser demos stay fixture-backed.** Docling/OCR are heavy native deps → optional extras, never imported by
+  any stlite/Pyodide path. The conformance test skips cleanly when the optional dep is absent.
+- **Deterministic tests.** contract/orchestration/reliability are pure-Python and fully deterministic; the
+  Docling test is a Protocol-conformance check that skips without the dep. No network, no nondeterminism in CI.
+- **Reliability designed in, not bolted on.** `reliability.py` ships in Phase 0.

--- a/packages/stranske_pdf_extract/docs/DESIGN.md
+++ b/packages/stranske_pdf_extract/docs/DESIGN.md
@@ -38,7 +38,7 @@ fleet-wide. We design it in from day one.
 
 ## 1. The shared core — what the library owns
 
-```
+```text
 stranske_pdf_extract/
   contract.py        # the one result + page-level-provenance contract (generalizes PD + IMI)
   provider.py        # ExtractionProvider / MultiModalExtractionProvider Protocols + registry + OCR seam
@@ -105,10 +105,9 @@ Per the methodology doc §5 (cheapest + most trustworthy first):
    deterministic code does the arithmetic** — never let the model do the sum.
 2. **Cross-check** — two structurally different providers → agree=auto-accept, disagree=flag the *specific*
    field for review (label-free correctness signal).
-3. **Calibration + confidence routing** — ECE measurement, a `ConfidenceCalibrator` seam
-   (temperature/Platt/isotonic), and a double-threshold router (auto-accept high / auto-reject low /
-   human-review the ambiguous middle, ~85% gate). LLMs are systematically overconfident; never route on raw
-   confidence without measuring ECE on real data first.
+3. **Confidence routing** — ECE measurement and the existing double-threshold router
+   (`accept_at=0.95`, `reject_below=0.50`). If calibration is added later, document it as future work. LLMs
+   are systematically overconfident; never route on raw confidence without measuring ECE on real data first.
 
 ### 1.5 Eval harness (`eval/harness.py`)
 

--- a/packages/stranske_pdf_extract/pyproject.toml
+++ b/packages/stranske_pdf_extract/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "stranske-pdf-extract"
+version = "0.1.0"
+description = "Single-source PDF text-extraction ladder, page-level provenance contract, fallback orchestration, and reliability layer for the stranske/* fleet."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "stranske fleet platform" }]
+# Core has NO heavy/native deps: the ladder degrades gracefully and the contract,
+# orchestration, and reliability layers are pure-Python and deterministic.
+# Real extractors and OCR are OPTIONAL extras so confidentiality-sensitive consumers
+# install only what they need and browser (stlite/Pyodide) paths never pull native deps.
+dependencies = []
+
+[project.optional-dependencies]
+# Pure-python baseline extractors (native-text PDFs, no system packages required beyond wheels).
+baseline = ["pdfplumber>=0.11", "pypdf>=5.4"]
+# Local layout/table extractor — primary REAL extractor for proprietary docs (MIT, local).
+docling = ["docling>=2.0"]
+# Bundled OCR (Counter_Risk's pattern). Consumers may instead inject their own OcrExtract callable.
+ocr = ["pytesseract>=0.3.10", "pdf2image>=1.17"]
+# Managed sanity-check fallback only (data leaves the building) — off by default.
+textract = ["boto3>=1.34"]
+# Schema-constrained structured output for LLM-assisted fields (portable, retry-on-ValidationError).
+schema = ["pydantic>=2", "instructor>=1.0"]
+# Shared golden-set eval harness CI gate.
+eval = ["deepeval>=1.0"]
+dev = ["pytest>=8", "pytest-cov>=5"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/stranske_pdf_extract"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/__init__.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/__init__.py
@@ -1,0 +1,21 @@
+"""stranske-pdf-extract — single-source PDF extraction for the stranske/* fleet.
+
+Public surface:
+
+* :mod:`stranske_pdf_extract.contract` — the one result + page-level-provenance contract.
+* :mod:`stranske_pdf_extract.provider` — provider Protocols, OCR seam, name registry.
+* :mod:`stranske_pdf_extract.orchestration` — the fallback-ladder primitive.
+* :mod:`stranske_pdf_extract.reliability` — arithmetic/business-rule checks, cross-check,
+  calibration + confidence routing.
+
+Providers live under :mod:`stranske_pdf_extract.providers`. Domain field-parsing stays in
+each consumer — this package never learns a consumer's schema. See ``docs/DESIGN.md``.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from . import contract, orchestration, provider, reliability
+
+__all__ = ["contract", "provider", "orchestration", "reliability", "__version__"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
@@ -231,6 +231,17 @@ def _validate_snippet_metadata(metadata: SnippetMetadata) -> None:
         raise ValueError("SnippetMetadata.char_end must be >= char_start when provided")
 
 
+def _validate_evidence_ref(
+    evidence: EvidenceRef, *, expected_source_doc_id: str, context: str
+) -> None:
+    if not evidence.source_doc_id:
+        raise ValueError(f"EvidenceRef.source_doc_id must be non-empty for {context}")
+    if evidence.source_doc_id != expected_source_doc_id:
+        raise ValueError(f"EvidenceRef.source_doc_id must match result for {context}")
+    if evidence.page_number is not None and evidence.page_number <= 0:
+        raise ValueError("EvidenceRef.page_number must be >= 1 when provided")
+
+
 def validate_provider_output(output: ProviderExtractionOutput) -> None:
     """Validate raw multimodal output emitted by an extraction provider."""
     if not output.source_doc_id:
@@ -286,6 +297,10 @@ def validate_extracted_document_result(
             )
         if f.snippet_metadata is not None:
             _validate_snippet_metadata(f.snippet_metadata)
+        if f.evidence is not None:
+            _validate_evidence_ref(
+                f.evidence, expected_source_doc_id=result.source_doc_id, context=f"field:{f.key}"
+            )
         if strict_evidence and f.evidence is None:
             family = f.key.split(".", 1)[0].split("_", 1)[0].lower()
             if family in HIGH_IMPACT_PREFIXES:

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
@@ -17,7 +17,7 @@ consumer; this module only models *where a value came from* and *how confident w
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal, Protocol, runtime_checkable
 
 # Extraction path that produced a value. Superset of Pension-Data's `method` enum

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/contract.py
@@ -1,0 +1,322 @@
+"""The single result + page-level-provenance contract for fleet PDF extraction.
+
+This generalizes the two most mature fleet contracts so each consumer keeps the
+other's strengths (see ``docs/DESIGN.md`` §1.1):
+
+* **Inv-Man-Intake** contributed the modality-grouped raw output and ``SourceLocation``
+  with **bbox** + char-offset provenance (the superset locator) and runtime-checkable
+  validators.
+* **Pension-Data** contributed the evidence-ref canonicalization, the ``ExtractionMethod``
+  enum, stable content-hashed ids (enrichment never changes identity), and per-link
+  confidence used for citation export.
+
+Everything here is pure-Python and deterministic. Domain field schemas stay in the
+consumer; this module only models *where a value came from* and *how confident we are*.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, runtime_checkable
+
+# Extraction path that produced a value. Superset of Pension-Data's `method` enum
+# ("table"|"text"|"fallback"|"ocr"|"llm") extended with the methodology doc's vision path.
+ExtractionMethod = Literal["text", "table", "ocr", "fallback", "llm", "vision"]
+
+BBox = tuple[float, float, float, float]  # (x0, y0, x1, y1) in PDF points
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    """Where a fragment lives in the source document.
+
+    ``bbox`` is the superset locator (Inv-Man-Intake). Pension-Data's string refs such as
+    ``p.40#table`` are derivable from ``page`` + ``table_index`` via :class:`EvidenceRef`,
+    so both consumers serialize losslessly.
+    """
+
+    source_doc_id: str
+    source_page: int | None = None
+    bbox: BBox | None = None
+    table_index: int | None = None
+    image_index: int | None = None
+
+
+@dataclass(frozen=True)
+class SnippetMetadata:
+    """Replayable excerpt offsets for a field's supporting text (Inv-Man-Intake)."""
+
+    kind: str
+    char_start: int | None = None
+    char_end: int | None = None
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """Canonical, stable reference to supporting evidence (Pension-Data).
+
+    ``ref_id`` is a content hash over the *locator only* — enrichment fields (``excerpt``,
+    ``method``) are deliberately excluded so enriching a locator never changes its identity,
+    exactly as Pension-Data's ``evidence_ref_id`` does.
+    """
+
+    source_doc_id: str
+    page_number: int | None = None
+    section_hint: str | None = None
+    snippet_anchor: str | None = None
+    method: ExtractionMethod | None = None
+    excerpt: str | None = None
+
+    @property
+    def canonical(self) -> str:
+        """Stable human-readable locator string.
+
+        Mirrors Pension-Data's citation export forms: ``doc#page=n``, ``doc#anchor=…``,
+        ``doc#section=…``, falling back to the bare doc id.
+        """
+        if self.snippet_anchor:
+            return f"{self.source_doc_id}#anchor={self.snippet_anchor}"
+        if self.page_number is not None:
+            return f"{self.source_doc_id}#page={self.page_number}"
+        if self.section_hint:
+            return f"{self.source_doc_id}#section={self.section_hint}"
+        return self.source_doc_id
+
+    @property
+    def ref_id(self) -> str:
+        """Deterministic id over the locator (excludes enrichment fields)."""
+        parts = (
+            self.source_doc_id,
+            "" if self.page_number is None else str(self.page_number),
+            self.section_hint or "",
+            self.snippet_anchor or "",
+        )
+        digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+        return f"evidence:{digest[:16]}"
+
+
+# --- Raw modality output (Inv-Man-Intake): what a layout extractor emits ---------------
+
+
+@dataclass(frozen=True)
+class ExtractedTextBlock:
+    text: str
+    location: SourceLocation
+
+
+@dataclass(frozen=True)
+class ExtractedTableCell:
+    row_index: int
+    column_index: int
+    value: str
+    confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class ExtractedTable:
+    cells: tuple[ExtractedTableCell, ...]
+    location: SourceLocation | None = None
+    table_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtractedImage:
+    location: SourceLocation
+    image_id: str | None = None
+    mime_type: str | None = None
+    ocr_text: str | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class ProviderExtractionOutput:
+    """Raw multimodal extraction output, grouped by modality (Inv-Man-Intake)."""
+
+    source_doc_id: str
+    provider_name: str
+    text_blocks: tuple[ExtractedTextBlock, ...] = ()
+    tables: tuple[ExtractedTable, ...] = ()
+    images: tuple[ExtractedImage, ...] = ()
+
+
+# --- Field-level result (Inv-Man-Intake fields + Pension-Data outcome metadata) --------
+
+
+@dataclass(frozen=True)
+class ExtractedField:
+    """One extracted field with evidence metadata."""
+
+    key: str
+    value: str
+    confidence: float
+    source_doc_id: str
+    source_page: int
+    method: str
+    location: SourceLocation | None = None
+    snippet: str | None = None
+    snippet_metadata: SnippetMetadata | None = None
+    evidence: EvidenceRef | None = None
+
+
+@dataclass(frozen=True)
+class ParserAttempt:
+    """Structured record of one orchestration stage attempt (Pension-Data)."""
+
+    stage_name: str
+    parser_name: str
+    succeeded: bool
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class EscalationEvent:
+    """Emitted when every fallback stage fails (Pension-Data)."""
+
+    domain: str
+    reason: str
+    exhausted_stage_count: int
+    attempts: tuple[ParserAttempt, ...]
+
+
+@dataclass(frozen=True)
+class ExtractedDocumentResult:
+    """Canonical extraction result.
+
+    Inv-Man-Intake's field-level result fused with Pension-Data's ``PDFParserResult``
+    outcome metadata (stage / attempts / escalation / flags / provenance), so both
+    consumers adopt one result type.
+    """
+
+    source_doc_id: str
+    provider_name: str
+    fields: tuple[ExtractedField, ...] = ()
+    stage_name: str | None = None
+    stage_confidence: float = 0.0
+    attempts: tuple[ParserAttempt, ...] = ()
+    escalation: EscalationEvent | None = None
+    escalation_required: bool = False
+    flags: tuple[str, ...] = ()
+    provenance_refs: tuple[str, ...] = ()
+
+
+# --- Validators (Inv-Man-Intake, extended with Pension-Data strict-mode rule) ----------
+
+# High-impact field families must carry an evidence ref in strict mode (Pension-Data).
+HIGH_IMPACT_PREFIXES: tuple[str, ...] = ("funded", "actuarial", "allocation", "holding", "fee")
+
+
+def _validate_source_location(
+    location: SourceLocation, *, expected_source_doc_id: str, context: str
+) -> None:
+    if not location.source_doc_id:
+        raise ValueError(f"SourceLocation.source_doc_id must be non-empty for {context}")
+    if location.source_doc_id != expected_source_doc_id:
+        raise ValueError(f"SourceLocation.source_doc_id must match output for {context}")
+    if location.source_page is not None and location.source_page < 0:
+        raise ValueError("SourceLocation.source_page must be >= 0 when provided")
+
+
+def _validate_snippet_metadata(metadata: SnippetMetadata) -> None:
+    if not metadata.kind.strip():
+        raise ValueError("SnippetMetadata.kind must be non-empty")
+    for name, value in (("char_start", metadata.char_start), ("char_end", metadata.char_end)):
+        if value is not None and value < 0:
+            raise ValueError(f"SnippetMetadata.{name} must be >= 0 when provided")
+    if (
+        metadata.char_start is not None
+        and metadata.char_end is not None
+        and metadata.char_end < metadata.char_start
+    ):
+        raise ValueError("SnippetMetadata.char_end must be >= char_start when provided")
+
+
+def validate_provider_output(output: ProviderExtractionOutput) -> None:
+    """Validate raw multimodal output emitted by an extraction provider."""
+    if not output.source_doc_id:
+        raise ValueError("ProviderExtractionOutput.source_doc_id must be non-empty")
+    if not output.provider_name:
+        raise ValueError("ProviderExtractionOutput.provider_name must be non-empty")
+    for block in output.text_blocks:
+        _validate_source_location(
+            block.location, expected_source_doc_id=output.source_doc_id, context="text_blocks"
+        )
+    for table in output.tables:
+        if table.location is not None:
+            _validate_source_location(
+                table.location, expected_source_doc_id=output.source_doc_id, context="tables"
+            )
+        for cell in table.cells:
+            if cell.confidence is not None and not 0.0 <= cell.confidence <= 1.0:
+                raise ValueError("ExtractedTableCell.confidence must be within [0.0, 1.0]")
+    for image in output.images:
+        _validate_source_location(
+            image.location, expected_source_doc_id=output.source_doc_id, context="images"
+        )
+
+
+def validate_extracted_document_result(
+    result: ExtractedDocumentResult, *, strict_evidence: bool = False
+) -> None:
+    """Validate the canonical result.
+
+    With ``strict_evidence=True``, high-impact fields (see :data:`HIGH_IMPACT_PREFIXES`)
+    must carry an :class:`EvidenceRef` — Pension-Data's strict-mode provenance rule.
+    """
+    if not result.source_doc_id:
+        raise ValueError("ExtractedDocumentResult.source_doc_id must be non-empty")
+    if not result.provider_name:
+        raise ValueError("ExtractedDocumentResult.provider_name must be non-empty")
+    for f in result.fields:
+        if not f.key:
+            raise ValueError("ExtractedField.key must be non-empty")
+        if not f.value:
+            raise ValueError("ExtractedField.value must be non-empty")
+        if not 0.0 <= f.confidence <= 1.0:
+            raise ValueError("ExtractedField.confidence must be within [0.0, 1.0]")
+        if f.source_doc_id != result.source_doc_id:
+            raise ValueError("ExtractedField.source_doc_id must match the result")
+        if f.source_page < 0:
+            raise ValueError("ExtractedField.source_page must be >= 0")
+        if not f.method.strip():
+            raise ValueError("ExtractedField.method must be non-empty")
+        if f.location is not None:
+            _validate_source_location(
+                f.location, expected_source_doc_id=result.source_doc_id, context=f"field:{f.key}"
+            )
+        if f.snippet_metadata is not None:
+            _validate_snippet_metadata(f.snippet_metadata)
+        if strict_evidence and f.evidence is None:
+            family = f.key.split(".", 1)[0].split("_", 1)[0].lower()
+            if family in HIGH_IMPACT_PREFIXES:
+                raise ValueError(
+                    f"ExtractedField {f.key!r} is high-impact and requires an EvidenceRef "
+                    "under strict_evidence"
+                )
+
+
+@runtime_checkable
+class _HasName(Protocol):  # pragma: no cover - structural helper only
+    @property
+    def name(self) -> str: ...
+
+
+__all__ = [
+    "BBox",
+    "ExtractionMethod",
+    "SourceLocation",
+    "SnippetMetadata",
+    "EvidenceRef",
+    "ExtractedTextBlock",
+    "ExtractedTableCell",
+    "ExtractedTable",
+    "ExtractedImage",
+    "ProviderExtractionOutput",
+    "ExtractedField",
+    "ParserAttempt",
+    "EscalationEvent",
+    "ExtractedDocumentResult",
+    "HIGH_IMPACT_PREFIXES",
+    "validate_provider_output",
+    "validate_extracted_document_result",
+]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/__init__.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/__init__.py
@@ -1,0 +1,7 @@
+"""Shared golden-set evaluation harness (see ``harness.py``)."""
+
+from __future__ import annotations
+
+from .harness import FieldScore, ScoreReport, normalize_value, score_against_golden
+
+__all__ = ["FieldScore", "ScoreReport", "normalize_value", "score_against_golden"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
@@ -50,7 +50,7 @@ class ScoreReport:
     per_field: tuple[FieldScore, ...]
     macro_f1: float
 
-    def regressed_against(self, baseline: "ScoreReport", *, tol: float = 1e-9) -> tuple[str, ...]:
+    def regressed_against(self, baseline: ScoreReport, *, tol: float = 1e-9) -> tuple[str, ...]:
         """Field keys whose F1 dropped vs a baseline report (for a PR gate)."""
         base = {fs.key: fs.f1 for fs in baseline.per_field}
         return tuple(

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
@@ -1,0 +1,102 @@
+"""Golden-set evaluation harness — normalize-then-compare, per-field macro-F1.
+
+Methodology doc §6: score against a golden set built from human corrections; compare
+**normalized** values (numbers as numerics, dates canonical) not raw exact-match; report
+per-field precision/recall/F1 **macro-averaged** so rare-but-critical fields count. The
+core scorer here is deterministic and dependency-free; DeepEval (CI gate) and LangSmith
+(online sampling) are optional hooks layered on top, shipped so every consumer inherits
+one scorer and one gate.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+_NUMERIC_RE = re.compile(r"^[-+(]?\$?\s*\d[\d,]*(?:\.\d+)?\)?%?$")
+
+
+def normalize_value(value: str) -> str:
+    """Canonicalize a cell for comparison.
+
+    Numbers -> a canonical numeric string (strip $, commas, %, parens=negative);
+    everything else -> casefolded, whitespace-collapsed text. Deterministic.
+    """
+    raw = value.strip()
+    if _NUMERIC_RE.match(raw):
+        negative = raw.startswith("(") and raw.endswith(")")
+        cleaned = raw.strip("()").replace("$", "").replace(",", "").replace("%", "").strip()
+        try:
+            number = float(cleaned)
+        except ValueError:
+            return raw.casefold()
+        if negative:
+            number = -number
+        return repr(number)
+    return " ".join(raw.casefold().split())
+
+
+@dataclass(frozen=True)
+class FieldScore:
+    key: str
+    precision: float
+    recall: float
+    f1: float
+
+
+@dataclass(frozen=True)
+class ScoreReport:
+    per_field: tuple[FieldScore, ...]
+    macro_f1: float
+
+    def regressed_against(self, baseline: "ScoreReport", *, tol: float = 1e-9) -> tuple[str, ...]:
+        """Field keys whose F1 dropped vs a baseline report (for a PR gate)."""
+        base = {fs.key: fs.f1 for fs in baseline.per_field}
+        return tuple(
+            fs.key for fs in self.per_field if fs.key in base and fs.f1 < base[fs.key] - tol
+        )
+
+
+def score_against_golden(
+    predictions: Sequence[Mapping[str, str]],
+    golden: Sequence[Mapping[str, str]],
+) -> ScoreReport:
+    """Per-field precision/recall/F1 (normalized), macro-averaged across fields.
+
+    ``predictions`` and ``golden`` are aligned per-document field maps (same length,
+    same document order). A field counts as a true positive when present in both and
+    normalized-equal.
+    """
+    if len(predictions) != len(golden):
+        raise ValueError("predictions and golden must have the same number of documents")
+
+    keys = sorted({k for doc in golden for k in doc} | {k for doc in predictions for k in doc})
+    scores: list[FieldScore] = []
+    for key in keys:
+        tp = fp = fn = 0
+        for pred, gold in zip(predictions, golden, strict=True):
+            p = pred.get(key)
+            g = gold.get(key)
+            if p is None and g is None:
+                continue
+            if p is not None and g is not None:
+                if normalize_value(p) == normalize_value(g):
+                    tp += 1
+                else:
+                    fp += 1
+                    fn += 1
+            elif p is not None:
+                fp += 1
+            else:
+                fn += 1
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        scores.append(FieldScore(key=key, precision=precision, recall=recall, f1=f1))
+
+    macro_f1 = sum(s.f1 for s in scores) / len(scores) if scores else 0.0
+    return ScoreReport(per_field=tuple(scores), macro_f1=macro_f1)
+
+
+__all__ = ["FieldScore", "ScoreReport", "normalize_value", "score_against_golden"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/eval/harness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 
 _NUMERIC_RE = re.compile(r"^[-+(]?\$?\s*\d[\d,]*(?:\.\d+)?\)?%?$")
 
@@ -28,12 +29,12 @@ def normalize_value(value: str) -> str:
         negative = raw.startswith("(") and raw.endswith(")")
         cleaned = raw.strip("()").replace("$", "").replace(",", "").replace("%", "").strip()
         try:
-            number = float(cleaned)
-        except ValueError:
+            number = Decimal(cleaned)
+        except InvalidOperation:
             return raw.casefold()
         if negative:
             number = -number
-        return repr(number)
+        return format(number.normalize(), "f")
     return " ".join(raw.casefold().split())
 
 

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/orchestration.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/orchestration.py
@@ -1,0 +1,104 @@
+"""Fallback-ladder orchestration primitive.
+
+Lifted from Pension-Data's ``extract/orchestration/fallback.py`` — it was already
+generic over the stage result type. Try stages in order, accept the first that
+satisfies ``is_complete``, escalate with a structured event on exhaustion, and keep
+a best-partial when nothing fully completes. This is the canonical primitive for
+"pdfplumber -> pypdf -> OCR" style ladders and for provider primary/fallback chains.
+
+``ParserAttempt`` and ``EscalationEvent`` live in :mod:`contract` so the same types
+flow straight into :class:`contract.ExtractedDocumentResult`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from .contract import EscalationEvent, ParserAttempt
+
+
+@dataclass(frozen=True, slots=True)
+class ParserStage[TResult]:
+    """One stage in a fallback chain."""
+
+    stage_name: str
+    parser_name: str
+    parse: Callable[[], TResult]
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackOutcome[TResult]:
+    """Outcome of running a fallback chain."""
+
+    result: TResult | None
+    attempts: tuple[ParserAttempt, ...]
+    escalation: EscalationEvent | None
+
+
+def run_fallback_chain[TResult](
+    *,
+    domain: str,
+    stages: Sequence[ParserStage[TResult]],
+    is_complete: Callable[[TResult], bool],
+) -> FallbackOutcome[TResult]:
+    """Execute stages in order; accept first complete result, else escalate."""
+    attempts: list[ParserAttempt] = []
+    for stage in stages:
+        try:
+            parsed = stage.parse()
+        except Exception as exc:  # noqa: BLE001 - structured failure path is the point
+            attempts.append(
+                ParserAttempt(
+                    stage_name=stage.stage_name,
+                    parser_name=stage.parser_name,
+                    succeeded=False,
+                    failure_reason=f"exception:{type(exc).__name__}:{exc}",
+                )
+            )
+            continue
+
+        if not is_complete(parsed):
+            attempts.append(
+                ParserAttempt(
+                    stage_name=stage.stage_name,
+                    parser_name=stage.parser_name,
+                    succeeded=False,
+                    failure_reason="incomplete-required-fields",
+                )
+            )
+            continue
+
+        attempts.append(
+            ParserAttempt(
+                stage_name=stage.stage_name, parser_name=stage.parser_name, succeeded=True
+            )
+        )
+        return FallbackOutcome(result=parsed, attempts=tuple(attempts), escalation=None)
+
+    return FallbackOutcome(
+        result=None,
+        attempts=tuple(attempts),
+        escalation=EscalationEvent(
+            domain=domain,
+            reason="parser_fallback_exhaustion",
+            exhausted_stage_count=len(stages),
+            attempts=tuple(attempts),
+        ),
+    )
+
+
+def best_partial[TResult](
+    candidates: Sequence[TResult], *, score: Callable[[TResult], float]
+) -> TResult | None:
+    """Pick the highest-scoring partial when no stage fully completed.
+
+    Generalizes Pension-Data's ``_best_partial`` (which ranked by fewest missing
+    metrics then confidence) to any caller-supplied score (higher = better).
+    """
+    if not candidates:
+        return None
+    return max(candidates, key=score)
+
+
+__all__ = ["ParserStage", "FallbackOutcome", "run_fallback_chain", "best_partial"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/orchestration.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/orchestration.py
@@ -47,6 +47,7 @@ def run_fallback_chain[TResult](
     for stage in stages:
         try:
             parsed = stage.parse()
+            complete = is_complete(parsed)
         except Exception as exc:  # noqa: BLE001 - structured failure path is the point
             attempts.append(
                 ParserAttempt(
@@ -58,7 +59,7 @@ def run_fallback_chain[TResult](
             )
             continue
 
-        if not is_complete(parsed):
+        if not complete:
             attempts.append(
                 ParserAttempt(
                     stage_name=stage.stage_name,

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/provider.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/provider.py
@@ -43,9 +43,7 @@ class MultiModalExtractionProvider(Protocol):
         """Stable provider name used in orchestration logs and the registry."""
         ...
 
-    def extract_modalities(
-        self, source_doc_id: str, content: bytes
-    ) -> ProviderExtractionOutput:
+    def extract_modalities(self, source_doc_id: str, content: bytes) -> ProviderExtractionOutput:
         """Extract text, table, and image outputs from raw document bytes."""
         ...
 
@@ -71,9 +69,7 @@ def build_provider(name: str, **kwargs: object) -> object:
     try:
         factory = _PROVIDERS[name]
     except KeyError:
-        raise KeyError(
-            f"unknown provider {name!r}; registered: {sorted(_PROVIDERS)}"
-        ) from None
+        raise KeyError(f"unknown provider {name!r}; registered: {sorted(_PROVIDERS)}") from None
     return factory(**kwargs)
 
 

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/provider.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/provider.py
@@ -1,0 +1,91 @@
+"""Extraction provider Protocols, the OCR injection seam, and a name registry.
+
+The two ``@runtime_checkable`` Protocols are lifted from Inv-Man-Intake — they are
+already the right seam. Docling, the pure-python baseline, OCR, and managed APIs
+(Textract/Azure) are all just providers behind these Protocols, resolved by name.
+
+The OCR seam is Pension-Data's idea promoted to a named type: a repo can **bundle**
+Tesseract (Counter_Risk) or **inject** its own callable (Pension-Data). The library
+never hard-codes an OCR engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Protocol, runtime_checkable
+
+from .contract import ExtractedDocumentResult, ProviderExtractionOutput
+
+# Injectable OCR: bytes -> per-page text. None means "OCR not configured" (graceful skip).
+OcrExtract = Callable[[bytes], Sequence[str]]
+
+
+@runtime_checkable
+class ExtractionProvider(Protocol):
+    """Field-level provider: raw bytes -> canonical document result."""
+
+    @property
+    def name(self) -> str:
+        """Stable provider name used in orchestration logs and the registry."""
+        ...
+
+    def extract(self, source_doc_id: str, content: bytes) -> ExtractedDocumentResult:
+        """Extract canonical fields from raw document bytes."""
+        ...
+
+
+@runtime_checkable
+class MultiModalExtractionProvider(Protocol):
+    """Raw-modality provider: bytes -> text/table/image output (e.g. Docling)."""
+
+    @property
+    def name(self) -> str:
+        """Stable provider name used in orchestration logs and the registry."""
+        ...
+
+    def extract_modalities(
+        self, source_doc_id: str, content: bytes
+    ) -> ProviderExtractionOutput:
+        """Extract text, table, and image outputs from raw document bytes."""
+        ...
+
+
+# --- Minimal name registry -------------------------------------------------------------
+
+_PROVIDERS: dict[str, Callable[..., object]] = {}
+
+
+def register_provider(name: str, factory: Callable[..., object]) -> None:
+    """Register a provider factory under a stable name.
+
+    ``factory`` is called lazily (so optional heavy deps are imported only on use).
+    Re-registering the same name overwrites — last registration wins.
+    """
+    if not name.strip():
+        raise ValueError("provider name must be non-empty")
+    _PROVIDERS[name] = factory
+
+
+def build_provider(name: str, **kwargs: object) -> object:
+    """Instantiate a registered provider by name."""
+    try:
+        factory = _PROVIDERS[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown provider {name!r}; registered: {sorted(_PROVIDERS)}"
+        ) from None
+    return factory(**kwargs)
+
+
+def registered_providers() -> tuple[str, ...]:
+    return tuple(sorted(_PROVIDERS))
+
+
+__all__ = [
+    "OcrExtract",
+    "ExtractionProvider",
+    "MultiModalExtractionProvider",
+    "register_provider",
+    "build_provider",
+    "registered_providers",
+]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/__init__.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/__init__.py
@@ -1,0 +1,18 @@
+"""Extraction providers behind the shared Protocols.
+
+Importing this package registers the always-available pure-python baseline and the
+(optional-dep) Docling provider factory by name. Importing ``DoclingProvider`` does not
+require the ``docling`` extra; only calling ``extract_modalities`` does.
+"""
+
+from __future__ import annotations
+
+from .docling_provider import DoclingProvider, DoclingUnavailableError, docling_available
+from .text_baseline import TextBaselineProvider
+
+__all__ = [
+    "TextBaselineProvider",
+    "DoclingProvider",
+    "DoclingUnavailableError",
+    "docling_available",
+]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
@@ -1,0 +1,141 @@
+"""Docling-backed real extractor behind ``MultiModalExtractionProvider``.
+
+Docling (IBM, **MIT**, local) is the primary real extractor for proprietary fleet docs:
+layout model + TableFormer tables, no per-page fee, nothing leaves the building
+(methodology doc §1, §7). It is a heavy native dep, so it is an **optional extra**
+(``pip install stranske-pdf-extract[docling]``) and is never imported by browser
+(stlite/Pyodide) paths.
+
+This is the single REAL extractor required by the scaffold deliverable, and the shared
+implementation that Inv-Man-Intake #713 should CONSUME instead of writing a 5th private
+Docling provider. The class conforms to the Protocol whether or not Docling is installed;
+calling :meth:`extract_modalities` without the dep raises a clear, actionable error.
+"""
+
+from __future__ import annotations
+
+from ..contract import (
+    ExtractedTable,
+    ExtractedTableCell,
+    ExtractedTextBlock,
+    ProviderExtractionOutput,
+    SourceLocation,
+)
+from ..provider import MultiModalExtractionProvider, register_provider
+
+
+class DoclingUnavailableError(RuntimeError):
+    """Raised when the optional ``docling`` extra is not installed."""
+
+
+def docling_available() -> bool:
+    """True when the optional ``docling`` dependency can be imported."""
+    try:
+        import docling  # noqa: F401
+    except Exception:  # noqa: BLE001 - any import failure means "unavailable"
+        return False
+    return True
+
+
+class DoclingProvider:
+    """Map a ``DoclingDocument`` onto the shared modality contract."""
+
+    name = "docling"
+
+    def __init__(self, *, do_ocr: bool = False) -> None:
+        # Stored, not used until extract — construction must not require the heavy dep,
+        # so the Protocol-conformance test can run with the extra absent.
+        self._do_ocr = do_ocr
+
+    def extract_modalities(
+        self, source_doc_id: str, content: bytes
+    ) -> ProviderExtractionOutput:
+        if not docling_available():
+            raise DoclingUnavailableError(
+                "the 'docling' extra is not installed; "
+                "install with: pip install stranske-pdf-extract[docling]"
+            )
+        return self._extract_real(source_doc_id, content)
+
+    def _extract_real(
+        self, source_doc_id: str, content: bytes
+    ) -> ProviderExtractionOutput:  # pragma: no cover - requires the optional heavy dep
+        import io
+
+        from docling.document_converter import DocumentConverter  # type: ignore[import-not-found]
+        from docling.datamodel.base_models import DocumentStream  # type: ignore[import-not-found]
+
+        source = DocumentStream(name=source_doc_id, stream=io.BytesIO(content))
+        document = DocumentConverter().convert(source).document
+
+        text_blocks: list[ExtractedTextBlock] = []
+        tables: list[ExtractedTable] = []
+
+        for item, _level in document.iterate_items():
+            page_no = _page_of(item)
+            bbox = _bbox_of(item)
+            text = getattr(item, "text", None)
+            if text:
+                text_blocks.append(
+                    ExtractedTextBlock(
+                        text=text,
+                        location=SourceLocation(
+                            source_doc_id=source_doc_id, source_page=page_no, bbox=bbox
+                        ),
+                    )
+                )
+
+        for t_index, table in enumerate(getattr(document, "tables", []) or []):
+            cells = tuple(
+                ExtractedTableCell(
+                    row_index=getattr(cell, "start_row_offset_idx", 0),
+                    column_index=getattr(cell, "start_col_offset_idx", 0),
+                    value=str(getattr(cell, "text", "")),
+                )
+                for cell in getattr(getattr(table, "data", None), "table_cells", []) or []
+            )
+            tables.append(
+                ExtractedTable(
+                    cells=cells,
+                    location=SourceLocation(
+                        source_doc_id=source_doc_id,
+                        source_page=_page_of(table),
+                        table_index=t_index,
+                    ),
+                    table_id=f"table-{t_index}",
+                )
+            )
+
+        return ProviderExtractionOutput(
+            source_doc_id=source_doc_id,
+            provider_name=self.name,
+            text_blocks=tuple(text_blocks),
+            tables=tuple(tables),
+        )
+
+
+def _page_of(item: object) -> int | None:  # pragma: no cover - exercised with the dep
+    prov = getattr(item, "prov", None) or []
+    if prov:
+        return getattr(prov[0], "page_no", None)
+    return None
+
+
+def _bbox_of(item: object):  # pragma: no cover - exercised with the dep
+    prov = getattr(item, "prov", None) or []
+    if not prov:
+        return None
+    bbox = getattr(prov[0], "bbox", None)
+    if bbox is None:
+        return None
+    return (
+        getattr(bbox, "l", 0.0),
+        getattr(bbox, "t", 0.0),
+        getattr(bbox, "r", 0.0),
+        getattr(bbox, "b", 0.0),
+    )
+
+
+register_provider("docling", DoclingProvider)
+
+__all__ = ["DoclingProvider", "DoclingUnavailableError", "docling_available"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
@@ -21,7 +21,7 @@ from ..contract import (
     ProviderExtractionOutput,
     SourceLocation,
 )
-from ..provider import MultiModalExtractionProvider, register_provider
+from ..provider import register_provider
 
 
 class DoclingUnavailableError(RuntimeError):
@@ -47,9 +47,7 @@ class DoclingProvider:
         # so the Protocol-conformance test can run with the extra absent.
         self._do_ocr = do_ocr
 
-    def extract_modalities(
-        self, source_doc_id: str, content: bytes
-    ) -> ProviderExtractionOutput:
+    def extract_modalities(self, source_doc_id: str, content: bytes) -> ProviderExtractionOutput:
         if not docling_available():
             raise DoclingUnavailableError(
                 "the 'docling' extra is not installed; "
@@ -62,8 +60,8 @@ class DoclingProvider:
     ) -> ProviderExtractionOutput:  # pragma: no cover - requires the optional heavy dep
         import io
 
-        from docling.document_converter import DocumentConverter  # type: ignore[import-not-found]
         from docling.datamodel.base_models import DocumentStream  # type: ignore[import-not-found]
+        from docling.document_converter import DocumentConverter  # type: ignore[import-not-found]
 
         source = DocumentStream(name=source_doc_id, stream=io.BytesIO(content))
         document = DocumentConverter().convert(source).document

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py
@@ -60,11 +60,26 @@ class DoclingProvider:
     ) -> ProviderExtractionOutput:  # pragma: no cover - requires the optional heavy dep
         import io
 
-        from docling.datamodel.base_models import DocumentStream  # type: ignore[import-not-found]
-        from docling.document_converter import DocumentConverter  # type: ignore[import-not-found]
+        from docling.datamodel.base_models import (
+            DocumentStream,  # type: ignore[import-not-found]
+            InputFormat,  # type: ignore[import-not-found]
+        )
+        from docling.datamodel.pipeline_options import (  # type: ignore[import-not-found]
+            PdfPipelineOptions,
+        )
+        from docling.document_converter import (
+            DocumentConverter,  # type: ignore[import-not-found]
+            PdfFormatOption,  # type: ignore[import-not-found]
+        )
 
         source = DocumentStream(name=source_doc_id, stream=io.BytesIO(content))
-        document = DocumentConverter().convert(source).document
+        pipeline_options = PdfPipelineOptions(do_ocr=self._do_ocr)
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+            }
+        )
+        document = converter.convert(source).document
 
         text_blocks: list[ExtractedTextBlock] = []
         tables: list[ExtractedTable] = []

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
@@ -16,7 +16,7 @@ from ..contract import (
     ProviderExtractionOutput,
     SourceLocation,
 )
-from ..provider import OcrExtract, MultiModalExtractionProvider, register_provider
+from ..provider import MultiModalExtractionProvider, OcrExtract, register_provider
 
 _log = logging.getLogger(__name__)
 
@@ -29,9 +29,7 @@ class TextBaselineProvider:
     def __init__(self, *, ocr_extract: OcrExtract | None = None) -> None:
         self._ocr_extract = ocr_extract
 
-    def extract_modalities(
-        self, source_doc_id: str, content: bytes
-    ) -> ProviderExtractionOutput:
+    def extract_modalities(self, source_doc_id: str, content: bytes) -> ProviderExtractionOutput:
         pages = (
             self._with_pdfplumber(content)
             or self._with_pypdf(content)

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
@@ -90,7 +90,7 @@ class TextBaselineProvider:
         decoded = content.decode("latin-1", errors="ignore")
         normalized = decoded.replace("\r\n", "\n").replace("\r", "\n")
         if "\f" in normalized:
-            return [p for p in normalized.split("\f")]
+            return normalized.split("\f")
         return [normalized]
 
 

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
@@ -31,10 +31,11 @@ class TextBaselineProvider:
 
     def extract_modalities(self, source_doc_id: str, content: bytes) -> ProviderExtractionOutput:
         pages = (
-            self._with_pdfplumber(content)
-            or self._with_pypdf(content)
-            or self._with_ocr(content)
-            or self._raw_decode(content)
+            self._usable_pages(self._with_pdfplumber(content))
+            or self._usable_pages(self._with_pypdf(content))
+            or self._usable_pages(self._with_ocr(content))
+            or self._usable_pages(self._raw_decode(content))
+            or []
         )
         blocks = tuple(
             ExtractedTextBlock(
@@ -83,6 +84,10 @@ class TextBaselineProvider:
         except Exception:  # noqa: BLE001
             _log.warning("injected OCR failed", exc_info=True)
             return []
+
+    @staticmethod
+    def _usable_pages(pages: list[str]) -> list[str]:
+        return pages if any(page.strip() for page in pages) else []
 
     @staticmethod
     def _raw_decode(content: bytes) -> list[str]:

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/text_baseline.py
@@ -1,0 +1,108 @@
+"""Pure-python baseline extractor: pdfplumber -> pypdf -> injected OCR -> raw decode.
+
+This is Counter_Risk's graceful-degradation ladder, generalized to emit the shared
+``ProviderExtractionOutput``. Every stage is import-guarded so the provider runs (and
+the test suite passes) with **no** native deps installed: it degrades to a latin-1
+decode of native-text bytes, exactly like Pension-Data's fallback. Real consumers add
+``[baseline]`` (pdfplumber/pypdf) and/or an injected ``OcrExtract`` callable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..contract import (
+    ExtractedTextBlock,
+    ProviderExtractionOutput,
+    SourceLocation,
+)
+from ..provider import OcrExtract, MultiModalExtractionProvider, register_provider
+
+_log = logging.getLogger(__name__)
+
+
+class TextBaselineProvider:
+    """Native-text ladder emitting one text block per page."""
+
+    name = "text_baseline"
+
+    def __init__(self, *, ocr_extract: OcrExtract | None = None) -> None:
+        self._ocr_extract = ocr_extract
+
+    def extract_modalities(
+        self, source_doc_id: str, content: bytes
+    ) -> ProviderExtractionOutput:
+        pages = (
+            self._with_pdfplumber(content)
+            or self._with_pypdf(content)
+            or self._with_ocr(content)
+            or self._raw_decode(content)
+        )
+        blocks = tuple(
+            ExtractedTextBlock(
+                text=text,
+                location=SourceLocation(source_doc_id=source_doc_id, source_page=i),
+            )
+            for i, text in enumerate(pages, start=1)
+            if text.strip()
+        )
+        return ProviderExtractionOutput(
+            source_doc_id=source_doc_id, provider_name=self.name, text_blocks=blocks
+        )
+
+    def _with_pdfplumber(self, content: bytes) -> list[str]:
+        try:
+            import io
+
+            import pdfplumber
+        except ImportError:
+            return []
+        try:
+            with pdfplumber.open(io.BytesIO(content)) as pdf:
+                return [page.extract_text() or "" for page in pdf.pages]
+        except Exception:  # noqa: BLE001 - fall through to next ladder stage
+            _log.warning("pdfplumber failed for %s", source_doc_id_safe(content), exc_info=True)
+            return []
+
+    def _with_pypdf(self, content: bytes) -> list[str]:
+        try:
+            import io
+
+            from pypdf import PdfReader
+        except ImportError:
+            return []
+        try:
+            reader = PdfReader(io.BytesIO(content), strict=False)
+            return [page.extract_text() or "" for page in reader.pages]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def _with_ocr(self, content: bytes) -> list[str]:
+        if self._ocr_extract is None:
+            return []
+        try:
+            return [t for t in self._ocr_extract(content) if isinstance(t, str)]
+        except Exception:  # noqa: BLE001
+            _log.warning("injected OCR failed", exc_info=True)
+            return []
+
+    @staticmethod
+    def _raw_decode(content: bytes) -> list[str]:
+        # Last resort: native-text bytes / sanitized .pdf test fixtures.
+        decoded = content.decode("latin-1", errors="ignore")
+        normalized = decoded.replace("\r\n", "\n").replace("\r", "\n")
+        if "\f" in normalized:
+            return [p for p in normalized.split("\f")]
+        return [normalized]
+
+
+def source_doc_id_safe(content: bytes) -> str:  # pragma: no cover - log helper
+    return f"<{len(content)} bytes>"
+
+
+# Confirm the class satisfies the Protocol at import time (cheap structural check).
+assert isinstance(TextBaselineProvider(), MultiModalExtractionProvider)
+
+register_provider("text_baseline", TextBaselineProvider)
+
+__all__ = ["TextBaselineProvider"]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
@@ -1,0 +1,218 @@
+"""Reliability layer — the highest-leverage piece, currently absent fleet-wide.
+
+Three stacked layers from the methodology doc §5, cheapest + most trustworthy first:
+
+1. **Arithmetic / business-rule validation** — the document carries its own ground
+   truth. Foot/cross-foot subtotals->totals, weights sum to 100%, sign/currency sanity,
+   date-in-period. Deterministic; the LLM says *what*, this code does the arithmetic.
+2. **Cross-check** — two structurally different extractors; agree=accept, disagree=flag
+   the *specific* field (label-free correctness signal).
+3. **Calibration + routing** — ECE measurement and a double-threshold router
+   (auto-accept high / auto-reject low / human-review the middle). LLMs are
+   systematically overconfident; never route on raw confidence without measuring ECE.
+
+All pure-Python and deterministic. No network, no model calls here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+
+Severity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class RuleViolation:
+    """A failed business rule, localized to its evidence ref for targeted re-review."""
+
+    rule: str
+    message: str
+    severity: Severity = "error"
+    evidence_ref: str | None = None
+
+
+# --- Layer 1: arithmetic / business-rule validation ------------------------------------
+
+
+def check_foots(
+    *,
+    line_items: Sequence[float],
+    total: float,
+    rule: str = "foot_total",
+    tolerance: float = 0.01,
+    evidence_ref: str | None = None,
+) -> RuleViolation | None:
+    """Line items must sum to the stated total (re-foot)."""
+    summed = sum(line_items)
+    if abs(summed - total) > tolerance:
+        return RuleViolation(
+            rule=rule,
+            message=f"line items sum to {summed:.4g}, stated total is {total:.4g}",
+            evidence_ref=evidence_ref,
+        )
+    return None
+
+
+def check_weights_sum_to_one(
+    *,
+    weights: Sequence[float],
+    rule: str = "weights_sum",
+    expected: float = 1.0,
+    tolerance: float = 0.005,
+    evidence_ref: str | None = None,
+) -> RuleViolation | None:
+    """Allocation weights must sum to 1.0 (or 100%). Pass percents as fractions."""
+    summed = sum(weights)
+    if abs(summed - expected) > tolerance:
+        return RuleViolation(
+            rule=rule,
+            message=f"weights sum to {summed:.4g}, expected {expected:.4g}",
+            evidence_ref=evidence_ref,
+        )
+    return None
+
+
+def check_date_in_period(
+    *,
+    value: date,
+    period_start: date,
+    period_end: date,
+    rule: str = "date_in_period",
+    evidence_ref: str | None = None,
+) -> RuleViolation | None:
+    """An effective/as-of date must fall within the reporting period."""
+    if not (period_start <= value <= period_end):
+        return RuleViolation(
+            rule=rule,
+            message=f"date {value.isoformat()} outside period "
+            f"[{period_start.isoformat()}, {period_end.isoformat()}]",
+            evidence_ref=evidence_ref,
+        )
+    return None
+
+
+def check_sign(
+    *,
+    value: float,
+    expected: Literal["non_negative", "non_positive"],
+    rule: str = "sign_sanity",
+    evidence_ref: str | None = None,
+) -> RuleViolation | None:
+    """Sign sanity (e.g. a market value should be non-negative)."""
+    if expected == "non_negative" and value < 0:
+        return RuleViolation(rule=rule, message=f"{value} should be >= 0", evidence_ref=evidence_ref)
+    if expected == "non_positive" and value > 0:
+        return RuleViolation(rule=rule, message=f"{value} should be <= 0", evidence_ref=evidence_ref)
+    return None
+
+
+# --- Layer 2: cross-check between two structurally different extractors -----------------
+
+
+@dataclass(frozen=True)
+class CrossCheckResult:
+    """Per-field agreement between two extractors."""
+
+    agreed: tuple[str, ...]
+    disagreed: tuple[str, ...]
+    only_in_a: tuple[str, ...]
+    only_in_b: tuple[str, ...]
+
+    @property
+    def needs_review(self) -> tuple[str, ...]:
+        """Fields a reviewer should look at: disagreements + one-sided extractions."""
+        return tuple(sorted({*self.disagreed, *self.only_in_a, *self.only_in_b}))
+
+
+def cross_check(
+    a: Mapping[str, str],
+    b: Mapping[str, str],
+    *,
+    normalize: bool = True,
+) -> CrossCheckResult:
+    """Compare two extractors' field maps; flag the specific disagreeing fields.
+
+    Uses the shared numeric-aware ``normalize_value`` so e.g. ``100.0`` and ``100.00``
+    agree — the same normalize-then-compare rule the eval harness applies.
+    """
+    from .eval.harness import normalize_value
+
+    def norm(v: str) -> str:
+        return normalize_value(v) if normalize else v
+
+    keys_a, keys_b = set(a), set(b)
+    shared = keys_a & keys_b
+    agreed = tuple(sorted(k for k in shared if norm(a[k]) == norm(b[k])))
+    disagreed = tuple(sorted(k for k in shared if norm(a[k]) != norm(b[k])))
+    return CrossCheckResult(
+        agreed=agreed,
+        disagreed=disagreed,
+        only_in_a=tuple(sorted(keys_a - keys_b)),
+        only_in_b=tuple(sorted(keys_b - keys_a)),
+    )
+
+
+# --- Layer 3: calibration + confidence routing -----------------------------------------
+
+
+def expected_calibration_error(
+    pairs: Sequence[tuple[float, bool]], *, n_bins: int = 10
+) -> float:
+    """Expected Calibration Error over (confidence, was_correct) pairs.
+
+    Measure this on YOUR data before routing on confidence — LLM/OCR confidences are
+    systematically overconfident. Returns 0.0 for an empty input.
+    """
+    if not pairs:
+        return 0.0
+    bins: list[list[tuple[float, bool]]] = [[] for _ in range(n_bins)]
+    for conf, correct in pairs:
+        idx = min(int(conf * n_bins), n_bins - 1)
+        bins[idx].append((conf, correct))
+    total = len(pairs)
+    ece = 0.0
+    for bucket in bins:
+        if not bucket:
+            continue
+        avg_conf = sum(c for c, _ in bucket) / len(bucket)
+        accuracy = sum(1 for _, ok in bucket if ok) / len(bucket)
+        ece += (len(bucket) / total) * abs(avg_conf - accuracy)
+    return ece
+
+
+Route = Literal["auto_accept", "human_review", "auto_reject"]
+
+
+def route_by_confidence(
+    confidence: float, *, accept_at: float = 0.95, reject_below: float = 0.50
+) -> Route:
+    """Double-threshold router: accept high, reject low, review the ambiguous middle.
+
+    Defaults reflect the methodology doc's finance gate (flag < ~95%). Tune
+    ``accept_at`` from a reliability diagram on real data, not by guess.
+    """
+    if not 0.0 <= confidence <= 1.0:
+        raise ValueError("confidence must be within [0.0, 1.0]")
+    if reject_below > accept_at:
+        raise ValueError("reject_below must be <= accept_at")
+    if confidence >= accept_at:
+        return "auto_accept"
+    if confidence < reject_below:
+        return "auto_reject"
+    return "human_review"
+
+
+__all__ = [
+    "RuleViolation",
+    "check_foots",
+    "check_weights_sum_to_one",
+    "check_date_in_period",
+    "check_sign",
+    "CrossCheckResult",
+    "cross_check",
+    "expected_calibration_error",
+    "route_by_confidence",
+]

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
@@ -102,6 +102,8 @@ def check_sign(
     evidence_ref: str | None = None,
 ) -> RuleViolation | None:
     """Sign sanity (e.g. a market value should be non-negative)."""
+    if expected not in {"non_negative", "non_positive"}:
+        raise ValueError("expected must be 'non_negative' or 'non_positive'")
     if expected == "non_negative" and value < 0:
         return RuleViolation(
             rule=rule, message=f"{value} should be >= 0", evidence_ref=evidence_ref
@@ -168,10 +170,14 @@ def expected_calibration_error(pairs: Sequence[tuple[float, bool]], *, n_bins: i
     Measure this on YOUR data before routing on confidence — LLM/OCR confidences are
     systematically overconfident. Returns 0.0 for an empty input.
     """
+    if n_bins < 1:
+        raise ValueError("n_bins must be >= 1")
     if not pairs:
         return 0.0
     bins: list[list[tuple[float, bool]]] = [[] for _ in range(n_bins)]
     for conf, correct in pairs:
+        if not 0.0 <= conf <= 1.0:
+            raise ValueError("confidence values must be within [0.0, 1.0]")
         idx = min(int(conf * n_bins), n_bins - 1)
         bins[idx].append((conf, correct))
     total = len(pairs)

--- a/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
+++ b/packages/stranske_pdf_extract/src/stranske_pdf_extract/reliability.py
@@ -103,9 +103,13 @@ def check_sign(
 ) -> RuleViolation | None:
     """Sign sanity (e.g. a market value should be non-negative)."""
     if expected == "non_negative" and value < 0:
-        return RuleViolation(rule=rule, message=f"{value} should be >= 0", evidence_ref=evidence_ref)
+        return RuleViolation(
+            rule=rule, message=f"{value} should be >= 0", evidence_ref=evidence_ref
+        )
     if expected == "non_positive" and value > 0:
-        return RuleViolation(rule=rule, message=f"{value} should be <= 0", evidence_ref=evidence_ref)
+        return RuleViolation(
+            rule=rule, message=f"{value} should be <= 0", evidence_ref=evidence_ref
+        )
     return None
 
 
@@ -158,9 +162,7 @@ def cross_check(
 # --- Layer 3: calibration + confidence routing -----------------------------------------
 
 
-def expected_calibration_error(
-    pairs: Sequence[tuple[float, bool]], *, n_bins: int = 10
-) -> float:
+def expected_calibration_error(pairs: Sequence[tuple[float, bool]], *, n_bins: int = 10) -> float:
     """Expected Calibration Error over (confidence, was_correct) pairs.
 
     Measure this on YOUR data before routing on confidence — LLM/OCR confidences are

--- a/packages/stranske_pdf_extract/tests/test_contract.py
+++ b/packages/stranske_pdf_extract/tests/test_contract.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import pytest
-
 from stranske_pdf_extract.contract import (
     EvidenceRef,
-    ExtractedField,
     ExtractedDocumentResult,
+    ExtractedField,
     ProviderExtractionOutput,
     SourceLocation,
     validate_extracted_document_result,
@@ -17,7 +16,12 @@ from stranske_pdf_extract.contract import (
 
 def _field(**kw) -> ExtractedField:
     base = dict(
-        key="nav", value="100.0", confidence=0.9, source_doc_id="doc1", source_page=1, method="table"
+        key="nav",
+        value="100.0",
+        confidence=0.9,
+        source_doc_id="doc1",
+        source_page=1,
+        method="table",
     )
     base.update(kw)
     return ExtractedField(**base)
@@ -74,7 +78,9 @@ def test_strict_evidence_requires_ref_for_high_impact_fields():
     ok = ExtractedDocumentResult(
         source_doc_id="doc1",
         provider_name="p",
-        fields=(_field(key="funded_ratio", value="0.84", evidence=EvidenceRef("doc1", page_number=40)),),
+        fields=(
+            _field(key="funded_ratio", value="0.84", evidence=EvidenceRef("doc1", page_number=40)),
+        ),
     )
     validate_extracted_document_result(ok, strict_evidence=True)
 

--- a/packages/stranske_pdf_extract/tests/test_contract.py
+++ b/packages/stranske_pdf_extract/tests/test_contract.py
@@ -85,6 +85,38 @@ def test_strict_evidence_requires_ref_for_high_impact_fields():
     validate_extracted_document_result(ok, strict_evidence=True)
 
 
+def test_evidence_ref_must_match_result_document():
+    result = ExtractedDocumentResult(
+        source_doc_id="doc1",
+        provider_name="p",
+        fields=(
+            _field(
+                key="funded_ratio",
+                value="0.84",
+                evidence=EvidenceRef("other-doc", page_number=40),
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="EvidenceRef.source_doc_id"):
+        validate_extracted_document_result(result, strict_evidence=True)
+
+
+def test_evidence_ref_page_number_must_be_positive():
+    result = ExtractedDocumentResult(
+        source_doc_id="doc1",
+        provider_name="p",
+        fields=(
+            _field(
+                key="funded_ratio",
+                value="0.84",
+                evidence=EvidenceRef("doc1", page_number=0),
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="page_number"):
+        validate_extracted_document_result(result, strict_evidence=True)
+
+
 def test_validate_provider_output_checks_locations():
     bad = ProviderExtractionOutput(
         source_doc_id="doc1",

--- a/packages/stranske_pdf_extract/tests/test_contract.py
+++ b/packages/stranske_pdf_extract/tests/test_contract.py
@@ -15,14 +15,14 @@ from stranske_pdf_extract.contract import (
 
 
 def _field(**kw) -> ExtractedField:
-    base = dict(
-        key="nav",
-        value="100.0",
-        confidence=0.9,
-        source_doc_id="doc1",
-        source_page=1,
-        method="table",
-    )
+    base = {
+        "key": "nav",
+        "value": "100.0",
+        "confidence": 0.9,
+        "source_doc_id": "doc1",
+        "source_page": 1,
+        "method": "table",
+    }
     base.update(kw)
     return ExtractedField(**base)
 
@@ -92,11 +92,6 @@ def test_validate_provider_output_checks_locations():
         text_blocks=(),
     )
     validate_provider_output(bad)  # empty is valid
-    mismatched = ProviderExtractionOutput(
-        source_doc_id="doc1",
-        provider_name="p",
-        images=(),
-    )
     # SourceLocation doc id must match the output doc id.
     loc = SourceLocation(source_doc_id="WRONG", source_page=1)
     from stranske_pdf_extract.contract import ExtractedImage

--- a/packages/stranske_pdf_extract/tests/test_contract.py
+++ b/packages/stranske_pdf_extract/tests/test_contract.py
@@ -1,0 +1,103 @@
+"""Contract validators + evidence-ref identity (deterministic, no deps)."""
+
+from __future__ import annotations
+
+import pytest
+
+from stranske_pdf_extract.contract import (
+    EvidenceRef,
+    ExtractedField,
+    ExtractedDocumentResult,
+    ProviderExtractionOutput,
+    SourceLocation,
+    validate_extracted_document_result,
+    validate_provider_output,
+)
+
+
+def _field(**kw) -> ExtractedField:
+    base = dict(
+        key="nav", value="100.0", confidence=0.9, source_doc_id="doc1", source_page=1, method="table"
+    )
+    base.update(kw)
+    return ExtractedField(**base)
+
+
+def test_evidence_ref_canonical_forms():
+    assert EvidenceRef("doc1", page_number=40).canonical == "doc1#page=40"
+    assert EvidenceRef("doc1", snippet_anchor="nav").canonical == "doc1#anchor=nav"
+    assert EvidenceRef("doc1", section_hint="summary").canonical == "doc1#section=summary"
+    assert EvidenceRef("doc1").canonical == "doc1"
+
+
+def test_evidence_ref_id_excludes_enrichment():
+    # Enriching a locator with method/excerpt must NOT change its stable identity.
+    bare = EvidenceRef("doc1", page_number=40)
+    enriched = EvidenceRef("doc1", page_number=40, method="table", excerpt="Funded ratio 84%")
+    assert bare.ref_id == enriched.ref_id
+    # A different locator gets a different id.
+    assert EvidenceRef("doc1", page_number=41).ref_id != bare.ref_id
+
+
+def test_validate_good_result_passes():
+    result = ExtractedDocumentResult(
+        source_doc_id="doc1", provider_name="text_baseline", fields=(_field(),)
+    )
+    validate_extracted_document_result(result)  # no raise
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _field(value=""),
+        _field(confidence=1.5),
+        _field(method="   "),
+        _field(source_doc_id="other"),
+        _field(source_page=-1),
+    ],
+)
+def test_validate_rejects_bad_fields(bad):
+    result = ExtractedDocumentResult(source_doc_id="doc1", provider_name="p", fields=(bad,))
+    with pytest.raises(ValueError):
+        validate_extracted_document_result(result)
+
+
+def test_strict_evidence_requires_ref_for_high_impact_fields():
+    funded = _field(key="funded_ratio", value="0.84")
+    result = ExtractedDocumentResult(source_doc_id="doc1", provider_name="p", fields=(funded,))
+    # Lenient mode tolerates the missing ref...
+    validate_extracted_document_result(result)
+    # ...strict mode requires it.
+    with pytest.raises(ValueError, match="high-impact"):
+        validate_extracted_document_result(result, strict_evidence=True)
+    # Supplying the evidence ref satisfies strict mode.
+    ok = ExtractedDocumentResult(
+        source_doc_id="doc1",
+        provider_name="p",
+        fields=(_field(key="funded_ratio", value="0.84", evidence=EvidenceRef("doc1", page_number=40)),),
+    )
+    validate_extracted_document_result(ok, strict_evidence=True)
+
+
+def test_validate_provider_output_checks_locations():
+    bad = ProviderExtractionOutput(
+        source_doc_id="doc1",
+        provider_name="p",
+        text_blocks=(),
+    )
+    validate_provider_output(bad)  # empty is valid
+    mismatched = ProviderExtractionOutput(
+        source_doc_id="doc1",
+        provider_name="p",
+        images=(),
+    )
+    # SourceLocation doc id must match the output doc id.
+    loc = SourceLocation(source_doc_id="WRONG", source_page=1)
+    from stranske_pdf_extract.contract import ExtractedImage
+
+    with pytest.raises(ValueError):
+        validate_provider_output(
+            ProviderExtractionOutput(
+                source_doc_id="doc1", provider_name="p", images=(ExtractedImage(location=loc),)
+            )
+        )

--- a/packages/stranske_pdf_extract/tests/test_docling_provider.py
+++ b/packages/stranske_pdf_extract/tests/test_docling_provider.py
@@ -1,0 +1,60 @@
+"""Provider conformance.
+
+``test_docling_provider_conforms_to_protocol`` is the named acceptance gate for the
+build issue: the real Docling provider must satisfy the runtime-checkable Protocol
+WHETHER OR NOT the heavy optional dep is installed (construction must not require it).
+This mirrors Inv-Man-Intake #713's conformance test, which should point at this shared
+provider rather than a private re-implementation.
+"""
+
+from __future__ import annotations
+
+from stranske_pdf_extract.provider import (
+    MultiModalExtractionProvider,
+    build_provider,
+    registered_providers,
+)
+from stranske_pdf_extract.providers import (
+    DoclingProvider,
+    DoclingUnavailableError,
+    TextBaselineProvider,
+    docling_available,
+)
+
+
+def test_docling_provider_conforms_to_protocol():
+    # Construction never requires the optional dep; conformance holds regardless.
+    provider = DoclingProvider()
+    assert isinstance(provider, MultiModalExtractionProvider)
+    assert provider.name == "docling"
+
+
+def test_docling_extract_raises_clearly_without_dep():
+    if docling_available():
+        import pytest
+
+        pytest.skip("docling installed; the no-dep error path is not exercised")
+    provider = DoclingProvider()
+    try:
+        provider.extract_modalities("doc1", b"%PDF-1.4 ...")
+    except DoclingUnavailableError as exc:
+        assert "pip install" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected DoclingUnavailableError without the docling extra")
+
+
+def test_baseline_provider_conforms_and_extracts_text():
+    provider = TextBaselineProvider()
+    assert isinstance(provider, MultiModalExtractionProvider)
+    # Pure-python ladder degrades to a raw decode on native-text bytes (no deps needed).
+    out = provider.extract_modalities("doc1", b"Funded ratio 84%\fPage two text")
+    assert out.provider_name == "text_baseline"
+    assert len(out.text_blocks) == 2
+    assert out.text_blocks[0].location.source_page == 1
+    assert "Funded ratio" in out.text_blocks[0].text
+
+
+def test_registry_resolves_providers_by_name():
+    assert {"docling", "text_baseline"} <= set(registered_providers())
+    assert isinstance(build_provider("text_baseline"), TextBaselineProvider)
+    assert isinstance(build_provider("docling"), DoclingProvider)

--- a/packages/stranske_pdf_extract/tests/test_eval.py
+++ b/packages/stranske_pdf_extract/tests/test_eval.py
@@ -12,6 +12,11 @@ def test_normalize_value_numbers_and_text():
     assert normalize_value("  Acme   Capital ") == "acme capital"
 
 
+def test_normalize_value_preserves_large_decimal_precision():
+    assert normalize_value("9007199254740992") != normalize_value("9007199254740993")
+    assert normalize_value("12345678901234567890.01") != normalize_value("12345678901234567890.02")
+
+
 def test_score_against_golden_perfect_and_partial():
     golden = [{"nav": "100.0", "ccy": "USD"}, {"nav": "200.0", "ccy": "EUR"}]
     perfect = score_against_golden(golden, golden)

--- a/packages/stranske_pdf_extract/tests/test_eval.py
+++ b/packages/stranske_pdf_extract/tests/test_eval.py
@@ -1,0 +1,33 @@
+"""Golden-set eval harness: normalize-then-compare, macro-F1, regression detection."""
+
+from __future__ import annotations
+
+from stranske_pdf_extract.eval import normalize_value, score_against_golden
+
+
+def test_normalize_value_numbers_and_text():
+    assert normalize_value("$1,234.50") == normalize_value("1234.5")
+    assert normalize_value("(100)") == normalize_value("-100")
+    assert normalize_value("84%") == normalize_value("84")
+    assert normalize_value("  Acme   Capital ") == "acme capital"
+
+
+def test_score_against_golden_perfect_and_partial():
+    golden = [{"nav": "100.0", "ccy": "USD"}, {"nav": "200.0", "ccy": "EUR"}]
+    perfect = score_against_golden(golden, golden)
+    assert perfect.macro_f1 == 1.0
+
+    preds = [{"nav": "100.00", "ccy": "USD"}, {"nav": "999.0", "ccy": "EUR"}]
+    report = score_against_golden(preds, golden)
+    nav = next(fs for fs in report.per_field if fs.key == "nav")
+    ccy = next(fs for fs in report.per_field if fs.key == "ccy")
+    assert ccy.f1 == 1.0  # both currencies correct
+    assert nav.f1 < 1.0  # one nav wrong (normalized 100.0==100.00, 999!=200)
+
+
+def test_regression_detection():
+    golden = [{"nav": "100.0"}]
+    baseline = score_against_golden([{"nav": "100.0"}], golden)
+    worse = score_against_golden([{"nav": "0"}], golden)
+    assert "nav" in worse.regressed_against(baseline)
+    assert baseline.regressed_against(baseline) == ()

--- a/packages/stranske_pdf_extract/tests/test_orchestration.py
+++ b/packages/stranske_pdf_extract/tests/test_orchestration.py
@@ -41,6 +41,19 @@ def test_skips_incomplete_and_exceptions_then_succeeds():
     assert "incomplete-required-fields" in reasons
 
 
+def test_is_complete_exception_is_recorded_as_stage_failure():
+    outcome = run_fallback_chain(
+        domain="funded",
+        stages=(_stage("a", {"broken": True}), _stage("b", {"ok": 1})),
+        is_complete=lambda r: (
+            (_ for _ in ()).throw(ValueError("bad completeness")) if "broken" in r else bool(r)
+        ),
+    )
+    assert outcome.result == {"ok": 1}
+    assert outcome.attempts[0].succeeded is False
+    assert outcome.attempts[0].failure_reason == "exception:ValueError:bad completeness"
+
+
 def test_escalates_when_chain_exhausts():
     outcome = run_fallback_chain(
         domain="actuarial",

--- a/packages/stranske_pdf_extract/tests/test_orchestration.py
+++ b/packages/stranske_pdf_extract/tests/test_orchestration.py
@@ -1,0 +1,60 @@
+"""Fallback-ladder orchestration primitive (deterministic, no deps)."""
+
+from __future__ import annotations
+
+from stranske_pdf_extract.orchestration import (
+    ParserStage,
+    best_partial,
+    run_fallback_chain,
+)
+
+
+def _stage(name: str, value, *, boom: bool = False):
+    def parse():
+        if boom:
+            raise RuntimeError("kaboom")
+        return value
+
+    return ParserStage(stage_name=name, parser_name=f"parser_{name}", parse=parse)
+
+
+def test_accepts_first_complete_stage():
+    outcome = run_fallback_chain(
+        domain="funded",
+        stages=(_stage("a", {"x": 1}), _stage("b", {"x": 2})),
+        is_complete=lambda r: bool(r),
+    )
+    assert outcome.result == {"x": 1}
+    assert outcome.escalation is None
+    assert outcome.attempts[-1].succeeded is True
+
+
+def test_skips_incomplete_and_exceptions_then_succeeds():
+    outcome = run_fallback_chain(
+        domain="funded",
+        stages=(_stage("a", {}, boom=True), _stage("b", {}), _stage("c", {"ok": 1})),
+        is_complete=lambda r: bool(r),
+    )
+    assert outcome.result == {"ok": 1}
+    reasons = [a.failure_reason for a in outcome.attempts if not a.succeeded]
+    assert any(r and r.startswith("exception:RuntimeError") for r in reasons)
+    assert "incomplete-required-fields" in reasons
+
+
+def test_escalates_when_chain_exhausts():
+    outcome = run_fallback_chain(
+        domain="actuarial",
+        stages=(_stage("a", {}), _stage("b", {})),
+        is_complete=lambda r: bool(r),
+    )
+    assert outcome.result is None
+    assert outcome.escalation is not None
+    assert outcome.escalation.reason == "parser_fallback_exhaustion"
+    assert outcome.escalation.exhausted_stage_count == 2
+
+
+def test_best_partial_picks_highest_score():
+    candidates = [{"missing": 3}, {"missing": 1}, {"missing": 2}]
+    chosen = best_partial(candidates, score=lambda c: -c["missing"])
+    assert chosen == {"missing": 1}
+    assert best_partial([], score=lambda c: 0.0) is None

--- a/packages/stranske_pdf_extract/tests/test_reliability.py
+++ b/packages/stranske_pdf_extract/tests/test_reliability.py
@@ -35,6 +35,8 @@ def test_check_date_in_period_and_sign():
     )
     assert check_sign(value=5.0, expected="non_negative") is None
     assert check_sign(value=-5.0, expected="non_negative") is not None
+    with pytest.raises(ValueError, match="expected must"):
+        check_sign(value=5.0, expected="positive")  # type: ignore[arg-type]
 
 
 def test_cross_check_flags_specific_fields():
@@ -56,6 +58,10 @@ def test_expected_calibration_error():
     overconfident = [(0.99, False), (0.98, False)]
     assert expected_calibration_error(overconfident) > 0.9
     assert expected_calibration_error([]) == 0.0
+    with pytest.raises(ValueError, match="n_bins"):
+        expected_calibration_error([(0.5, True)], n_bins=0)
+    with pytest.raises(ValueError, match="confidence"):
+        expected_calibration_error([(1.5, True)])
 
 
 def test_route_by_confidence_double_threshold():

--- a/packages/stranske_pdf_extract/tests/test_reliability.py
+++ b/packages/stranske_pdf_extract/tests/test_reliability.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
-
 from stranske_pdf_extract.reliability import (
     check_date_in_period,
     check_foots,
@@ -31,7 +30,9 @@ def test_check_weights_sum():
 def test_check_date_in_period_and_sign():
     start, end = date(2026, 1, 1), date(2026, 3, 31)
     assert check_date_in_period(value=date(2026, 2, 15), period_start=start, period_end=end) is None
-    assert check_date_in_period(value=date(2026, 4, 1), period_start=start, period_end=end) is not None
+    assert (
+        check_date_in_period(value=date(2026, 4, 1), period_start=start, period_end=end) is not None
+    )
     assert check_sign(value=5.0, expected="non_negative") is None
     assert check_sign(value=-5.0, expected="non_negative") is not None
 

--- a/packages/stranske_pdf_extract/tests/test_reliability.py
+++ b/packages/stranske_pdf_extract/tests/test_reliability.py
@@ -1,0 +1,67 @@
+"""Reliability layer: arithmetic checks, cross-check, calibration + routing."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from stranske_pdf_extract.reliability import (
+    check_date_in_period,
+    check_foots,
+    check_sign,
+    check_weights_sum_to_one,
+    cross_check,
+    expected_calibration_error,
+    route_by_confidence,
+)
+
+
+def test_check_foots_passes_and_fails():
+    assert check_foots(line_items=[10.0, 20.0, 70.0], total=100.0) is None
+    v = check_foots(line_items=[10.0, 20.0, 69.0], total=100.0, evidence_ref="doc1#page=3")
+    assert v is not None and v.rule == "foot_total" and v.evidence_ref == "doc1#page=3"
+
+
+def test_check_weights_sum():
+    assert check_weights_sum_to_one(weights=[0.5, 0.3, 0.2]) is None
+    assert check_weights_sum_to_one(weights=[0.5, 0.3, 0.1]) is not None
+
+
+def test_check_date_in_period_and_sign():
+    start, end = date(2026, 1, 1), date(2026, 3, 31)
+    assert check_date_in_period(value=date(2026, 2, 15), period_start=start, period_end=end) is None
+    assert check_date_in_period(value=date(2026, 4, 1), period_start=start, period_end=end) is not None
+    assert check_sign(value=5.0, expected="non_negative") is None
+    assert check_sign(value=-5.0, expected="non_negative") is not None
+
+
+def test_cross_check_flags_specific_fields():
+    a = {"nav": "100.0", "ccy": "USD", "manager": "Acme"}
+    b = {"nav": "100.00", "ccy": "EUR", "aum": "5B"}
+    result = cross_check(a, b)
+    assert "nav" in result.agreed  # 100.0 vs 100.00 normalize-equal
+    assert "ccy" in result.disagreed
+    assert "manager" in result.only_in_a
+    assert "aum" in result.only_in_b
+    assert set(result.needs_review) == {"ccy", "manager", "aum"}
+
+
+def test_expected_calibration_error():
+    # Perfectly calibrated: confidence == accuracy in each bin -> ECE 0.
+    perfect = [(1.0, True), (1.0, True), (0.0, False)]
+    assert expected_calibration_error(perfect) == pytest.approx(0.0, abs=1e-9)
+    # Overconfident: high confidence, all wrong -> large ECE.
+    overconfident = [(0.99, False), (0.98, False)]
+    assert expected_calibration_error(overconfident) > 0.9
+    assert expected_calibration_error([]) == 0.0
+
+
+def test_route_by_confidence_double_threshold():
+    assert route_by_confidence(0.99) == "auto_accept"
+    assert route_by_confidence(0.80) == "human_review"
+    assert route_by_confidence(0.10) == "auto_reject"
+    with pytest.raises(ValueError):
+        route_by_confidence(1.5)
+    with pytest.raises(ValueError):
+        route_by_confidence(0.9, accept_at=0.5, reject_below=0.8)

--- a/packages/stranske_pdf_extract/tests/test_text_baseline.py
+++ b/packages/stranske_pdf_extract/tests/test_text_baseline.py
@@ -1,0 +1,15 @@
+"""Pure-python text baseline fallback behavior."""
+
+from __future__ import annotations
+
+from stranske_pdf_extract.providers.text_baseline import TextBaselineProvider
+
+
+def test_blank_native_pages_fall_through_to_ocr(monkeypatch):
+    provider = TextBaselineProvider(ocr_extract=lambda _content: ["ocr page"])
+    monkeypatch.setattr(provider, "_with_pdfplumber", lambda _content: ["   "])
+    monkeypatch.setattr(provider, "_with_pypdf", lambda _content: ["\n"])
+
+    output = provider.extract_modalities("doc1", b"%PDF")
+
+    assert [block.text for block in output.text_blocks] == ["ocr page"]


### PR DESCRIPTION
## Summary

Scaffolds **`stranske-pdf-extract`** — the single-source PDF text-extraction library for the `stranske/*`
fleet — replacing four independent, diverging implementations (Counter_Risk, Pension-Data, Inv-Man-Intake,
Manager-Database) with one installable package. Implements deliverable 5 (scaffold) of the initiative;
design, distribution decision, and migration plan are in
[`docs/DESIGN.md`](packages/stranske_pdf_extract/docs/DESIGN.md).

Related to #2711; resolves the build half without closing the source issue.

## What's here

| Module | Role |
|--------|------|
| `contract.py` | the one result + page-level-provenance contract (generalizes Pension-Data's evidence model + Inv-Man-Intake's bbox `SourceLocation`/Protocols — not a third invented contract) |
| `provider.py` | `ExtractionProvider` / `MultiModalExtractionProvider` Protocols, injectable OCR seam, name registry |
| `orchestration.py` | `run_fallback_chain` ladder primitive (lifted from Pension-Data, already generic) |
| `reliability.py` | **greenfield** — foot/cross-foot, weights, dates, cross-check, ECE, confidence routing (absent fleet-wide) |
| `providers/docling_provider.py` | one **real** extractor behind the Protocol (Docling, MIT, local; optional `[docling]` extra) — IMI #713 should consume this |
| `providers/text_baseline.py` | pure-python pdfplumber→pypdf→OCR→raw-decode ladder; runs with no native deps |
| `eval/harness.py` | golden-set scorer: normalize-then-compare, macro-F1, regression gate |

## Distribution decision

**Installable pip package, not Workflows `sync-manifest` copy-sync** (see `docs/DESIGN.md` §2): optional native
deps need extras; only 4/13 consumers need it; consumers must pin and migrate independently without breaking
tests. Homed as a subdirectory package; **not** added to `sync-manifest.yml`.

## Tests

27 deterministic tests, no network, no heavy deps required:

```
cd packages/stranske_pdf_extract && PYTHONPATH=src python -m pytest -q   # 27 passed
```

Named conformance gate `tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol` is proven
falsifiable via the deliberate-break pattern (commenting out `DoclingProvider.name` → test FAILS → revert →
passes), demonstrated during scaffolding.

## Follow-ups (tracked, not in this PR)

- #2711 — also wire the package suite into CI and tag `pdf-extract-v0.1.0`.
- Migrations in dependency order: #2712 (Pension-Data) → #2713 (Inv-Man-Intake, consumes IMI #713) →
  #2714 (Counter_Risk) → #2715 (Manager-Database). Each keeps its domain parser + existing tests as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `stranske-pdf-extract`, a pip-installable PDF text-extraction library with installable extras for baseline parsing, Docling-backed extraction, OCR, and AWS fallback.
  * Introduced a unified extraction contract with page-level provenance and provider output validation.
  * Added fallback-ladder orchestration, reliability checks (business rules, cross-checking, confidence routing), and a golden-set evaluation harness.
  * Published comprehensive documentation and design for the new shared approach.

* **Bug Fixes**
  * Improved validation to catch malformed fields, confidence/location mismatches, and strict evidence requirements for high-impact fields.
  * Added Docling provider behavior when the optional dependency is unavailable.

* **Tests**
  * Added coverage for contract validation, orchestration behavior, reliability logic, evaluation scoring, and Docling conformance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-preamble:start -->
<!-- meta:issue:2711 -->
> **Source:** Issue #2711

Closes #2711

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PDF text-EXTRACTION is independently reimplemented in **four** fleet repos with four divergent
result contracts and three OCR strategies (verified by reading source, 2026-06-28, and confirmed by a
fresh clone-grep across all branches — exactly four, none missed):

- Counter_Risk `src/counter_risk/parsers/daily_holdings_pdf.py:81` (`_extract_text` ladder pdfplumber→pypdf→OCR).
- Pension-Data `src/pension_data/parser/pdf_pipeline.py:455` (`parse_pdf_to_funded_input`) + `src/pension_data/extract/orchestration/fallback.py:53` (`run_fallback_chain`) + `db/models/provenance.py`.
- Inv-Man-Intake `src/inv_man_intake/extraction/providers/base.py:204` (`ExtractionProvider` Protocol; `:218` `MultiModalExtractionProvider`) — current `pdf_primary.py` extractor is fixture-grade, not real.
- Manager-Database `utils/extract.py:20` (`_extract_pdf`, pdfplumber→`str`).

Missing/duplicated behavior: items 1–4 of the shape (text-extraction ladder, OCR fallback, orchestration,
result/provenance contract) are rebuilt per repo; a reliability layer (arithmetic/business-rule validation +
cross-check + calibrated confidence) is **absent in all four**. This is **latent fragility + duplicated effort**,
not a current break. Grounding: `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` and `…-methodology.md`.
A validated scaffold (this design) already exists at `packages/stranske_pdf_extract/` with 27 passing
deterministic tests; this issue tracks landing it on `main` and finishing the optional-dep paths.

#### Tasks
- [ ] Land `packages/stranske_pdf_extract/` on `main` (the validated scaffold): `pyproject.toml` (extras
  `baseline,docling,ocr,textract,schema,eval`), `src/stranske_pdf_extract/{contract,provider,orchestration,reliability}.py`,
  `providers/{docling_provider,text_baseline}.py`, `eval/harness.py`, `docs/DESIGN.md`, `README.md`, and `tests/`.
- [ ] Wire the package's `tests/` into Workflows CI (a non-default job, e.g. extend `.github/workflows/selftest-ci.yml`
  or add a `packages-pdf-extract` job) running `PYTHONPATH=packages/stranske_pdf_extract/src python -m pytest packages/stranske_pdf_extract/tests`.
- [ ] Tag the release `pdf-extract-v0.1.0` and document the install URL
  `git+https://github.com/stranske/Workflows@pdf-extract-v0.1.0#subdirectory=packages/stranske_pdf_extract` in `README.md`.
- [ ] Complete the Docling real path (`providers/docling_provider.py:_extract_real`) behind the `[docling]` extra and
  add an opt-in test that runs only when `docling_available()` is true (skips cleanly otherwise).
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert.

#### Acceptance criteria
- [ ] Named test gate: `packages/stranske_pdf_extract/tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol`
  passes in CI (asserts `isinstance(DoclingProvider(), MultiModalExtractionProvider)`), AND the full package suite
  collects a non-zero count and passes (confirmed-green locally: 27 passed).
- [ ] **Deliberate-break gate:** temporarily comment out the `name = "docling"` attribute in
  `src/stranske_pdf_extract/providers/docling_provider.py` (class `DoclingProvider`). With this change,
  `test_docling_provider.py::test_docling_provider_conforms_to_protocol` **must FAIL** with
  `assert isinstance(...) == False`. Revert and confirm it passes. (Demonstrated locally during scaffolding.)
- [ ] `pip install "git+…#subdirectory=packages/stranske_pdf_extract"` imports `stranske_pdf_extract` with the
  core (no extras) and `import` of `providers` does not require `docling` (only `extract_modalities` does).

**Head SHA:** d4fa7d2969e74513d2cf6c13e7b06de2c301508f
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Gate | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239615) |
| Health 40 Sweep | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239612) |
| Health 44 Gate Branch Protection | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239536) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239458) |
| Health 50 Security Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239448) |
| Health 52 Semgrep Scan | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239464) |
| Maint 52 Validate Workflows | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239444) |
| PR 11 - Minimal invariant CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239445) |
| Selftest CI | ✅ success | [View run](https://github.com/stranske/Workflows/actions/runs/28434239449) |
<!-- auto-status-summary:end -->