### PR TITLE
fix: honor provider slot fallbacks

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -229,12 +229,21 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
 
     registry = load_model_registry()
     slots: list[SlotDefinition] = []
+    fallback_by_position = dict(enumerate(fallback_slots, start=1))
+    fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
     for idx, entry in enumerate(_slot_entries(payload, path), start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()
         if provider and not model and tier:
             model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
+        if provider and not model:
+            fallback_slot = fallback_by_position.get(idx)
+            if fallback_slot and fallback_slot.provider != provider:
+                fallback_slot = fallback_by_provider.get(provider)
+            fallback_slot = fallback_slot or fallback_by_provider.get(provider)
+            if fallback_slot and fallback_slot.provider == provider:
+                model = fallback_slot.model
         if not provider or not model:
             continue
         if is_model_blocked(provider, model, registry=registry):

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -120,6 +120,37 @@ def test_dominated_pin_uses_slot_quality_tier():
     assert findings == []
 
 
+def test_dominated_pin_normalizes_slot_quality_tier():
+    reg = _registry()
+    reg["models"] = [
+        {
+            "model_id": "old-t3",
+            "provider": "openai",
+            "quality": {"T3": 0.50, "T5": 0.99},
+        },
+        {
+            "model_id": "new-t3",
+            "provider": "openai",
+            "quality": {"T3": 0.80, "T5": 0.10},
+        },
+    ]
+    slots = {
+        "slots": [
+            {
+                "name": "slot1",
+                "provider": "openai",
+                "model": "old-t3",
+                "quality_tier": "t3",
+            }
+        ]
+    }
+
+    findings = gate.evaluate(reg, slots, today=TODAY)
+
+    assert _kinds(findings) == ["dominated_pin"]
+    assert "new-t3" in findings[0]["detail"]
+
+
 def test_tier_derived_slot_without_model_is_not_flagged():
     # A slot with no pinned model derives from the registry at runtime -> non-ossifying.
     slots = {"slots": [{"name": "slot1", "provider": "anthropic", "quality_tier": "T5"}]}

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -270,10 +270,52 @@ def test_load_model_registry_rejects_non_list_models(
     assert llm_registry.load_model_registry() == []
 
 
+def test_load_model_registry_excludes_boolean_quality_scores(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "models": [
+                    {
+                        "provider": "anthropic",
+                        "model_id": "claude-sonnet-4-6",
+                        "quality": {"T1": True, "T2": 0.8},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(langchain_client.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    [entry] = llm_registry.load_model_registry()
+
+    assert entry.quality == {"T2": 0.8}
+
+
 def test_load_slot_config_uses_provider_fallback_after_position_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(
+        llm_registry,
+        "default_slots",
+        lambda *, github_default_model: [
+            llm_registry.SlotDefinition(
+                name="slot1",
+                provider=langchain_client.PROVIDER_OPENAI,
+                model="gpt-default",
+            ),
+            llm_registry.SlotDefinition(
+                name="slot2",
+                provider=langchain_client.PROVIDER_ANTHROPIC,
+                model="claude-sonnet-4-6",
+            ),
+        ],
+    )
     slot_path = tmp_path / "slots.json"
     slot_path.write_text(
         json.dumps({"slots": [{"name": "primary-claude", "provider": "anthropic"}]}),

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -270,6 +270,28 @@ def test_load_model_registry_rejects_non_list_models(
     assert llm_registry.load_model_registry() == []
 
 
+def test_load_slot_config_uses_provider_fallback_after_position_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    slot_path = tmp_path / "slots.json"
+    slot_path.write_text(
+        json.dumps({"slots": [{"name": "primary-claude", "provider": "anthropic"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(langchain_client.ENV_SLOT_CONFIG, str(slot_path))
+
+    slots = llm_registry.load_slot_config(github_default_model="github-default")
+
+    assert slots == [
+        llm_registry.SlotDefinition(
+            name="primary-claude",
+            provider=langchain_client.PROVIDER_ANTHROPIC,
+            model="claude-sonnet-4-6",
+        )
+    ]
+
+
 def test_slot_env_override_reverts_to_original_when_override_blocked(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -56,6 +56,10 @@ def _headline_quality(entry: dict[str, Any]) -> float:
     return max(values) if values else 0.0
 
 
+def _normalize_tier(value: str) -> str:
+    return value.strip().upper()
+
+
 def _parse_date(value: str) -> _dt.date:
     return _dt.date.fromisoformat(str(value).strip())
 
@@ -143,7 +147,7 @@ def evaluate(
                 }
             )
             continue
-        tier = str(slot.get("quality_tier", "")).strip()
+        tier = _normalize_tier(str(slot.get("quality_tier", "")))
 
         def _slot_quality(model_entry: dict[str, Any], slot_tier: str = tier) -> float:
             if not slot_tier:

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -105,7 +105,7 @@ def load_model_registry() -> list[ModelRegistryEntry]:
         quality = {
             str(tier).upper(): float(score)
             for tier, score in quality_payload.items()
-            if isinstance(score, (int, float))
+            if isinstance(score, (int, float)) and not isinstance(score, bool)
         }
         entries.append(
             ModelRegistryEntry(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -105,7 +105,7 @@ def load_model_registry() -> list[ModelRegistryEntry]:
         quality = {
             str(tier).upper(): float(score)
             for tier, score in quality_payload.items()
-            if isinstance(score, int | float)
+            if isinstance(score, (int, float))
         }
         entries.append(
             ModelRegistryEntry(
@@ -238,7 +238,10 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
         if provider and not model and tier:
             model = select_model_for_tier(provider=provider, tier=tier, registry=registry) or ""
         if provider and not model:
-            fallback_slot = fallback_by_position.get(idx) or fallback_by_provider.get(provider)
+            fallback_slot = fallback_by_position.get(idx)
+            if fallback_slot and fallback_slot.provider != provider:
+                fallback_slot = fallback_by_provider.get(provider)
+            fallback_slot = fallback_slot or fallback_by_provider.get(provider)
             if fallback_slot and fallback_slot.provider == provider:
                 model = fallback_slot.model
         if not provider or not model:


### PR DESCRIPTION
## Summary
- honor provider fallback models when slot configs reorder provider-only entries
- normalize quality-tier keys in the model-registry freshness gate
- add regression coverage for the sync-review findings

## Validation
- python3 -m pytest tests/tools/test_langchain_client.py tests/test_check_model_registry_freshness.py -q
- git diff --check

Related to sync/dependency cleanup campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model tier matching by normalizing `quality_tier` casing before quality-score lookup.
  * Fixed slot fallback resolution to respect provider when tier-based or positional selection doesn’t yield a usable model.
  * Updated model registry quality parsing to ignore boolean values while keeping numeric quality scores.
* **Tests**
  * Added coverage for `quality_tier` case normalization and for provider-aware fallback behavior after slot position mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->