### PR TITLE
fix: keep template model registry fresh

### DIFF
--- a/templates/consumer-repo/config/llm_slots.json
+++ b/templates/consumer-repo/config/llm_slots.json
@@ -8,7 +8,7 @@
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "quality_tier": "T5"
     },
     {
       "name": "slot3",

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -1,6 +1,8 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-04-14",
+  "last_updated": "2026-06-29",
+  "review_interval_days": 60,
+  "review_by": "2026-08-28",
   "models": [
     {
       "model_id": "gpt-5.4",
@@ -103,7 +105,7 @@
     },
     {
       "model_id": "codex-mini-latest",
-      "provider": "openai",
+      "provider": "github-models",
       "api": "chat",
       "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
       "cost_score": 0.80,

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -167,6 +167,18 @@ def test_real_repo_files_parse_and_run(tmp_path):
     assert isinstance(findings, list)
 
 
+def test_consumer_template_registry_defaults_are_fresh():
+    root = Path(__file__).resolve().parent.parent
+    reg = json.loads(
+        (root / "templates" / "consumer-repo" / "config" / "model_registry.json").read_text()
+    )
+    slots = json.loads(
+        (root / "templates" / "consumer-repo" / "config" / "llm_slots.json").read_text()
+    )
+    findings = gate.evaluate(reg, slots, today=dt.date(2026, 6, 30))
+    assert findings == []
+
+
 def test_main_exit_codes(tmp_path):
     reg = tmp_path / "reg.json"
     slots = tmp_path / "slots.json"


### PR DESCRIPTION
## Summary
- sync consumer template model registry metadata with the canonical root registry
- align the template LLM slot defaults with the non-ossifying root slot config
- add a regression proving template defaults pass the freshness gate on 2026-06-30

## Validation
- python3 -m pytest tests/test_check_model_registry_freshness.py -q
- python3 scripts/validate_template_sync.py
- python3 scripts/validate_template_completeness.py
- git diff --check
- python3 tools/check_model_registry_freshness.py --registry templates/consumer-repo/config/model_registry.json --slots templates/consumer-repo/config/llm_slots.json --today 2026-06-30 --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the consumer template’s model and slot configuration to reflect the latest approved settings and review dates.
  * Switched one model entry to a different provider for improved consistency.

* **Tests**
  * Added coverage to verify the consumer template’s registry settings remain valid and up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->