### PR TITLE
fix: repair shared sync gate failures

### DIFF
--- a/scripts/autopilot_step_timer.py
+++ b/scripts/autopilot_step_timer.py
@@ -62,7 +62,9 @@ def _summary_env_details() -> dict[str, str]:
     return details
 
 
-def _write_failure_summary(*, error: Exception, exit_code: int, step_name: str | None) -> None:
+def _write_failure_summary(
+    *, error: BaseException, exit_code: int, step_name: str | None
+) -> None:
     summary_path = os.environ.get("AUTOPILOT_METRICS_SUMMARY_PATH")
     if not summary_path:
         return

--- a/scripts/autopilot_step_timer.py
+++ b/scripts/autopilot_step_timer.py
@@ -62,9 +62,7 @@ def _summary_env_details() -> dict[str, str]:
     return details
 
 
-def _write_failure_summary(
-    *, error: BaseException, exit_code: int, step_name: str | None
-) -> None:
+def _write_failure_summary(*, error: BaseException, exit_code: int, step_name: str | None) -> None:
     summary_path = os.environ.get("AUTOPILOT_METRICS_SUMMARY_PATH")
     if not summary_path:
         return

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -1372,8 +1372,20 @@ jobs:
                 : { createTokenAwareRetry: async () => ({
                   withRetry: (fn) => fn(github),
                   paginateWithRetry: async (method, params) => {
-                    const response = await method({ ...params, per_page: params?.per_page || 100 });
-                    return response.data || [];
+                    const perPage = params?.per_page || 100;
+                    const items = [];
+                    let page = params?.page || 1;
+                    while (true) {
+                      const response = await method({ ...params, per_page: perPage, page });
+                      const data = response?.data;
+                      const pageItems = Array.isArray(data)
+                        ? data
+                        : Object.values(data || {}).find((value) => Array.isArray(value)) || [];
+                      items.push(...pageItems);
+                      if (pageItems.length < perPage) break;
+                      page += 1;
+                    }
+                    return items;
                   }
                 }) };
             const { withRetry, paginateWithRetry } = await createTokenAwareRetry({ github, core });
@@ -1577,8 +1589,20 @@ jobs:
                   createTokenAwareRetry: async () => ({
                     withRetry: (fn) => fn(github),
                     paginateWithRetry: async (method, params) => {
-                      const response = await method({ ...params, per_page: params?.per_page || 100 });
-                      return response.data || [];
+                      const perPage = params?.per_page || 100;
+                      const items = [];
+                      let page = params?.page || 1;
+                      while (true) {
+                        const response = await method({ ...params, per_page: perPage, page });
+                        const data = response?.data;
+                        const pageItems = Array.isArray(data)
+                          ? data
+                          : Object.values(data || {}).find((value) => Array.isArray(value)) || [];
+                        items.push(...pageItems);
+                        if (pageItems.length < perPage) break;
+                        page += 1;
+                      }
+                      return items;
                     },
                   }),
                 };

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -1283,6 +1283,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1353,6 +1354,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
@@ -1366,10 +1368,13 @@ jobs:
             const fs = require('fs');
             const retryPath = './.github/scripts/github-api-with-retry.js';
             const { createTokenAwareRetry } = fs.existsSync(retryPath)
-              ? require(retryPath)
-              : { createTokenAwareRetry: async () => ({
+                ? require(retryPath)
+                : { createTokenAwareRetry: async () => ({
                   withRetry: (fn) => fn(github),
-                  paginateWithRetry: (method, params) => github.paginate(method, params)
+                  paginateWithRetry: async (method, params) => {
+                    const response = await method({ ...params, per_page: params?.per_page || 100 });
+                    return response.data || [];
+                  }
                 }) };
             const { withRetry, paginateWithRetry } = await createTokenAwareRetry({ github, core });
 
@@ -1551,6 +1556,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
+            .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js
@@ -1570,7 +1576,10 @@ jobs:
               : {
                   createTokenAwareRetry: async () => ({
                     withRetry: (fn) => fn(github),
-                    paginateWithRetry: (method, params) => github.paginate(method, params),
+                    paginateWithRetry: async (method, params) => {
+                      const response = await method({ ...params, per_page: params?.per_page || 100 });
+                      return response.data || [];
+                    },
                   }),
                 };
             const { withRetry, paginateWithRetry } = await createTokenAwareRetry({ github, core });

--- a/tests/workflows/test_github_api_retry_standard.py
+++ b/tests/workflows/test_github_api_retry_standard.py
@@ -23,6 +23,7 @@ WORKFLOW_PATHS = [
     Path("templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-73-codex-belt-conveyor.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml"),
+    Path("templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-verifier.yml"),
     Path("templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml"),
     Path("templates/consumer-repo/.github/workflows/autofix.yml"),


### PR DESCRIPTION
## Summary
- include `error_classifier.js` in `agents-81-gate-followups.yml` retry-helper sparse checkouts
- add `agents-81-gate-followups.yml` to the retry/sparse-checkout guard test
- allow `autopilot_step_timer` failure summaries to accept `SystemExit` from argparse

## Validation
- `/opt/anaconda3/bin/python3.12 -m pytest tests/workflows/test_github_api_retry_standard.py tests/scripts/test_autopilot_step_timer.py tests/scripts/test_autopilot_step_timer_failure_handling.py -q`
- `python3 scripts/validate_template_sync.py`
- `python3 scripts/validate_template_completeness.py`
- `git diff --check`

Related to sync/dependency cleanup campaign blockers on Manager-Database#1343 and trip-planner#1506.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in automation retries and pagination when fallback behavior is used.
  * Expanded failure reporting to handle a wider range of error types without breaking summary generation.

* **Chores**
  * Updated workflow coverage so validation checks now include an additional automation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->