### PR TITLE
ci(pdf-extract): add package verification gate

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -274,6 +274,8 @@ jobs:
       - environment-gate
     if: ${{ needs.detect.outputs.doc_only != 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: packages/stranske_pdf_extract

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -267,6 +267,34 @@ jobs:
       - run: pytest tests/workflows/github_scripts
         if: ${{ steps.script_tests.outputs.python_tests == 'true' }}
 
+  packages-pdf-extract:
+    name: stranske-pdf-extract package tests
+    needs:
+      - detect
+      - environment-gate
+    if: ${{ needs.detect.outputs.doc_only != 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/stranske_pdf_extract
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: packages/stranske_pdf_extract/pyproject.toml
+      - name: Install package test dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Run package test suite
+        env:
+          PYTHONPATH: src
+        run: python -m pytest tests
+
   issue-consistency:
     name: issue consistency
     needs:
@@ -438,6 +466,7 @@ jobs:
       - docs-guard
       - docker-smoke
       - github-scripts-tests
+      - packages-pdf-extract
       - issue-consistency
       - test-quality
       - ledger-validation

--- a/.github/workflows/selftest-ci.yml
+++ b/.github/workflows/selftest-ci.yml
@@ -91,6 +91,31 @@ jobs:
             tests/scripts/test_pr_verifier_issue_creation.py \
             -v
 
+  packages-pdf-extract:
+    name: stranske-pdf-extract package tests
+    needs: classify
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.classify.outputs.is_docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/stranske_pdf_extract
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: packages/stranske_pdf_extract/pyproject.toml
+
+      - name: Install package test dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run package test suite
+        env:
+          PYTHONPATH: src
+        run: python -m pytest tests
+
   lint-and-validate:
     name: Lint, Format & YAML Validation
     needs: classify

--- a/.github/workflows/selftest-ci.yml
+++ b/.github/workflows/selftest-ci.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/packages/stranske_pdf_extract/README.md
+++ b/packages/stranske_pdf_extract/README.md
@@ -5,6 +5,7 @@ independent, diverging implementations (Counter_Risk, Pension-Data, Inv-Man-Inta
 Manager-Database) with one installable library.
 
 > **Design, distribution decision, and migration plan: [`docs/DESIGN.md`](docs/DESIGN.md).**
+> Release and CI evidence: [`docs/VERIFICATION.md`](docs/VERIFICATION.md).
 > Grounding audits: `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` and
 > `…-methodology.md`.
 

--- a/packages/stranske_pdf_extract/docs/VERIFICATION.md
+++ b/packages/stranske_pdf_extract/docs/VERIFICATION.md
@@ -1,0 +1,39 @@
+# stranske-pdf-extract verification evidence
+
+This note records the release and verification evidence for Workflows issue #2711.
+
+## CI gate
+
+Selftest CI includes a dedicated `stranske-pdf-extract package tests` job that runs:
+
+```bash
+cd packages/stranske_pdf_extract
+PYTHONPATH=src python -m pytest tests
+```
+
+The suite includes the named acceptance gate:
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol
+```
+
+## Deliberate-break proof
+
+The conformance gate depends on `DoclingProvider.name = "docling"`. A deliberate local
+mutation that changes or removes that attribute must fail
+`tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol` at:
+
+```python
+assert provider.name == "docling"
+```
+
+Before release, run the mutation, capture the failure, revert the mutation, and confirm
+the same test passes.
+
+## Release tag
+
+The release tag is `pdf-extract-v0.1.0`. The install URL is:
+
+```bash
+pip install "git+https://github.com/stranske/Workflows@pdf-extract-v0.1.0#subdirectory=packages/stranske_pdf_extract"
+```

--- a/packages/stranske_pdf_extract/docs/VERIFICATION.md
+++ b/packages/stranske_pdf_extract/docs/VERIFICATION.md
@@ -4,7 +4,8 @@ This note records the release and verification evidence for Workflows issue #271
 
 ## CI gate
 
-Selftest CI includes a dedicated `stranske-pdf-extract package tests` job that runs:
+Gate includes a required `stranske-pdf-extract package tests` job, and Selftest CI mirrors
+the same package suite for repository self-checks. Both jobs run:
 
 ```bash
 cd packages/stranske_pdf_extract

--- a/packages/stranske_pdf_extract/pyproject.toml
+++ b/packages/stranske_pdf_extract/pyproject.toml
@@ -7,7 +7,7 @@ name = "stranske-pdf-extract"
 version = "0.1.0"
 description = "Single-source PDF text-extraction ladder, page-level provenance contract, fallback orchestration, and reliability layer for the stranske/* fleet."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "stranske fleet platform" }]
 # Core has NO heavy/native deps: the ladder degrades gracefully and the contract,

--- a/packages/stranske_pdf_extract/tests/conftest.py
+++ b/packages/stranske_pdf_extract/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest bootstrap for running package tests from the monorepo root."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2711 -->
> **Source:** Issue #2711

Closes #2711

<!-- pr-preamble:end -->

## Why

PDF text-EXTRACTION is independently reimplemented in **four** fleet repos with four divergent
result contracts and three OCR strategies (verified by reading source, 2026-06-28, and confirmed by a
fresh clone-grep across all branches — exactly four, none missed):

- Counter_Risk `src/counter_risk/parsers/daily_holdings_pdf.py:81` (`_extract_text` ladder pdfplumber→pypdf→OCR).
- Pension-Data `src/pension_data/parser/pdf_pipeline.py:455` (`parse_pdf_to_funded_input`) + `src/pension_data/extract/orchestration/fallback.py:53` (`run_fallback_chain`) + `db/models/provenance.py`.
- Inv-Man-Intake `src/inv_man_intake/extraction/providers/base.py:204` (`ExtractionProvider` Protocol; `:218` `MultiModalExtractionProvider`) — current `pdf_primary.py` extractor is fixture-grade, not real.
- Manager-Database `utils/extract.py:20` (`_extract_pdf`, pdfplumber→`str`).

Missing/duplicated behavior: items 1–4 of the shape (text-extraction ladder, OCR fallback, orchestration,
result/provenance contract) are rebuilt per repo; a reliability layer (arithmetic/business-rule validation +
cross-check + calibrated confidence) is **absent in all four**. This is **latent fragility + duplicated effort**,
not a current break. Grounding: `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` and `…-methodology.md`.
A validated scaffold (this design) already exists at `packages/stranske_pdf_extract/` with 27 passing
deterministic tests; this issue tracks landing it on `main` and finishing the optional-dep paths.

## Scope

Land the single-source library `stranske-pdf-extract` as a **pip-installable subdirectory package** in
Workflows at `packages/stranske_pdf_extract/` (distribution decision: package, NOT sync-manifest copy-sync —
see `packages/stranske_pdf_extract/docs/DESIGN.md` §2). The package owns: the generalized result + page-level
provenance contract (`contract.py`, generalizing Pension-Data + Inv-Man-Intake), the provider Protocols + OCR
seam + registry (`provider.py`), the fallback-ladder primitive (`orchestration.py`, lifted from Pension-Data),
the greenfield reliability layer (`reliability.py`), one REAL extractor behind the Protocol
(`providers/docling_provider.py`, Docling/MIT/local, optional `[docling]` extra), a pure-python baseline
(`providers/text_baseline.py`), and the golden-set eval harness (`eval/harness.py`). Tag `pdf-extract-v0.1.0`.

## Non-Goals

- Do NOT add the package to `.github/sync-manifest.yml` — distribution is `pip`, not copy-sync. The only
  sync/doc touch is a note that the package exists and is pip-installed (so a future audit does not "fix" its absence).
- Do NOT run Docling or OCR in any stlite/Pyodide browser path; keep them optional extras never imported there.
- Do NOT migrate any consumer in this issue — migrations are separate, dependency-ordered tracking issues.
- Do NOT learn any consumer's domain schema; domain field-parsing stays in each consumer.
- Scaffold-only completion does NOT count: landing the tree with the named conformance gate collecting **0**
  tests, or the deliberate-break below not demonstrated, is a failure of this issue.

## Tasks

- [ ] Land `packages/stranske_pdf_extract/` on `main` (the validated scaffold): `pyproject.toml` (extras
  `baseline,docling,ocr,textract,schema,eval`), `src/stranske_pdf_extract/{contract,provider,orchestration,reliability}.py`,
  `providers/{docling_provider,text_baseline}.py`, `eval/harness.py`, `docs/DESIGN.md`, `README.md`, and `tests/`.
- [ ] Wire the package's `tests/` into Workflows CI (a non-default job, e.g. extend `.github/workflows/selftest-ci.yml`
  or add a `packages-pdf-extract` job) running `PYTHONPATH=packages/stranske_pdf_extract/src python -m pytest packages/stranske_pdf_extract/tests`.
- [ ] Tag the release `pdf-extract-v0.1.0` and document the install URL
  `git+https://github.com/stranske/Workflows@pdf-extract-v0.1.0#subdirectory=packages/stranske_pdf_extract` in `README.md`.
- [ ] Complete the Docling real path (`providers/docling_provider.py:_extract_real`) behind the `[docling]` extra and
  add an opt-in test that runs only when `docling_available()` is true (skips cleanly otherwise).
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert.

## Acceptance Criteria

- [ ] Named test gate: `packages/stranske_pdf_extract/tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol`
  passes in CI (asserts `isinstance(DoclingProvider(), MultiModalExtractionProvider)`), AND the full package suite
  collects a non-zero count and passes (confirmed-green locally: 27 passed).
- [ ] **Deliberate-break gate:** <!-- deliberate-break: test=packages/stranske_pdf_extract/tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol test-file=packages/stranske_pdf_extract/tests/test_docling_provider.py break-file=packages/stranske_pdf_extract/src/stranske_pdf_extract/providers/docling_provider.py --> temporarily comment out the `name = "docling"` attribute in
  `src/stranske_pdf_extract/providers/docling_provider.py` (class `DoclingProvider`). With this change,
  `test_docling_provider.py::test_docling_provider_conforms_to_protocol` **must FAIL** with
  `assert isinstance(...) == False`. Revert and confirm it passes. (Demonstrated locally during scaffolding.)
- [ ] `pip install "git+…#subdirectory=packages/stranske_pdf_extract"` imports `stranske_pdf_extract` with the
  core (no extras) and `import` of `providers` does not require `docling` (only `extract_modalities` does).

## Implementation Notes

- Confirmed-green local reproduction: `cd packages/stranske_pdf_extract && PYTHONPATH=src python -m pytest -q` → `27 passed`.
- Core has zero runtime deps by design; native deps (Docling/Tesseract) are extras so confidentiality-sensitive
  consumers install only what they need.
- Contract merge rule and migration order are in `packages/stranske_pdf_extract/docs/DESIGN.md`.

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PDF text-EXTRACTION is independently reimplemented in **four** fleet repos with four divergent
result contracts and three OCR strategies (verified by reading source, 2026-06-28, and confirmed by a
fresh clone-grep across all branches — exactly four, none missed):

- Counter_Risk `src/counter_risk/parsers/daily_holdings_pdf.py:81` (`_extract_text` ladder pdfplumber→pypdf→OCR).
- Pension-Data `src/pension_data/parser/pdf_pipeline.py:455` (`parse_pdf_to_funded_input`) + `src/pension_data/extract/orchestration/fallback.py:53` (`run_fallback_chain`) + `db/models/provenance.py`.
- Inv-Man-Intake `src/inv_man_intake/extraction/providers/base.py:204` (`ExtractionProvider` Protocol; `:218` `MultiModalExtractionProvider`) — current `pdf_primary.py` extractor is fixture-grade, not real.
- Manager-Database `utils/extract.py:20` (`_extract_pdf`, pdfplumber→`str`).

Missing/duplicated behavior: items 1–4 of the shape (text-extraction ladder, OCR fallback, orchestration,
result/provenance contract) are rebuilt per repo; a reliability layer (arithmetic/business-rule validation +
cross-check + calibrated confidence) is **absent in all four**. This is **latent fragility + duplicated effort**,
not a current break. Grounding: `Code/Audits/2026-06-28-fleet-pdf-extraction-survey.md` and `…-methodology.md`.
A validated scaffold (this design) already exists at `packages/stranske_pdf_extract/` with 27 passing
deterministic tests; this issue tracks landing it on `main` and finishing the optional-dep paths.

#### Tasks
- [ ] Land `packages/stranske_pdf_extract/` on `main` (the validated scaffold): `pyproject.toml` (extras
  `baseline,docling,ocr,textract,schema,eval`), `src/stranske_pdf_extract/{contract,provider,orchestration,reliability}.py`,
  `providers/{docling_provider,text_baseline}.py`, `eval/harness.py`, `docs/DESIGN.md`, `README.md`, and `tests/`.
- [ ] Wire the package's `tests/` into Workflows CI (a non-default job, e.g. extend `.github/workflows/selftest-ci.yml`
  or add a `packages-pdf-extract` job) running `PYTHONPATH=packages/stranske_pdf_extract/src python -m pytest packages/stranske_pdf_extract/tests`.
- [ ] Tag the release `pdf-extract-v0.1.0` and document the install URL
  `git+https://github.com/stranske/Workflows@pdf-extract-v0.1.0#subdirectory=packages/stranske_pdf_extract` in `README.md`.
- [ ] Complete the Docling real path (`providers/docling_provider.py:_extract_real`) behind the `[docling]` extra and
  add an opt-in test that runs only when `docling_available()` is true (skips cleanly otherwise).
- [ ] Perform the deliberate-break verification (see Acceptance Criteria), capture the FAIL output, then revert.

#### Acceptance criteria
- [ ] Named test gate: `packages/stranske_pdf_extract/tests/test_docling_provider.py::test_docling_provider_conforms_to_protocol`
  passes in CI (asserts `isinstance(DoclingProvider(), MultiModalExtractionProvider)`), AND the full package suite
  collects a non-zero count and passes (confirmed-green locally: 27 passed).
- [ ] **Deliberate-break gate:** temporarily comment out the `name = "docling"` attribute in
  `src/stranske_pdf_extract/providers/docling_provider.py` (class `DoclingProvider`). With this change,
  `test_docling_provider.py::test_docling_provider_conforms_to_protocol` **must FAIL** with
  `assert isinstance(...) == False`. Revert and confirm it passes. (Demonstrated locally during scaffolding.)
- [ ] `pip install "git+…#subdirectory=packages/stranske_pdf_extract"` imports `stranske_pdf_extract` with the
  core (no extras) and `import` of `providers` does not require `docling` (only `extract_modalities` does).

<!-- auto-status-summary:end -->