### PR TITLE
fix: ignore tier slots with malformed registry

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -118,6 +118,21 @@ def load_model_registry() -> list[ModelRegistryEntry]:
     return entries
 
 
+def _model_registry_format_valid() -> bool:
+    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if not path.is_file():
+        return True
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    raw_models = payload.get("models", [])
+    return isinstance(raw_models, list)
+
+
 def registry_entry_for(
     provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
 ) -> ModelRegistryEntry | None:
@@ -228,10 +243,18 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    slot_entries = _slot_entries(payload, path)
+    if not _model_registry_format_valid() and any(
+        str(entry.get("provider", "")).strip()
+        and not str(entry.get("model", "")).strip()
+        and str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        for entry in slot_entries
+    ):
+        return fallback_slots
     slots: list[SlotDefinition] = []
     fallback_by_position = dict(enumerate(fallback_slots, start=1))
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
-    for idx, entry in enumerate(_slot_entries(payload, path), start=1):
+    for idx, entry in enumerate(slot_entries, start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -296,6 +296,25 @@ def test_load_model_registry_excludes_boolean_quality_scores(
     assert entry.quality == {"T2": 0.8}
 
 
+def test_load_slot_config_ignores_tier_slot_when_registry_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+    slot_path = tmp_path / "slots.json"
+    slot_path.write_text(
+        json.dumps({"slots": [{"name": "primary", "provider": "openai", "quality_tier": "T3"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(langchain_client.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(langchain_client.ENV_SLOT_CONFIG, str(slot_path))
+
+    slots = llm_registry.load_slot_config(github_default_model=langchain_client.DEFAULT_MODEL)
+
+    assert slots == llm_registry.default_slots(github_default_model=langchain_client.DEFAULT_MODEL)
+
+
 def test_load_slot_config_uses_provider_fallback_after_position_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -118,6 +118,21 @@ def load_model_registry() -> list[ModelRegistryEntry]:
     return entries
 
 
+def _model_registry_format_valid() -> bool:
+    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if not path.is_file():
+        return True
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    raw_models = payload.get("models", [])
+    return isinstance(raw_models, list)
+
+
 def registry_entry_for(
     provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
 ) -> ModelRegistryEntry | None:
@@ -228,10 +243,18 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    slot_entries = _slot_entries(payload, path)
+    if not _model_registry_format_valid() and any(
+        str(entry.get("provider", "")).strip()
+        and not str(entry.get("model", "")).strip()
+        and str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        for entry in slot_entries
+    ):
+        return fallback_slots
     slots: list[SlotDefinition] = []
     fallback_by_position = dict(enumerate(fallback_slots, start=1))
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
-    for idx, entry in enumerate(_slot_entries(payload, path), start=1):
+    for idx, entry in enumerate(slot_entries, start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()


### PR DESCRIPTION
## Summary
- treat malformed model-registry payloads as a signal to keep the full default slot list when slot config depends on quality_tier resolution
- keep valid partial registries using the existing provider fallback behavior
- mirror the fix into the consumer template copy of tools/llm_registry.py

## Validation
- python3 -m pytest tests/tools/test_langchain_client.py tests/test_check_model_registry_freshness.py -q
- python3 scripts/validate_template_sync.py
- python3 scripts/validate_template_completeness.py
- git diff --check
- /opt/anaconda3/bin/python3.12 -m black --check tools/llm_registry.py templates/consumer-repo/tools/llm_registry.py tests/tools/test_langchain_client.py

Unblocks sync/dependency cleanup for stranske/Inv-Man-Intake#731, where malformed registry fallback currently resolves only the first provider slot instead of the complete default slot list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot loading so configurations continue to work when the model registry file is missing or malformed.
  * If a slot depends on tier-based model selection and the registry can’t be read in the expected format, the app now falls back to default slots instead of failing or misconfiguring slots.
  * Added coverage to ensure tier-based slot selection is ignored when the registry configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->