### PR TITLE
fix: baseline issue optimizer template drift

### DIFF
--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -94,8 +94,8 @@ reason = Intentional divergence re-baselined 2026-06-30: root and consumer guard
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
 main_sha256 = 1e2fb1b588d00f694fd9d02816944e68a4d1a8041f4f052730b1f30f3ad696db
-template_sha256 = bbd9d30e392d3df884ebabd9738fcd5864d79754dcfc04068466132e4c2e769d
-reason = Intentional divergence re-baselined 2026-07-07: root and consumer issue-optimizer workflows keep different auth plumbing/action pin surfaces, but both now use the pinned tools/requirements-llm.txt install path with python -m pip. Do not align wholesale because that would strip consumer action pins/token setup.
+template_sha256 = fc08646e57af311c0dfc1bcee79f79b13aa8377be1818381007a8151d3ac148b
+reason = Intentional divergence re-baselined 2026-07-07: root and consumer issue-optimizer workflows keep different auth plumbing/action pin surfaces, and the consumer template installs LLM deps from checked-out workflows-scripts/tools/requirements-llm.txt with python -m pip. Do not align wholesale because that would strip consumer action pins/token setup.
 
 [pair.12]
 main = .github/workflows/agents-keepalive-loop-reporter.yml


### PR DESCRIPTION
## Summary
- refresh the reviewed template drift baseline for agents-issue-optimizer after the consumer template LLM install path changed
- clarify that the consumer template installs from checked-out workflows-scripts/tools/requirements-llm.txt

## Validation
- python3 scripts/check_template_drift.py --allowlist config/template-drift-allowlist.txt
- python3 scripts/validate_template_sync.py
- python3 scripts/validate_template_completeness.py
- python3 -m pytest tests/docs/test_workflow_snippets_yaml.py tests/scripts/test_generate_llm_workflow_update_comment.py tests/workflows/test_workflow_llm_installs.py -q
- git diff --check