### PR TITLE
fix: align dev version sync PR body

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -280,11 +280,17 @@ jobs:
 
           git push --force -u origin "$branch_name"
 
+          changed_files="$(git show --name-only --format= HEAD)"
+          if printf '%s\n' "$changed_files" | grep -qx 'pyproject.toml'; then
+            pr_scope="This PR updates dev tool versions in \`pyproject.toml\` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows)."
+          else
+            pr_scope="This PR updates generated dev-tool pin files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows)."
+          fi
+
           # Create PR body
           pr_body="## Dev Tool Version Sync
 
-          This PR updates dev tool versions in \`pyproject.toml\` to match the central
-          version pins from [stranske/Workflows](https://github.com/stranske/Workflows).
+          ${pr_scope}
 
           ### Changes
           \`\`\`

--- a/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
+++ b/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
@@ -5,8 +5,15 @@ WORKFLOW = Path(".github/workflows/maint-52-sync-dev-versions.yml")
 
 def test_dev_version_sync_pr_body_matches_changed_files():
     text = WORKFLOW.read_text(encoding="utf-8")
+    pr_scope_lines = [
+        line.strip() for line in text.splitlines() if line.strip().startswith("pr_scope=")
+    ]
 
     assert 'changed_files="$(git show --name-only --format= HEAD)"' in text
     assert "grep -qx 'pyproject.toml'" in text
+    assert pr_scope_lines == [
+        'pr_scope="This PR updates dev tool versions in \\`pyproject.toml\\` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows)."',
+        'pr_scope="This PR updates generated dev-tool pin files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows)."',
+    ]
     assert "generated dev-tool pin files" in text
     assert "This PR updates dev tool versions in \\`pyproject.toml\\` to match" not in text

--- a/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
+++ b/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maint-52-sync-dev-versions.yml")
+
+
+def test_dev_version_sync_pr_body_matches_changed_files():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'changed_files="$(git show --name-only --format= HEAD)"' in text
+    assert "grep -qx 'pyproject.toml'" in text
+    assert "generated dev-tool pin files" in text
+    assert "This PR updates dev tool versions in \\`pyproject.toml\\` to match" not in text


### PR DESCRIPTION
## Summary
- make Maint 52 dev-tool-sync PR descriptions match the actual committed file set
- avoid claiming pyproject.toml changed for repos that only receive generated env/lockfile updates
- add a focused regression test for the generated body copy

## Validation
- PYTHONPYCACHEPREFIX=/tmp/codex-pycache-sync-closer-clean python3 -m pytest tests/workflows/test_maint52_sync_dev_versions_pr_body.py -q
- PYTHONPYCACHEPREFIX=/tmp/codex-pycache-sync-closer-clean python3 scripts/validate_template_completeness.py
- PYTHONPYCACHEPREFIX=/tmp/codex-pycache-sync-closer-clean python3 scripts/validate_template_sync.py
- git diff --check