### PR TITLE
fix: apply tracker:durable label when creating/updating weekly metrics tracker issue

### DIFF
--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -404,6 +404,7 @@ jobs:
                 repo,
                 title,
                 body: 'Tracking issue for weekly agent workflow metrics.\n\n' + body,
+                labels: ['tracker:durable', 'automated'],
               }));
               target = created.data;
             } else {
@@ -413,6 +414,15 @@ jobs:
                 issue_number: target.number,
                 body,
               }));
+              const hasLabel = target.labels.some(l => l.name === 'tracker:durable');
+              if (!hasLabel) {
+                await withRetry(() => github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: target.number,
+                  labels: ['tracker:durable'],
+                }));
+              }
             }
 
             core.setOutput('issue_number', target.number);

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -414,7 +414,9 @@ jobs:
                 issue_number: target.number,
                 body,
               }));
-              const hasLabel = target.labels.some(l => l.name === 'tracker:durable');
+              const hasLabel = (target.labels || []).some(
+                l => (typeof l === 'string' ? l : l?.name) === 'tracker:durable'
+              );
               if (!hasLabel) {
                 await withRetry(() => github.rest.issues.addLabels({
                   owner,

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -121,6 +121,6 @@ reason = Existing reviewed baseline drift; align the template or update this fin
 [pair.15]
 main = .github/workflows/agents-weekly-metrics.yml
 template = templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
-main_sha256 = 19eac2807db5cd043cc4c0cfe22e2eef0648912e8d6efc3a98f4096d072fcb15
-template_sha256 = c363daa771f8633c9565780c4230832b899f82c40d12c8f17ced58800337bf33
-reason = Intentional divergence (re-baselined 2026-06-14): consumer template SHA-pins third-party actions per the fleet action-pin contract (docs/HISTORY.md, PR #1925) and sets LangSmith tracing env; root uses floating major tags with repo-internal concurrency + sparse-checkout (docs/fixes/sparse-checkout-audit-2026-02-03.csv). Fingerprints refreshed after #2391/#2394 bumps. Do not align: would strip consumer action pins.
+main_sha256 = 3636b71e9b0e1aa8032fdbc04ff2c9269627c4c1d1adf05db0d323c6896c9db4
+template_sha256 = b068950b9726e7fbc006ff100673f70ed785919c6361df4c0ea2ac701764633b
+reason = Intentional divergence (re-baselined 2026-07-09): consumer template SHA-pins third-party actions per the fleet action-pin contract (docs/HISTORY.md, PR #1925) and sets LangSmith tracing env; root uses floating major tags with repo-internal concurrency + sparse-checkout (docs/fixes/sparse-checkout-audit-2026-02-03.csv). Fingerprints refreshed after #2738 (tracker:durable label fix). Do not align: would strip consumer action pins.

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -362,7 +362,9 @@ jobs:
                 issue_number: target.number,
                 body,
               }));
-              const hasLabel = target.labels.some(l => l.name === 'tracker:durable');
+              const hasLabel = (target.labels || []).some(
+                l => (typeof l === 'string' ? l : l?.name) === 'tracker:durable'
+              );
               if (!hasLabel) {
                 await withRetry(() => github.rest.issues.addLabels({
                   owner,

--- a/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
+++ b/templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml
@@ -352,6 +352,7 @@ jobs:
                 repo,
                 title,
                 body: 'Tracking issue for weekly agent workflow metrics.\n\n' + body,
+                labels: ['tracker:durable', 'automated'],
               }));
               target = created.data;
             } else {
@@ -361,6 +362,15 @@ jobs:
                 issue_number: target.number,
                 body,
               }));
+              const hasLabel = target.labels.some(l => l.name === 'tracker:durable');
+              if (!hasLabel) {
+                await withRetry(() => github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: target.number,
+                  labels: ['tracker:durable'],
+                }));
+              }
             }
 
             core.setOutput('issue_number', target.number);


### PR DESCRIPTION
## Summary

`agents-weekly-metrics.yml` created the "Agent metrics weekly summary" tracker issue without any labels, leaving it invisible to triage/stale-scan filters that key on `tracker:durable`. This was noted as a pre-existing gap in the review of PR 2737.

### What changed

**`agents-weekly-metrics.yml`** and **`templates/consumer-repo/.github/workflows/agents-weekly-metrics.yml`**:

- **On creation**: add `labels: ['tracker:durable', 'automated']` to the `issues.create` call so new tracker issues are correctly tagged from the start.
- **On update** (existing issue found): check whether `tracker:durable` is present and add it if missing — retroactively fixes issues created before this change (e.g. issue 2211).
- **Label normalization**: use `(target.labels || []).some(l => (typeof l === 'string' ? l : l?.name) === 'tracker:durable')` (matching the `sync_tracker_state/index.js` pattern) to handle both label-object and label-string API shapes safely.

### Also changed

**`config/template-drift-allowlist.txt`**: rebaselined the `agents-weekly-metrics.yml` fingerprint pair (pair.15) with new SHA256 values after the label fix. Root and template differ intentionally — do not align.

<!-- workflow-source:local_request -->