### PR TITLE
chore(coderabbit): focus reviews on core content — close Workflows blind spot + release filter + core-path guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,11 @@
 # CodeRabbit configuration — https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# Governs the Workflows repo ITSELF (which is the sync source, NOT a consumer).
+# Keep the auto_review block aligned with templates/consumer-repo/.coderabbit.yaml.
 # Tuned for the stranske autonomous-agent fleet:
-#   - strict review of agent-authored PRs (profile: assertive)
+#   - assertive review of substantial agent-authored PRs
 #   - ADVISORY / non-gating, matching the fleet rule that review never blocks a merge
-#   - a workflow-injection guard, since workflow YAML is synced to 9 consumer repos
+#   - maintenance-bot and generated release PRs do not spend review budget
+#   - guards for the workflow YAML and .github/scripts synced across the consumer repos
 language: en-US
 reviews:
   profile: assertive
@@ -12,6 +15,27 @@ reviews:
   auto_review:
     enabled: true
     drafts: false                      # opener creates drafts; review when marked ready
+    # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
+    # syncs) and generated release PRs. agents-workflows-bot is intentionally NOT listed —
+    # it authors substantial agent code PRs that should still be reviewed; its release-please
+    # PRs are caught by the "chore(main): release" title filter below instead.
+    ignore_usernames:
+      - "renovate[bot]"
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+      - "stranske-keepalive[bot]"
+    ignore_title_keywords:
+      - "chore(main): release"
+      - "chore: sync workflow templates"
+      - "sync workflow templates"
+    labels:
+      - "!sync"
+      - "!workflow:source-sync"
+      - "!workflow:source-maintenance"
+      - "!consumer-sync"
+      - "!integration-sync"
+      - "!workflows-sync"
+      - "!template-sync"
   path_filters:
     - "!**/*.lock"
     - "!**/vendor/**"
@@ -20,7 +44,17 @@ reviews:
     - path: ".github/workflows/**"
       instructions: >-
         Flag template-injection, unpinned third-party actions, and spoofable bot-actor
-        checks — this workflow YAML is synced to 9 consumer repos, so one bug replicates
-        fleet-wide.
+        checks — this workflow YAML is synced across the consumer repos, so one bug
+        replicates fleet-wide.
+    - path: ".github/scripts/**"
+      instructions: >-
+        These scripts run with an elevated GITHUB_TOKEN across the fleet. Flag unhandled
+        promise rejections, missing validation of GitHub API / event payloads, command or
+        template injection, and spoofable bot-actor checks.
+    - path: "**/*.py"
+      instructions: >-
+        Prioritize correctness, error handling, and test coverage. Flag new or changed
+        behavior with no accompanying test, silently swallowed exceptions, and unguarded
+        NaN/None propagation in numeric or scoring code.
 chat:
   auto_reply: true

--- a/templates/consumer-repo/.coderabbit.yaml
+++ b/templates/consumer-repo/.coderabbit.yaml
@@ -3,8 +3,8 @@
 # Tuned for the stranske autonomous-agent fleet:
 #   - assertive review of substantial agent-authored PRs
 #   - advisory / non-gating, matching the fleet rule that review never blocks a merge
-#   - maintenance-bot PRs and generated sync/draft PRs do not spend review budget
-#   - a workflow-injection guard, since workflow YAML is synced across consumer repos
+#   - maintenance-bot, generated sync/release, and draft PRs do not spend review budget
+#   - path guidance concentrates review depth on core source, migrations, and workflow YAML
 language: en-US
 reviews:
   profile: assertive
@@ -15,15 +15,16 @@ reviews:
     enabled: true
     drafts: false                      # opener creates drafts; review when marked ready
     # Skip automatic-review budget on maintenance-bot PRs (dependency bumps, CI/version
-    # syncs). agents-workflows-bot is intentionally NOT listed — it authors substantial
-    # agent code PRs (e.g. "Agent belt for #N") that should still be reviewed.
+    # syncs) and generated sync/release PRs. agents-workflows-bot is intentionally NOT listed
+    # — it authors substantial agent code PRs (e.g. "Agent belt for #N") that should still be
+    # reviewed; its release-please PRs are caught by the "chore(main): release" title filter.
     ignore_usernames:
       - "renovate[bot]"
       - "dependabot[bot]"
       - "github-actions[bot]"
       - "stranske-keepalive[bot]"
-    # Also skip generated maintenance / sync PRs by title and by negative label.
     ignore_title_keywords:
+      - "chore(main): release"
       - "chore: sync workflow templates"
       - "sync workflow templates"
     labels:
@@ -44,5 +45,22 @@ reviews:
         Flag template-injection, unpinned third-party actions, and spoofable bot-actor
         checks — this workflow YAML is synced across consumer repos, so one bug
         replicates fleet-wide.
+    - path: "**/*.py"
+      instructions: >-
+        Prioritize correctness, error handling, and test coverage. Flag new or changed
+        behavior with no accompanying test, silently swallowed exceptions, and unguarded
+        NaN/None propagation in numeric or scoring code.
+    - path: "**/alembic/**"
+      instructions: >-
+        Verify migrations are reversible and portable across SQLite (CI) and PostgreSQL
+        (prod): keep constraint/index identifiers within Postgres' 63-char limit, use
+        op.f() for auto-named constraints, and guard dialect-specific SQL. Flag a
+        downgrade() that does not invert upgrade().
+    - path: "**/migrations/**"
+      instructions: >-
+        Verify migrations are reversible and portable across SQLite (CI) and PostgreSQL
+        (prod): keep constraint/index identifiers within Postgres' 63-char limit, use
+        op.f() for auto-named constraints, and guard dialect-specific SQL. Flag a
+        downgrade() that does not invert upgrade().
 chat:
   auto_reply: true


### PR DESCRIPTION
## What

Follow-up to #2706, from a 30-day review of CodeRabbit's PR engagement. Closes the gaps that #2706 (consumer-template only) didn't cover, and adds guidance that deepens review on core content.

Two files:
- **`.coderabbit.yaml` (root)** — governs the Workflows repo itself, which is **not** a consumer, so #2706 never reached it. Adds `ignore_usernames` (maintenance bots) + `ignore_title_keywords` (release) + core-path `path_instructions`.
- **`templates/consumer-repo/.coderabbit.yaml`** — adds the release title-ignore and core/migration `path_instructions` on top of #2706.

## Why (measured, 30 days, org-wide)

- CodeRabbit commented on **1,741 / 2,309 PRs (75%)**; **~63% of that engagement was maintenance** — renovate (460) + `sync workflow templates` (634) + release (9).
- #2706 suppresses renovate + sync in **consumer repos**, but the **Workflows repo was a blind spot**: 343 PRs, 226 CR-reviewed, incl. **~35 renovate + 9 release + chore/pins** still leaking — in the repo where the most core pipeline work happens.
- `chore(main): release` (release-please, 26/mo) wasn't ignored anywhere.

## Changes

**Reduce maintenance:**
- Root config now ignores `renovate[bot]`, `dependabot[bot]`, `github-actions[bot]`, `stranske-keepalive[bot]` (agents-workflows-bot deliberately kept — it authors real code; its release PRs are caught by title).
- Both configs add `chore(main): release` to `ignore_title_keywords`.

**Increase core-review depth (`path_instructions`):**
- `**/*.py` — prioritize correctness, error handling, test coverage; flag untested behavior, swallowed exceptions, unguarded NaN/None in numeric/scoring code.
- `**/alembic/**`, `**/migrations/**` (template) — SQLite-CI-vs-Postgres-prod portability: 63-char identifier limit, `op.f()` for auto-named constraints, reversible `downgrade()`. (Targets a repeatedly-observed fleet failure class.)
- `.github/scripts/**` (root) — elevated-token JS safety: unhandled rejections, payload validation, injection, spoofable actor checks.

`profile: assertive` and advisory/non-gating (`request_changes_workflow: false`) are unchanged — no blocking gate, per the fleet rule.

## Rollout

Root config applies to Workflows on merge. Template rides the daily 05:00 UTC `maint-68` sync to all 13 consumers (same path as #2706).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
