### PR TITLE
Fix agent runner base action sparse checkout

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -220,6 +220,7 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
+          sparse-checkout-cone-mode: false
           token: ${{ steps.bootstrap_app_token.outputs.token || github.token }}
 
       - name: Agent run base setup

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -247,6 +247,7 @@ jobs:
           path: .workflows-actions
           sparse-checkout: |
             .github/actions/agent-run-base
+          sparse-checkout-cone-mode: false
           token: ${{ steps.bootstrap_app_token.outputs.token || github.token }}
 
       - name: Agent run base setup

--- a/tests/workflows/test_reusable_run_shared_base.py
+++ b/tests/workflows/test_reusable_run_shared_base.py
@@ -123,6 +123,7 @@ def test_extracted_setup_steps_not_duplicated_in_runners(workflow_rel: str) -> N
     checkout_with = run_base_checkout_steps[0]["with"]
     assert checkout_with["path"] == RUN_BASE_CHECKOUT_PATH
     assert ".github/actions/agent-run-base" in checkout_with["sparse-checkout"]
+    assert checkout_with["sparse-checkout-cone-mode"] is False
     assert ".workflows-actions" in src
     assert (
         checkout_with["token"] == "${{ steps.bootstrap_app_token.outputs.token || github.token }}"


### PR DESCRIPTION
## Summary
- use non-cone sparse checkout when reusable Codex/Claude runners fetch `.github/actions/agent-run-base`
- cover the checkout mode in the shared runner regression test

## Root cause
Workflows PR #2744 failed `Keepalive next task (Codex) / Codex (keepalive)` in run 29066229837/job 86278429797 after the agent run. GitHub could not reload the local action at `.workflows-actions/.github/actions/agent-run-base` during post-job cleanup. The pre-checkout was sparse-checking a nested action path without `sparse-checkout-cone-mode: false`, unlike the other local-action sparse checkouts in this repo.

## Validation
- `python -m pytest -q tests/workflows/test_reusable_run_shared_base.py`
- `python -m pytest -q tests/scripts/test_validate_workflow_yaml.py`
- `git diff --check`

Fixes keepalive runner infrastructure for #2744.