### PR TITLE
Issue #2742: Propagate keepalive execution profiles

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -5,6 +5,24 @@ default_agent: codex
 # Shared keepalive marker prefix (agent-agnostic)
 keepalive_marker_prefix: agent-keepalive
 
+execution_profiles:
+  codex-default:
+    agent: codex
+    model: gpt-5.5
+    fallback_model: gpt-5.4
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+  codex-fast:
+    agent: codex
+    model: gpt-5.4
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+
 agents:
   codex:
     runner_workflow: .github/workflows/reusable-codex-run.yml

--- a/.github/scripts/__tests__/agent-registry.test.js
+++ b/.github/scripts/__tests__/agent-registry.test.js
@@ -234,6 +234,42 @@ test('resolveExecutionProfile rejects unknown profiles before worker execution',
   );
 });
 
+test('validateAgentRegistry rejects unknown execution profile model ids', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-registry-models-'));
+  const modelRegistryPath = path.join(tmpDir, 'model_registry.json');
+  fs.writeFileSync(
+    modelRegistryPath,
+    JSON.stringify({ models: [{ model_id: 'gpt-known' }] }),
+  );
+
+  assert.throws(
+    () => {
+      validateAgentRegistry(
+        {
+          agents: {
+            codex: {
+              capacity: { window: '5h', limit: 1 },
+            },
+          },
+          execution_profiles: {
+            'codex-default': {
+              agent: 'codex',
+              model: 'gpt-typo',
+              fallback_model: 'gpt-known',
+              runner: 'reusable-codex-run',
+              capacity_pool: 'codex-standard',
+              safety: 'standard',
+              lifecycle: 'active',
+            },
+          },
+        },
+        { modelRegistryPath },
+      );
+    },
+    /unknown model: gpt-typo/,
+  );
+});
+
 test('validateAgentRegistry rejects invalid capacity entries', () => {
   assert.throws(
     () => {

--- a/.github/scripts/__tests__/agent-registry.test.js
+++ b/.github/scripts/__tests__/agent-registry.test.js
@@ -15,6 +15,7 @@ const {
   resolveAgentRoutingFromLabels,
   getAgentEntries,
   getAgentPreflightConfigs,
+  resolveExecutionProfile,
   validateAgentRegistry,
 } = require('../agent_registry');
 
@@ -217,6 +218,22 @@ test('loadAgentRegistry exposes live and disabled planned-agent capacity blocks'
   assert.deepEqual(registry.agents.aider.capacity, { window: 'daily', limit: 1 });
 });
 
+test('resolveExecutionProfile returns registry-backed codex model contract', () => {
+  const profile = resolveExecutionProfile('codex-default', { registryPath: REGISTRY_PATH });
+  assert.equal(profile.id, 'codex-default');
+  assert.equal(profile.agent, 'codex');
+  assert.equal(profile.model, 'gpt-5.5');
+  assert.equal(profile.fallback_model, 'gpt-5.4');
+  assert.equal(profile.runner, 'reusable-codex-run');
+});
+
+test('resolveExecutionProfile rejects unknown profiles before worker execution', () => {
+  assert.throws(
+    () => resolveExecutionProfile('does-not-exist', { registryPath: REGISTRY_PATH }),
+    /Unknown execution profile: does-not-exist/,
+  );
+});
+
 test('validateAgentRegistry rejects invalid capacity entries', () => {
   assert.throws(
     () => {
@@ -242,5 +259,30 @@ test('validateAgentRegistry rejects invalid capacity entries', () => {
       });
     },
     /capacity\.limit must be a positive integer/,
+  );
+});
+
+test('validateAgentRegistry rejects profiles with unknown agents', () => {
+  assert.throws(
+    () => {
+      validateAgentRegistry({
+        agents: {
+          codex: {
+            capacity: { window: '5h', limit: 1 },
+          },
+        },
+        execution_profiles: {
+          bogus: {
+            agent: 'missing-agent',
+            model: 'gpt-5.5',
+            runner: 'reusable-codex-run',
+            capacity_pool: 'codex-standard',
+            safety: 'standard',
+            lifecycle: 'active',
+          },
+        },
+      });
+    },
+    /references unknown agent/,
   );
 });

--- a/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
+++ b/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
@@ -74,7 +74,7 @@ test('reusable codex runner attempts selected profile fallback models', () => {
   const reusable = readWorkflow('.github/workflows/reusable-codex-run.yml');
   assert.match(
     reusable,
-    /printf '%s\\n' "\$model" \$FALLBACK_CODEX_MODELS/,
+    /printf '%s\\n' "\$model" "\$\{fallback_models\[@\]\}"/,
     'expected non-default profile fallback models to be included in candidate order',
   );
   assert.doesNotMatch(

--- a/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
+++ b/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function readWorkflow(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+test('profile reaches codex runner', () => {
+  const keepalive = readWorkflow('.github/workflows/agents-keepalive-loop.yml');
+  assert.match(
+    keepalive,
+    /execution_profile:\s*\$\{\{\s*steps\.evaluate\.outputs\.execution_profile\s*\}\}/,
+    'expected execution profile to be exposed from evaluate',
+  );
+  assert.match(
+    keepalive,
+    /worker_requested_model:\s*\$\{\{\s*steps\.evaluate\.outputs\.worker_requested_model\s*\}\}/,
+    'expected requested worker model evaluate output',
+  );
+  assert.match(
+    keepalive,
+    /codex_model:\s*\$\{\{\s*needs\.evaluate\.outputs\.worker_requested_model\s*\}\}/,
+    'expected selected profile model in reusable runner inputs',
+  );
+  assert.match(
+    keepalive,
+    /codex_fallback_models:\s*\$\{\{\s*needs\.evaluate\.outputs\.worker_fallback_model\s*\}\}/,
+    'expected selected profile fallback chain in reusable runner inputs',
+  );
+});
+
+test('reusable codex runner exposes worker model telemetry outputs', () => {
+  const reusable = readWorkflow('.github/workflows/reusable-codex-run.yml');
+  for (const outputName of [
+    'worker-profile-id',
+    'worker-requested-model',
+    'worker-selected-model',
+    'worker-model-selection-reason',
+  ]) {
+    assert.match(reusable, new RegExp(`${outputName}:`), `missing ${outputName} output`);
+  }
+  assert.match(
+    reusable,
+    /worker-selected-model:\s*\$\{\{\s*steps\.run_codex\.outputs\.model\s*\}\}/,
+    'expected selected model to come from Run Codex step output',
+  );
+});

--- a/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
+++ b/.github/scripts/__tests__/keepalive-model-profile-contract.test.js
@@ -35,6 +35,24 @@ test('profile reaches codex runner', () => {
   );
 });
 
+test('workflow dispatch profile input is honored when PR body omits a profile', () => {
+  const keepaliveLoop = readWorkflow('.github/scripts/keepalive_loop.js');
+  assert.match(
+    keepaliveLoop,
+    /normalise\(config\.execution_profile\)\s*\|\|\s*normalise\(process\.env\.INPUT_EXECUTION_PROFILE\)/,
+    'expected blank PR config to fall back to workflow_dispatch INPUT_EXECUTION_PROFILE',
+  );
+});
+
+test('profile validation is limited to codex execution actions', () => {
+  const keepaliveLoop = readWorkflow('.github/scripts/keepalive_loop.js');
+  assert.match(
+    keepaliveLoop,
+    /if\s*\(\s*AGENT_EXECUTION_ACTIONS\.has\(action\)\s*&&\s*resolvedAgentType\s*===\s*'codex'\s*\)/,
+    'expected wait/skip/stop paths not to hard-fail on execution profile validation',
+  );
+});
+
 test('reusable codex runner exposes worker model telemetry outputs', () => {
   const reusable = readWorkflow('.github/workflows/reusable-codex-run.yml');
   for (const outputName of [
@@ -49,5 +67,38 @@ test('reusable codex runner exposes worker model telemetry outputs', () => {
     reusable,
     /worker-selected-model:\s*\$\{\{\s*steps\.run_codex\.outputs\.model\s*\}\}/,
     'expected selected model to come from Run Codex step output',
+  );
+});
+
+test('reusable codex runner attempts selected profile fallback models', () => {
+  const reusable = readWorkflow('.github/workflows/reusable-codex-run.yml');
+  assert.match(
+    reusable,
+    /printf '%s\\n' "\$model" \$FALLBACK_CODEX_MODELS/,
+    'expected non-default profile fallback models to be included in candidate order',
+  );
+  assert.doesNotMatch(
+    reusable,
+    /if \[ "\$model" = "\$DEFAULT_CODEX_MODEL" \]; then\s*candidates="\$DEFAULT_CODEX_MODEL \$FALLBACK_CODEX_MODELS"/,
+    'fallback candidates must not be limited to the default model',
+  );
+});
+
+test('reusable codex runner emits worker langsmith fleet artifact', () => {
+  const reusable = readWorkflow('.github/workflows/reusable-codex-run.yml');
+  assert.match(
+    reusable,
+    /"schema": "langsmith-fleet\/v1"/,
+    'expected worker telemetry artifact schema marker',
+  );
+  assert.match(
+    reusable,
+    /"operation_role": "worker"/,
+    'expected worker operation role in telemetry artifact',
+  );
+  assert.match(
+    reusable,
+    /name: langsmith-fleet-v1-worker-attempt-/,
+    'expected uploaded worker attempt artifact',
   );
 });

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 const ALLOWED_CAPACITY_WINDOWS = new Set(['5h', 'weekly', 'daily']);
 
@@ -158,8 +159,36 @@ function loadAgentRegistry(options = {}) {
   if (!registry.default_agent || typeof registry.default_agent !== 'string') {
     throw new Error('Agent registry missing required "default_agent" string');
   }
-  validateAgentRegistry(registry);
+  validateAgentRegistry(registry, { registryPath: path });
   return registry;
+}
+
+function resolveModelRegistryPath(options = {}) {
+  if (options.modelRegistryPath) {
+    return options.modelRegistryPath;
+  }
+  const registryPath = options.registryPath || '.github/agents/registry.yml';
+  if (path.isAbsolute(registryPath)) {
+    return path.resolve(path.dirname(registryPath), '..', '..', 'config', 'model_registry.json');
+  }
+  return path.resolve(process.cwd(), 'config', 'model_registry.json');
+}
+
+function loadModelRegistryIds(options = {}) {
+  const modelRegistryPath = resolveModelRegistryPath(options);
+  if (!fs.existsSync(modelRegistryPath)) {
+    return null;
+  }
+  const raw = fs.readFileSync(modelRegistryPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.models)) {
+    throw new Error(`Model registry ${modelRegistryPath} missing required models array`);
+  }
+  return new Set(
+    parsed.models
+      .map((model) => String(model?.model_id || '').trim())
+      .filter(Boolean),
+  );
 }
 
 function validateAgentCapacity(agentKey, agentConfig) {
@@ -184,17 +213,19 @@ function validateAgentCapacity(agentKey, agentConfig) {
   }
 }
 
-function validateAgentRegistry(registry) {
+function validateAgentRegistry(registry, options = {}) {
+  const knownModelIds = loadModelRegistryIds(options);
+
   for (const [agentKey, agentConfig] of Object.entries(registry.agents || {})) {
     validateAgentCapacity(agentKey, agentConfig);
   }
 
   for (const [profileId, profile] of Object.entries(registry.execution_profiles || {})) {
-    validateExecutionProfile(profileId, profile, registry);
+    validateExecutionProfile(profileId, profile, registry, { knownModelIds });
   }
 }
 
-function validateExecutionProfile(profileId, profile, registry) {
+function validateExecutionProfile(profileId, profile, registry, options = {}) {
   if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
     throw new Error(`Execution profile ${profileId} must be an object`);
   }
@@ -205,6 +236,16 @@ function validateExecutionProfile(profileId, profile, registry) {
   for (const field of ['model', 'runner', 'capacity_pool', 'safety', 'lifecycle']) {
     if (!String(profile[field] || '').trim()) {
       throw new Error(`Execution profile ${profileId} missing required field: ${field}`);
+    }
+  }
+  if (options.knownModelIds) {
+    for (const field of ['model', 'fallback_model']) {
+      const modelId = String(profile[field] || '').trim();
+      if (modelId && !options.knownModelIds.has(modelId)) {
+        throw new Error(
+          `Execution profile ${profileId} references unknown ${field}: ${modelId}`,
+        );
+      }
     }
   }
 }

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -188,6 +188,43 @@ function validateAgentRegistry(registry) {
   for (const [agentKey, agentConfig] of Object.entries(registry.agents || {})) {
     validateAgentCapacity(agentKey, agentConfig);
   }
+
+  for (const [profileId, profile] of Object.entries(registry.execution_profiles || {})) {
+    validateExecutionProfile(profileId, profile, registry);
+  }
+}
+
+function validateExecutionProfile(profileId, profile, registry) {
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`Execution profile ${profileId} must be an object`);
+  }
+  const agent = String(profile.agent || '').trim();
+  if (!agent || !registry.agents?.[agent]) {
+    throw new Error(`Execution profile ${profileId} references unknown agent: ${agent || '(empty)'}`);
+  }
+  for (const field of ['model', 'runner', 'capacity_pool', 'safety', 'lifecycle']) {
+    if (!String(profile[field] || '').trim()) {
+      throw new Error(`Execution profile ${profileId} missing required field: ${field}`);
+    }
+  }
+}
+
+function resolveExecutionProfile(profileId, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
+  const registry = loadAgentRegistry({ registryPath });
+  const id = String(profileId || '').trim() || 'codex-default';
+  const profile = registry.execution_profiles?.[id];
+  if (!profile) {
+    const known = Object.keys(registry.execution_profiles || {}).sort();
+    throw new Error(
+      `Unknown execution profile: ${id}. Known profiles: ${known.join(', ') || '(none)'}`,
+    );
+  }
+  validateExecutionProfile(id, profile, registry);
+  return {
+    id,
+    ...profile,
+  };
 }
 
 function normalizeLabel(label) {
@@ -373,6 +410,7 @@ module.exports = {
   getRunnerWorkflow,
   loadAgentRegistry,
   parseRegistryYaml,
+  resolveExecutionProfile,
   resolveAgentFromLabels,
   resolveAgentRoutingFromLabels,
   validateAgentRegistry,

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2837,26 +2837,6 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     });
     const promptMode = promptModeOverride || promptRoute.mode;
     const promptFile = promptFileOverride || promptRoute.file;
-    const requestedExecutionProfile = normalise(
-      config.execution_profile ?? process.env.INPUT_EXECUTION_PROFILE ?? '',
-    ) || 'codex-default';
-    let executionProfile = null;
-    try {
-      const { resolveExecutionProfile } = require('./agent_registry.js');
-      executionProfile = resolveExecutionProfile(requestedExecutionProfile);
-      if (executionProfile.agent !== 'codex') {
-        throw new Error(
-          `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
-        );
-      }
-      core?.info?.(
-        `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
-          `fallback=${executionProfile.fallback_model || ''}`,
-      );
-    } catch (profileError) {
-      throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
-    }
-
     // For verification steps, prefer a different agent than the one that did
     // the implementation work.  This avoids the structural problem where the
     // same model that produced the work also verifies it — a conflict of
@@ -2869,6 +2849,34 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       if (verifierAgentType !== agentType && core) {
         core.info(`Verification step: switching agent from ${agentType} to ${verifierAgentType} for independent verification`);
       }
+    }
+    const resolvedAgentType = isVerificationReason ? verifierAgentType : agentType;
+
+    const requestedExecutionProfile = normalise(config.execution_profile)
+      || normalise(process.env.INPUT_EXECUTION_PROFILE)
+      || 'codex-default';
+    let executionProfile = null;
+    if (AGENT_EXECUTION_ACTIONS.has(action) && resolvedAgentType === 'codex') {
+      try {
+        const { resolveExecutionProfile } = require('./agent_registry.js');
+        executionProfile = resolveExecutionProfile(requestedExecutionProfile);
+        if (executionProfile.agent !== 'codex') {
+          throw new Error(
+            `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
+          );
+        }
+        core?.info?.(
+          `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
+            `fallback=${executionProfile.fallback_model || ''}`,
+        );
+      } catch (profileError) {
+        throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
+      }
+    } else if (core && requestedExecutionProfile !== 'codex-default') {
+      core.info(
+        `Skipping execution profile validation for non-Codex/non-execution action ` +
+          `${resolvedAgentType || '(none)'}/${action || '(none)'}`,
+      );
     }
 
     return {
@@ -2889,7 +2897,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       checkboxCounts,
       hasAgentLabel,
       hasHighPrivilege,
-      agentType: isVerificationReason ? verifierAgentType : agentType,
+      agentType: resolvedAgentType,
       agentRoutingMode,
       delegationReason,
       delegationShouldSwitch,

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -1604,6 +1604,9 @@ function normaliseConfig(config = {}) {
   const promptMode = normalise(cfg.prompt_mode ?? cfg.promptMode);
   const promptFile = normalise(cfg.prompt_file ?? cfg.promptFile);
   const promptScenario = normalise(cfg.prompt_scenario ?? cfg.promptScenario);
+  const executionProfile = normalise(
+    cfg.execution_profile ?? cfg.executionProfile ?? cfg.worker_profile ?? cfg.workerProfile,
+  );
   return {
     keepalive_enabled: toBool(
       cfg.keepalive_enabled ?? cfg.enable_keepalive ?? cfg.keepalive,
@@ -1617,6 +1620,7 @@ function normaliseConfig(config = {}) {
     prompt_mode: promptMode,
     prompt_file: promptFile,
     prompt_scenario: promptScenario,
+    execution_profile: executionProfile,
     verifier_agent: normalise(cfg.verifier_agent),
     progress_review_threshold: cfg.progress_review_threshold != null ? toNumber(cfg.progress_review_threshold, 4) : undefined,
     complete_gate_failure_rounds: cfg.complete_gate_failure_rounds != null ? toNumber(cfg.complete_gate_failure_rounds, 3) : undefined,
@@ -2833,6 +2837,25 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     });
     const promptMode = promptModeOverride || promptRoute.mode;
     const promptFile = promptFileOverride || promptRoute.file;
+    const requestedExecutionProfile = normalise(
+      config.execution_profile ?? process.env.INPUT_EXECUTION_PROFILE ?? '',
+    ) || 'codex-default';
+    let executionProfile = null;
+    try {
+      const { resolveExecutionProfile } = require('./agent_registry.js');
+      executionProfile = resolveExecutionProfile(requestedExecutionProfile);
+      if (executionProfile.agent !== 'codex') {
+        throw new Error(
+          `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
+        );
+      }
+      core?.info?.(
+        `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
+          `fallback=${executionProfile.fallback_model || ''}`,
+      );
+    } catch (profileError) {
+      throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
+    }
 
     // For verification steps, prefer a different agent than the one that did
     // the implementation work.  This avoids the structural problem where the
@@ -2857,6 +2880,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       reason,
       promptMode,
       promptFile,
+      executionProfile,
       gateConclusion,
       config,
       iteration,

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: ''
         type: string
+      execution_profile:
+        description: 'Registry-backed worker execution profile ID.'
+        required: false
+        default: 'codex-default'
+        type: string
 
 permissions:
   contents: write
@@ -71,6 +76,9 @@ jobs:
       has_high_privilege: ${{ steps.evaluate.outputs.has_high_privilege }}
       agent_type: ${{ steps.evaluate.outputs.agent_type }}
       agent_routing_mode: ${{ steps.evaluate.outputs.agent_routing_mode }}
+      execution_profile: ${{ steps.evaluate.outputs.execution_profile }}
+      worker_requested_model: ${{ steps.evaluate.outputs.worker_requested_model }}
+      worker_fallback_model: ${{ steps.evaluate.outputs.worker_fallback_model }}
       delegation_reason: ${{ steps.evaluate.outputs.delegation_reason }}
       delegation_should_switch: ${{ steps.evaluate.outputs.delegation_should_switch }}
       # task_appendix is delivered via artifact upload (keepalive-task-appendix-<pr>)
@@ -351,6 +359,7 @@ jobs:
                  github.event.label.name == 'agent:retry') ||
                 github.event.inputs.force_retry ||
                 'false' }}
+          INPUT_EXECUTION_PROFILE: ${{ github.event.inputs.execution_profile || '' }}
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
@@ -433,6 +442,9 @@ jobs:
               has_high_privilege: String(result.hasHighPrivilege ?? 'false'),
               agent_type: String(result.agentType || ''),
               agent_routing_mode: String(result.agentRoutingMode || ''),
+              execution_profile: String(result.executionProfile?.id || ''),
+              worker_requested_model: String(result.executionProfile?.model || ''),
+              worker_fallback_model: String(result.executionProfile?.fallback_model || ''),
               delegation_reason: String(result.delegationReason || ''),
               delegation_should_switch: String(result.delegationShouldSwitch ?? 'false'),
               trace: String(result.config?.trace || result.state?.trace || ''),
@@ -713,6 +725,9 @@ jobs:
       iteration: ${{ needs.evaluate.outputs.iteration }}
       orchestrator_skill_pack: ${{ github.event.inputs.orchestrator_skill_pack || '' }}
       orchestrator_skill_enabled: ${{ github.event.inputs.orchestrator_skill_enabled || '' }}
+      execution_profile: ${{ needs.evaluate.outputs.execution_profile }}
+      codex_model: ${{ needs.evaluate.outputs.worker_requested_model }}
+      codex_fallback_models: ${{ needs.evaluate.outputs.worker_fallback_model }}
       environment: >-
         ${{
           needs.evaluate.outputs.has_high_privilege == 'true' &&

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -743,8 +743,9 @@ jobs:
             reason="default"
           fi
 
+          IFS=' ' read -r -a fallback_models <<< "${FALLBACK_CODEX_MODELS:-}"
           candidates="$(
-            printf '%s\n' "$model" $FALLBACK_CODEX_MODELS |
+            printf '%s\n' "$model" "${fallback_models[@]}" |
               awk 'NF && !seen[$0]++ { printf "%s%s", sep, $0; sep=" " }'
           )"
 
@@ -755,7 +756,7 @@ jobs:
               model="$DEFAULT_CODEX_MODEL"
               reason="fallback-unsupported-chatgpt-codex-model"
               candidates="$(
-                printf '%s\n' "$DEFAULT_CODEX_MODEL" $FALLBACK_CODEX_MODELS |
+                printf '%s\n' "$DEFAULT_CODEX_MODEL" "${fallback_models[@]}" |
                   awk 'NF && !seen[$0]++ { printf "%s%s", sep, $0; sep=" " }'
               )"
               ;;

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -743,10 +743,10 @@ jobs:
             reason="default"
           fi
 
-          candidates="$model"
-          if [ "$model" = "$DEFAULT_CODEX_MODEL" ]; then
-            candidates="$DEFAULT_CODEX_MODEL $FALLBACK_CODEX_MODELS"
-          fi
+          candidates="$(
+            printf '%s\n' "$model" $FALLBACK_CODEX_MODELS |
+              awk 'NF && !seen[$0]++ { printf "%s%s", sep, $0; sep=" " }'
+          )"
 
           case "$model" in
             *-codex*)
@@ -754,7 +754,10 @@ jobs:
                 "with the configured ChatGPT auth; trying '$DEFAULT_CODEX_MODEL' first."
               model="$DEFAULT_CODEX_MODEL"
               reason="fallback-unsupported-chatgpt-codex-model"
-              candidates="$DEFAULT_CODEX_MODEL $FALLBACK_CODEX_MODELS"
+              candidates="$(
+                printf '%s\n' "$DEFAULT_CODEX_MODEL" $FALLBACK_CODEX_MODELS |
+                  awk 'NF && !seen[$0]++ { printf "%s%s", sep, $0; sep=" " }'
+              )"
               ;;
           esac
 
@@ -1052,6 +1055,54 @@ jobs:
 
           # Exit with original code to mark job as failed if Codex failed
           exit "$CODEX_EXIT"
+
+      - name: Write worker model attempt artifact
+        if: always()
+        env:
+          EXECUTION_PROFILE: ${{ inputs.execution_profile }}
+          WORKER_REQUESTED_MODEL: ${{ inputs.codex_model }}
+          WORKER_FALLBACK_MODELS: ${{ inputs.codex_fallback_models }}
+          WORKER_SELECTED_MODEL: ${{ steps.run_codex.outputs.model }}
+          WORKER_MODEL_SELECTION_REASON: ${{ steps.run_codex.outputs.model-selection-reason }}
+          RUNNER_WORKFLOW: reusable-codex-run
+          CODEX_CLI_VERSION: ${{ inputs.codex_cli_version }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          payload = {
+              "schema": "langsmith-fleet/v1",
+              "operation_role": "worker",
+              "agent": "codex",
+              "runner": os.environ.get("RUNNER_WORKFLOW", ""),
+              "cli_version": os.environ.get("CODEX_CLI_VERSION", ""),
+              "execution_profile": os.environ.get("EXECUTION_PROFILE", ""),
+              "requested_model": os.environ.get("WORKER_REQUESTED_MODEL", ""),
+              "fallback_models": [
+                  item for item in os.environ.get("WORKER_FALLBACK_MODELS", "").split()
+                  if item
+              ],
+              "selected_model": os.environ.get("WORKER_SELECTED_MODEL", ""),
+              "selection_reason": os.environ.get("WORKER_MODEL_SELECTION_REASON", ""),
+              "pr_number": os.environ.get("PR_NUMBER", ""),
+              "emitted_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+          }
+          with open("langsmith-fleet-worker-attempt.json", "w", encoding="utf-8") as fh:
+              json.dump(payload, fh, indent=2, sort_keys=True)
+              fh.write("\n")
+          PY
+
+      - name: Upload worker model attempt artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: langsmith-fleet-v1-worker-attempt-${{ inputs.pr_number || github.run_id }}
+          path: langsmith-fleet-worker-attempt.json
+          retention-days: 30
 
       - name: Analyze Codex session
         id: analyze_session

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -62,6 +62,16 @@ on:
         required: false
         default: 'gpt-5.5'
         type: string
+      codex_fallback_models:
+        description: 'Space-separated fallback Codex model IDs for the selected profile.'
+        required: false
+        default: 'gpt-5.4'
+        type: string
+      execution_profile:
+        description: 'Registry execution profile ID used by caller.'
+        required: false
+        default: 'codex-default'
+        type: string
       codex_args:
         description: 'Optional Codex CLI arguments (string or JSON array).'
         required: false
@@ -133,6 +143,18 @@ on:
       files-changed:
         description: 'Number of files changed by Codex'
         value: ${{ jobs.codex.outputs.files-changed }}
+      worker-profile-id:
+        description: 'Registry execution profile ID supplied by caller'
+        value: ${{ jobs.codex.outputs.worker-profile-id }}
+      worker-requested-model:
+        description: 'Model requested through the registry execution profile'
+        value: ${{ jobs.codex.outputs.worker-requested-model }}
+      worker-selected-model:
+        description: 'Actual Codex model selected after runner fallback'
+        value: ${{ jobs.codex.outputs.worker-selected-model }}
+      worker-model-selection-reason:
+        description: 'Reason for the selected worker model'
+        value: ${{ jobs.codex.outputs.worker-model-selection-reason }}
       error-category:
         description: 'Error category if failure occurred (transient/auth/resource/logic/unknown)'
         value: ${{ jobs.codex.outputs.error-category }}
@@ -205,6 +227,10 @@ jobs:
       changes-made: ${{ steps.commit.outputs.changes-made }}
       commit-sha: ${{ steps.commit.outputs.commit-sha }}
       files-changed: ${{ steps.commit.outputs.files-changed }}
+      worker-profile-id: ${{ inputs.execution_profile }}
+      worker-requested-model: ${{ inputs.codex_model }}
+      worker-selected-model: ${{ steps.run_codex.outputs.model }}
+      worker-model-selection-reason: ${{ steps.run_codex.outputs.model-selection-reason }}
       error-category: ${{ steps.classify_failure.outputs.error_category }}
       error-type: ${{ steps.classify_failure.outputs.error_type }}
       error-recovery: ${{ steps.classify_failure.outputs.error_recovery }}
@@ -702,7 +728,7 @@ jobs:
         id: codex_model
         env:
           DEFAULT_CODEX_MODEL: gpt-5.5
-          FALLBACK_CODEX_MODELS: gpt-5.4
+          FALLBACK_CODEX_MODELS: ${{ inputs.codex_fallback_models }}
           REQUESTED_MODEL: ${{ inputs.codex_model }}
         run: |
           set -euo pipefail

--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -1,4 +1,5 @@
 {
+  "purpose": "Auxiliary judge/evaluator slots only; do not treat these as coding-worker execution profiles.",
   "slots": [
     {
       "name": "slot1",

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -9,7 +9,7 @@
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.97, "T2": 0.97, "T3": 0.98, "T4": 0.98, "T5": 0.98 },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -6,6 +6,15 @@
   "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
   "models": [
     {
+      "model_id": "gpt-5.5",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.97, "T2": 0.97, "T3": 0.98, "T4": 0.98, "T5": 0.98 },
+      "cost_score": 0.18,
+      "speed_score": 0.58,
+      "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
+    },
+    {
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -3,6 +3,7 @@
   "last_updated": "2026-06-29",
   "review_interval_days": 60,
   "review_by": "2026-08-28",
+  "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
   "models": [
     {
       "model_id": "gpt-5.4",

--- a/docs/ci/WORKFLOW_OUTPUTS.md
+++ b/docs/ci/WORKFLOW_OUTPUTS.md
@@ -83,6 +83,10 @@ reusable workflow in the no-output section.
 | `reusable-codex-run.yml` | `changes-made` | string (boolean-like) | Whether Codex made file changes (true/false) | `needs.codex.outputs.changes-made` |
 | `reusable-codex-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed | `needs.codex.outputs.commit-sha` |
 | `reusable-codex-run.yml` | `files-changed` | string (number-like) | Number of files changed by Codex | `needs.codex.outputs.files-changed` |
+| `reusable-codex-run.yml` | `worker-profile-id` | string | Registry execution profile ID supplied by caller | `needs.codex.outputs.worker-profile-id` |
+| `reusable-codex-run.yml` | `worker-requested-model` | string | Model requested through the registry execution profile | `needs.codex.outputs.worker-requested-model` |
+| `reusable-codex-run.yml` | `worker-selected-model` | string | Actual Codex model selected after runner fallback | `needs.codex.outputs.worker-selected-model` |
+| `reusable-codex-run.yml` | `worker-model-selection-reason` | string | Reason for the selected worker model | `needs.codex.outputs.worker-model-selection-reason` |
 | `reusable-codex-run.yml` | `error-category` | string | Error category if failure occurred (transient/auth/resource/logic/unknown) | `needs.codex.outputs.error-category` |
 | `reusable-codex-run.yml` | `error-type` | string | Error type if failure occurred (codex/infrastructure/auth/unknown) | `needs.codex.outputs.error-type` |
 | `reusable-codex-run.yml` | `error-recovery` | string | Suggested recovery action if failure occurred | `needs.codex.outputs.error-recovery` |

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -5,6 +5,24 @@ default_agent: codex
 # Shared keepalive marker prefix (agent-agnostic)
 keepalive_marker_prefix: agent-keepalive
 
+execution_profiles:
+  codex-default:
+    agent: codex
+    model: gpt-5.5
+    fallback_model: gpt-5.4
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+  codex-fast:
+    agent: codex
+    model: gpt-5.4
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: active
+
 agents:
   codex:
     runner_workflow: .github/workflows/reusable-codex-run.yml

--- a/templates/consumer-repo/.github/scripts/agent_registry.js
+++ b/templates/consumer-repo/.github/scripts/agent_registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 const ALLOWED_CAPACITY_WINDOWS = new Set(['5h', 'weekly', 'daily']);
 
@@ -158,8 +159,36 @@ function loadAgentRegistry(options = {}) {
   if (!registry.default_agent || typeof registry.default_agent !== 'string') {
     throw new Error('Agent registry missing required "default_agent" string');
   }
-  validateAgentRegistry(registry);
+  validateAgentRegistry(registry, { registryPath: path });
   return registry;
+}
+
+function resolveModelRegistryPath(options = {}) {
+  if (options.modelRegistryPath) {
+    return options.modelRegistryPath;
+  }
+  const registryPath = options.registryPath || '.github/agents/registry.yml';
+  if (path.isAbsolute(registryPath)) {
+    return path.resolve(path.dirname(registryPath), '..', '..', 'config', 'model_registry.json');
+  }
+  return path.resolve(process.cwd(), 'config', 'model_registry.json');
+}
+
+function loadModelRegistryIds(options = {}) {
+  const modelRegistryPath = resolveModelRegistryPath(options);
+  if (!fs.existsSync(modelRegistryPath)) {
+    return null;
+  }
+  const raw = fs.readFileSync(modelRegistryPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.models)) {
+    throw new Error(`Model registry ${modelRegistryPath} missing required models array`);
+  }
+  return new Set(
+    parsed.models
+      .map((model) => String(model?.model_id || '').trim())
+      .filter(Boolean),
+  );
 }
 
 function validateAgentCapacity(agentKey, agentConfig) {
@@ -184,17 +213,19 @@ function validateAgentCapacity(agentKey, agentConfig) {
   }
 }
 
-function validateAgentRegistry(registry) {
+function validateAgentRegistry(registry, options = {}) {
+  const knownModelIds = loadModelRegistryIds(options);
+
   for (const [agentKey, agentConfig] of Object.entries(registry.agents || {})) {
     validateAgentCapacity(agentKey, agentConfig);
   }
 
   for (const [profileId, profile] of Object.entries(registry.execution_profiles || {})) {
-    validateExecutionProfile(profileId, profile, registry);
+    validateExecutionProfile(profileId, profile, registry, { knownModelIds });
   }
 }
 
-function validateExecutionProfile(profileId, profile, registry) {
+function validateExecutionProfile(profileId, profile, registry, options = {}) {
   if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
     throw new Error(`Execution profile ${profileId} must be an object`);
   }
@@ -205,6 +236,16 @@ function validateExecutionProfile(profileId, profile, registry) {
   for (const field of ['model', 'runner', 'capacity_pool', 'safety', 'lifecycle']) {
     if (!String(profile[field] || '').trim()) {
       throw new Error(`Execution profile ${profileId} missing required field: ${field}`);
+    }
+  }
+  if (options.knownModelIds) {
+    for (const field of ['model', 'fallback_model']) {
+      const modelId = String(profile[field] || '').trim();
+      if (modelId && !options.knownModelIds.has(modelId)) {
+        throw new Error(
+          `Execution profile ${profileId} references unknown ${field}: ${modelId}`,
+        );
+      }
     }
   }
 }

--- a/templates/consumer-repo/.github/scripts/agent_registry.js
+++ b/templates/consumer-repo/.github/scripts/agent_registry.js
@@ -188,6 +188,43 @@ function validateAgentRegistry(registry) {
   for (const [agentKey, agentConfig] of Object.entries(registry.agents || {})) {
     validateAgentCapacity(agentKey, agentConfig);
   }
+
+  for (const [profileId, profile] of Object.entries(registry.execution_profiles || {})) {
+    validateExecutionProfile(profileId, profile, registry);
+  }
+}
+
+function validateExecutionProfile(profileId, profile, registry) {
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new Error(`Execution profile ${profileId} must be an object`);
+  }
+  const agent = String(profile.agent || '').trim();
+  if (!agent || !registry.agents?.[agent]) {
+    throw new Error(`Execution profile ${profileId} references unknown agent: ${agent || '(empty)'}`);
+  }
+  for (const field of ['model', 'runner', 'capacity_pool', 'safety', 'lifecycle']) {
+    if (!String(profile[field] || '').trim()) {
+      throw new Error(`Execution profile ${profileId} missing required field: ${field}`);
+    }
+  }
+}
+
+function resolveExecutionProfile(profileId, options = {}) {
+  const { registryPath } = normalizeRegistryOptions(options);
+  const registry = loadAgentRegistry({ registryPath });
+  const id = String(profileId || '').trim() || 'codex-default';
+  const profile = registry.execution_profiles?.[id];
+  if (!profile) {
+    const known = Object.keys(registry.execution_profiles || {}).sort();
+    throw new Error(
+      `Unknown execution profile: ${id}. Known profiles: ${known.join(', ') || '(none)'}`,
+    );
+  }
+  validateExecutionProfile(id, profile, registry);
+  return {
+    id,
+    ...profile,
+  };
 }
 
 function normalizeLabel(label) {
@@ -373,6 +410,7 @@ module.exports = {
   getRunnerWorkflow,
   loadAgentRegistry,
   parseRegistryYaml,
+  resolveExecutionProfile,
   resolveAgentFromLabels,
   resolveAgentRoutingFromLabels,
   validateAgentRegistry,

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -2837,26 +2837,6 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     });
     const promptMode = promptModeOverride || promptRoute.mode;
     const promptFile = promptFileOverride || promptRoute.file;
-    const requestedExecutionProfile = normalise(
-      config.execution_profile ?? process.env.INPUT_EXECUTION_PROFILE ?? '',
-    ) || 'codex-default';
-    let executionProfile = null;
-    try {
-      const { resolveExecutionProfile } = require('./agent_registry.js');
-      executionProfile = resolveExecutionProfile(requestedExecutionProfile);
-      if (executionProfile.agent !== 'codex') {
-        throw new Error(
-          `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
-        );
-      }
-      core?.info?.(
-        `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
-          `fallback=${executionProfile.fallback_model || ''}`,
-      );
-    } catch (profileError) {
-      throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
-    }
-
     // For verification steps, prefer a different agent than the one that did
     // the implementation work.  This avoids the structural problem where the
     // same model that produced the work also verifies it — a conflict of
@@ -2869,6 +2849,34 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       if (verifierAgentType !== agentType && core) {
         core.info(`Verification step: switching agent from ${agentType} to ${verifierAgentType} for independent verification`);
       }
+    }
+    const resolvedAgentType = isVerificationReason ? verifierAgentType : agentType;
+
+    const requestedExecutionProfile = normalise(config.execution_profile)
+      || normalise(process.env.INPUT_EXECUTION_PROFILE)
+      || 'codex-default';
+    let executionProfile = null;
+    if (AGENT_EXECUTION_ACTIONS.has(action) && resolvedAgentType === 'codex') {
+      try {
+        const { resolveExecutionProfile } = require('./agent_registry.js');
+        executionProfile = resolveExecutionProfile(requestedExecutionProfile);
+        if (executionProfile.agent !== 'codex') {
+          throw new Error(
+            `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
+          );
+        }
+        core?.info?.(
+          `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
+            `fallback=${executionProfile.fallback_model || ''}`,
+        );
+      } catch (profileError) {
+        throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
+      }
+    } else if (core && requestedExecutionProfile !== 'codex-default') {
+      core.info(
+        `Skipping execution profile validation for non-Codex/non-execution action ` +
+          `${resolvedAgentType || '(none)'}/${action || '(none)'}`,
+      );
     }
 
     return {
@@ -2889,7 +2897,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       checkboxCounts,
       hasAgentLabel,
       hasHighPrivilege,
-      agentType: isVerificationReason ? verifierAgentType : agentType,
+      agentType: resolvedAgentType,
       agentRoutingMode,
       delegationReason,
       delegationShouldSwitch,

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -1604,6 +1604,9 @@ function normaliseConfig(config = {}) {
   const promptMode = normalise(cfg.prompt_mode ?? cfg.promptMode);
   const promptFile = normalise(cfg.prompt_file ?? cfg.promptFile);
   const promptScenario = normalise(cfg.prompt_scenario ?? cfg.promptScenario);
+  const executionProfile = normalise(
+    cfg.execution_profile ?? cfg.executionProfile ?? cfg.worker_profile ?? cfg.workerProfile,
+  );
   return {
     keepalive_enabled: toBool(
       cfg.keepalive_enabled ?? cfg.enable_keepalive ?? cfg.keepalive,
@@ -1617,6 +1620,7 @@ function normaliseConfig(config = {}) {
     prompt_mode: promptMode,
     prompt_file: promptFile,
     prompt_scenario: promptScenario,
+    execution_profile: executionProfile,
     verifier_agent: normalise(cfg.verifier_agent),
     progress_review_threshold: cfg.progress_review_threshold != null ? toNumber(cfg.progress_review_threshold, 4) : undefined,
     complete_gate_failure_rounds: cfg.complete_gate_failure_rounds != null ? toNumber(cfg.complete_gate_failure_rounds, 3) : undefined,
@@ -2833,6 +2837,25 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
     });
     const promptMode = promptModeOverride || promptRoute.mode;
     const promptFile = promptFileOverride || promptRoute.file;
+    const requestedExecutionProfile = normalise(
+      config.execution_profile ?? process.env.INPUT_EXECUTION_PROFILE ?? '',
+    ) || 'codex-default';
+    let executionProfile = null;
+    try {
+      const { resolveExecutionProfile } = require('./agent_registry.js');
+      executionProfile = resolveExecutionProfile(requestedExecutionProfile);
+      if (executionProfile.agent !== 'codex') {
+        throw new Error(
+          `Execution profile ${executionProfile.id} routes to ${executionProfile.agent}; keepalive codex runner requires codex`,
+        );
+      }
+      core?.info?.(
+        `Resolved execution profile ${executionProfile.id}: model=${executionProfile.model}, ` +
+          `fallback=${executionProfile.fallback_model || ''}`,
+      );
+    } catch (profileError) {
+      throw new Error(`Invalid keepalive execution profile: ${profileError.message}`);
+    }
 
     // For verification steps, prefer a different agent than the one that did
     // the implementation work.  This avoids the structural problem where the
@@ -2857,6 +2880,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
       reason,
       promptMode,
       promptFile,
+      executionProfile,
       gateConclusion,
       config,
       iteration,

--- a/templates/consumer-repo/config/llm_slots.json
+++ b/templates/consumer-repo/config/llm_slots.json
@@ -1,4 +1,5 @@
 {
+  "purpose": "Auxiliary judge/evaluator slots only; do not treat these as coding-worker execution profiles.",
   "slots": [
     {
       "name": "slot1",

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -9,7 +9,7 @@
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.97, "T2": 0.97, "T3": 0.98, "T4": 0.98, "T5": 0.98 },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -6,6 +6,15 @@
   "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
   "models": [
     {
+      "model_id": "gpt-5.5",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.97, "T2": 0.97, "T3": 0.98, "T4": 0.98, "T5": 0.98 },
+      "cost_score": 0.18,
+      "speed_score": 0.58,
+      "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
+    },
+    {
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -3,6 +3,7 @@
   "last_updated": "2026-06-29",
   "review_interval_days": 60,
   "review_by": "2026-08-28",
+  "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
   "models": [
     {
       "model_id": "gpt-5.4",

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -48,9 +48,17 @@ def _workflow_call_inputs(workflow: dict) -> dict:
     return on_block["workflow_call"]["inputs"]
 
 
-def _codex_run_model_candidates(resolve_step: dict) -> list[str]:
+def _resolve_codex_fallback_models(resolve_step: dict, inputs: dict) -> list[str]:
+    fallback_value = resolve_step["env"]["FALLBACK_CODEX_MODELS"]
+    input_expression = "${{ inputs.codex_fallback_models }}"
+    if fallback_value == input_expression:
+        fallback_value = inputs["codex_fallback_models"]["default"]
+    return fallback_value.split()
+
+
+def _codex_run_model_candidates(resolve_step: dict, inputs: dict) -> list[str]:
     default_model = resolve_step["env"]["DEFAULT_CODEX_MODEL"]
-    fallback_models = resolve_step["env"]["FALLBACK_CODEX_MODELS"].split()
+    fallback_models = _resolve_codex_fallback_models(resolve_step, inputs)
     return [default_model, *fallback_models]
 
 
@@ -267,7 +275,8 @@ def test_reusable_codex_run_prefers_gpt_55_with_non_codex_fallback() -> None:
     assert inputs["codex_cli_version"]["default"] == "0.125.0"
     assert resolve_step.get("id") == "codex_model"
     assert resolve_step["env"]["DEFAULT_CODEX_MODEL"] == "gpt-5.5"
-    assert resolve_step["env"]["FALLBACK_CODEX_MODELS"] == "gpt-5.4"
+    assert inputs["codex_fallback_models"]["default"] == "gpt-5.4"
+    assert resolve_step["env"]["FALLBACK_CODEX_MODELS"] == "${{ inputs.codex_fallback_models }}"
     assert "fallback-unsupported-chatgpt-codex-model" in resolve_step["run"]
     assert "*-codex*" in resolve_step["run"]
     assert '[ "$model" = "$DEFAULT_CODEX_MODEL" ]' in resolve_step["run"]
@@ -286,7 +295,7 @@ def test_reusable_codex_run_model_cli_compatibility_contract() -> None:
     resolve_step = _find_step_by_name(workflow, "Resolve Codex run model")
 
     installed_cli = _parse_version_tuple(inputs["codex_cli_version"]["default"])
-    candidates = _codex_run_model_candidates(resolve_step)
+    candidates = _codex_run_model_candidates(resolve_step, inputs)
     unreviewed_models = [model for model in candidates if model not in MIN_CODEX_CLI_BY_RUN_MODEL]
     assert not unreviewed_models, (
         "Reusable Codex run model candidates need an explicit reviewed minimum CLI mapping: "

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -279,8 +279,9 @@ def test_reusable_codex_run_prefers_gpt_55_with_non_codex_fallback() -> None:
     assert resolve_step["env"]["FALLBACK_CODEX_MODELS"] == "${{ inputs.codex_fallback_models }}"
     assert "fallback-unsupported-chatgpt-codex-model" in resolve_step["run"]
     assert "*-codex*" in resolve_step["run"]
-    assert '[ "$model" = "$DEFAULT_CODEX_MODEL" ]' in resolve_step["run"]
-    assert 'candidates="$DEFAULT_CODEX_MODEL $FALLBACK_CODEX_MODELS"' in resolve_step["run"]
+    assert 'printf \'%s\\n\' "$model" "${fallback_models[@]}"' in resolve_step["run"]
+    assert 'printf \'%s\\n\' "$DEFAULT_CODEX_MODEL" "${fallback_models[@]}"' in resolve_step["run"]
+    assert "awk 'NF && !seen[$0]++" in resolve_step["run"]
     assert "gpt-5.3-codex" not in resolve_step["run"]
 
     assert "CODEX_MODEL_CANDIDATES" in run_step["env"]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2742 -->
> **Source:** Issue #2742

Closes #2742

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Workflows is close to supporting remote model choice but does not wire it through Keepalive. On verified `origin/main`, `.github/workflows/reusable-codex-run.yml:55-64` accepts `codex_model`, resolves/falls back it at `:700-746`, runs Codex with `--model` at `:925-979`, and emits selected-model details at `:990-1000`. The Keepalive caller at `.github/workflows/agents-keepalive-loop.yml:687-715` does not pass that input. Routing remains agent-label only (`docs/keepalive/MULTI_AGENT_ROUTING.md:10-21`), and `.github/agents/registry.yml` has no registry-backed execution profile.

Missing behavior: a local provider/model decision cannot reach the remote coding worker or return causally valid requested/resolved worker identity; evaluator telemetry can currently be mistaken for worker identity.

#### Tasks
- [ ] Add registry-backed allowed execution profile IDs and fallback chains to `.github/agents/registry.yml` or a companion versioned registry, including exact model, runner, capacity-pool references, safety defaults, and lifecycle state.
- [ ] Add a validated profile input to `.github/workflows/agents-keepalive-loop.yml` and pass the corresponding exact model into `.github/workflows/reusable-codex-run.yml`; reject unknown profiles before worker execution.
- [ ] Extend the runner's `langsmith-fleet/v1` artifact to emit operation role `worker`, profile ID, requested model, selected/resolved model, fallback reason, and runner/CLI version separately from evaluator/verifier traces.
- [ ] Update `config/model_registry.json` and `config/llm_slots.json` documentation so auxiliary judge models are not confused with coding-worker profiles.
- [ ] Update `templates/consumer-repo` workflow/registry copies and Workflows freshness/sync tests from the canonical source.

#### Acceptance criteria
- [ ] A Workflows keepalive contract test proves a known profile reaches `reusable-codex-run.yml` and its exact model reaches the Codex command.
- [ ] An unknown profile fails before any coding worker step starts and emits a bounded registry-validation reason.
- [ ] A fallback fixture emits both requested and selected/resolved worker models plus fallback reason as a worker attempt; evaluator traces remain separate.
- [ ] Template freshness tests prove the root workflow, consumer workflow, and registry contract remain synchronized.
- [ ] Deliberate break: in the call currently rooted at `.github/workflows/agents-keepalive-loop.yml:687-715`, delete only the new `execution_profile`/`codex_model` forwarding line; run exact test `.github/scripts/__tests__/keepalive-model-profile-contract.test.js::profile reaches codex runner` via `node --test .github/scripts/__tests__/keepalive-model-profile-contract.test.js --test-name-pattern='profile reaches codex runner'`; observe `AssertionError: expected selected profile model in reusable runner inputs`; revert and show the exact test passes.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Codex execution profiles, including default and fast options.
  - Keepalive workflows now accept an execution profile and route model selections accordingly.
  - Added configurable fallback models when the preferred model is unavailable.
  - Workflow results now report the selected profile, model, and selection details.

- **Bug Fixes**
  - Added validation and clear errors for unknown or incomplete execution profiles.

- **Documentation**
  - Clarified the distinction between coding-worker profiles and auxiliary evaluator model catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->