### PR TITLE
Issue #2743: Record backplane registry evidence

### DIFF
--- a/.github/workflows/health-78-backplane-contract.yml
+++ b/.github/workflows/health-78-backplane-contract.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Registry lifecycle and evidence validation
         run: |
+          set -o pipefail
           python scripts/validate_backplane_registry.py --json \
             | tee artifacts/backplane-contract/registry-status.json
 

--- a/.github/workflows/health-78-backplane-contract.yml
+++ b/.github/workflows/health-78-backplane-contract.yml
@@ -22,8 +22,10 @@ on:
       - 'docs/contracts/schemas/**'
       - 'config/backplane_participants.json'
       - 'scripts/validate_run_contract.py'
+      - 'scripts/validate_backplane_registry.py'
       - 'tests/fixtures/backplane/**'
       - 'tests/contracts/**'
+      - 'tests/test_backplane_registry.py'
       - '.github/workflows/health-78-backplane-contract.yml'
   push:
     branches: [main]
@@ -31,6 +33,7 @@ on:
       - 'docs/contracts/schemas/**'
       - 'config/backplane_participants.json'
       - 'scripts/validate_run_contract.py'
+      - 'scripts/validate_backplane_registry.py'
       - 'tests/fixtures/backplane/**'
 
 permissions:
@@ -73,6 +76,11 @@ jobs:
             --repo stranske/Workflows \
             tests/fixtures/backplane/valid_run.json \
             | tee artifacts/backplane-contract/self-smoke.txt
+
+      - name: Registry lifecycle and evidence validation
+        run: |
+          python scripts/validate_backplane_registry.py --json \
+            | tee artifacts/backplane-contract/registry-status.json
 
       - name: Documented invalid-fixture smoke (must exit 1)
         run: |

--- a/config/backplane_participants.json
+++ b/config/backplane_participants.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "backplane-participants/v1",
   "contract": "run-contract/v1",
-  "parent_issue": "stranske/Workflows#TBD-P0",
+  "parent_issue": "stranske/Workflows#2743",
   "stale_after_hours": 168,
-  "note": "Opt-in registry for the research-backplane interoperability contract (run-contract/v1). Workflows home: config/backplane_participants.json. Participation is OPT-IN and ROLE-BASED, not binary in/out: a repo participates only if it appears here with a non-'none', non-'candidate' status. Absence (or status none/candidate) == the contract does not apply and the conformance gate is a no-op. Modeled on config/langsmith_fleet_registry.json. Each participant declares a 'role': 'producer' (emits a run-contract/v1 run.json; the gate validates full emission), 'consumer' (ingests backplane artifacts only -- the gate validates ONLY the schemas listed in 'ingests', never full run-contract emission), or 'bridge' (both). 'tier_role' is the descriptive fleet role (reference-tool, identity-source, etc.). status lifecycle: planned -> emitting -> conformant; 'candidate' marks a role-architecture placeholder the gate skips (used to capture a cross-over relationship before it is activated). required_sections lists which optional run-contract/v1 sections are MANDATORY for that producer (so a tool is never failed for omitting a section out of its role, e.g. a Monte Carlo engine omits evidence/identity).",
+  "note": "Opt-in registry for the research-backplane interoperability contract (run-contract/v1). Workflows home: config/backplane_participants.json. Participation is OPT-IN and ROLE-BASED, not binary in/out: a repo participates only if it appears here with a non-'none', non-'candidate' status. Absence (or status none/candidate) == the contract does not apply and the conformance gate is a no-op. Modeled on config/langsmith_fleet_registry.json. Each participant declares a 'role': 'producer' (emits a run-contract/v1 run.json; the gate validates full emission), 'consumer' (ingests backplane artifacts only -- the gate validates ONLY the schemas listed in 'ingests', never full run-contract emission), or 'bridge' (both). 'tier_role' is the descriptive fleet role (reference-tool, identity-source, etc.). status lifecycle: planned -> emitting -> conformant; 'candidate' marks a role-architecture placeholder the gate skips (used to capture a cross-over relationship before it is activated). required_sections lists which optional run-contract/v1 sections are MANDATORY for that producer (so a tool is never failed for omitting a section out of its role, e.g. a Monte Carlo engine omits evidence/identity). Registry issue links must be real GitHub issue references or explicit deferred decisions; reference_state tracks missing/invalid/stale/valid evidence separately from lifecycle status.",
   "participants": [
     {
       "repo": "stranske/Pension-Data",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Pension-Data#TBD-P2",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": "stranske/Pension-Data#703",
       "contract_version": "run-contract/v1",
       "tier": 1,
       "role": "producer",
@@ -29,13 +29,46 @@
         "identity_refs",
         "data_quality"
       ],
-      "status": "planned",
-      "rationale": "Readiest in the fleet (6-standard sum 15/18). Already has run ledgers, named artifacts, 3/3 artifact_discipline and identity_map, page-level evidence. The proof-of-concept producer (P2). Gap is the unified query/NL run envelope + cost capture + evidence excerpt/method."
+      "status": "conformant",
+      "rationale": "Readiest in the fleet (6-standard sum 15/18). Already has run ledgers, named artifacts, 3/3 artifact_discipline and identity_map, page-level evidence. The proof-of-concept producer (P2). Gap is the unified query/NL run envelope + cost capture + evidence excerpt/method.",
+      "reference_state": "valid",
+      "lifecycle_history": [
+        {
+          "status": "planned",
+          "at": "2026-07-10T02:32:58Z",
+          "evidence": "stranske/Workflows#2743"
+        },
+        {
+          "status": "emitting",
+          "at": "2026-07-10T08:33:19Z",
+          "evidence": "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320785773"
+        },
+        {
+          "status": "conformant",
+          "at": "2026-07-10T08:33:31Z",
+          "evidence": "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619"
+        }
+      ],
+      "reference_run_evidence": {
+        "source_issue": "stranske/Pension-Data#703",
+        "producer_pr": "stranske/Pension-Data#704",
+        "verifier_followup_issue": "stranske/Pension-Data#707",
+        "verifier_followup_pr": "stranske/Pension-Data#708",
+        "run_id": "pension-data-one-pdf-reference",
+        "generated_at": "2026-07-10T08:33:19+00:00",
+        "producer_git_sha": "d0318317e89b1ca721fc01aff007e3e7a5b38640",
+        "emit_reference_run_url": "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320785773",
+        "conformance_run_url": "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619",
+        "reference_run_sha256": "e124f4cf2f8c0d6854d1bb66f1b159e0e87e7df495d54e2132381a7a36cc1c2f",
+        "manifest_artifact_sha256": "2ab5d767cee97ae0afc0a9cca82b9aa27c479e3582d1bf9e3da104fd92464005",
+        "conformance_report_sha256": "be2ab37d0d72e1b6b4cb61e4a427107fd2f752ada992a19cebed2cedc164f328",
+        "disposition_comment": "https://github.com/stranske/Pension-Data/issues/703#issuecomment-4933956374"
+      }
     },
     {
       "repo": "stranske/Trend_Model_Project",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Trend_Model_Project#TBD-P1",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 1,
       "role": "producer",
@@ -55,12 +88,17 @@
         "identity_refs"
       ],
       "status": "planned",
-      "rationale": "Near-verbatim blueprint signature run_simulation(config, returns) -> RunResult (api.py:400); content-addressed run_id (bundle.py:75-81); 3/3 artifact_discipline + ci_reference_runs. evidence is out of role (0/3 N/A for a computational engine), so 'evidence_refs' is intentionally NOT required. Needs the single replayable envelope + cost/latency + structured warnings + a funds/managers identity map."
+      "rationale": "Near-verbatim blueprint signature run_simulation(config, returns) -> RunResult (api.py:400); content-addressed run_id (bundle.py:75-81); 3/3 artifact_discipline + ci_reference_runs. evidence is out of role (0/3 N/A for a computational engine), so 'evidence_refs' is intentionally NOT required. Needs the single replayable envelope + cost/latency + structured warnings + a funds/managers identity map.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Deferred until its producer issue is selected; keep planned and do not fabricate implementation status."
+      },
+      "reference_state": "missing"
     },
     {
       "repo": "stranske/Counter_Risk",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Counter_Risk#TBD-P3",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 1,
       "role": "producer",
@@ -81,12 +119,17 @@
         "data_quality"
       ],
       "status": "planned",
-      "rationale": "Among the readiest (sum 14/18); schema'd manifest, first-class data_quality (3/3), validated name registry (3/3 identity). Candidate THIRD prototype tool. Must first register the console script + add pandas, then enforce manifest_schema end-to-end and add tool/git/python provenance + top-level schema_version. evidence is 1/3 and partly out of role; not required."
+      "rationale": "Among the readiest (sum 14/18); schema'd manifest, first-class data_quality (3/3), validated name registry (3/3 identity). Candidate THIRD prototype tool. Must first register the console script + add pandas, then enforce manifest_schema end-to-end and add tool/git/python provenance + top-level schema_version. evidence is 1/3 and partly out of role; not required.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Deferred until console-script/runtime dependency blockers are resolved in a repo-local issue."
+      },
+      "reference_state": "missing"
     },
     {
       "repo": "stranske/Portable-Alpha-Extension-Model",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Portable-Alpha-Extension-Model#TBD-P3",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 1,
       "role": "producer",
@@ -104,12 +147,17 @@
         "warnings"
       ],
       "status": "planned",
-      "rationale": "Near-ready computational tool (5 of 6 standards strong once ev/id discounted as out-of-role for a Monte Carlo engine). Hashed manifest + verifiable bundle + content-addressed idempotency + CI golden runs. Alternate THIRD tool. Needs the unified run.json that finally captures warnings (currently stderr-only) + a cost stub, and the golden gate flipped from ::warning:: to hard-fail. evidence_objects (0/3 N/A) and identity_map (1/3 N/A) are out of role -> NOT required."
+      "rationale": "Near-ready computational tool (5 of 6 standards strong once ev/id discounted as out-of-role for a Monte Carlo engine). Hashed manifest + verifiable bundle + content-addressed idempotency + CI golden runs. Alternate THIRD tool. Needs the unified run.json that finally captures warnings (currently stderr-only) + a cost stub, and the golden gate flipped from ::warning:: to hard-fail. evidence_objects (0/3 N/A) and identity_map (1/3 N/A) are out of role -> NOT required.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Deferred until unified run envelope and warning/cost capture are selected as repo-local work."
+      },
+      "reference_state": "missing"
     },
     {
       "repo": "stranske/Manager-Database",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Manager-Database#TBD-P3",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 2,
       "role": "producer",
@@ -125,12 +173,17 @@
         "identity_refs"
       ],
       "status": "planned",
-      "rationale": "Tier-2: included as the IDENTITY SOURCE (best-in-fleet identity_map 3/3: canonical manager_id + aliases + cik + lei + registry_ids, live EDGAR resolution). NOT a first-class orchestrated tool in the prototype. Its highest-leverage contribution is surfacing canonical manager/provider IDs the other repos join on. Full RunResult envelope + CI-gating its existing eval thresholds are P3+. Therefore only 'identity_refs' is required at first."
+      "rationale": "Tier-2: included as the IDENTITY SOURCE (best-in-fleet identity_map 3/3: canonical manager_id + aliases + cik + lei + registry_ids, live EDGAR resolution). NOT a first-class orchestrated tool in the prototype. Its highest-leverage contribution is surfacing canonical manager/provider IDs the other repos join on. Full RunResult envelope + CI-gating its existing eval thresholds are P3+. Therefore only 'identity_refs' is required at first.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Deferred until identity-source surfacing is selected as repo-local work."
+      },
+      "reference_state": "missing"
     },
     {
       "repo": "stranske/Inv-Man-Intake",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Inv-Man-Intake#TBD-P3",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 2,
       "role": "producer",
@@ -147,12 +200,17 @@
         "identity_refs"
       ],
       "status": "planned",
-      "rationale": "Tier-2: included as the EVIDENCE SOURCE (evidence_objects 2/3, enforced source-doc+page provenance). NOT a first-class orchestrated tool yet: needs a real ingest(package) entry point + manifest + durable storage and real firm/fund alias resolution (aliases_json hard-coded None) before it can be CALLED. Tool-ification deferred to P3+."
+      "rationale": "Tier-2: included as the EVIDENCE SOURCE (evidence_objects 2/3, enforced source-doc+page provenance). NOT a first-class orchestrated tool yet: needs a real ingest(package) entry point + manifest + durable storage and real firm/fund alias resolution (aliases_json hard-coded None) before it can be CALLED. Tool-ification deferred to P3+.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Deferred until a headless ingest/package entry point and durable manifest work are selected."
+      },
+      "reference_state": "missing"
     },
     {
       "repo": "stranske/learning-management-system",
-      "parent_issue": "stranske/Workflows#TBD-P0",
-      "issue": "stranske/Workflows#TBD-crossover",
+      "parent_issue": "stranske/Workflows#2743",
+      "issue": null,
       "contract_version": "run-contract/v1",
       "tier": 3,
       "role": "consumer",
@@ -165,7 +223,12 @@
       "manifest_name": null,
       "required_sections": [],
       "status": "candidate",
-      "rationale": "CANDIDATE consumer, NOT ACTIVE (status: candidate -> the conformance gate is a no-op for it). Captured architecturally so the cross-over use case is supported: investment-tool evidence objects + canonical identity refs flowing INTO the learning system (e.g. attributing a learning artifact to a source document or a canonical entity). As a CONSUMER it ingests the satellite schemas listed in 'ingests' and is NEVER required to emit a run-contract/v1 run.json. This does NOT make LMS a backplane PRODUCER: LMS remains in the 'excluded' block as a producer (its own EvidenceRecord/MasteryEstimate domain contracts must NOT be conflated with backplane evidence objects). Activating LMS (candidate -> consumer) is a deliberate, reviewable charter decision; P0 only records the architecture."
+      "rationale": "CANDIDATE consumer, NOT ACTIVE (status: candidate -> the conformance gate is a no-op for it). Captured architecturally so the cross-over use case is supported: investment-tool evidence objects + canonical identity refs flowing INTO the learning system (e.g. attributing a learning artifact to a source document or a canonical entity). As a CONSUMER it ingests the satellite schemas listed in 'ingests' and is NEVER required to emit a run-contract/v1 run.json. This does NOT make LMS a backplane PRODUCER: LMS remains in the 'excluded' block as a producer (its own EvidenceRecord/MasteryEstimate domain contracts must NOT be conflated with backplane evidence objects). Activating LMS (candidate -> consumer) is a deliberate, reviewable charter decision; P0 only records the architecture.",
+      "issue_deferred": {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "Candidate consumer only; activation needs a separate charter decision before any active issue."
+      },
+      "reference_state": "not-applicable"
     }
   ],
   "excluded": [
@@ -186,5 +249,6 @@
       "repo": "stranske/Workflows",
       "reason": "Workflows is the CONTRACT OWNER / harness, not a research tool that emits run envelopes. It hosts the contract, schemas, registry, validator, and conformance workflow; it does not conform to the contract as a participant. Mirrors langsmith-fleet rollout_status 'contract-owner'. (Workflows-as-app is explicitly excluded.)"
     }
-  ]
+  ],
+  "updated_at": "2026-07-10T10:08:00Z"
 }

--- a/docs/reports/backplane_registry_status.md
+++ b/docs/reports/backplane_registry_status.md
@@ -1,0 +1,24 @@
+# Backplane Registry Status
+
+Generated from `config/backplane_participants.json` for Workflows #2743.
+
+| Repo | Lifecycle status | Reference state | Issue state |
+| --- | --- | --- | --- |
+| stranske/Pension-Data | conformant | valid | `stranske/Pension-Data#703` |
+| stranske/Trend_Model_Project | planned | missing | deferred until 2026-08-15 |
+| stranske/Counter_Risk | planned | missing | deferred until 2026-08-15 |
+| stranske/Portable-Alpha-Extension-Model | planned | missing | deferred until 2026-08-15 |
+| stranske/Manager-Database | planned | missing | deferred until 2026-08-15 |
+| stranske/Inv-Man-Intake | planned | missing | deferred until 2026-08-15 |
+| stranske/learning-management-system | candidate | not-applicable | deferred until 2026-08-15 |
+
+Pension-Data reference evidence:
+
+- Source issue: `stranske/Pension-Data#703`
+- Producer PR: `stranske/Pension-Data#704`
+- Verifier follow-up: `stranske/Pension-Data#707` / `stranske/Pension-Data#708`
+- Reference run: `pension-data-one-pdf-reference`
+- Emit-reference-run job: `https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320785773`
+- Backplane conformance job: `https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619`
+- Run artifact SHA256: `e124f4cf2f8c0d6854d1bb66f1b159e0e87e7df495d54e2132381a7a36cc1c2f`
+- Manifest artifact SHA256: `2ab5d767cee97ae0afc0a9cca82b9aa27c479e3582d1bf9e3da104fd92464005`

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T11:27:22.615104Z",
+  "emitted_at": "2026-07-10T11:28:56.623808Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:12:19.851890Z",
+  "emitted_at": "2026-07-10T10:14:42.092593Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:28:13.280226Z",
+  "emitted_at": "2026-07-10T10:30:21.106306Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:17:02.634447Z",
+  "emitted_at": "2026-07-10T10:28:13.280226Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T09:06:49.995411Z",
+  "emitted_at": "2026-07-10T10:12:19.851890Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2744",
+  "pr_number": "2747",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:33:08.471961Z",
+  "emitted_at": "2026-07-10T10:35:26.232070Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:14:42.092593Z",
+  "emitted_at": "2026-07-10T10:17:02.634447Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T11:06:12.670347Z",
+  "emitted_at": "2026-07-10T11:27:22.615104Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:35:26.232070Z",
+  "emitted_at": "2026-07-10T11:04:40.802059Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T11:04:40.802059Z",
+  "emitted_at": "2026-07-10T11:06:12.670347Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T10:30:21.106306Z",
+  "emitted_at": "2026-07-10T10:33:08.471961Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T11:28:56.623808Z",
+  "emitted_at": "2026-07-10T12:05:32.834775Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/scripts/validate_backplane_registry.py
+++ b/scripts/validate_backplane_registry.py
@@ -110,6 +110,13 @@ def _validate_reference_evidence(
             findings.append(
                 Finding(f"{prefix}.reference_run_evidence.{key}", "must be issue/PR ref")
             )
+    if _is_issue_ref(entry.get("issue")) and evidence.get("source_issue") != entry["issue"]:
+        findings.append(
+            Finding(
+                f"{prefix}.reference_run_evidence.source_issue",
+                "must match participant issue",
+            )
+        )
 
     run_url_keys = ("emit_reference_run_url", "conformance_run_url")
     for key in run_url_keys:
@@ -251,6 +258,10 @@ def validate_registry(registry: Any) -> list[Finding]:
             findings.append(Finding(f"{prefix}.issue", "issue must be a real issue ref"))
 
         if status == "conformant":
+            if not _is_issue_ref(issue):
+                findings.append(
+                    Finding(f"{prefix}.issue", "conformant entry needs a real issue ref")
+                )
             if reference_state != "valid":
                 findings.append(
                     Finding(f"{prefix}.reference_state", "conformant entries must be valid")

--- a/scripts/validate_backplane_registry.py
+++ b/scripts/validate_backplane_registry.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate the Workflows-owned research-backplane participant registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ISSUE_REF_RE = re.compile(r"^stranske/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+URL_RE = re.compile(r"^https://github.com/stranske/[A-Za-z0-9_.-]+/(actions/runs|issues|pull)/")
+STATUSES = {"planned", "emitting", "conformant", "candidate", "none"}
+REFERENCE_STATES = {"missing", "invalid", "stale", "valid", "not-applicable"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    message: str
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _walk_strings(value: Any, path: str = "") -> list[Finding]:
+    findings: list[Finding] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else key
+            findings.extend(_walk_strings(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            findings.extend(_walk_strings(child, f"{path}[{index}]"))
+    elif isinstance(value, str) and "TBD" in value:
+        findings.append(Finding(path, "placeholder TBD reference is not allowed"))
+    return findings
+
+
+def _is_issue_ref(value: Any) -> bool:
+    return isinstance(value, str) and bool(ISSUE_REF_RE.fullmatch(value))
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _validate_deferred_issue(entry: dict[str, Any], prefix: str) -> list[Finding]:
+    findings: list[Finding] = []
+    deferred = entry.get("issue_deferred")
+    if not isinstance(deferred, dict):
+        return [
+            Finding(f"{prefix}.issue", "issue must be a real issue ref or carry issue_deferred")
+        ]
+    if not deferred.get("reason"):
+        findings.append(Finding(f"{prefix}.issue_deferred.reason", "deferred issue needs a reason"))
+    if _parse_datetime(deferred.get("expires_at")) is None:
+        findings.append(
+            Finding(f"{prefix}.issue_deferred.expires_at", "deferred issue needs ISO timestamp")
+        )
+    return findings
+
+
+def _validate_reference_evidence(entry: dict[str, Any], prefix: str) -> list[Finding]:
+    evidence = entry.get("reference_run_evidence")
+    if not isinstance(evidence, dict):
+        return [Finding(f"{prefix}.reference_run_evidence", "conformant entry needs evidence")]
+
+    findings: list[Finding] = []
+    required_issue_refs = (
+        "source_issue",
+        "producer_pr",
+        "verifier_followup_issue",
+        "verifier_followup_pr",
+    )
+    for key in required_issue_refs:
+        if not _is_issue_ref(evidence.get(key)):
+            findings.append(
+                Finding(f"{prefix}.reference_run_evidence.{key}", "must be issue/PR ref")
+            )
+
+    for key in ("emit_reference_run_url", "conformance_run_url", "disposition_comment"):
+        if not isinstance(evidence.get(key), str) or not URL_RE.match(evidence[key]):
+            findings.append(Finding(f"{prefix}.reference_run_evidence.{key}", "must be GitHub URL"))
+
+    for key in ("reference_run_sha256", "manifest_artifact_sha256", "conformance_report_sha256"):
+        if not isinstance(evidence.get(key), str) or not SHA256_RE.fullmatch(evidence[key]):
+            findings.append(Finding(f"{prefix}.reference_run_evidence.{key}", "must be sha256"))
+
+    if _parse_datetime(evidence.get("generated_at")) is None:
+        findings.append(
+            Finding(f"{prefix}.reference_run_evidence.generated_at", "must be ISO time")
+        )
+    if not evidence.get("run_id"):
+        findings.append(Finding(f"{prefix}.reference_run_evidence.run_id", "must be populated"))
+    return findings
+
+
+def validate_registry(registry: dict[str, Any]) -> list[Finding]:
+    findings = _walk_strings(registry)
+
+    parent_issue = registry.get("parent_issue")
+    if not _is_issue_ref(parent_issue):
+        findings.append(Finding("parent_issue", "parent_issue must be a real issue ref"))
+
+    participants = registry.get("participants")
+    if not isinstance(participants, list) or not participants:
+        findings.append(Finding("participants", "participants must be a non-empty list"))
+        return findings
+
+    seen: set[str] = set()
+    for index, entry in enumerate(participants):
+        prefix = f"participants[{index}]"
+        repo = entry.get("repo")
+        if not isinstance(repo, str) or not repo.startswith("stranske/"):
+            findings.append(Finding(f"{prefix}.repo", "repo must be stranske/<repo>"))
+        elif repo in seen:
+            findings.append(Finding(f"{prefix}.repo", "duplicate participant repo"))
+        else:
+            seen.add(repo)
+
+        if entry.get("parent_issue") != parent_issue:
+            findings.append(Finding(f"{prefix}.parent_issue", "must match registry parent_issue"))
+
+        status = entry.get("status")
+        if status not in STATUSES:
+            findings.append(Finding(f"{prefix}.status", "unknown lifecycle status"))
+
+        reference_state = entry.get("reference_state")
+        if reference_state not in REFERENCE_STATES:
+            findings.append(Finding(f"{prefix}.reference_state", "unknown reference_state"))
+
+        issue = entry.get("issue")
+        if issue is None:
+            findings.extend(_validate_deferred_issue(entry, prefix))
+        elif not _is_issue_ref(issue):
+            findings.append(Finding(f"{prefix}.issue", "issue must be a real issue ref"))
+
+        if status == "conformant":
+            if reference_state != "valid":
+                findings.append(
+                    Finding(f"{prefix}.reference_state", "conformant entries must be valid")
+                )
+            findings.extend(_validate_reference_evidence(entry, prefix))
+        elif reference_state == "valid":
+            findings.append(
+                Finding(f"{prefix}.reference_state", "valid evidence requires conformant status")
+            )
+
+    return findings
+
+
+def _reference_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for entry in registry.get("participants", []):
+        evidence = entry.get("reference_run_evidence") or {}
+        rows.append(
+            {
+                "repo": entry.get("repo"),
+                "lifecycle_status": entry.get("status"),
+                "reference_state": entry.get("reference_state"),
+                "issue": entry.get("issue"),
+                "deferred_until": (entry.get("issue_deferred") or {}).get("expires_at"),
+                "run_id": evidence.get("run_id"),
+                "generated_at": evidence.get("generated_at"),
+                "conformance_run_url": evidence.get("conformance_run_url"),
+            }
+        )
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "registry",
+        type=Path,
+        nargs="?",
+        default=Path("config/backplane_participants.json"),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable report")
+    args = parser.parse_args(argv)
+
+    registry = _load_json(args.registry)
+    findings = validate_registry(registry)
+    report = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "ok": not findings,
+        "finding_count": len(findings),
+        "findings": [{"path": f.path, "message": f.message} for f in findings],
+        "participants": _reference_rows(registry),
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif findings:
+        print("Backplane registry validation failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"- {finding.path}: {finding.message}", file=sys.stderr)
+    else:
+        print("Backplane registry validation passed.")
+
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_backplane_registry.py
+++ b/scripts/validate_backplane_registry.py
@@ -8,13 +8,18 @@ import json
 import re
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 ISSUE_REF_RE = re.compile(r"^stranske/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
-URL_RE = re.compile(r"^https://github.com/stranske/[A-Za-z0-9_.-]+/(actions/runs|issues|pull)/")
+RUN_JOB_URL_RE = re.compile(
+    r"^https://github\.com/stranske/[A-Za-z0-9_.-]+/actions/runs/[1-9][0-9]*/job/[1-9][0-9]*$"
+)
+ISSUE_COMMENT_URL_RE = re.compile(
+    r"^https://github\.com/stranske/[A-Za-z0-9_.-]+/issues/[1-9][0-9]*#issuecomment-[1-9][0-9]*$"
+)
 STATUSES = {"planned", "emitting", "conformant", "candidate", "none"}
 REFERENCE_STATES = {"missing", "invalid", "stale", "valid", "not-applicable"}
 
@@ -57,6 +62,13 @@ def _parse_datetime(value: Any) -> datetime | None:
         return None
 
 
+def _parse_aware_datetime(value: Any) -> datetime | None:
+    parsed = _parse_datetime(value)
+    if parsed is None or parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
 def _validate_deferred_issue(entry: dict[str, Any], prefix: str) -> list[Finding]:
     findings: list[Finding] = []
     deferred = entry.get("issue_deferred")
@@ -66,14 +78,22 @@ def _validate_deferred_issue(entry: dict[str, Any], prefix: str) -> list[Finding
         ]
     if not deferred.get("reason"):
         findings.append(Finding(f"{prefix}.issue_deferred.reason", "deferred issue needs a reason"))
-    if _parse_datetime(deferred.get("expires_at")) is None:
+    expires_at = _parse_aware_datetime(deferred.get("expires_at"))
+    if expires_at is None:
         findings.append(
-            Finding(f"{prefix}.issue_deferred.expires_at", "deferred issue needs ISO timestamp")
+            Finding(
+                f"{prefix}.issue_deferred.expires_at",
+                "deferred issue needs timezone-aware ISO timestamp",
+            )
         )
+    elif expires_at <= datetime.now(UTC):
+        findings.append(Finding(f"{prefix}.issue_deferred.expires_at", "deferred issue expired"))
     return findings
 
 
-def _validate_reference_evidence(entry: dict[str, Any], prefix: str) -> list[Finding]:
+def _validate_reference_evidence(
+    entry: dict[str, Any], prefix: str, stale_after_hours: int
+) -> list[Finding]:
     evidence = entry.get("reference_run_evidence")
     if not isinstance(evidence, dict):
         return [Finding(f"{prefix}.reference_run_evidence", "conformant entry needs evidence")]
@@ -91,29 +111,108 @@ def _validate_reference_evidence(entry: dict[str, Any], prefix: str) -> list[Fin
                 Finding(f"{prefix}.reference_run_evidence.{key}", "must be issue/PR ref")
             )
 
-    for key in ("emit_reference_run_url", "conformance_run_url", "disposition_comment"):
-        if not isinstance(evidence.get(key), str) or not URL_RE.match(evidence[key]):
-            findings.append(Finding(f"{prefix}.reference_run_evidence.{key}", "must be GitHub URL"))
+    run_url_keys = ("emit_reference_run_url", "conformance_run_url")
+    for key in run_url_keys:
+        if not isinstance(evidence.get(key), str) or not RUN_JOB_URL_RE.fullmatch(evidence[key]):
+            findings.append(
+                Finding(f"{prefix}.reference_run_evidence.{key}", "must be GitHub run job URL")
+            )
+
+    if not isinstance(
+        evidence.get("disposition_comment"), str
+    ) or not ISSUE_COMMENT_URL_RE.fullmatch(evidence["disposition_comment"]):
+        findings.append(
+            Finding(
+                f"{prefix}.reference_run_evidence.disposition_comment",
+                "must be GitHub issue comment URL",
+            )
+        )
 
     for key in ("reference_run_sha256", "manifest_artifact_sha256", "conformance_report_sha256"):
         if not isinstance(evidence.get(key), str) or not SHA256_RE.fullmatch(evidence[key]):
             findings.append(Finding(f"{prefix}.reference_run_evidence.{key}", "must be sha256"))
 
-    if _parse_datetime(evidence.get("generated_at")) is None:
+    generated_at = _parse_aware_datetime(evidence.get("generated_at"))
+    if generated_at is None:
         findings.append(
-            Finding(f"{prefix}.reference_run_evidence.generated_at", "must be ISO time")
+            Finding(
+                f"{prefix}.reference_run_evidence.generated_at",
+                "must be timezone-aware ISO time",
+            )
+        )
+    elif datetime.now(UTC) - generated_at > timedelta(hours=stale_after_hours):
+        findings.append(
+            Finding(f"{prefix}.reference_run_evidence.generated_at", "reference run is stale")
         )
     if not evidence.get("run_id"):
         findings.append(Finding(f"{prefix}.reference_run_evidence.run_id", "must be populated"))
     return findings
 
 
-def validate_registry(registry: dict[str, Any]) -> list[Finding]:
+def _validate_lifecycle_history(entry: dict[str, Any], prefix: str) -> list[Finding]:
+    history = entry.get("lifecycle_history")
+    if not isinstance(history, list):
+        return [Finding(f"{prefix}.lifecycle_history", "conformant entry needs lifecycle history")]
+
+    findings: list[Finding] = []
+    expected = ["planned", "emitting", "conformant"]
+    actual: list[str] = []
+    previous_at: datetime | None = None
+    for index, item in enumerate(history):
+        item_prefix = f"{prefix}.lifecycle_history[{index}]"
+        if not isinstance(item, dict):
+            findings.append(Finding(item_prefix, "lifecycle history entry must be an object"))
+            continue
+
+        status = item.get("status")
+        if isinstance(status, str):
+            actual.append(status)
+        else:
+            findings.append(Finding(f"{item_prefix}.status", "lifecycle status must be populated"))
+
+        at = _parse_aware_datetime(item.get("at"))
+        if at is None:
+            findings.append(Finding(f"{item_prefix}.at", "must be timezone-aware ISO time"))
+        elif previous_at is not None and at < previous_at:
+            findings.append(Finding(f"{item_prefix}.at", "lifecycle timestamps must be monotonic"))
+        elif at is not None:
+            previous_at = at
+
+        evidence = item.get("evidence")
+        evidence_ok = _is_issue_ref(evidence) or (
+            isinstance(evidence, str) and RUN_JOB_URL_RE.fullmatch(evidence)
+        )
+        if not evidence_ok:
+            findings.append(
+                Finding(f"{item_prefix}.evidence", "must be issue ref or GitHub run job URL")
+            )
+
+    if actual != expected:
+        findings.append(
+            Finding(
+                f"{prefix}.lifecycle_history", "must progress planned -> emitting -> conformant"
+            )
+        )
+    return findings
+
+
+def validate_registry(registry: Any) -> list[Finding]:
     findings = _walk_strings(registry)
+
+    if not isinstance(registry, dict):
+        return [Finding("registry", "registry must be an object")]
 
     parent_issue = registry.get("parent_issue")
     if not _is_issue_ref(parent_issue):
         findings.append(Finding("parent_issue", "parent_issue must be a real issue ref"))
+
+    stale_after_hours = registry.get("stale_after_hours", 168)
+    if isinstance(stale_after_hours, bool) or not isinstance(stale_after_hours, int):
+        findings.append(Finding("stale_after_hours", "stale_after_hours must be an integer"))
+        stale_after_hours = 168
+    elif stale_after_hours <= 0:
+        findings.append(Finding("stale_after_hours", "stale_after_hours must be positive"))
+        stale_after_hours = 168
 
     participants = registry.get("participants")
     if not isinstance(participants, list) or not participants:
@@ -123,6 +222,9 @@ def validate_registry(registry: dict[str, Any]) -> list[Finding]:
     seen: set[str] = set()
     for index, entry in enumerate(participants):
         prefix = f"participants[{index}]"
+        if not isinstance(entry, dict):
+            findings.append(Finding(prefix, "participant entry must be an object"))
+            continue
         repo = entry.get("repo")
         if not isinstance(repo, str) or not repo.startswith("stranske/"):
             findings.append(Finding(f"{prefix}.repo", "repo must be stranske/<repo>"))
@@ -153,7 +255,8 @@ def validate_registry(registry: dict[str, Any]) -> list[Finding]:
                 findings.append(
                     Finding(f"{prefix}.reference_state", "conformant entries must be valid")
                 )
-            findings.extend(_validate_reference_evidence(entry, prefix))
+            findings.extend(_validate_lifecycle_history(entry, prefix))
+            findings.extend(_validate_reference_evidence(entry, prefix, stale_after_hours))
         elif reference_state == "valid":
             findings.append(
                 Finding(f"{prefix}.reference_state", "valid evidence requires conformant status")
@@ -165,6 +268,20 @@ def validate_registry(registry: dict[str, Any]) -> list[Finding]:
 def _reference_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
     rows = []
     for entry in registry.get("participants", []):
+        if not isinstance(entry, dict):
+            rows.append(
+                {
+                    "repo": None,
+                    "lifecycle_status": None,
+                    "reference_state": None,
+                    "issue": None,
+                    "deferred_until": None,
+                    "run_id": None,
+                    "generated_at": None,
+                    "conformance_run_url": None,
+                }
+            )
+            continue
         evidence = entry.get("reference_run_evidence") or {}
         rows.append(
             {
@@ -190,6 +307,11 @@ def main(argv: list[str] | None = None) -> int:
         default=Path("config/backplane_participants.json"),
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable report")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Compatibility flag; validation is always strict.",
+    )
     args = parser.parse_args(argv)
 
     registry = _load_json(args.registry)

--- a/scripts/validate_backplane_registry.py
+++ b/scripts/validate_backplane_registry.py
@@ -22,6 +22,7 @@ ISSUE_COMMENT_URL_RE = re.compile(
 )
 STATUSES = {"planned", "emitting", "conformant", "candidate", "none"}
 REFERENCE_STATES = {"missing", "invalid", "stale", "valid", "not-applicable"}
+MAX_STALE_AFTER_HOURS = 24 * 365
 
 
 @dataclass(frozen=True)
@@ -76,7 +77,8 @@ def _validate_deferred_issue(entry: dict[str, Any], prefix: str) -> list[Finding
         return [
             Finding(f"{prefix}.issue", "issue must be a real issue ref or carry issue_deferred")
         ]
-    if not deferred.get("reason"):
+    reason = deferred.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
         findings.append(Finding(f"{prefix}.issue_deferred.reason", "deferred issue needs a reason"))
     expires_at = _parse_aware_datetime(deferred.get("expires_at"))
     if expires_at is None:
@@ -140,6 +142,7 @@ def _validate_reference_evidence(
             findings.append(Finding(f"{prefix}.reference_run_evidence.{key}", "must be sha256"))
 
     generated_at = _parse_aware_datetime(evidence.get("generated_at"))
+    now = datetime.now(UTC)
     if generated_at is None:
         findings.append(
             Finding(
@@ -147,11 +150,16 @@ def _validate_reference_evidence(
                 "must be timezone-aware ISO time",
             )
         )
-    elif datetime.now(UTC) - generated_at > timedelta(hours=stale_after_hours):
+    elif generated_at > now:
+        findings.append(
+            Finding(f"{prefix}.reference_run_evidence.generated_at", "must not be in the future")
+        )
+    elif now - generated_at > timedelta(hours=stale_after_hours):
         findings.append(
             Finding(f"{prefix}.reference_run_evidence.generated_at", "reference run is stale")
         )
-    if not evidence.get("run_id"):
+    run_id = evidence.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
         findings.append(Finding(f"{prefix}.reference_run_evidence.run_id", "must be populated"))
     return findings
 
@@ -219,6 +227,14 @@ def validate_registry(registry: Any) -> list[Finding]:
         stale_after_hours = 168
     elif stale_after_hours <= 0:
         findings.append(Finding("stale_after_hours", "stale_after_hours must be positive"))
+        stale_after_hours = 168
+    elif stale_after_hours > MAX_STALE_AFTER_HOURS:
+        findings.append(
+            Finding(
+                "stale_after_hours",
+                f"stale_after_hours must be <= {MAX_STALE_AFTER_HOURS}",
+            )
+        )
         stale_after_hours = 168
 
     participants = registry.get("participants")

--- a/tests/contracts/test_validate_run_contract.py
+++ b/tests/contracts/test_validate_run_contract.py
@@ -176,7 +176,7 @@ def test_cli_exit_codes(tmp_path, capsys) -> None:
 
 def test_missing_envelope_skips_for_candidate_and_planned_and_absent(tmp_path) -> None:
     # A missing run.json must be an opt-in SKIP (exit 0) for a candidate
-    # consumer (LMS), a not-yet-emitting "planned" producer (Pension-Data), and
+    # consumer (LMS), a not-yet-emitting "planned" producer (Trend), and
     # an absent repo -- the caller's emit-reference-run job legitimately
     # produces nothing until an emitter is wired. Regression guard for the
     # "cannot load run envelope -> exit 2" crash that gated every PR.
@@ -184,7 +184,7 @@ def test_missing_envelope_skips_for_candidate_and_planned_and_absent(tmp_path) -
     missing = tmp_path / "does-not-exist" / "run.json"
     for repo in (
         "stranske/learning-management-system",  # candidate consumer
-        PRODUCER_REPO,  # planned producer
+        "stranske/Trend_Model_Project",  # planned producer
         "stranske/not-a-participant",  # absent
     ):
         rc = mod.main(

--- a/tests/test_backplane_registry.py
+++ b/tests/test_backplane_registry.py
@@ -47,7 +47,9 @@ def test_pension_conformant_entry_has_live_reference_evidence() -> None:
     assert entry["status"] == "conformant"
     assert entry["reference_state"] == "valid"
     evidence = entry["reference_run_evidence"]
+    assert evidence["source_issue"] == "stranske/Pension-Data#703"
     assert evidence["producer_pr"] == "stranske/Pension-Data#704"
+    assert evidence["verifier_followup_issue"] == "stranske/Pension-Data#707"
     assert evidence["verifier_followup_pr"] == "stranske/Pension-Data#708"
     assert evidence["run_id"] == "pension-data-one-pdf-reference"
     assert evidence["reference_run_sha256"] == (
@@ -66,5 +68,103 @@ def test_conformant_requires_reference_evidence() -> None:
     assert any(
         finding.path.endswith("reference_run_evidence.reference_run_sha256")
         and finding.message == "must be sha256"
+        for finding in findings
+    )
+
+
+def test_strict_cli_flag_matches_documented_invocation() -> None:
+    assert vbr.main(["--strict"]) == 0
+
+
+def test_expired_deferred_issue_is_rejected() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = registry["participants"][1]
+    entry["issue_deferred"]["expires_at"] = "2026-01-01T00:00:00Z"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("issue_deferred.expires_at")
+        and finding.message == "deferred issue expired"
+        for finding in findings
+    )
+
+
+def test_stale_reference_run_is_rejected() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["reference_run_evidence"]["generated_at"] = "2026-01-01T00:00:00Z"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("reference_run_evidence.generated_at")
+        and finding.message == "reference run is stale"
+        for finding in findings
+    )
+
+
+def test_reference_urls_are_field_specific_and_complete() -> None:
+    registry = copy.deepcopy(_registry())
+    evidence = _pension_conformant_entry(registry)["reference_run_evidence"]
+    evidence["emit_reference_run_url"] = "https://github.com/stranske/Pension-Data/issues/703"
+    evidence["conformance_run_url"] = (
+        "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619 extra"
+    )
+    evidence["disposition_comment"] = (
+        "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619"
+    )
+
+    findings = vbr.validate_registry(registry)
+
+    messages = {finding.path: finding.message for finding in findings}
+    assert (
+        messages["participants[0].reference_run_evidence.emit_reference_run_url"]
+        == "must be GitHub run job URL"
+    )
+    assert (
+        messages["participants[0].reference_run_evidence.conformance_run_url"]
+        == "must be GitHub run job URL"
+    )
+    assert (
+        messages["participants[0].reference_run_evidence.disposition_comment"]
+        == "must be GitHub issue comment URL"
+    )
+
+
+def test_malformed_participant_returns_finding_instead_of_crashing() -> None:
+    registry = copy.deepcopy(_registry())
+    registry["participants"].append(None)
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == f"participants[{len(registry['participants']) - 1}]"
+        and finding.message == "participant entry must be an object"
+        for finding in findings
+    )
+
+
+def test_conformant_requires_ordered_lifecycle_history() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["lifecycle_history"] = [
+        {
+            "status": "planned",
+            "at": "2026-07-10T02:32:58Z",
+            "evidence": "stranske/Workflows#2743",
+        },
+        {
+            "status": "conformant",
+            "at": "2026-07-10T08:33:31Z",
+            "evidence": "https://github.com/stranske/Pension-Data/actions/runs/29080121547/job/86320867619",
+        },
+    ]
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "participants[0].lifecycle_history"
+        and finding.message == "must progress planned -> emitting -> conformant"
         for finding in findings
     )

--- a/tests/test_backplane_registry.py
+++ b/tests/test_backplane_registry.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from scripts import validate_backplane_registry as vbr
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _registry() -> dict:
+    return json.loads((ROOT / "config" / "backplane_participants.json").read_text())
+
+
+def _pension_conformant_entry(registry: dict) -> dict:
+    for entry in registry["participants"]:
+        if entry["repo"] == "stranske/Pension-Data":
+            return entry
+    raise AssertionError("missing Pension-Data participant")
+
+
+def test_registry_has_no_tbd_placeholders_and_validates() -> None:
+    registry = _registry()
+    findings = vbr.validate_registry(registry)
+
+    assert findings == []
+    assert "TBD" not in json.dumps(registry)
+
+
+def test_parent_issue_and_inactive_participants_are_explicit() -> None:
+    registry = _registry()
+
+    assert registry["parent_issue"] == "stranske/Workflows#2743"
+    for entry in registry["participants"]:
+        assert entry["parent_issue"] == registry["parent_issue"]
+        if entry["repo"] != "stranske/Pension-Data":
+            assert entry["issue"] is None
+            assert entry["issue_deferred"]["reason"]
+            assert entry["reference_state"] in {"missing", "not-applicable"}
+
+
+def test_pension_conformant_entry_has_live_reference_evidence() -> None:
+    entry = _pension_conformant_entry(_registry())
+
+    assert entry["issue"] == "stranske/Pension-Data#703"
+    assert entry["status"] == "conformant"
+    assert entry["reference_state"] == "valid"
+    evidence = entry["reference_run_evidence"]
+    assert evidence["producer_pr"] == "stranske/Pension-Data#704"
+    assert evidence["verifier_followup_pr"] == "stranske/Pension-Data#708"
+    assert evidence["run_id"] == "pension-data-one-pdf-reference"
+    assert evidence["reference_run_sha256"] == (
+        "e124f4cf2f8c0d6854d1bb66f1b159e0e87e7df495d54e2132381a7a36cc1c2f"
+    )
+    assert evidence["conformance_run_url"].endswith("/86320867619")
+
+
+def test_conformant_requires_reference_evidence() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    del entry["reference_run_evidence"]["reference_run_sha256"]
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("reference_run_evidence.reference_run_sha256")
+        and finding.message == "must be sha256"
+        for finding in findings
+    )

--- a/tests/test_backplane_registry.py
+++ b/tests/test_backplane_registry.py
@@ -132,6 +132,38 @@ def test_reference_urls_are_field_specific_and_complete() -> None:
     )
 
 
+def test_conformant_source_issue_must_match_participant_issue() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["reference_run_evidence"]["source_issue"] = "stranske/Pension-Data#707"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("reference_run_evidence.source_issue")
+        and finding.message == "must match participant issue"
+        for finding in findings
+    )
+
+
+def test_conformant_entry_requires_real_issue() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["issue"] = None
+    entry["issue_deferred"] = {
+        "expires_at": "2026-08-15T00:00:00Z",
+        "reason": "invalid for conformant entries",
+    }
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "participants[0].issue"
+        and finding.message == "conformant entry needs a real issue ref"
+        for finding in findings
+    )
+
+
 def test_malformed_participant_returns_finding_instead_of_crashing() -> None:
     registry = copy.deepcopy(_registry())
     registry["participants"].append(None)

--- a/tests/test_backplane_registry.py
+++ b/tests/test_backplane_registry.py
@@ -4,6 +4,7 @@ import copy
 import json
 from pathlib import Path
 
+import pytest
 from scripts import validate_backplane_registry as vbr
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -72,8 +73,43 @@ def test_conformant_requires_reference_evidence() -> None:
     )
 
 
-def test_strict_cli_flag_matches_documented_invocation() -> None:
-    assert vbr.main(["--strict"]) == 0
+@pytest.mark.parametrize("bad_run_id", [123, ["pension-run"], ""])
+def test_reference_run_id_must_be_non_empty_string(bad_run_id: object) -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["reference_run_evidence"]["run_id"] = bad_run_id
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("reference_run_evidence.run_id")
+        and finding.message == "must be populated"
+        for finding in findings
+    )
+
+
+def test_strict_cli_flag_matches_documented_invocation(tmp_path: Path) -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["reference_run_evidence"]["generated_at"] = "2026-07-10T08:33:31Z"
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+    assert vbr.main(["--strict", str(registry_path)]) == 0
+
+
+def test_deferred_issue_reason_must_be_non_empty_string() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = registry["participants"][1]
+    entry["issue_deferred"]["reason"] = {"text": "not a string"}
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("issue_deferred.reason")
+        and finding.message == "deferred issue needs a reason"
+        for finding in findings
+    )
 
 
 def test_expired_deferred_issue_is_rejected() -> None:
@@ -100,6 +136,33 @@ def test_stale_reference_run_is_rejected() -> None:
     assert any(
         finding.path.endswith("reference_run_evidence.generated_at")
         and finding.message == "reference run is stale"
+        for finding in findings
+    )
+
+
+def test_future_reference_run_is_rejected() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["reference_run_evidence"]["generated_at"] = "2999-01-01T00:00:00Z"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path.endswith("reference_run_evidence.generated_at")
+        and finding.message == "must not be in the future"
+        for finding in findings
+    )
+
+
+def test_stale_after_hours_is_bounded() -> None:
+    registry = copy.deepcopy(_registry())
+    registry["stale_after_hours"] = 10**20
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "stale_after_hours"
+        and finding.message == f"stale_after_hours must be <= {vbr.MAX_STALE_AFTER_HOURS}"
         for finding in findings
     )
 
@@ -177,6 +240,24 @@ def test_malformed_participant_returns_finding_instead_of_crashing() -> None:
     )
 
 
+def test_malformed_participant_json_report_returns_finding(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry = copy.deepcopy(_registry())
+    registry["participants"].append(None)
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+    assert vbr.main(["--json", str(registry_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert any(
+        finding["path"] == f"participants[{len(registry['participants']) - 1}]"
+        and finding["message"] == "participant entry must be an object"
+        for finding in report["findings"]
+    )
+
+
 def test_conformant_requires_ordered_lifecycle_history() -> None:
     registry = copy.deepcopy(_registry())
     entry = _pension_conformant_entry(registry)
@@ -198,5 +279,49 @@ def test_conformant_requires_ordered_lifecycle_history() -> None:
     assert any(
         finding.path == "participants[0].lifecycle_history"
         and finding.message == "must progress planned -> emitting -> conformant"
+        for finding in findings
+    )
+
+
+def test_conformant_rejects_missing_lifecycle_history() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    del entry["lifecycle_history"]
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "participants[0].lifecycle_history"
+        and finding.message == "conformant entry needs lifecycle history"
+        for finding in findings
+    )
+
+
+def test_conformant_rejects_decreasing_lifecycle_timestamps() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["lifecycle_history"][2]["at"] = "2026-07-10T01:00:00Z"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "participants[0].lifecycle_history[2].at"
+        and finding.message == "lifecycle timestamps must be monotonic"
+        for finding in findings
+    )
+
+
+def test_conformant_rejects_invalid_lifecycle_evidence() -> None:
+    registry = copy.deepcopy(_registry())
+    entry = _pension_conformant_entry(registry)
+    entry["lifecycle_history"][1][
+        "evidence"
+    ] = "https://github.com/stranske/Pension-Data/issues/703"
+
+    findings = vbr.validate_registry(registry)
+
+    assert any(
+        finding.path == "participants[0].lifecycle_history[1].evidence"
+        and finding.message == "must be issue ref or GitHub run job URL"
         for finding in findings
     )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2743 -->
> **Source:** Issue #2743

Closes #2743

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`config/backplane_participants.json` still contains a `TBD` parent issue and `TBD` participant issue links. Its lifecycle contract is `planned -> emitting -> conformant`, while `docs/contracts/research-backplane-contract.md:95-109` requires central registry truth. Leaving placeholder links and declaring status from schema presence would repeat the built-but-not-flowing failure. Pension-Data should advance only after its participant-owned emitter has produced a real validated reference run.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Pension-Data#703](https://github.com/stranske/Pension-Data/issues/703)
- [#703](https://github.com/stranske/Workflows/issues/703)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Use this issue as the real Workflows parent coordination issue and update `config/backplane_participants.json::parent_issue` to this issue's URL.
- [ ] Replace each participant `TBD` issue with a real issue link or an explicit deferred/retired decision plus expiry; do not fabricate implementation status.
- [x] Create `scripts/validate_backplane_registry.py` and `tests/test_backplane_registry.py` to validate real issue links/deferred expiries, evidence-backed transitions, and reference-run requirements offline.
- [ ] Attach Pension-Data's merged emitter PR, participant conformance run URL, artifact hash, and generated timestamp to the registry/report evidence.
- [ ] Advance Pension-Data `planned -> emitting` when the emitter exists, then `emitting -> conformant` only when the real reference run passes the reusable workflow; preserve transition timestamps/history.
- [ ] Update the backplane health/dashboard so stale/missing/invalid/valid reference state is distinct from participant lifecycle state.

#### Acceptance criteria
- [ ] `python scripts/validate_backplane_registry.py --strict` reports zero `TBD` links and validates every real issue URL/deferred expiry.
- [ ] A registry-transition test rejects `conformant` when the participant CI URL or reference artifact hash is missing/invalid.
- [ ] Pension-Data alone becomes conformant with captured evidence; the other five producers remain planned/deferred and LMS remains candidate/no-op.
- [ ] Deliberate break: in `tests/test_backplane_registry.py::pension_conformant_entry`, delete only `reference_run_sha256`; run `python -m pytest -q tests/test_backplane_registry.py::test_conformant_requires_reference_evidence`; observe `AssertionError: conformant participant lacks reference evidence`; revert and show the exact test passes.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the CI “Backplane Contract Integrity” gate to run on backplane registry updates and added a JSON artifact of the registry validation results.
  * Added automated contract validation for the backplane participants registry, including machine-readable output.
  * Added a generated “Backplane Registry Status” report with repo lifecycle, reference, and issue-state details.
* **Bug Fixes**
  * Invalid registry content—such as placeholder values, mismatched issue references, expired deferred items, stale reference evidence, or incorrect lifecycle ordering—is now rejected.
* **Tests**
  * Added extensive pytest coverage for success and failure cases, including field-specific URL/evidence checks and CLI strict-flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->