### PR TITLE
Add explicit Sol Terra Luna execution profiles

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -22,6 +22,30 @@ execution_profiles:
     capacity_pool: codex-standard
     safety: standard
     lifecycle: active
+  codex-5.6-sol-high:
+    agent: codex
+    model: gpt-5.6-sol
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
+  codex-5.6-terra-high:
+    agent: codex
+    model: gpt-5.6-terra
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
+  codex-5.6-luna-high:
+    agent: codex
+    model: gpt-5.6-luna
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
 
 agents:
   codex:

--- a/.github/scripts/__tests__/agent-registry.test.js
+++ b/.github/scripts/__tests__/agent-registry.test.js
@@ -227,6 +227,23 @@ test('resolveExecutionProfile returns registry-backed codex model contract', () 
   assert.equal(profile.runner, 'reusable-codex-run');
 });
 
+test('resolveExecutionProfile exposes the explicit Sol Terra Luna trial profiles', () => {
+  const expected = {
+    'codex-5.6-sol-high': ['gpt-5.6-sol', 'gpt-5.5'],
+    'codex-5.6-terra-high': ['gpt-5.6-terra', 'gpt-5.5'],
+    'codex-5.6-luna-high': ['gpt-5.6-luna', 'gpt-5.5'],
+  };
+  for (const [profileId, [model, fallback]] of Object.entries(expected)) {
+    const profile = resolveExecutionProfile(profileId, { registryPath: REGISTRY_PATH });
+    assert.equal(profile.agent, 'codex');
+    assert.equal(profile.model, model);
+    assert.equal(profile.fallback_model, fallback);
+    assert.equal(profile.runner, 'reusable-codex-run');
+    assert.equal(profile.capacity_pool, 'codex-standard');
+    assert.equal(profile.lifecycle, 'trial');
+  }
+});
+
 test('resolveExecutionProfile rejects unknown profiles before worker execution', () => {
   assert.throws(
     () => resolveExecutionProfile('does-not-exist', { registryPath: REGISTRY_PATH }),

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -1,15 +1,21 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-29",
+  "last_updated": "2026-07-10",
   "review_interval_days": 60,
-  "review_by": "2026-08-28",
-  "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
+  "review_by": "2026-09-08",
+  "purpose": "Auxiliary judge/evaluator catalog plus explicit coding-worker IDs required for execution-profile validation. Trial worker entries intentionally carry no quality or cost claims.",
   "models": [
     {
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
+      "quality": {
+        "T1": 0.96,
+        "T2": 0.96,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.96
+      },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
@@ -18,7 +24,13 @@
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.97 },
+      "quality": {
+        "T1": 0.96,
+        "T2": 0.96,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.97
+      },
       "cost_score": 0.25,
       "speed_score": 0.64,
       "notes": "Current flagship verifier default. Highest-quality general evaluator."
@@ -27,8 +39,14 @@
       "model_id": "gpt-5.1",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.90, "T3": 0.92, "T4": 0.92, "T5": 0.93 },
-      "cost_score": 0.40,
+      "quality": {
+        "T1": 0.9,
+        "T2": 0.9,
+        "T3": 0.92,
+        "T4": 0.92,
+        "T5": 0.93
+      },
+      "cost_score": 0.4,
       "speed_score": 0.72,
       "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
     },
@@ -36,16 +54,28 @@
       "model_id": "gpt-5.1-codex",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.92, "T3": 0.95, "T4": 0.93, "T5": 0.94 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.92,
+        "T3": 0.95,
+        "T4": 0.93,
+        "T5": 0.94
+      },
       "cost_score": 0.38,
-      "speed_score": 0.70,
+      "speed_score": 0.7,
       "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
     },
     {
       "model_id": "gpt-5.1-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.80, "T3": 0.75, "T4": 0.72, "T5": 0.68 },
+      "quality": {
+        "T1": 0.82,
+        "T2": 0.8,
+        "T3": 0.75,
+        "T4": 0.72,
+        "T5": 0.68
+      },
       "cost_score": 0.82,
       "speed_score": 0.92,
       "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
@@ -54,7 +84,13 @@
       "model_id": "gpt-5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.90, "T4": 0.90, "T5": 0.90 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.88,
+        "T3": 0.9,
+        "T4": 0.9,
+        "T5": 0.9
+      },
       "cost_score": 0.45,
       "speed_score": 0.75,
       "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
@@ -63,7 +99,13 @@
       "model_id": "gpt-5-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.78, "T2": 0.75, "T3": 0.70, "T4": 0.68, "T5": 0.62 },
+      "quality": {
+        "T1": 0.78,
+        "T2": 0.75,
+        "T3": 0.7,
+        "T4": 0.68,
+        "T5": 0.62
+      },
       "cost_score": 0.85,
       "speed_score": 0.93,
       "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
@@ -72,7 +114,13 @@
       "model_id": "gpt-5.4-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.84, "T2": 0.82, "T3": 0.78, "T4": 0.76, "T5": 0.72 },
+      "quality": {
+        "T1": 0.84,
+        "T2": 0.82,
+        "T3": 0.78,
+        "T4": 0.76,
+        "T5": 0.72
+      },
       "cost_score": 0.88,
       "speed_score": 0.94,
       "notes": "High-quality mini. Default for progress review where speed still matters."
@@ -81,7 +129,13 @@
       "model_id": "gpt-5-nano",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.70, "T2": 0.65, "T3": 0.55, "T4": 0.50, "T5": 0.40 },
+      "quality": {
+        "T1": 0.7,
+        "T2": 0.65,
+        "T3": 0.55,
+        "T4": 0.5,
+        "T5": 0.4
+      },
       "cost_score": 0.95,
       "speed_score": 0.98,
       "notes": "Smallest GPT-5. Only suitable for T1 tasks."
@@ -90,17 +144,29 @@
       "model_id": "gpt-4.1",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.88, "T4": 0.87, "T5": 0.88 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.88,
+        "T3": 0.88,
+        "T4": 0.87,
+        "T5": 0.88
+      },
       "cost_score": 0.55,
-      "speed_score": 0.80,
+      "speed_score": 0.8,
       "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
     },
     {
       "model_id": "gpt-4.1-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.65 },
-      "cost_score": 0.90,
+      "quality": {
+        "T1": 0.8,
+        "T2": 0.78,
+        "T3": 0.72,
+        "T4": 0.7,
+        "T5": 0.65
+      },
+      "cost_score": 0.9,
       "speed_score": 0.95,
       "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
     },
@@ -108,17 +174,29 @@
       "model_id": "gpt-4.1-nano",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.68, "T2": 0.63, "T3": 0.52, "T4": 0.48, "T5": 0.38 },
-      "cost_score": 1.00,
-      "speed_score": 1.00,
+      "quality": {
+        "T1": 0.68,
+        "T2": 0.63,
+        "T3": 0.52,
+        "T4": 0.48,
+        "T5": 0.38
+      },
+      "cost_score": 1,
+      "speed_score": 1,
       "notes": "Cheapest and fastest. Only for trivial classification."
     },
     {
       "model_id": "codex-mini-latest",
       "provider": "github-models",
       "api": "chat",
-      "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
-      "cost_score": 0.80,
+      "quality": {
+        "T1": 0.75,
+        "T2": 0.8,
+        "T3": 0.78,
+        "T4": 0.72,
+        "T5": 0.65
+      },
+      "cost_score": 0.8,
       "speed_score": 0.88,
       "notes": "Rolling Codex alias. Good for code-centric extraction."
     },
@@ -126,8 +204,14 @@
       "model_id": "o4-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.88, "T3": 0.92, "T4": 0.88, "T5": 0.93 },
-      "cost_score": 0.30,
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.88,
+        "T3": 0.92,
+        "T4": 0.88,
+        "T5": 0.93
+      },
+      "cost_score": 0.3,
       "speed_score": 0.35,
       "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
     },
@@ -135,7 +219,13 @@
       "model_id": "o3",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.92, "T3": 0.95, "T4": 0.92, "T5": 0.96 },
+      "quality": {
+        "T1": 0.9,
+        "T2": 0.92,
+        "T3": 0.95,
+        "T4": 0.92,
+        "T5": 0.96
+      },
       "cost_score": 0.15,
       "speed_score": 0.15,
       "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
@@ -144,25 +234,43 @@
       "model_id": "o3-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.83, "T2": 0.85, "T3": 0.88, "T4": 0.85, "T5": 0.90 },
+      "quality": {
+        "T1": 0.83,
+        "T2": 0.85,
+        "T3": 0.88,
+        "T4": 0.85,
+        "T5": 0.9
+      },
       "cost_score": 0.35,
-      "speed_score": 0.30,
+      "speed_score": 0.3,
       "notes": "Legacy reasoning mini. Superseded by o4-mini."
     },
     {
       "model_id": "gpt-4o",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.85, "T4": 0.84, "T5": 0.84 },
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.85,
+        "T3": 0.85,
+        "T4": 0.84,
+        "T5": 0.84
+      },
       "cost_score": 0.55,
-      "speed_score": 0.80,
+      "speed_score": 0.8,
       "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
     },
     {
       "model_id": "gpt-4o-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.60, "T2": 0.55, "T3": 0.45, "T4": 0.40, "T5": 0.30 },
+      "quality": {
+        "T1": 0.6,
+        "T2": 0.55,
+        "T3": 0.45,
+        "T4": 0.4,
+        "T5": 0.3
+      },
       "cost_score": 0.78,
       "speed_score": 0.88,
       "blocked": true,
@@ -172,7 +280,13 @@
       "model_id": "claude-opus-4-6",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.93, "T2": 0.94, "T3": 0.96, "T4": 0.96, "T5": 0.98 },
+      "quality": {
+        "T1": 0.93,
+        "T2": 0.94,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.98
+      },
       "cost_score": 0.08,
       "speed_score": 0.38,
       "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
@@ -181,16 +295,28 @@
       "model_id": "claude-opus-4-5",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.92, "T2": 0.93, "T3": 0.95, "T4": 0.95, "T5": 0.97 },
-      "cost_score": 0.10,
-      "speed_score": 0.40,
+      "quality": {
+        "T1": 0.92,
+        "T2": 0.93,
+        "T3": 0.95,
+        "T4": 0.95,
+        "T5": 0.97
+      },
+      "cost_score": 0.1,
+      "speed_score": 0.4,
       "notes": "Opus tier. Overkill for most tasks, great for T5."
     },
     {
       "model_id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.91, "T2": 0.91, "T3": 0.93, "T4": 0.93, "T5": 0.95 },
+      "quality": {
+        "T1": 0.91,
+        "T2": 0.91,
+        "T3": 0.93,
+        "T4": 0.93,
+        "T5": 0.95
+      },
       "cost_score": 0.35,
       "speed_score": 0.63,
       "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
@@ -199,8 +325,14 @@
       "model_id": "claude-sonnet-4-0",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.88, "T4": 0.88, "T5": 0.90 },
-      "cost_score": 0.40,
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.85,
+        "T3": 0.88,
+        "T4": 0.88,
+        "T5": 0.9
+      },
+      "cost_score": 0.4,
       "speed_score": 0.65,
       "notes": "Previous Sonnet. Proven but superseded by 4-5."
     },
@@ -208,19 +340,58 @@
       "model_id": "claude-haiku-4-5",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.62 },
+      "quality": {
+        "T1": 0.8,
+        "T2": 0.78,
+        "T3": 0.72,
+        "T4": 0.7,
+        "T5": 0.62
+      },
       "cost_score": 0.75,
-      "speed_score": 0.90,
+      "speed_score": 0.9,
       "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
     },
     {
       "model_id": "claude-3-7-sonnet-latest",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.82, "T3": 0.85, "T4": 0.85, "T5": 0.87 },
+      "quality": {
+        "T1": 0.82,
+        "T2": 0.82,
+        "T3": 0.85,
+        "T4": 0.85,
+        "T5": 0.87
+      },
       "cost_score": 0.42,
       "speed_score": 0.65,
       "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
+    },
+    {
+      "model_id": "gpt-5.6-sol",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-sol; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.6-terra",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-terra; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.6-luna",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-luna; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
     }
   ]
 }

--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -9,13 +9,7 @@
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": {
-        "T1": 0.96,
-        "T2": 0.96,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.96
-      },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
@@ -24,347 +18,10 @@
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",
-      "quality": {
-        "T1": 0.96,
-        "T2": 0.96,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.97
-      },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.97 },
       "cost_score": 0.25,
       "speed_score": 0.64,
       "notes": "Current flagship verifier default. Highest-quality general evaluator."
-    },
-    {
-      "model_id": "gpt-5.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.9,
-        "T2": 0.9,
-        "T3": 0.92,
-        "T4": 0.92,
-        "T5": 0.93
-      },
-      "cost_score": 0.4,
-      "speed_score": 0.72,
-      "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
-    },
-    {
-      "model_id": "gpt-5.1-codex",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.92,
-        "T3": 0.95,
-        "T4": 0.93,
-        "T5": 0.94
-      },
-      "cost_score": 0.38,
-      "speed_score": 0.7,
-      "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
-    },
-    {
-      "model_id": "gpt-5.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.82,
-        "T2": 0.8,
-        "T3": 0.75,
-        "T4": 0.72,
-        "T5": 0.68
-      },
-      "cost_score": 0.82,
-      "speed_score": 0.92,
-      "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
-    },
-    {
-      "model_id": "gpt-5",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.88,
-        "T3": 0.9,
-        "T4": 0.9,
-        "T5": 0.9
-      },
-      "cost_score": 0.45,
-      "speed_score": 0.75,
-      "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
-    },
-    {
-      "model_id": "gpt-5-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.78,
-        "T2": 0.75,
-        "T3": 0.7,
-        "T4": 0.68,
-        "T5": 0.62
-      },
-      "cost_score": 0.85,
-      "speed_score": 0.93,
-      "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
-    },
-    {
-      "model_id": "gpt-5.4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.84,
-        "T2": 0.82,
-        "T3": 0.78,
-        "T4": 0.76,
-        "T5": 0.72
-      },
-      "cost_score": 0.88,
-      "speed_score": 0.94,
-      "notes": "High-quality mini. Default for progress review where speed still matters."
-    },
-    {
-      "model_id": "gpt-5-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.7,
-        "T2": 0.65,
-        "T3": 0.55,
-        "T4": 0.5,
-        "T5": 0.4
-      },
-      "cost_score": 0.95,
-      "speed_score": 0.98,
-      "notes": "Smallest GPT-5. Only suitable for T1 tasks."
-    },
-    {
-      "model_id": "gpt-4.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.88,
-        "T3": 0.88,
-        "T4": 0.87,
-        "T5": 0.88
-      },
-      "cost_score": 0.55,
-      "speed_score": 0.8,
-      "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
-    },
-    {
-      "model_id": "gpt-4.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.8,
-        "T2": 0.78,
-        "T3": 0.72,
-        "T4": 0.7,
-        "T5": 0.65
-      },
-      "cost_score": 0.9,
-      "speed_score": 0.95,
-      "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
-    },
-    {
-      "model_id": "gpt-4.1-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.68,
-        "T2": 0.63,
-        "T3": 0.52,
-        "T4": 0.48,
-        "T5": 0.38
-      },
-      "cost_score": 1,
-      "speed_score": 1,
-      "notes": "Cheapest and fastest. Only for trivial classification."
-    },
-    {
-      "model_id": "codex-mini-latest",
-      "provider": "github-models",
-      "api": "chat",
-      "quality": {
-        "T1": 0.75,
-        "T2": 0.8,
-        "T3": 0.78,
-        "T4": 0.72,
-        "T5": 0.65
-      },
-      "cost_score": 0.8,
-      "speed_score": 0.88,
-      "notes": "Rolling Codex alias. Good for code-centric extraction."
-    },
-    {
-      "model_id": "o4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.88,
-        "T3": 0.92,
-        "T4": 0.88,
-        "T5": 0.93
-      },
-      "cost_score": 0.3,
-      "speed_score": 0.35,
-      "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
-    },
-    {
-      "model_id": "o3",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.9,
-        "T2": 0.92,
-        "T3": 0.95,
-        "T4": 0.92,
-        "T5": 0.96
-      },
-      "cost_score": 0.15,
-      "speed_score": 0.15,
-      "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
-    },
-    {
-      "model_id": "o3-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.83,
-        "T2": 0.85,
-        "T3": 0.88,
-        "T4": 0.85,
-        "T5": 0.9
-      },
-      "cost_score": 0.35,
-      "speed_score": 0.3,
-      "notes": "Legacy reasoning mini. Superseded by o4-mini."
-    },
-    {
-      "model_id": "gpt-4o",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.85,
-        "T3": 0.85,
-        "T4": 0.84,
-        "T5": 0.84
-      },
-      "cost_score": 0.55,
-      "speed_score": 0.8,
-      "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
-    },
-    {
-      "model_id": "gpt-4o-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.6,
-        "T2": 0.55,
-        "T3": 0.45,
-        "T4": 0.4,
-        "T5": 0.3
-      },
-      "cost_score": 0.78,
-      "speed_score": 0.88,
-      "blocked": true,
-      "notes": "BLOCKED: Documented as too lenient, passes obvious deficiencies."
-    },
-    {
-      "model_id": "claude-opus-4-6",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.93,
-        "T2": 0.94,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.98
-      },
-      "cost_score": 0.08,
-      "speed_score": 0.38,
-      "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
-    },
-    {
-      "model_id": "claude-opus-4-5",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.92,
-        "T2": 0.93,
-        "T3": 0.95,
-        "T4": 0.95,
-        "T5": 0.97
-      },
-      "cost_score": 0.1,
-      "speed_score": 0.4,
-      "notes": "Opus tier. Overkill for most tasks, great for T5."
-    },
-    {
-      "model_id": "claude-sonnet-4-6",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.91,
-        "T2": 0.91,
-        "T3": 0.93,
-        "T4": 0.93,
-        "T5": 0.95
-      },
-      "cost_score": 0.35,
-      "speed_score": 0.63,
-      "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
-    },
-    {
-      "model_id": "claude-sonnet-4-0",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.85,
-        "T3": 0.88,
-        "T4": 0.88,
-        "T5": 0.9
-      },
-      "cost_score": 0.4,
-      "speed_score": 0.65,
-      "notes": "Previous Sonnet. Proven but superseded by 4-5."
-    },
-    {
-      "model_id": "claude-haiku-4-5",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.8,
-        "T2": 0.78,
-        "T3": 0.72,
-        "T4": 0.7,
-        "T5": 0.62
-      },
-      "cost_score": 0.75,
-      "speed_score": 0.9,
-      "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
-    },
-    {
-      "model_id": "claude-3-7-sonnet-latest",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.82,
-        "T2": 0.82,
-        "T3": 0.85,
-        "T4": 0.85,
-        "T5": 0.87
-      },
-      "cost_score": 0.42,
-      "speed_score": 0.65,
-      "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
     },
     {
       "model_id": "gpt-5.6-sol",
@@ -392,6 +49,205 @@
       "lifecycle": "trial",
       "quality": {},
       "notes": "Coding-worker trial profile gpt-5.6-luna; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.1",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.90, "T2": 0.90, "T3": 0.92, "T4": 0.92, "T5": 0.93 },
+      "cost_score": 0.40,
+      "speed_score": 0.72,
+      "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
+    },
+    {
+      "model_id": "gpt-5.1-codex",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.92, "T3": 0.95, "T4": 0.93, "T5": 0.94 },
+      "cost_score": 0.38,
+      "speed_score": 0.70,
+      "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
+    },
+    {
+      "model_id": "gpt-5.1-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.82, "T2": 0.80, "T3": 0.75, "T4": 0.72, "T5": 0.68 },
+      "cost_score": 0.82,
+      "speed_score": 0.92,
+      "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
+    },
+    {
+      "model_id": "gpt-5",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.90, "T4": 0.90, "T5": 0.90 },
+      "cost_score": 0.45,
+      "speed_score": 0.75,
+      "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
+    },
+    {
+      "model_id": "gpt-5-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.78, "T2": 0.75, "T3": 0.70, "T4": 0.68, "T5": 0.62 },
+      "cost_score": 0.85,
+      "speed_score": 0.93,
+      "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
+    },
+    {
+      "model_id": "gpt-5.4-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.84, "T2": 0.82, "T3": 0.78, "T4": 0.76, "T5": 0.72 },
+      "cost_score": 0.88,
+      "speed_score": 0.94,
+      "notes": "High-quality mini. Default for progress review where speed still matters."
+    },
+    {
+      "model_id": "gpt-5-nano",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.70, "T2": 0.65, "T3": 0.55, "T4": 0.50, "T5": 0.40 },
+      "cost_score": 0.95,
+      "speed_score": 0.98,
+      "notes": "Smallest GPT-5. Only suitable for T1 tasks."
+    },
+    {
+      "model_id": "gpt-4.1",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.88, "T4": 0.87, "T5": 0.88 },
+      "cost_score": 0.55,
+      "speed_score": 0.80,
+      "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
+    },
+    {
+      "model_id": "gpt-4.1-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.65 },
+      "cost_score": 0.90,
+      "speed_score": 0.95,
+      "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
+    },
+    {
+      "model_id": "gpt-4.1-nano",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.68, "T2": 0.63, "T3": 0.52, "T4": 0.48, "T5": 0.38 },
+      "cost_score": 1.00,
+      "speed_score": 1.00,
+      "notes": "Cheapest and fastest. Only for trivial classification."
+    },
+    {
+      "model_id": "codex-mini-latest",
+      "provider": "github-models",
+      "api": "chat",
+      "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
+      "cost_score": 0.80,
+      "speed_score": 0.88,
+      "notes": "Rolling Codex alias. Good for code-centric extraction."
+    },
+    {
+      "model_id": "o4-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.88, "T3": 0.92, "T4": 0.88, "T5": 0.93 },
+      "cost_score": 0.30,
+      "speed_score": 0.35,
+      "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
+    },
+    {
+      "model_id": "o3",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.90, "T2": 0.92, "T3": 0.95, "T4": 0.92, "T5": 0.96 },
+      "cost_score": 0.15,
+      "speed_score": 0.15,
+      "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
+    },
+    {
+      "model_id": "o3-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.83, "T2": 0.85, "T3": 0.88, "T4": 0.85, "T5": 0.90 },
+      "cost_score": 0.35,
+      "speed_score": 0.30,
+      "notes": "Legacy reasoning mini. Superseded by o4-mini."
+    },
+    {
+      "model_id": "gpt-4o",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.85, "T4": 0.84, "T5": 0.84 },
+      "cost_score": 0.55,
+      "speed_score": 0.80,
+      "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
+    },
+    {
+      "model_id": "gpt-4o-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.60, "T2": 0.55, "T3": 0.45, "T4": 0.40, "T5": 0.30 },
+      "cost_score": 0.78,
+      "speed_score": 0.88,
+      "blocked": true,
+      "notes": "BLOCKED: Documented as too lenient, passes obvious deficiencies."
+    },
+    {
+      "model_id": "claude-opus-4-6",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.93, "T2": 0.94, "T3": 0.96, "T4": 0.96, "T5": 0.98 },
+      "cost_score": 0.08,
+      "speed_score": 0.38,
+      "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
+    },
+    {
+      "model_id": "claude-opus-4-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.92, "T2": 0.93, "T3": 0.95, "T4": 0.95, "T5": 0.97 },
+      "cost_score": 0.10,
+      "speed_score": 0.40,
+      "notes": "Opus tier. Overkill for most tasks, great for T5."
+    },
+    {
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.91, "T2": 0.91, "T3": 0.93, "T4": 0.93, "T5": 0.95 },
+      "cost_score": 0.35,
+      "speed_score": 0.63,
+      "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
+    },
+    {
+      "model_id": "claude-sonnet-4-0",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.88, "T4": 0.88, "T5": 0.90 },
+      "cost_score": 0.40,
+      "speed_score": 0.65,
+      "notes": "Previous Sonnet. Proven but superseded by 4-5."
+    },
+    {
+      "model_id": "claude-haiku-4-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.62 },
+      "cost_score": 0.75,
+      "speed_score": 0.90,
+      "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
+    },
+    {
+      "model_id": "claude-3-7-sonnet-latest",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.82, "T2": 0.82, "T3": 0.85, "T4": 0.85, "T5": 0.87 },
+      "cost_score": 0.42,
+      "speed_score": 0.65,
+      "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
     }
   ]
 }

--- a/docs/MODEL_SELECTION_FRAMEWORK.md
+++ b/docs/MODEL_SELECTION_FRAMEWORK.md
@@ -1,6 +1,4 @@
-# M
-Worker-only validation entries may set `worker_profile: true` and a lifecycle while omitting quality, cost, and speed scores. Their presence proves that an execution-profile model ID is allowed; it is not evaluator evidence and must not be used to rank models.
-odel Selection Framework
+# Model Selection Framework
 
 > **Last updated**: February 7, 2026
 > **Purpose**: Define a model registry, selection algorithm, and slot-system
@@ -792,3 +790,5 @@ latency budget for the task tier.
   }
 }
 ```
+
+Worker-only validation entries may set `worker_profile: true` and a lifecycle while omitting quality, cost, and speed scores. Their presence proves that an execution-profile model ID is allowed; it is not evaluator evidence and must not be used to rank models.

--- a/docs/MODEL_SELECTION_FRAMEWORK.md
+++ b/docs/MODEL_SELECTION_FRAMEWORK.md
@@ -1,4 +1,6 @@
-# Model Selection Framework
+# M
+Worker-only validation entries may set `worker_profile: true` and a lifecycle while omitting quality, cost, and speed scores. Their presence proves that an execution-profile model ID is allowed; it is not evaluator evidence and must not be used to rank models.
+odel Selection Framework
 
 > **Last updated**: February 7, 2026
 > **Purpose**: Define a model registry, selection algorithm, and slot-system
@@ -761,6 +763,15 @@ latency budget for the task tier.
           "model_id": { "type": "string" },
           "provider": { "enum": ["openai", "anthropic", "github-models"] },
           "api": { "enum": ["chat", "responses"], "default": "chat" },
+          "worker_profile": {
+            "type": "boolean",
+            "default": false,
+            "description": "True when the entry exists only to validate a coding-worker execution profile"
+          },
+          "lifecycle": {
+            "enum": ["trial", "active", "retired"],
+            "description": "Optional coding-worker profile lifecycle; omitted for evaluator-only entries"
+          },
           "quality": {
             "type": "object",
             "properties": {

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -22,6 +22,30 @@ execution_profiles:
     capacity_pool: codex-standard
     safety: standard
     lifecycle: active
+  codex-5.6-sol-high:
+    agent: codex
+    model: gpt-5.6-sol
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
+  codex-5.6-terra-high:
+    agent: codex
+    model: gpt-5.6-terra
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
+  codex-5.6-luna-high:
+    agent: codex
+    model: gpt-5.6-luna
+    fallback_model: gpt-5.5
+    runner: reusable-codex-run
+    capacity_pool: codex-standard
+    safety: standard
+    lifecycle: trial
 
 agents:
   codex:

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -1,15 +1,21 @@
 {
   "version": "1.0.0",
-  "last_updated": "2026-06-29",
+  "last_updated": "2026-07-10",
   "review_interval_days": 60,
-  "review_by": "2026-08-28",
-  "purpose": "Auxiliary judge/evaluator model catalog. Coding-worker execution profiles live in .github/agents/registry.yml::execution_profiles.",
+  "review_by": "2026-09-08",
+  "purpose": "Auxiliary judge/evaluator catalog plus explicit coding-worker IDs required for execution-profile validation. Trial worker entries intentionally carry no quality or cost claims.",
   "models": [
     {
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
+      "quality": {
+        "T1": 0.96,
+        "T2": 0.96,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.96
+      },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
@@ -18,7 +24,13 @@
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.97 },
+      "quality": {
+        "T1": 0.96,
+        "T2": 0.96,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.97
+      },
       "cost_score": 0.25,
       "speed_score": 0.64,
       "notes": "Current flagship verifier default. Highest-quality general evaluator."
@@ -27,8 +39,14 @@
       "model_id": "gpt-5.1",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.90, "T3": 0.92, "T4": 0.92, "T5": 0.93 },
-      "cost_score": 0.40,
+      "quality": {
+        "T1": 0.9,
+        "T2": 0.9,
+        "T3": 0.92,
+        "T4": 0.92,
+        "T5": 0.93
+      },
+      "cost_score": 0.4,
       "speed_score": 0.72,
       "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
     },
@@ -36,16 +54,28 @@
       "model_id": "gpt-5.1-codex",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.92, "T3": 0.95, "T4": 0.93, "T5": 0.94 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.92,
+        "T3": 0.95,
+        "T4": 0.93,
+        "T5": 0.94
+      },
       "cost_score": 0.38,
-      "speed_score": 0.70,
+      "speed_score": 0.7,
       "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
     },
     {
       "model_id": "gpt-5.1-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.80, "T3": 0.75, "T4": 0.72, "T5": 0.68 },
+      "quality": {
+        "T1": 0.82,
+        "T2": 0.8,
+        "T3": 0.75,
+        "T4": 0.72,
+        "T5": 0.68
+      },
       "cost_score": 0.82,
       "speed_score": 0.92,
       "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
@@ -54,7 +84,13 @@
       "model_id": "gpt-5",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.90, "T4": 0.90, "T5": 0.90 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.88,
+        "T3": 0.9,
+        "T4": 0.9,
+        "T5": 0.9
+      },
       "cost_score": 0.45,
       "speed_score": 0.75,
       "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
@@ -63,7 +99,13 @@
       "model_id": "gpt-5-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.78, "T2": 0.75, "T3": 0.70, "T4": 0.68, "T5": 0.62 },
+      "quality": {
+        "T1": 0.78,
+        "T2": 0.75,
+        "T3": 0.7,
+        "T4": 0.68,
+        "T5": 0.62
+      },
       "cost_score": 0.85,
       "speed_score": 0.93,
       "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
@@ -72,7 +114,13 @@
       "model_id": "gpt-5.4-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.84, "T2": 0.82, "T3": 0.78, "T4": 0.76, "T5": 0.72 },
+      "quality": {
+        "T1": 0.84,
+        "T2": 0.82,
+        "T3": 0.78,
+        "T4": 0.76,
+        "T5": 0.72
+      },
       "cost_score": 0.88,
       "speed_score": 0.94,
       "notes": "High-quality mini. Default for progress review where speed still matters."
@@ -81,7 +129,13 @@
       "model_id": "gpt-5-nano",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.70, "T2": 0.65, "T3": 0.55, "T4": 0.50, "T5": 0.40 },
+      "quality": {
+        "T1": 0.7,
+        "T2": 0.65,
+        "T3": 0.55,
+        "T4": 0.5,
+        "T5": 0.4
+      },
       "cost_score": 0.95,
       "speed_score": 0.98,
       "notes": "Smallest GPT-5. Only suitable for T1 tasks."
@@ -90,17 +144,29 @@
       "model_id": "gpt-4.1",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.88, "T4": 0.87, "T5": 0.88 },
+      "quality": {
+        "T1": 0.88,
+        "T2": 0.88,
+        "T3": 0.88,
+        "T4": 0.87,
+        "T5": 0.88
+      },
       "cost_score": 0.55,
-      "speed_score": 0.80,
+      "speed_score": 0.8,
       "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
     },
     {
       "model_id": "gpt-4.1-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.65 },
-      "cost_score": 0.90,
+      "quality": {
+        "T1": 0.8,
+        "T2": 0.78,
+        "T3": 0.72,
+        "T4": 0.7,
+        "T5": 0.65
+      },
+      "cost_score": 0.9,
       "speed_score": 0.95,
       "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
     },
@@ -108,17 +174,29 @@
       "model_id": "gpt-4.1-nano",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.68, "T2": 0.63, "T3": 0.52, "T4": 0.48, "T5": 0.38 },
-      "cost_score": 1.00,
-      "speed_score": 1.00,
+      "quality": {
+        "T1": 0.68,
+        "T2": 0.63,
+        "T3": 0.52,
+        "T4": 0.48,
+        "T5": 0.38
+      },
+      "cost_score": 1,
+      "speed_score": 1,
       "notes": "Cheapest and fastest. Only for trivial classification."
     },
     {
       "model_id": "codex-mini-latest",
       "provider": "github-models",
       "api": "chat",
-      "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
-      "cost_score": 0.80,
+      "quality": {
+        "T1": 0.75,
+        "T2": 0.8,
+        "T3": 0.78,
+        "T4": 0.72,
+        "T5": 0.65
+      },
+      "cost_score": 0.8,
       "speed_score": 0.88,
       "notes": "Rolling Codex alias. Good for code-centric extraction."
     },
@@ -126,8 +204,14 @@
       "model_id": "o4-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.88, "T3": 0.92, "T4": 0.88, "T5": 0.93 },
-      "cost_score": 0.30,
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.88,
+        "T3": 0.92,
+        "T4": 0.88,
+        "T5": 0.93
+      },
+      "cost_score": 0.3,
       "speed_score": 0.35,
       "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
     },
@@ -135,7 +219,13 @@
       "model_id": "o3",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.90, "T2": 0.92, "T3": 0.95, "T4": 0.92, "T5": 0.96 },
+      "quality": {
+        "T1": 0.9,
+        "T2": 0.92,
+        "T3": 0.95,
+        "T4": 0.92,
+        "T5": 0.96
+      },
       "cost_score": 0.15,
       "speed_score": 0.15,
       "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
@@ -144,25 +234,43 @@
       "model_id": "o3-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.83, "T2": 0.85, "T3": 0.88, "T4": 0.85, "T5": 0.90 },
+      "quality": {
+        "T1": 0.83,
+        "T2": 0.85,
+        "T3": 0.88,
+        "T4": 0.85,
+        "T5": 0.9
+      },
       "cost_score": 0.35,
-      "speed_score": 0.30,
+      "speed_score": 0.3,
       "notes": "Legacy reasoning mini. Superseded by o4-mini."
     },
     {
       "model_id": "gpt-4o",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.85, "T4": 0.84, "T5": 0.84 },
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.85,
+        "T3": 0.85,
+        "T4": 0.84,
+        "T5": 0.84
+      },
       "cost_score": 0.55,
-      "speed_score": 0.80,
+      "speed_score": 0.8,
       "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
     },
     {
       "model_id": "gpt-4o-mini",
       "provider": "openai",
       "api": "chat",
-      "quality": { "T1": 0.60, "T2": 0.55, "T3": 0.45, "T4": 0.40, "T5": 0.30 },
+      "quality": {
+        "T1": 0.6,
+        "T2": 0.55,
+        "T3": 0.45,
+        "T4": 0.4,
+        "T5": 0.3
+      },
       "cost_score": 0.78,
       "speed_score": 0.88,
       "blocked": true,
@@ -172,7 +280,13 @@
       "model_id": "claude-opus-4-6",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.93, "T2": 0.94, "T3": 0.96, "T4": 0.96, "T5": 0.98 },
+      "quality": {
+        "T1": 0.93,
+        "T2": 0.94,
+        "T3": 0.96,
+        "T4": 0.96,
+        "T5": 0.98
+      },
       "cost_score": 0.08,
       "speed_score": 0.38,
       "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
@@ -181,16 +295,28 @@
       "model_id": "claude-opus-4-5",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.92, "T2": 0.93, "T3": 0.95, "T4": 0.95, "T5": 0.97 },
-      "cost_score": 0.10,
-      "speed_score": 0.40,
+      "quality": {
+        "T1": 0.92,
+        "T2": 0.93,
+        "T3": 0.95,
+        "T4": 0.95,
+        "T5": 0.97
+      },
+      "cost_score": 0.1,
+      "speed_score": 0.4,
       "notes": "Opus tier. Overkill for most tasks, great for T5."
     },
     {
       "model_id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.91, "T2": 0.91, "T3": 0.93, "T4": 0.93, "T5": 0.95 },
+      "quality": {
+        "T1": 0.91,
+        "T2": 0.91,
+        "T3": 0.93,
+        "T4": 0.93,
+        "T5": 0.95
+      },
       "cost_score": 0.35,
       "speed_score": 0.63,
       "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
@@ -199,8 +325,14 @@
       "model_id": "claude-sonnet-4-0",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.88, "T4": 0.88, "T5": 0.90 },
-      "cost_score": 0.40,
+      "quality": {
+        "T1": 0.85,
+        "T2": 0.85,
+        "T3": 0.88,
+        "T4": 0.88,
+        "T5": 0.9
+      },
+      "cost_score": 0.4,
       "speed_score": 0.65,
       "notes": "Previous Sonnet. Proven but superseded by 4-5."
     },
@@ -208,19 +340,58 @@
       "model_id": "claude-haiku-4-5",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.62 },
+      "quality": {
+        "T1": 0.8,
+        "T2": 0.78,
+        "T3": 0.72,
+        "T4": 0.7,
+        "T5": 0.62
+      },
       "cost_score": 0.75,
-      "speed_score": 0.90,
+      "speed_score": 0.9,
       "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
     },
     {
       "model_id": "claude-3-7-sonnet-latest",
       "provider": "anthropic",
       "api": "chat",
-      "quality": { "T1": 0.82, "T2": 0.82, "T3": 0.85, "T4": 0.85, "T5": 0.87 },
+      "quality": {
+        "T1": 0.82,
+        "T2": 0.82,
+        "T3": 0.85,
+        "T4": 0.85,
+        "T5": 0.87
+      },
       "cost_score": 0.42,
       "speed_score": 0.65,
       "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
+    },
+    {
+      "model_id": "gpt-5.6-sol",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-sol; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.6-terra",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-terra; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.6-luna",
+      "provider": "openai",
+      "api": "chat",
+      "worker_profile": true,
+      "lifecycle": "trial",
+      "quality": {},
+      "notes": "Coding-worker trial profile gpt-5.6-luna; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
     }
   ]
 }

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -9,13 +9,7 @@
       "model_id": "gpt-5.5",
       "provider": "openai",
       "api": "chat",
-      "quality": {
-        "T1": 0.96,
-        "T2": 0.96,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.96
-      },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.96 },
       "cost_score": 0.18,
       "speed_score": 0.58,
       "notes": "Coding-worker execution profile default. Listed here so execution profile validation can reject typos before dispatch."
@@ -24,347 +18,10 @@
       "model_id": "gpt-5.4",
       "provider": "openai",
       "api": "chat",
-      "quality": {
-        "T1": 0.96,
-        "T2": 0.96,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.97
-      },
+      "quality": { "T1": 0.96, "T2": 0.96, "T3": 0.96, "T4": 0.96, "T5": 0.97 },
       "cost_score": 0.25,
       "speed_score": 0.64,
       "notes": "Current flagship verifier default. Highest-quality general evaluator."
-    },
-    {
-      "model_id": "gpt-5.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.9,
-        "T2": 0.9,
-        "T3": 0.92,
-        "T4": 0.92,
-        "T5": 0.93
-      },
-      "cost_score": 0.4,
-      "speed_score": 0.72,
-      "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
-    },
-    {
-      "model_id": "gpt-5.1-codex",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.92,
-        "T3": 0.95,
-        "T4": 0.93,
-        "T5": 0.94
-      },
-      "cost_score": 0.38,
-      "speed_score": 0.7,
-      "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
-    },
-    {
-      "model_id": "gpt-5.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.82,
-        "T2": 0.8,
-        "T3": 0.75,
-        "T4": 0.72,
-        "T5": 0.68
-      },
-      "cost_score": 0.82,
-      "speed_score": 0.92,
-      "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
-    },
-    {
-      "model_id": "gpt-5",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.88,
-        "T3": 0.9,
-        "T4": 0.9,
-        "T5": 0.9
-      },
-      "cost_score": 0.45,
-      "speed_score": 0.75,
-      "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
-    },
-    {
-      "model_id": "gpt-5-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.78,
-        "T2": 0.75,
-        "T3": 0.7,
-        "T4": 0.68,
-        "T5": 0.62
-      },
-      "cost_score": 0.85,
-      "speed_score": 0.93,
-      "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
-    },
-    {
-      "model_id": "gpt-5.4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.84,
-        "T2": 0.82,
-        "T3": 0.78,
-        "T4": 0.76,
-        "T5": 0.72
-      },
-      "cost_score": 0.88,
-      "speed_score": 0.94,
-      "notes": "High-quality mini. Default for progress review where speed still matters."
-    },
-    {
-      "model_id": "gpt-5-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.7,
-        "T2": 0.65,
-        "T3": 0.55,
-        "T4": 0.5,
-        "T5": 0.4
-      },
-      "cost_score": 0.95,
-      "speed_score": 0.98,
-      "notes": "Smallest GPT-5. Only suitable for T1 tasks."
-    },
-    {
-      "model_id": "gpt-4.1",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.88,
-        "T2": 0.88,
-        "T3": 0.88,
-        "T4": 0.87,
-        "T5": 0.88
-      },
-      "cost_score": 0.55,
-      "speed_score": 0.8,
-      "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
-    },
-    {
-      "model_id": "gpt-4.1-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.8,
-        "T2": 0.78,
-        "T3": 0.72,
-        "T4": 0.7,
-        "T5": 0.65
-      },
-      "cost_score": 0.9,
-      "speed_score": 0.95,
-      "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
-    },
-    {
-      "model_id": "gpt-4.1-nano",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.68,
-        "T2": 0.63,
-        "T3": 0.52,
-        "T4": 0.48,
-        "T5": 0.38
-      },
-      "cost_score": 1,
-      "speed_score": 1,
-      "notes": "Cheapest and fastest. Only for trivial classification."
-    },
-    {
-      "model_id": "codex-mini-latest",
-      "provider": "github-models",
-      "api": "chat",
-      "quality": {
-        "T1": 0.75,
-        "T2": 0.8,
-        "T3": 0.78,
-        "T4": 0.72,
-        "T5": 0.65
-      },
-      "cost_score": 0.8,
-      "speed_score": 0.88,
-      "notes": "Rolling Codex alias. Good for code-centric extraction."
-    },
-    {
-      "model_id": "o4-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.88,
-        "T3": 0.92,
-        "T4": 0.88,
-        "T5": 0.93
-      },
-      "cost_score": 0.3,
-      "speed_score": 0.35,
-      "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
-    },
-    {
-      "model_id": "o3",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.9,
-        "T2": 0.92,
-        "T3": 0.95,
-        "T4": 0.92,
-        "T5": 0.96
-      },
-      "cost_score": 0.15,
-      "speed_score": 0.15,
-      "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
-    },
-    {
-      "model_id": "o3-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.83,
-        "T2": 0.85,
-        "T3": 0.88,
-        "T4": 0.85,
-        "T5": 0.9
-      },
-      "cost_score": 0.35,
-      "speed_score": 0.3,
-      "notes": "Legacy reasoning mini. Superseded by o4-mini."
-    },
-    {
-      "model_id": "gpt-4o",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.85,
-        "T3": 0.85,
-        "T4": 0.84,
-        "T5": 0.84
-      },
-      "cost_score": 0.55,
-      "speed_score": 0.8,
-      "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
-    },
-    {
-      "model_id": "gpt-4o-mini",
-      "provider": "openai",
-      "api": "chat",
-      "quality": {
-        "T1": 0.6,
-        "T2": 0.55,
-        "T3": 0.45,
-        "T4": 0.4,
-        "T5": 0.3
-      },
-      "cost_score": 0.78,
-      "speed_score": 0.88,
-      "blocked": true,
-      "notes": "BLOCKED: Documented as too lenient, passes obvious deficiencies."
-    },
-    {
-      "model_id": "claude-opus-4-6",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.93,
-        "T2": 0.94,
-        "T3": 0.96,
-        "T4": 0.96,
-        "T5": 0.98
-      },
-      "cost_score": 0.08,
-      "speed_score": 0.38,
-      "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
-    },
-    {
-      "model_id": "claude-opus-4-5",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.92,
-        "T2": 0.93,
-        "T3": 0.95,
-        "T4": 0.95,
-        "T5": 0.97
-      },
-      "cost_score": 0.1,
-      "speed_score": 0.4,
-      "notes": "Opus tier. Overkill for most tasks, great for T5."
-    },
-    {
-      "model_id": "claude-sonnet-4-6",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.91,
-        "T2": 0.91,
-        "T3": 0.93,
-        "T4": 0.93,
-        "T5": 0.95
-      },
-      "cost_score": 0.35,
-      "speed_score": 0.63,
-      "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
-    },
-    {
-      "model_id": "claude-sonnet-4-0",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.85,
-        "T2": 0.85,
-        "T3": 0.88,
-        "T4": 0.88,
-        "T5": 0.9
-      },
-      "cost_score": 0.4,
-      "speed_score": 0.65,
-      "notes": "Previous Sonnet. Proven but superseded by 4-5."
-    },
-    {
-      "model_id": "claude-haiku-4-5",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.8,
-        "T2": 0.78,
-        "T3": 0.72,
-        "T4": 0.7,
-        "T5": 0.62
-      },
-      "cost_score": 0.75,
-      "speed_score": 0.9,
-      "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
-    },
-    {
-      "model_id": "claude-3-7-sonnet-latest",
-      "provider": "anthropic",
-      "api": "chat",
-      "quality": {
-        "T1": 0.82,
-        "T2": 0.82,
-        "T3": 0.85,
-        "T4": 0.85,
-        "T5": 0.87
-      },
-      "cost_score": 0.42,
-      "speed_score": 0.65,
-      "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
     },
     {
       "model_id": "gpt-5.6-sol",
@@ -392,6 +49,205 @@
       "lifecycle": "trial",
       "quality": {},
       "notes": "Coding-worker trial profile gpt-5.6-luna; do not use as evaluator evidence. Worker requested/selected identity must be recorded separately from verifier telemetry."
+    },
+    {
+      "model_id": "gpt-5.1",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.90, "T2": 0.90, "T3": 0.92, "T4": 0.92, "T5": 0.93 },
+      "cost_score": 0.40,
+      "speed_score": 0.72,
+      "notes": "Nov 2025 flagship. Reasoning defaults to none — set effort explicitly."
+    },
+    {
+      "model_id": "gpt-5.1-codex",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.92, "T3": 0.95, "T4": 0.93, "T5": 0.94 },
+      "cost_score": 0.38,
+      "speed_score": 0.70,
+      "notes": "Code-optimized GPT-5.1. Strong candidate for Codex session analysis."
+    },
+    {
+      "model_id": "gpt-5.1-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.82, "T2": 0.80, "T3": 0.75, "T4": 0.72, "T5": 0.68 },
+      "cost_score": 0.82,
+      "speed_score": 0.92,
+      "notes": "Lightweight 5.1. Risk of leniency on analysis tasks."
+    },
+    {
+      "model_id": "gpt-5",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.90, "T4": 0.90, "T5": 0.90 },
+      "cost_score": 0.45,
+      "speed_score": 0.75,
+      "notes": "Aug 2025 flagship. Proven, superseded by 5.1+."
+    },
+    {
+      "model_id": "gpt-5-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.78, "T2": 0.75, "T3": 0.70, "T4": 0.68, "T5": 0.62 },
+      "cost_score": 0.85,
+      "speed_score": 0.93,
+      "notes": "Budget GPT-5. Good speed/cost, but not chosen for verifier-critical tasks."
+    },
+    {
+      "model_id": "gpt-5.4-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.84, "T2": 0.82, "T3": 0.78, "T4": 0.76, "T5": 0.72 },
+      "cost_score": 0.88,
+      "speed_score": 0.94,
+      "notes": "High-quality mini. Default for progress review where speed still matters."
+    },
+    {
+      "model_id": "gpt-5-nano",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.70, "T2": 0.65, "T3": 0.55, "T4": 0.50, "T5": 0.40 },
+      "cost_score": 0.95,
+      "speed_score": 0.98,
+      "notes": "Smallest GPT-5. Only suitable for T1 tasks."
+    },
+    {
+      "model_id": "gpt-4.1",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.88, "T2": 0.88, "T3": 0.88, "T4": 0.87, "T5": 0.88 },
+      "cost_score": 0.55,
+      "speed_score": 0.80,
+      "notes": "Battle-tested (Apr 2025). Excellent stability and structured output."
+    },
+    {
+      "model_id": "gpt-4.1-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.65 },
+      "cost_score": 0.90,
+      "speed_score": 0.95,
+      "notes": "Lightweight 4.1. Good for T1/T2, risky for T3+."
+    },
+    {
+      "model_id": "gpt-4.1-nano",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.68, "T2": 0.63, "T3": 0.52, "T4": 0.48, "T5": 0.38 },
+      "cost_score": 1.00,
+      "speed_score": 1.00,
+      "notes": "Cheapest and fastest. Only for trivial classification."
+    },
+    {
+      "model_id": "codex-mini-latest",
+      "provider": "github-models",
+      "api": "chat",
+      "quality": { "T1": 0.75, "T2": 0.80, "T3": 0.78, "T4": 0.72, "T5": 0.65 },
+      "cost_score": 0.80,
+      "speed_score": 0.88,
+      "notes": "Rolling Codex alias. Good for code-centric extraction."
+    },
+    {
+      "model_id": "o4-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.88, "T3": 0.92, "T4": 0.88, "T5": 0.93 },
+      "cost_score": 0.30,
+      "speed_score": 0.35,
+      "notes": "Reasoning model. High quality but 5-15s latency. Use for high-stakes only."
+    },
+    {
+      "model_id": "o3",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.90, "T2": 0.92, "T3": 0.95, "T4": 0.92, "T5": 0.96 },
+      "cost_score": 0.15,
+      "speed_score": 0.15,
+      "notes": "Deep reasoning. 10-30s response. Generally too slow for CI/CD."
+    },
+    {
+      "model_id": "o3-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.83, "T2": 0.85, "T3": 0.88, "T4": 0.85, "T5": 0.90 },
+      "cost_score": 0.35,
+      "speed_score": 0.30,
+      "notes": "Legacy reasoning mini. Superseded by o4-mini."
+    },
+    {
+      "model_id": "gpt-4o",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.85, "T4": 0.84, "T5": 0.84 },
+      "cost_score": 0.55,
+      "speed_score": 0.80,
+      "notes": "Legacy — currently used as DEFAULT_MODEL. Two generations behind."
+    },
+    {
+      "model_id": "gpt-4o-mini",
+      "provider": "openai",
+      "api": "chat",
+      "quality": { "T1": 0.60, "T2": 0.55, "T3": 0.45, "T4": 0.40, "T5": 0.30 },
+      "cost_score": 0.78,
+      "speed_score": 0.88,
+      "blocked": true,
+      "notes": "BLOCKED: Documented as too lenient, passes obvious deficiencies."
+    },
+    {
+      "model_id": "claude-opus-4-6",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.93, "T2": 0.94, "T3": 0.96, "T4": 0.96, "T5": 0.98 },
+      "cost_score": 0.08,
+      "speed_score": 0.38,
+      "notes": "Just released Feb 5, 2026. Highest quality, very expensive."
+    },
+    {
+      "model_id": "claude-opus-4-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.92, "T2": 0.93, "T3": 0.95, "T4": 0.95, "T5": 0.97 },
+      "cost_score": 0.10,
+      "speed_score": 0.40,
+      "notes": "Opus tier. Overkill for most tasks, great for T5."
+    },
+    {
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.91, "T2": 0.91, "T3": 0.93, "T4": 0.93, "T5": 0.95 },
+      "cost_score": 0.35,
+      "speed_score": 0.63,
+      "notes": "Current Anthropic compare-mode default. Strong cross-provider verifier."
+    },
+    {
+      "model_id": "claude-sonnet-4-0",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.85, "T2": 0.85, "T3": 0.88, "T4": 0.88, "T5": 0.90 },
+      "cost_score": 0.40,
+      "speed_score": 0.65,
+      "notes": "Previous Sonnet. Proven but superseded by 4-5."
+    },
+    {
+      "model_id": "claude-haiku-4-5",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.80, "T2": 0.78, "T3": 0.72, "T4": 0.70, "T5": 0.62 },
+      "cost_score": 0.75,
+      "speed_score": 0.90,
+      "notes": "Fast and cheap Claude. Good for T1/T2, untested for T3+."
+    },
+    {
+      "model_id": "claude-3-7-sonnet-latest",
+      "provider": "anthropic",
+      "api": "chat",
+      "quality": { "T1": 0.82, "T2": 0.82, "T3": 0.85, "T4": 0.85, "T5": 0.87 },
+      "cost_score": 0.42,
+      "speed_score": 0.65,
+      "notes": "Legacy Claude 3.7. Superseded by Claude 4 Sonnet."
     }
   ]
 }


### PR DESCRIPTION
## What changed

Adds explicit registry-backed coding-worker execution profiles for the Sol/Terra/Luna 5.6 trial:

- `codex-5.6-sol-high` → `gpt-5.6-sol`
- `codex-5.6-terra-high` → `gpt-5.6-terra`
- `codex-5.6-luna-high` → `gpt-5.6-luna`

Each profile has a transparent `gpt-5.5` fallback, shared `codex-standard` capacity-pool reference, `trial` lifecycle, and the same consumer-template mirror. The model registry now contains the three IDs as worker-only trial entries without invented quality/cost claims. A registry contract test verifies exact requested/fallback identity.

## Why

The local Orchestrator trial profiles cannot be sent through Workflows without explicit registry IDs. This change prevents unsupported model strings or silent aliases from contaminating worker provenance.

## Validation

- Registry validation cross-checks all profile model and fallback IDs against `config/model_registry.json`.
- Added Node contract coverage for all three profiles.
- Consumer-template registry and model catalog remain synchronized.