### PR TITLE
feat: add typed capability effect evidence to agent runners

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -714,7 +714,7 @@ jobs:
 
       - name: Run Claude
         id: run_claude
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PREFLIGHT_MISSING: ${{ steps.preflight.outputs.missing || 'false' }}
           PREFLIGHT_ERROR: ${{ steps.preflight.outputs.error || '' }}
@@ -860,7 +860,7 @@ jobs:
 
       - name: Commit and push changes
         id: commit
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PUSH_TOKEN: ${{ steps.run_base.outputs.push_token || '' }}
           PUSH_ALLOWED: ${{ steps.run_base.outputs.push_allowed }}

--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -91,6 +91,40 @@ on:
         required: false
         default: 'agent-standard'
         type: string
+      capability_id:
+        description: 'Optional existing capability ID for bounded outcome evidence.'
+        required: false
+        default: ''
+        type: string
+      effect_fingerprint:
+        description: 'Optional lowercase sha256 fingerprint of the bounded effect.'
+        required: false
+        default: ''
+        type: string
+      evidence_artifact_ref:
+        description: 'Optional durable logical reference to supporting evidence.'
+        required: false
+        default: ''
+        type: string
+      supervision_mode:
+        description: >-
+          Optional supervision mode (shadow, human-reviewed,
+          human-on-exception, unattended).
+        required: false
+        default: ''
+        type: string
+      capability_evidence_status:
+        description: 'Optional evidence status (accepted, rejected, not-evaluated).'
+        required: false
+        default: ''
+        type: string
+      terminal_disposition:
+        description: >-
+          Optional terminal disposition (success, failure, no-change, blocked,
+          cancelled).
+        required: false
+        default: ''
+        type: string
     secrets:
       CLAUDE_AUTH_JSON:
         description: >-
@@ -137,6 +171,24 @@ on:
       files-changed:
         description: 'Number of files changed by Claude'
         value: ${{ jobs.claude.outputs.files-changed }}
+      capability-id:
+        description: 'Validated existing capability identifier; empty when evidence is absent.'
+        value: ${{ jobs.claude.outputs.capability-id }}
+      effect-fingerprint:
+        description: 'Validated lowercase sha256 fingerprint of the bounded effect.'
+        value: ${{ jobs.claude.outputs.effect-fingerprint }}
+      evidence-artifact-ref:
+        description: 'Validated durable logical reference to supporting evidence.'
+        value: ${{ jobs.claude.outputs.evidence-artifact-ref }}
+      supervision-mode:
+        description: 'Validated supervision mode for this result.'
+        value: ${{ jobs.claude.outputs.supervision-mode }}
+      capability-evidence-status:
+        description: 'Validated capability evidence status.'
+        value: ${{ jobs.claude.outputs.capability-evidence-status }}
+      terminal-disposition:
+        description: 'Validated terminal disposition for the result.'
+        value: ${{ jobs.claude.outputs.terminal-disposition }}
       llm-analysis-run:
         description: 'Whether LLM analysis was performed'
         value: ${{ jobs.claude.outputs.llm-analysis-run }}
@@ -189,6 +241,13 @@ jobs:
       changes-made: ${{ steps.commit.outputs.changes-made }}
       commit-sha: ${{ steps.commit.outputs.commit-sha }}
       files-changed: ${{ steps.commit.outputs.files-changed }}
+      capability-id: ${{ steps.capability_evidence.outputs.capability-id }}
+      effect-fingerprint: ${{ steps.capability_evidence.outputs.effect-fingerprint }}
+      evidence-artifact-ref: ${{ steps.capability_evidence.outputs.evidence-artifact-ref }}
+      supervision-mode: ${{ steps.capability_evidence.outputs.supervision-mode }}
+      capability-evidence-status: >-
+        ${{ steps.capability_evidence.outputs.capability-evidence-status }}
+      terminal-disposition: ${{ steps.capability_evidence.outputs.terminal-disposition }}
       error-summary: ${{ steps.run_claude.outputs.error-summary }}
       llm-analysis-run: ${{ steps.compat.outputs.llm-analysis-run }}
       llm-provider: ${{ steps.compat.outputs.llm-provider }}
@@ -386,6 +445,25 @@ jobs:
               echo "::notice::LLM dependencies not installed, will fall back to regex analysis"
             }
           fi
+
+      - name: Validate optional capability effect evidence
+        id: capability_evidence
+        env:
+          CAPABILITY_ID: ${{ inputs.capability_id }}
+          EFFECT_FINGERPRINT: ${{ inputs.effect_fingerprint }}
+          EVIDENCE_ARTIFACT_REF: ${{ inputs.evidence_artifact_ref }}
+          SUPERVISION_MODE: ${{ inputs.supervision_mode }}
+          CAPABILITY_EVIDENCE_STATUS: ${{ inputs.capability_evidence_status }}
+          TERMINAL_DISPOSITION: ${{ inputs.terminal_disposition }}
+        run: |
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib normalize-evidence \
+              --capability-id "${CAPABILITY_ID}" \
+              --effect-fingerprint "${EFFECT_FINGERPRINT}" \
+              --evidence-artifact-ref "${EVIDENCE_ARTIFACT_REF}" \
+              --supervision-mode "${SUPERVISION_MODE}" \
+              --capability-evidence-status "${CAPABILITY_EVIDENCE_STATUS}" \
+              --terminal-disposition "${TERMINAL_DISPOSITION}"
 
       - name: Validate prompt template integrity
         id: guard

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -105,6 +105,40 @@ on:
         required: false
         default: 'agent-standard'
         type: string
+      capability_id:
+        description: 'Optional existing capability ID for bounded outcome evidence.'
+        required: false
+        default: ''
+        type: string
+      effect_fingerprint:
+        description: 'Optional lowercase sha256 fingerprint of the bounded effect.'
+        required: false
+        default: ''
+        type: string
+      evidence_artifact_ref:
+        description: 'Optional durable logical reference to supporting evidence.'
+        required: false
+        default: ''
+        type: string
+      supervision_mode:
+        description: >-
+          Optional supervision mode (shadow, human-reviewed,
+          human-on-exception, unattended).
+        required: false
+        default: ''
+        type: string
+      capability_evidence_status:
+        description: 'Optional evidence status (accepted, rejected, not-evaluated).'
+        required: false
+        default: ''
+        type: string
+      terminal_disposition:
+        description: >-
+          Optional terminal disposition (success, failure, no-change, blocked,
+          cancelled).
+        required: false
+        default: ''
+        type: string
     secrets:
       CODEX_AUTH_JSON:
         description: 'JSON contents of ~/.codex/auth.json for ChatGPT subscription auth'
@@ -143,6 +177,24 @@ on:
       files-changed:
         description: 'Number of files changed by Codex'
         value: ${{ jobs.codex.outputs.files-changed }}
+      capability-id:
+        description: 'Validated existing capability identifier; empty when evidence is absent.'
+        value: ${{ jobs.codex.outputs.capability-id }}
+      effect-fingerprint:
+        description: 'Validated lowercase sha256 fingerprint of the bounded effect.'
+        value: ${{ jobs.codex.outputs.effect-fingerprint }}
+      evidence-artifact-ref:
+        description: 'Validated durable logical reference to supporting evidence.'
+        value: ${{ jobs.codex.outputs.evidence-artifact-ref }}
+      supervision-mode:
+        description: 'Validated supervision mode for this result.'
+        value: ${{ jobs.codex.outputs.supervision-mode }}
+      capability-evidence-status:
+        description: 'Validated capability evidence status.'
+        value: ${{ jobs.codex.outputs.capability-evidence-status }}
+      terminal-disposition:
+        description: 'Validated terminal disposition for the result.'
+        value: ${{ jobs.codex.outputs.terminal-disposition }}
       worker-profile-id:
         description: 'Registry execution profile ID supplied by caller'
         value: ${{ jobs.codex.outputs.worker-profile-id }}
@@ -227,6 +279,13 @@ jobs:
       changes-made: ${{ steps.commit.outputs.changes-made }}
       commit-sha: ${{ steps.commit.outputs.commit-sha }}
       files-changed: ${{ steps.commit.outputs.files-changed }}
+      capability-id: ${{ steps.capability_evidence.outputs.capability-id }}
+      effect-fingerprint: ${{ steps.capability_evidence.outputs.effect-fingerprint }}
+      evidence-artifact-ref: ${{ steps.capability_evidence.outputs.evidence-artifact-ref }}
+      supervision-mode: ${{ steps.capability_evidence.outputs.supervision-mode }}
+      capability-evidence-status: >-
+        ${{ steps.capability_evidence.outputs.capability-evidence-status }}
+      terminal-disposition: ${{ steps.capability_evidence.outputs.terminal-disposition }}
       worker-profile-id: ${{ inputs.execution_profile }}
       worker-requested-model: ${{ inputs.codex_model }}
       worker-selected-model: ${{ steps.run_codex.outputs.model }}
@@ -442,6 +501,25 @@ jobs:
               echo "::notice::LLM dependencies not installed, will fall back to regex analysis"
             }
           fi
+
+      - name: Validate optional capability effect evidence
+        id: capability_evidence
+        env:
+          CAPABILITY_ID: ${{ inputs.capability_id }}
+          EFFECT_FINGERPRINT: ${{ inputs.effect_fingerprint }}
+          EVIDENCE_ARTIFACT_REF: ${{ inputs.evidence_artifact_ref }}
+          SUPERVISION_MODE: ${{ inputs.supervision_mode }}
+          CAPABILITY_EVIDENCE_STATUS: ${{ inputs.capability_evidence_status }}
+          TERMINAL_DISPOSITION: ${{ inputs.terminal_disposition }}
+        run: |
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib normalize-evidence \
+              --capability-id "${CAPABILITY_ID}" \
+              --effect-fingerprint "${EFFECT_FINGERPRINT}" \
+              --evidence-artifact-ref "${EVIDENCE_ARTIFACT_REF}" \
+              --supervision-mode "${SUPERVISION_MODE}" \
+              --capability-evidence-status "${CAPABILITY_EVIDENCE_STATUS}" \
+              --terminal-disposition "${TERMINAL_DISPOSITION}"
 
       - name: Validate prompt template integrity
         id: guard

--- a/.github/workflows/reusable-cursor-run.yml
+++ b/.github/workflows/reusable-cursor-run.yml
@@ -81,6 +81,40 @@ on:
         required: false
         default: 'agent-standard'
         type: string
+      capability_id:
+        description: 'Optional existing capability ID for bounded outcome evidence.'
+        required: false
+        default: ''
+        type: string
+      effect_fingerprint:
+        description: 'Optional lowercase sha256 fingerprint of the bounded effect.'
+        required: false
+        default: ''
+        type: string
+      evidence_artifact_ref:
+        description: 'Optional durable logical reference to supporting evidence.'
+        required: false
+        default: ''
+        type: string
+      supervision_mode:
+        description: >-
+          Optional supervision mode (shadow, human-reviewed,
+          human-on-exception, unattended).
+        required: false
+        default: ''
+        type: string
+      capability_evidence_status:
+        description: 'Optional evidence status (accepted, rejected, not-evaluated).'
+        required: false
+        default: ''
+        type: string
+      terminal_disposition:
+        description: >-
+          Optional terminal disposition (success, failure, no-change, blocked,
+          cancelled).
+        required: false
+        default: ''
+        type: string
     secrets:
       CURSOR_API_KEY:
         description: >-
@@ -121,6 +155,24 @@ on:
       files-changed:
         description: 'Number of files changed by Cursor'
         value: ${{ jobs.cursor.outputs.files-changed }}
+      capability-id:
+        description: 'Validated existing capability identifier; empty when evidence is absent.'
+        value: ${{ jobs.cursor.outputs.capability-id }}
+      effect-fingerprint:
+        description: 'Validated lowercase sha256 fingerprint of the bounded effect.'
+        value: ${{ jobs.cursor.outputs.effect-fingerprint }}
+      evidence-artifact-ref:
+        description: 'Validated durable logical reference to supporting evidence.'
+        value: ${{ jobs.cursor.outputs.evidence-artifact-ref }}
+      supervision-mode:
+        description: 'Validated supervision mode for this result.'
+        value: ${{ jobs.cursor.outputs.supervision-mode }}
+      capability-evidence-status:
+        description: 'Validated capability evidence status.'
+        value: ${{ jobs.cursor.outputs.capability-evidence-status }}
+      terminal-disposition:
+        description: 'Validated terminal disposition for the result.'
+        value: ${{ jobs.cursor.outputs.terminal-disposition }}
       llm-analysis-run:
         description: 'Whether LLM analysis was performed'
         value: ${{ jobs.cursor.outputs.llm-analysis-run }}
@@ -173,6 +225,13 @@ jobs:
       changes-made: ${{ steps.commit.outputs.changes-made }}
       commit-sha: ${{ steps.commit.outputs.commit-sha }}
       files-changed: ${{ steps.commit.outputs.files-changed }}
+      capability-id: ${{ steps.capability_evidence.outputs.capability-id }}
+      effect-fingerprint: ${{ steps.capability_evidence.outputs.effect-fingerprint }}
+      evidence-artifact-ref: ${{ steps.capability_evidence.outputs.evidence-artifact-ref }}
+      supervision-mode: ${{ steps.capability_evidence.outputs.supervision-mode }}
+      capability-evidence-status: >-
+        ${{ steps.capability_evidence.outputs.capability-evidence-status }}
+      terminal-disposition: ${{ steps.capability_evidence.outputs.terminal-disposition }}
       error-summary: ${{ steps.run_cursor.outputs.error-summary }}
       llm-analysis-run: ${{ steps.compat.outputs.llm-analysis-run }}
       llm-provider: ${{ steps.compat.outputs.llm-provider }}
@@ -403,6 +462,25 @@ jobs:
               echo "::notice::LLM dependencies not installed, will fall back to regex analysis"
             }
           fi
+
+      - name: Validate optional capability effect evidence
+        id: capability_evidence
+        env:
+          CAPABILITY_ID: ${{ inputs.capability_id }}
+          EFFECT_FINGERPRINT: ${{ inputs.effect_fingerprint }}
+          EVIDENCE_ARTIFACT_REF: ${{ inputs.evidence_artifact_ref }}
+          SUPERVISION_MODE: ${{ inputs.supervision_mode }}
+          CAPABILITY_EVIDENCE_STATUS: ${{ inputs.capability_evidence_status }}
+          TERMINAL_DISPOSITION: ${{ inputs.terminal_disposition }}
+        run: |
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib normalize-evidence \
+              --capability-id "${CAPABILITY_ID}" \
+              --effect-fingerprint "${EFFECT_FINGERPRINT}" \
+              --evidence-artifact-ref "${EVIDENCE_ARTIFACT_REF}" \
+              --supervision-mode "${SUPERVISION_MODE}" \
+              --capability-evidence-status "${CAPABILITY_EVIDENCE_STATUS}" \
+              --terminal-disposition "${TERMINAL_DISPOSITION}"
 
       - name: Validate prompt template integrity
         id: guard

--- a/.github/workflows/reusable-cursor-run.yml
+++ b/.github/workflows/reusable-cursor-run.yml
@@ -803,7 +803,7 @@ jobs:
 
       - name: Run Cursor
         id: run_cursor
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PREFLIGHT_MISSING: ${{ steps.preflight.outputs.missing || 'false' }}
           PREFLIGHT_ERROR: ${{ steps.preflight.outputs.error || '' }}
@@ -968,7 +968,7 @@ jobs:
 
       - name: Commit and push changes
         id: commit
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PUSH_TOKEN: ${{ steps.auth_token.outputs.push_token || '' }}
           PUSH_ALLOWED: ${{ steps.auth_token.outputs.push_allowed }}

--- a/.github/workflows/reusable-gemini-run.yml
+++ b/.github/workflows/reusable-gemini-run.yml
@@ -87,6 +87,40 @@ on:
         required: false
         default: 'agent-standard'
         type: string
+      capability_id:
+        description: 'Optional existing capability ID for bounded outcome evidence.'
+        required: false
+        default: ''
+        type: string
+      effect_fingerprint:
+        description: 'Optional lowercase sha256 fingerprint of the bounded effect.'
+        required: false
+        default: ''
+        type: string
+      evidence_artifact_ref:
+        description: 'Optional durable logical reference to supporting evidence.'
+        required: false
+        default: ''
+        type: string
+      supervision_mode:
+        description: >-
+          Optional supervision mode (shadow, human-reviewed,
+          human-on-exception, unattended).
+        required: false
+        default: ''
+        type: string
+      capability_evidence_status:
+        description: 'Optional evidence status (accepted, rejected, not-evaluated).'
+        required: false
+        default: ''
+        type: string
+      terminal_disposition:
+        description: >-
+          Optional terminal disposition (success, failure, no-change, blocked,
+          cancelled).
+        required: false
+        default: ''
+        type: string
     secrets:
       GEMINI_API_KEY:
         description: >-
@@ -127,6 +161,24 @@ on:
       files-changed:
         description: 'Number of files changed by Gemini'
         value: ${{ jobs.gemini.outputs.files-changed }}
+      capability-id:
+        description: 'Validated existing capability identifier; empty when evidence is absent.'
+        value: ${{ jobs.gemini.outputs.capability-id }}
+      effect-fingerprint:
+        description: 'Validated lowercase sha256 fingerprint of the bounded effect.'
+        value: ${{ jobs.gemini.outputs.effect-fingerprint }}
+      evidence-artifact-ref:
+        description: 'Validated durable logical reference to supporting evidence.'
+        value: ${{ jobs.gemini.outputs.evidence-artifact-ref }}
+      supervision-mode:
+        description: 'Validated supervision mode for this result.'
+        value: ${{ jobs.gemini.outputs.supervision-mode }}
+      capability-evidence-status:
+        description: 'Validated capability evidence status.'
+        value: ${{ jobs.gemini.outputs.capability-evidence-status }}
+      terminal-disposition:
+        description: 'Validated terminal disposition for the result.'
+        value: ${{ jobs.gemini.outputs.terminal-disposition }}
       llm-analysis-run:
         description: 'Whether LLM analysis was performed'
         value: ${{ jobs.gemini.outputs.llm-analysis-run }}
@@ -179,6 +231,13 @@ jobs:
       changes-made: ${{ steps.commit.outputs.changes-made }}
       commit-sha: ${{ steps.commit.outputs.commit-sha }}
       files-changed: ${{ steps.commit.outputs.files-changed }}
+      capability-id: ${{ steps.capability_evidence.outputs.capability-id }}
+      effect-fingerprint: ${{ steps.capability_evidence.outputs.effect-fingerprint }}
+      evidence-artifact-ref: ${{ steps.capability_evidence.outputs.evidence-artifact-ref }}
+      supervision-mode: ${{ steps.capability_evidence.outputs.supervision-mode }}
+      capability-evidence-status: >-
+        ${{ steps.capability_evidence.outputs.capability-evidence-status }}
+      terminal-disposition: ${{ steps.capability_evidence.outputs.terminal-disposition }}
       error-summary: ${{ steps.run_gemini.outputs.error-summary }}
       llm-analysis-run: ${{ steps.compat.outputs.llm-analysis-run }}
       llm-provider: ${{ steps.compat.outputs.llm-provider }}
@@ -411,6 +470,25 @@ jobs:
               echo "::notice::LLM dependencies not installed, will fall back to regex analysis"
             }
           fi
+
+      - name: Validate optional capability effect evidence
+        id: capability_evidence
+        env:
+          CAPABILITY_ID: ${{ inputs.capability_id }}
+          EFFECT_FINGERPRINT: ${{ inputs.effect_fingerprint }}
+          EVIDENCE_ARTIFACT_REF: ${{ inputs.evidence_artifact_ref }}
+          SUPERVISION_MODE: ${{ inputs.supervision_mode }}
+          CAPABILITY_EVIDENCE_STATUS: ${{ inputs.capability_evidence_status }}
+          TERMINAL_DISPOSITION: ${{ inputs.terminal_disposition }}
+        run: |
+          PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+            python -m scripts.runner_lib normalize-evidence \
+              --capability-id "${CAPABILITY_ID}" \
+              --effect-fingerprint "${EFFECT_FINGERPRINT}" \
+              --evidence-artifact-ref "${EVIDENCE_ARTIFACT_REF}" \
+              --supervision-mode "${SUPERVISION_MODE}" \
+              --capability-evidence-status "${CAPABILITY_EVIDENCE_STATUS}" \
+              --terminal-disposition "${TERMINAL_DISPOSITION}"
 
       - name: Validate prompt template integrity
         id: guard

--- a/.github/workflows/reusable-gemini-run.yml
+++ b/.github/workflows/reusable-gemini-run.yml
@@ -802,7 +802,7 @@ jobs:
 
       - name: Run Gemini
         id: run_gemini
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PREFLIGHT_MISSING: ${{ steps.preflight.outputs.missing || 'false' }}
           PREFLIGHT_ERROR: ${{ steps.preflight.outputs.error || '' }}
@@ -956,7 +956,7 @@ jobs:
 
       - name: Commit and push changes
         id: commit
-        if: always()
+        if: always() && steps.capability_evidence.outcome != 'failure'
         env:
           PUSH_TOKEN: ${{ steps.auth_token.outputs.push_token || '' }}
           PUSH_ALLOWED: ${{ steps.auth_token.outputs.push_allowed }}

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -151,6 +151,13 @@ jobs:
 
 Caller-facing outputs are available only from a subset of reusable workflows. The quick index below highlights the most common `workflow_call` outputs and artifact-only reusable workflows; consult the exhaustive catalog before assuming an unlisted workflow has no caller-facing outputs.
 
+All registry-backed agent runners expose the optional provider-neutral
+capability evidence outputs `capability-id`, `effect-fingerprint`,
+`evidence-artifact-ref`, `supervision-mode`,
+`capability-evidence-status`, and `terminal-disposition`. They are empty by
+default and are accepted only as one complete validated record; callers must
+not derive them from free-form agent output.
+
 The exhaustive output reference is [`docs/ci/WORKFLOW_OUTPUTS.md`](ci/WORKFLOW_OUTPUTS.md). It documents each exported `workflow_call` output with its type, description, and usage expression, and it also lists reusable workflows that intentionally publish artifacts or logs without job outputs. Use that page as the source of truth when wiring dependent jobs; the table below is a quick index for the most common chaining surfaces.
 
 Coverage evidence: `tests/workflows/test_reusable_workflow_outputs_doc.py` loads every `.github/workflows/reusable-*.yml` declaration, compares each `on.workflow_call.outputs` key and description against the catalog table, and verifies reusable workflows with no caller-facing outputs appear in the no-output list. That test is the audit guard for the acceptance requirement that all reusable workflow outputs are documented.
@@ -242,6 +249,12 @@ Reusable workflows with caller-facing `workflow_call` outputs:
 | `reusable-codex-run.yml` | `changes-made` | string (boolean-like) | Whether Codex made file changes. | `needs.codex.outputs.changes-made` |
 | `reusable-codex-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed. | `needs.codex.outputs.commit-sha` |
 | `reusable-codex-run.yml` | `files-changed` | string (number-like) | Number of files changed by Codex. | `needs.codex.outputs.files-changed` |
+| `reusable-codex-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.codex.outputs.capability-id` |
+| `reusable-codex-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.codex.outputs.effect-fingerprint` |
+| `reusable-codex-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.codex.outputs.evidence-artifact-ref` |
+| `reusable-codex-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.codex.outputs.supervision-mode` |
+| `reusable-codex-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.codex.outputs.capability-evidence-status` |
+| `reusable-codex-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.codex.outputs.terminal-disposition` |
 | `reusable-codex-run.yml` | `error-category` | string | Error category if failure occurred. | `needs.codex.outputs.error-category` |
 | `reusable-codex-run.yml` | `error-type` | string | Error type if failure occurred. | `needs.codex.outputs.error-type` |
 | `reusable-codex-run.yml` | `error-recovery` | string | Suggested recovery action if failure occurred. | `needs.codex.outputs.error-recovery` |
@@ -264,6 +277,12 @@ Reusable workflows with caller-facing `workflow_call` outputs:
 | `reusable-claude-run.yml` | `changes-made` | string (boolean-like) | Whether Claude made file changes. | `needs.claude.outputs.changes-made` |
 | `reusable-claude-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed. | `needs.claude.outputs.commit-sha` |
 | `reusable-claude-run.yml` | `files-changed` | string (number-like) | Number of files changed by Claude. | `needs.claude.outputs.files-changed` |
+| `reusable-claude-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.claude.outputs.capability-id` |
+| `reusable-claude-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.claude.outputs.effect-fingerprint` |
+| `reusable-claude-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.claude.outputs.evidence-artifact-ref` |
+| `reusable-claude-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.claude.outputs.supervision-mode` |
+| `reusable-claude-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.claude.outputs.capability-evidence-status` |
+| `reusable-claude-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.claude.outputs.terminal-disposition` |
 | `reusable-claude-run.yml` | `llm-analysis-run` | string (boolean-like) | Whether LLM analysis was performed. | `needs.claude.outputs.llm-analysis-run` |
 | `reusable-claude-run.yml` | `llm-provider` | string | LLM provider used for analysis. | `needs.claude.outputs.llm-provider` |
 | `reusable-claude-run.yml` | `llm-model` | string | Specific model used for analysis. | `needs.claude.outputs.llm-model` |

--- a/docs/ci/WORKFLOW_OUTPUTS.md
+++ b/docs/ci/WORKFLOW_OUTPUTS.md
@@ -83,6 +83,12 @@ reusable workflow in the no-output section.
 | `reusable-codex-run.yml` | `changes-made` | string (boolean-like) | Whether Codex made file changes (true/false) | `needs.codex.outputs.changes-made` |
 | `reusable-codex-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed | `needs.codex.outputs.commit-sha` |
 | `reusable-codex-run.yml` | `files-changed` | string (number-like) | Number of files changed by Codex | `needs.codex.outputs.files-changed` |
+| `reusable-codex-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.codex.outputs.capability-id` |
+| `reusable-codex-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.codex.outputs.effect-fingerprint` |
+| `reusable-codex-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.codex.outputs.evidence-artifact-ref` |
+| `reusable-codex-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.codex.outputs.supervision-mode` |
+| `reusable-codex-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.codex.outputs.capability-evidence-status` |
+| `reusable-codex-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.codex.outputs.terminal-disposition` |
 | `reusable-codex-run.yml` | `worker-profile-id` | string | Registry execution profile ID supplied by caller | `needs.codex.outputs.worker-profile-id` |
 | `reusable-codex-run.yml` | `worker-requested-model` | string | Model requested through the registry execution profile | `needs.codex.outputs.worker-requested-model` |
 | `reusable-codex-run.yml` | `worker-selected-model` | string | Actual Codex model selected after runner fallback | `needs.codex.outputs.worker-selected-model` |
@@ -109,6 +115,12 @@ reusable workflow in the no-output section.
 | `reusable-claude-run.yml` | `changes-made` | string (boolean-like) | Whether Claude made file changes (true/false) | `needs.claude.outputs.changes-made` |
 | `reusable-claude-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed | `needs.claude.outputs.commit-sha` |
 | `reusable-claude-run.yml` | `files-changed` | string (number-like) | Number of files changed by Claude | `needs.claude.outputs.files-changed` |
+| `reusable-claude-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.claude.outputs.capability-id` |
+| `reusable-claude-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.claude.outputs.effect-fingerprint` |
+| `reusable-claude-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.claude.outputs.evidence-artifact-ref` |
+| `reusable-claude-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.claude.outputs.supervision-mode` |
+| `reusable-claude-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.claude.outputs.capability-evidence-status` |
+| `reusable-claude-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.claude.outputs.terminal-disposition` |
 | `reusable-claude-run.yml` | `llm-analysis-run` | string (boolean-like) | Whether LLM analysis was performed | `needs.claude.outputs.llm-analysis-run` |
 | `reusable-claude-run.yml` | `llm-provider` | string | LLM provider used for analysis (placeholder for compatibility) | `needs.claude.outputs.llm-provider` |
 | `reusable-claude-run.yml` | `llm-model` | string | Specific model used for analysis (placeholder for compatibility) | `needs.claude.outputs.llm-model` |
@@ -125,6 +137,12 @@ reusable workflow in the no-output section.
 | `reusable-cursor-run.yml` | `changes-made` | string (boolean-like) | Whether Cursor made file changes (true/false) | `needs.cursor.outputs.changes-made` |
 | `reusable-cursor-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed | `needs.cursor.outputs.commit-sha` |
 | `reusable-cursor-run.yml` | `files-changed` | string (number-like) | Number of files changed by Cursor | `needs.cursor.outputs.files-changed` |
+| `reusable-cursor-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.cursor.outputs.capability-id` |
+| `reusable-cursor-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.cursor.outputs.effect-fingerprint` |
+| `reusable-cursor-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.cursor.outputs.evidence-artifact-ref` |
+| `reusable-cursor-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.cursor.outputs.supervision-mode` |
+| `reusable-cursor-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.cursor.outputs.capability-evidence-status` |
+| `reusable-cursor-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.cursor.outputs.terminal-disposition` |
 | `reusable-cursor-run.yml` | `llm-analysis-run` | string (boolean-like) | Whether LLM analysis was performed | `needs.cursor.outputs.llm-analysis-run` |
 | `reusable-cursor-run.yml` | `llm-provider` | string | LLM provider used for analysis (placeholder for compatibility) | `needs.cursor.outputs.llm-provider` |
 | `reusable-cursor-run.yml` | `llm-model` | string | Specific model used for analysis (placeholder for compatibility) | `needs.cursor.outputs.llm-model` |
@@ -141,6 +159,12 @@ reusable workflow in the no-output section.
 | `reusable-gemini-run.yml` | `changes-made` | string (boolean-like) | Whether Gemini made file changes (true/false) | `needs.gemini.outputs.changes-made` |
 | `reusable-gemini-run.yml` | `commit-sha` | string | SHA of the commit if changes were pushed | `needs.gemini.outputs.commit-sha` |
 | `reusable-gemini-run.yml` | `files-changed` | string (number-like) | Number of files changed by Gemini | `needs.gemini.outputs.files-changed` |
+| `reusable-gemini-run.yml` | `capability-id` | string | Validated existing capability identifier; empty when evidence is absent. | `needs.gemini.outputs.capability-id` |
+| `reusable-gemini-run.yml` | `effect-fingerprint` | string | Validated lowercase sha256 fingerprint of the bounded effect. | `needs.gemini.outputs.effect-fingerprint` |
+| `reusable-gemini-run.yml` | `evidence-artifact-ref` | string | Validated durable logical reference to supporting evidence. | `needs.gemini.outputs.evidence-artifact-ref` |
+| `reusable-gemini-run.yml` | `supervision-mode` | string enum | Validated supervision mode for this result. | `needs.gemini.outputs.supervision-mode` |
+| `reusable-gemini-run.yml` | `capability-evidence-status` | string enum | Validated capability evidence status. | `needs.gemini.outputs.capability-evidence-status` |
+| `reusable-gemini-run.yml` | `terminal-disposition` | string enum | Validated terminal disposition for the result. | `needs.gemini.outputs.terminal-disposition` |
 | `reusable-gemini-run.yml` | `llm-analysis-run` | string (boolean-like) | Whether LLM analysis was performed | `needs.gemini.outputs.llm-analysis-run` |
 | `reusable-gemini-run.yml` | `llm-provider` | string | LLM provider used for analysis (placeholder for compatibility) | `needs.gemini.outputs.llm-provider` |
 | `reusable-gemini-run.yml` | `llm-model` | string | Specific model used for analysis (placeholder for compatibility) | `needs.gemini.outputs.llm-model` |
@@ -223,3 +247,13 @@ jobs:
     steps:
       - run: echo "${{ needs.codex.outputs.final-message-summary }}"
 ```
+## Provider-neutral optional capability evidence
+
+All four registry-backed runners (`reusable-codex-run.yml`,
+`reusable-claude-run.yml`, `reusable-cursor-run.yml`, and
+`reusable-gemini-run.yml`) expose the same optional outputs:
+`capability-id`, `effect-fingerprint`, `evidence-artifact-ref`,
+`supervision-mode`, `capability-evidence-status`, and
+`terminal-disposition`. Values are empty unless the caller supplies a complete
+record accepted by `scripts.runner_lib normalize-evidence`; partial or invalid
+records fail before agent execution.

--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -1,8 +1,8 @@
 # Agent Runner Output Contract
 
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Canonical specification
-**Last Updated:** February 17, 2026
+**Last Updated:** July 10, 2026
 
 ## Purpose
 
@@ -103,6 +103,26 @@ All runners MUST support LLM-based task completion analysis:
 | `llm-completed-tasks` | string | JSON array of completed task descriptions | `'["Add tests", "Fix bug"]'` |
 | `llm-has-completions` | string | Whether any task completions were detected (`"true"` \| `"false"`) | `"true"` |
 
+### Optional Capability Effect Evidence
+
+These provider-neutral outputs are empty by default. A caller MAY supply a
+complete evidence record when the run is exercising an existing bounded
+capability. Runners MUST validate the record through the shared runner library;
+they MUST NOT infer capability identity or effects from free-form agent prose.
+
+| Output | Type | Description | Example |
+|--------|------|-------------|---------|
+| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:...` |
+| `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
+| `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |
+| `capability-evidence-status` | string | `accepted` \| `rejected` \| `not-evaluated` | `accepted` |
+| `terminal-disposition` | string | `success` \| `failure` \| `no-change` \| `blocked` \| `cancelled` | `no-change` |
+
+Evidence is all-or-none: if any field is non-empty, every field is required.
+Invalid or partial evidence fails before agent execution. Empty evidence retains
+the v1.0 behavior and is not interpreted as a rejected capability outcome.
+
 ---
 
 ## Output Semantics
@@ -200,6 +220,10 @@ New optional outputs MAY be added without breaking compatibility:
 - Add output with default empty string value
 - Update this document
 - Update all existing runners to provide the output
+
+Capability evidence added in v1.1 follows this rule: all existing runners
+provide the outputs, and all values remain empty unless a caller supplies one
+complete validated record.
 
 ### Deprecating Outputs
 

--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -113,7 +113,7 @@ they MUST NOT infer capability identity or effects from free-form agent prose.
 | Output | Type | Description | Example |
 |--------|------|-------------|---------|
 | `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
-| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:...` |
+| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
 | `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
 | `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |
 | `capability-evidence-status` | string | `accepted` \| `rejected` \| `not-evaluated` | `accepted` |

--- a/docs/guides/AGENT_RUNNER_IMPLEMENTATION.md
+++ b/docs/guides/AGENT_RUNNER_IMPLEMENTATION.md
@@ -15,7 +15,8 @@ This guide covers the implementation patterns that every agent runner workflow (
 4. [Commit and Push Step](#4-commit-and-push-step)
 5. [Push Retry with Rebase](#5-push-retry-with-rebase)
 6. [Output Encoding](#6-output-encoding)
-7. [Common Pitfalls](#7-common-pitfalls)
+7. [Capability Effect Evidence](#7-capability-effect-evidence)
+8. [Common Pitfalls](#8-common-pitfalls)
 
 ---
 
@@ -298,7 +299,28 @@ Set both `final-message` (full, encoded) and `final-message-summary` (first 500 
 
 ---
 
-## 7. Common Pitfalls
+## 7. Capability Effect Evidence
+
+All registry-backed runners expose the same optional capability/effect fields.
+Validate them before invoking the agent:
+
+```bash
+PYTHONPATH="${GITHUB_WORKSPACE}/.workflows-lib:${GITHUB_WORKSPACE}" \
+  python -m scripts.runner_lib normalize-evidence \
+    --capability-id "$CAPABILITY_ID" \
+    --effect-fingerprint "$EFFECT_FINGERPRINT" \
+    --evidence-artifact-ref "$EVIDENCE_ARTIFACT_REF" \
+    --supervision-mode "$SUPERVISION_MODE" \
+    --capability-evidence-status "$CAPABILITY_EVIDENCE_STATUS" \
+    --terminal-disposition "$TERMINAL_DISPOSITION"
+```
+
+An entirely empty record is valid for backwards compatibility. Partial,
+malformed, oversized, or secret-like records fail closed. Do not parse these
+values from the final message: the caller supplies typed intent and the runner
+only validates and relays it. Downstream promotion remains Orchestrator-owned.
+
+## 8. Common Pitfalls
 
 ### Silent loss of agent work
 

--- a/docs/keepalive/Observability_Contract.md
+++ b/docs/keepalive/Observability_Contract.md
@@ -143,9 +143,11 @@ Required report fields:
 Registry-backed runners may additionally expose the v1.1 agent-runner outputs
 `capability-id`, `effect-fingerprint`, `evidence-artifact-ref`,
 `supervision-mode`, `capability-evidence-status`, and `terminal-disposition`.
-These values are typed evidence for the existing Orchestrator completion-event
-plane; they do not create a second terminal-disposition record or authorize a
-capability transition. Empty values mean no capability evidence was supplied.
+These values are typed evidence intended for the existing Orchestrator
+completion-event plane. Runner validation and emission do not themselves add
+Orchestrator-side ingestion, create a second terminal-disposition record, or
+authorize a capability transition. Empty values mean no capability evidence was
+supplied.
 
 ---
 

--- a/docs/keepalive/Observability_Contract.md
+++ b/docs/keepalive/Observability_Contract.md
@@ -138,6 +138,15 @@ Required report fields:
   and `artifact_family` when the emitting workflow uploads them as Actions
   artifacts
 
+### Optional runner capability evidence
+
+Registry-backed runners may additionally expose the v1.1 agent-runner outputs
+`capability-id`, `effect-fingerprint`, `evidence-artifact-ref`,
+`supervision-mode`, `capability-evidence-status`, and `terminal-disposition`.
+These values are typed evidence for the existing Orchestrator completion-event
+plane; they do not create a second terminal-disposition record or authorize a
+capability transition. Empty values mean no capability evidence was supplied.
+
 ---
 
 ## 7) Lane Behavior (Dispatch Contract)

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T12:05:32.834775Z",
+  "emitted_at": "2026-07-11T02:07:01.797728Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2747",
+  "pr_number": "2755",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T01:16:38.568936Z",
+  "emitted_at": "2026-07-10T12:05:32.834775Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2755",
+  "pr_number": "2747",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T12:05:32.834775Z",
+  "emitted_at": "2026-07-11T01:16:38.568936Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2747",
+  "pr_number": "2755",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T02:07:01.797728Z",
+  "emitted_at": "2026-07-11T02:11:43.709749Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T01:11:44.854719Z",
+  "emitted_at": "2026-07-10T12:05:32.834775Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2755",
+  "pr_number": "2747",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T12:05:32.834775Z",
+  "emitted_at": "2026-07-11T01:08:09.614168Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2747",
+  "pr_number": "2755",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T01:08:09.614168Z",
+  "emitted_at": "2026-07-11T01:11:44.854719Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/scripts/runner_lib/__init__.py
+++ b/scripts/runner_lib/__init__.py
@@ -1,20 +1,24 @@
 """Shared helpers for dual-provider agent runner workflows."""
 
 from .core import (
+    CapabilityEffectEvidence,
     DebounceDecision,
     RunnerPrompt,
     RunnerResult,
     assemble_prompt,
+    normalize_capability_effect_evidence,
     parse_runner_output,
     record_completion,
     should_dispatch,
 )
 
 __all__ = [
+    "CapabilityEffectEvidence",
     "DebounceDecision",
     "RunnerPrompt",
     "RunnerResult",
     "assemble_prompt",
+    "normalize_capability_effect_evidence",
     "parse_runner_output",
     "record_completion",
     "should_dispatch",

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -86,6 +86,11 @@ class DebounceDecision:
 
 
 def _validate_capability_effect_evidence_values(values: dict[str, str]) -> None:
+    non_strings = [name for name, value in values.items() if not isinstance(value, str)]
+    if non_strings:
+        raise ValueError(
+            "capability evidence fields must be strings; invalid " + ", ".join(non_strings)
+        )
     if not any(values.values()):
         return
     missing = [name for name, value in values.items() if not value]
@@ -101,7 +106,7 @@ def _validate_capability_effect_evidence_values(values: dict[str, str]) -> None:
     if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
         raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
     lowered_ref = artifact_ref.lower()
-    if lowered_ref.startswith(SECRET_LIKE_EVIDENCE_PREFIXES):
+    if any(prefix in lowered_ref for prefix in SECRET_LIKE_EVIDENCE_PREFIXES):
         raise ValueError("evidence_artifact_ref has a credential-like prefix")
     if any(
         marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -38,7 +38,9 @@ TRUSTED_MARKER_AUTHORS = {
     "stranske-automation-bot",
 }
 TRUSTED_MARKER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
-CAPABILITY_ID_RE = re.compile(r"^capability:[a-z0-9][a-z0-9-]{2,127}$")
+CAPABILITY_ID_RE = re.compile(
+    r"^capability:(?=[a-z0-9-]{3,128}$)[a-z0-9]+(?:-[a-z0-9]+)*$"
+)
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
@@ -85,6 +87,36 @@ class DebounceDecision:
     prior_head_sha: str | None = None
 
 
+def _validate_capability_effect_evidence_values(values: dict[str, str]) -> None:
+    if not any(values.values()):
+        return
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        raise ValueError(
+            "partial capability evidence is not allowed; missing " + ", ".join(missing)
+        )
+    if not CAPABILITY_ID_RE.fullmatch(values["capability_id"]):
+        raise ValueError("capability_id must match capability:<lowercase-kebab-id>")
+    if not SHA256_RE.fullmatch(values["effect_fingerprint"]):
+        raise ValueError("effect_fingerprint must be a lowercase sha256 digest")
+    artifact_ref = values["evidence_artifact_ref"]
+    if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
+        raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
+    lowered_ref = artifact_ref.lower()
+    if lowered_ref.startswith(SECRET_LIKE_EVIDENCE_PREFIXES):
+        raise ValueError("evidence_artifact_ref has a credential-like prefix")
+    if any(
+        marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")
+    ):
+        raise ValueError("evidence_artifact_ref contains a secret-like marker")
+    if values["supervision_mode"] not in SUPERVISION_MODES:
+        raise ValueError("unsupported supervision_mode")
+    if values["capability_evidence_status"] not in CAPABILITY_EVIDENCE_STATUSES:
+        raise ValueError("unsupported capability_evidence_status")
+    if values["terminal_disposition"] not in TERMINAL_DISPOSITIONS:
+        raise ValueError("unsupported terminal_disposition")
+
+
 @dataclasses.dataclass(frozen=True)
 class CapabilityEffectEvidence:
     """Bounded, provider-neutral evidence carried by a runner result.
@@ -101,6 +133,18 @@ class CapabilityEffectEvidence:
     supervision_mode: str = ""
     capability_evidence_status: str = ""
     terminal_disposition: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_capability_effect_evidence_values(
+            {
+                "capability_id": self.capability_id,
+                "effect_fingerprint": self.effect_fingerprint,
+                "evidence_artifact_ref": self.evidence_artifact_ref,
+                "supervision_mode": self.supervision_mode,
+                "capability_evidence_status": self.capability_evidence_status,
+                "terminal_disposition": self.terminal_disposition,
+            }
+        )
 
     def github_outputs(self) -> dict[str, str]:
         return {
@@ -131,33 +175,7 @@ def normalize_capability_effect_evidence(
         "capability_evidence_status": str(capability_evidence_status or "").strip().lower(),
         "terminal_disposition": str(terminal_disposition or "").strip().lower(),
     }
-    if not any(values.values()):
-        return CapabilityEffectEvidence()
-    missing = [name for name, value in values.items() if not value]
-    if missing:
-        raise ValueError(
-            "partial capability evidence is not allowed; missing " + ", ".join(missing)
-        )
-    if not CAPABILITY_ID_RE.fullmatch(values["capability_id"]):
-        raise ValueError("capability_id must match capability:<lowercase-kebab-id>")
-    if not SHA256_RE.fullmatch(values["effect_fingerprint"]):
-        raise ValueError("effect_fingerprint must be a lowercase sha256 digest")
-    artifact_ref = values["evidence_artifact_ref"]
-    if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
-        raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
-    lowered_ref = artifact_ref.lower()
-    if lowered_ref.startswith(SECRET_LIKE_EVIDENCE_PREFIXES):
-        raise ValueError("evidence_artifact_ref has a credential-like prefix")
-    if any(
-        marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")
-    ):
-        raise ValueError("evidence_artifact_ref contains a secret-like marker")
-    if values["supervision_mode"] not in SUPERVISION_MODES:
-        raise ValueError("unsupported supervision_mode")
-    if values["capability_evidence_status"] not in CAPABILITY_EVIDENCE_STATUSES:
-        raise ValueError("unsupported capability_evidence_status")
-    if values["terminal_disposition"] not in TERMINAL_DISPOSITIONS:
-        raise ValueError("unsupported terminal_disposition")
+    _validate_capability_effect_evidence_values(values)
     return CapabilityEffectEvidence(**values)
 
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -38,6 +38,23 @@ TRUSTED_MARKER_AUTHORS = {
     "stranske-automation-bot",
 }
 TRUSTED_MARKER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+CAPABILITY_ID_RE = re.compile(r"^capability:[a-z0-9][a-z0-9-]{2,127}$")
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
+SUPERVISION_MODES = {
+    "shadow",
+    "human-reviewed",
+    "human-on-exception",
+    "unattended",
+}
+CAPABILITY_EVIDENCE_STATUSES = {"accepted", "rejected", "not-evaluated"}
+TERMINAL_DISPOSITIONS = {
+    "success",
+    "failure",
+    "no-change",
+    "blocked",
+    "cancelled",
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -65,6 +82,78 @@ class DebounceDecision:
     key: str
     prior_status: str | None = None
     prior_head_sha: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class CapabilityEffectEvidence:
+    """Bounded, provider-neutral evidence carried by a runner result.
+
+    Empty evidence is valid for backwards compatibility. Once any capability
+    field is present, the identity, effect fingerprint, durable artifact
+    reference, supervision mode, evidence status, and terminal disposition
+    must all be present and valid.
+    """
+
+    capability_id: str = ""
+    effect_fingerprint: str = ""
+    evidence_artifact_ref: str = ""
+    supervision_mode: str = ""
+    capability_evidence_status: str = ""
+    terminal_disposition: str = ""
+
+    def github_outputs(self) -> dict[str, str]:
+        return {
+            "capability-id": self.capability_id,
+            "effect-fingerprint": self.effect_fingerprint,
+            "evidence-artifact-ref": self.evidence_artifact_ref,
+            "supervision-mode": self.supervision_mode,
+            "capability-evidence-status": self.capability_evidence_status,
+            "terminal-disposition": self.terminal_disposition,
+        }
+
+
+def normalize_capability_effect_evidence(
+    *,
+    capability_id: str = "",
+    effect_fingerprint: str = "",
+    evidence_artifact_ref: str = "",
+    supervision_mode: str = "",
+    capability_evidence_status: str = "",
+    terminal_disposition: str = "",
+) -> CapabilityEffectEvidence:
+    """Validate optional runner capability evidence without inferring from prose."""
+    values = {
+        "capability_id": str(capability_id or "").strip().lower(),
+        "effect_fingerprint": str(effect_fingerprint or "").strip().lower(),
+        "evidence_artifact_ref": str(evidence_artifact_ref or "").strip(),
+        "supervision_mode": str(supervision_mode or "").strip().lower(),
+        "capability_evidence_status": str(capability_evidence_status or "").strip().lower(),
+        "terminal_disposition": str(terminal_disposition or "").strip().lower(),
+    }
+    if not any(values.values()):
+        return CapabilityEffectEvidence()
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        raise ValueError(
+            "partial capability evidence is not allowed; missing " + ", ".join(missing)
+        )
+    if not CAPABILITY_ID_RE.fullmatch(values["capability_id"]):
+        raise ValueError("capability_id must match capability:<lowercase-kebab-id>")
+    if not SHA256_RE.fullmatch(values["effect_fingerprint"]):
+        raise ValueError("effect_fingerprint must be a lowercase sha256 digest")
+    artifact_ref = values["evidence_artifact_ref"]
+    if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
+        raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
+    lowered_ref = artifact_ref.lower()
+    if any(marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")):
+        raise ValueError("evidence_artifact_ref contains a secret-like marker")
+    if values["supervision_mode"] not in SUPERVISION_MODES:
+        raise ValueError("unsupported supervision_mode")
+    if values["capability_evidence_status"] not in CAPABILITY_EVIDENCE_STATUSES:
+        raise ValueError("unsupported capability_evidence_status")
+    if values["terminal_disposition"] not in TERMINAL_DISPOSITIONS:
+        raise ValueError("unsupported terminal_disposition")
+    return CapabilityEffectEvidence(**values)
 
 
 class RunnerDispatchStorage(Protocol):
@@ -1084,6 +1173,21 @@ def _cmd_record_completion(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_normalize_evidence(args: argparse.Namespace) -> int:
+    evidence = normalize_capability_effect_evidence(
+        capability_id=args.capability_id,
+        effect_fingerprint=args.effect_fingerprint,
+        evidence_artifact_ref=args.evidence_artifact_ref,
+        supervision_mode=args.supervision_mode,
+        capability_evidence_status=args.capability_evidence_status,
+        terminal_disposition=args.terminal_disposition,
+    )
+    outputs = evidence.github_outputs()
+    _write_github_output(outputs)
+    print(json.dumps(outputs, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1129,6 +1233,17 @@ def build_parser() -> argparse.ArgumentParser:
     complete.add_argument("--summary", default="")
     complete.add_argument("--exit-code", default=None)
     complete.set_defaults(func=_cmd_record_completion)
+
+    evidence = subparsers.add_parser(
+        "normalize-evidence", help="validate optional capability/effect evidence"
+    )
+    evidence.add_argument("--capability-id", default="")
+    evidence.add_argument("--effect-fingerprint", default="")
+    evidence.add_argument("--evidence-artifact-ref", default="")
+    evidence.add_argument("--supervision-mode", default="")
+    evidence.add_argument("--capability-evidence-status", default="")
+    evidence.add_argument("--terminal-disposition", default="")
+    evidence.set_defaults(func=_cmd_normalize_evidence)
     return parser
 
 

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -38,9 +38,7 @@ TRUSTED_MARKER_AUTHORS = {
     "stranske-automation-bot",
 }
 TRUSTED_MARKER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
-CAPABILITY_ID_RE = re.compile(
-    r"^capability:(?=[a-z0-9-]{3,128}$)[a-z0-9]+(?:-[a-z0-9]+)*$"
-)
+CAPABILITY_ID_RE = re.compile(r"^capability:(?=[a-z0-9-]{3,128}$)[a-z0-9]+(?:-[a-z0-9]+)*$")
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -41,6 +41,7 @@ TRUSTED_MARKER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 CAPABILITY_ID_RE = re.compile(r"^capability:[a-z0-9][a-z0-9-]{2,127}$")
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
+SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
 SUPERVISION_MODES = {
     "shadow",
     "human-reviewed",
@@ -145,6 +146,8 @@ def normalize_capability_effect_evidence(
     if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
         raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
     lowered_ref = artifact_ref.lower()
+    if lowered_ref.startswith(SECRET_LIKE_EVIDENCE_PREFIXES):
+        raise ValueError("evidence_artifact_ref has a credential-like prefix")
     if any(
         marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")
     ):

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -145,7 +145,9 @@ def normalize_capability_effect_evidence(
     if not EVIDENCE_REF_RE.fullmatch(artifact_ref):
         raise ValueError("evidence_artifact_ref must be a bounded durable logical reference")
     lowered_ref = artifact_ref.lower()
-    if any(marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")):
+    if any(
+        marker in lowered_ref for marker in ("token", "secret", "password", "api-key", "apikey")
+    ):
         raise ValueError("evidence_artifact_ref contains a secret-like marker")
     if values["supervision_mode"] not in SUPERVISION_MODES:
         raise ValueError("unsupported supervision_mode")

--- a/templates/consumer-repo/docs/contracts/agent-runner-output.md
+++ b/templates/consumer-repo/docs/contracts/agent-runner-output.md
@@ -1,8 +1,8 @@
 # Agent Runner Output Contract
 
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Canonical specification
-**Last Updated:** February 17, 2026
+**Last Updated:** July 10, 2026
 
 ## Purpose
 
@@ -103,6 +103,26 @@ All runners MUST support LLM-based task completion analysis:
 | `llm-completed-tasks` | string | JSON array of completed task descriptions | `'["Add tests", "Fix bug"]'` |
 | `llm-has-completions` | string | Whether any task completions were detected (`"true"` \| `"false"`) | `"true"` |
 
+### Optional Capability Effect Evidence
+
+These provider-neutral outputs are empty by default. A caller MAY supply a
+complete evidence record when the run is exercising an existing bounded
+capability. Runners MUST validate the record through the shared runner library;
+they MUST NOT infer capability identity or effects from free-form agent prose.
+
+| Output | Type | Description | Example |
+|--------|------|-------------|---------|
+| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:...` |
+| `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
+| `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |
+| `capability-evidence-status` | string | `accepted` \| `rejected` \| `not-evaluated` | `accepted` |
+| `terminal-disposition` | string | `success` \| `failure` \| `no-change` \| `blocked` \| `cancelled` | `no-change` |
+
+Evidence is all-or-none: if any field is non-empty, every field is required.
+Invalid or partial evidence fails before agent execution. Empty evidence retains
+the v1.0 behavior and is not interpreted as a rejected capability outcome.
+
 ---
 
 ## Output Semantics
@@ -200,6 +220,10 @@ New optional outputs MAY be added without breaking compatibility:
 - Add output with default empty string value
 - Update this document
 - Update all existing runners to provide the output
+
+Capability evidence added in v1.1 follows this rule: all existing runners
+provide the outputs, and all values remain empty unless a caller supplies one
+complete validated record.
 
 ### Deprecating Outputs
 

--- a/templates/consumer-repo/docs/contracts/agent-runner-output.md
+++ b/templates/consumer-repo/docs/contracts/agent-runner-output.md
@@ -113,7 +113,7 @@ they MUST NOT infer capability identity or effects from free-form agent prose.
 | Output | Type | Description | Example |
 |--------|------|-------------|---------|
 | `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
-| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:...` |
+| `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
 | `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
 | `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |
 | `capability-evidence-status` | string | `accepted` \| `rejected` \| `not-evaluated` | `accepted` |

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -91,9 +91,7 @@ def test_capability_effect_evidence_rejects_spoofed_or_secret_bearing_values() -
             **{**valid, "evidence_artifact_ref": "artifact:secret-token:123"}
         )
     with pytest.raises(ValueError, match="supervision_mode"):
-        normalize_capability_effect_evidence(
-            **{**valid, "supervision_mode": "owner-will-fix-it"}
-        )
+        normalize_capability_effect_evidence(**{**valid, "supervision_mode": "owner-will-fix-it"})
 
 
 def test_normalize_evidence_cli_writes_github_outputs(tmp_path: Path) -> None:

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -10,6 +10,7 @@ import pytest
 import scripts.runner_lib.core as runner_core
 from scripts.runner_lib import (
     assemble_prompt,
+    normalize_capability_effect_evidence,
     parse_runner_output,
     record_completion,
     should_dispatch,
@@ -29,6 +30,104 @@ class MemoryRunnerStorage:
     def write_record(self, pr_number: int, provider: str, record: dict[str, Any]) -> None:
         self.records[(pr_number, provider)] = dict(record)
         self.writes.append(dict(record))
+
+
+def test_capability_effect_evidence_is_optional_and_empty() -> None:
+    evidence = normalize_capability_effect_evidence()
+
+    assert set(evidence.github_outputs().values()) == {""}
+
+
+def test_capability_effect_evidence_normalizes_provider_neutral_fields() -> None:
+    evidence = normalize_capability_effect_evidence(
+        capability_id=" CAPABILITY:CONSUMER-SYNC ",
+        effect_fingerprint="SHA256:" + "a" * 64,
+        evidence_artifact_ref="github-actions:owner/repo:123:consumer-sync-plan",
+        supervision_mode="HUMAN-ON-EXCEPTION",
+        capability_evidence_status="ACCEPTED",
+        terminal_disposition="SUCCESS",
+    )
+
+    assert evidence.github_outputs() == {
+        "capability-id": "capability:consumer-sync",
+        "effect-fingerprint": "sha256:" + "a" * 64,
+        "evidence-artifact-ref": "github-actions:owner/repo:123:consumer-sync-plan",
+        "supervision-mode": "human-on-exception",
+        "capability-evidence-status": "accepted",
+        "terminal-disposition": "success",
+    }
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"effect_fingerprint": "sha256:" + "a" * 64}, "partial capability evidence"),
+        ({"capability_id": "consumer sync"}, "partial capability evidence"),
+        ({"capability_id": "capability:Consumer_Sync"}, "partial capability evidence"),
+    ],
+)
+def test_capability_effect_evidence_rejects_partial_records(
+    overrides: dict[str, str], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        normalize_capability_effect_evidence(**overrides)
+
+
+def test_capability_effect_evidence_rejects_spoofed_or_secret_bearing_values() -> None:
+    valid = {
+        "capability_id": "capability:consumer-sync",
+        "effect_fingerprint": "sha256:" + "b" * 64,
+        "evidence_artifact_ref": "artifact:consumer-sync:123",
+        "supervision_mode": "shadow",
+        "capability_evidence_status": "accepted",
+        "terminal_disposition": "no-change",
+    }
+    with pytest.raises(ValueError, match="lowercase sha256"):
+        normalize_capability_effect_evidence(
+            **{**valid, "effect_fingerprint": "sha256:not-a-digest"}
+        )
+    with pytest.raises(ValueError, match="secret-like"):
+        normalize_capability_effect_evidence(
+            **{**valid, "evidence_artifact_ref": "artifact:secret-token:123"}
+        )
+    with pytest.raises(ValueError, match="supervision_mode"):
+        normalize_capability_effect_evidence(
+            **{**valid, "supervision_mode": "owner-will-fix-it"}
+        )
+
+
+def test_normalize_evidence_cli_writes_github_outputs(tmp_path: Path) -> None:
+    output = tmp_path / "github-output"
+    command = [
+        "python3",
+        "-m",
+        "scripts.runner_lib",
+        "normalize-evidence",
+        "--capability-id",
+        "capability:consumer-sync",
+        "--effect-fingerprint",
+        "sha256:" + "c" * 64,
+        "--evidence-artifact-ref",
+        "artifact:consumer-sync:123",
+        "--supervision-mode",
+        "shadow",
+        "--capability-evidence-status",
+        "accepted",
+        "--terminal-disposition",
+        "no-change",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=Path(__file__).parents[2],
+        env={"GITHUB_OUTPUT": str(output)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["capability-id"] == "capability:consumer-sync"
+    assert "effect-fingerprint=sha256:" in output.read_text(encoding="utf-8")
 
 
 def _write_prompt_fixture(root: Path) -> None:

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 import scripts.runner_lib.core as runner_core
 from scripts.runner_lib import (
+    CapabilityEffectEvidence,
     assemble_prompt,
     normalize_capability_effect_evidence,
     parse_runner_output,
@@ -64,7 +65,6 @@ def test_capability_effect_evidence_normalizes_provider_neutral_fields() -> None
     [
         ({"effect_fingerprint": "sha256:" + "a" * 64}, "partial capability evidence"),
         ({"capability_id": "consumer sync"}, "partial capability evidence"),
-        ({"capability_id": "capability:Consumer_Sync"}, "partial capability evidence"),
     ],
 )
 def test_capability_effect_evidence_rejects_partial_records(
@@ -87,6 +87,17 @@ def test_capability_effect_evidence_rejects_spoofed_or_secret_bearing_values() -
         normalize_capability_effect_evidence(
             **{**valid, "effect_fingerprint": "sha256:not-a-digest"}
         )
+    for invalid_capability_id in (
+        "capability:Consumer_Sync",
+        "capability:foo-",
+        "capability:foo--bar",
+    ):
+        with pytest.raises(ValueError, match="capability_id"):
+            normalize_capability_effect_evidence(
+                **{**valid, "capability_id": invalid_capability_id}
+            )
+    with pytest.raises(ValueError, match="partial capability evidence"):
+        CapabilityEffectEvidence(capability_id="capability:consumer-sync")
     with pytest.raises(ValueError, match="secret-like"):
         normalize_capability_effect_evidence(
             **{**valid, "evidence_artifact_ref": "artifact:secret-token:123"}

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -102,13 +102,25 @@ def test_capability_effect_evidence_rejects_spoofed_or_secret_bearing_values() -
         normalize_capability_effect_evidence(
             **{**valid, "evidence_artifact_ref": "artifact:secret-token:123"}
         )
-    for credential_like_ref in ("ghp_example", "github_pat_example", "sk-example"):
+    for credential_like_ref in (
+        "ghp_example",
+        "github_pat_example",
+        "sk-example",
+        "artifact:ghp_example",
+        "github-actions:owner/repo:123:sk-example",
+    ):
         with pytest.raises(ValueError, match="credential-like prefix"):
             normalize_capability_effect_evidence(
                 **{**valid, "evidence_artifact_ref": credential_like_ref}
             )
     with pytest.raises(ValueError, match="supervision_mode"):
         normalize_capability_effect_evidence(**{**valid, "supervision_mode": "owner-will-fix-it"})
+
+
+@pytest.mark.parametrize("invalid_value", [None, False])
+def test_capability_effect_evidence_rejects_non_string_direct_values(invalid_value: Any) -> None:
+    with pytest.raises(ValueError, match="fields must be strings"):
+        CapabilityEffectEvidence(capability_id=invalid_value)
 
 
 def test_normalize_evidence_cli_writes_github_outputs(tmp_path: Path) -> None:

--- a/tests/scripts/test_runner_lib.py
+++ b/tests/scripts/test_runner_lib.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import types
 from pathlib import Path
@@ -90,6 +91,11 @@ def test_capability_effect_evidence_rejects_spoofed_or_secret_bearing_values() -
         normalize_capability_effect_evidence(
             **{**valid, "evidence_artifact_ref": "artifact:secret-token:123"}
         )
+    for credential_like_ref in ("ghp_example", "github_pat_example", "sk-example"):
+        with pytest.raises(ValueError, match="credential-like prefix"):
+            normalize_capability_effect_evidence(
+                **{**valid, "evidence_artifact_ref": credential_like_ref}
+            )
     with pytest.raises(ValueError, match="supervision_mode"):
         normalize_capability_effect_evidence(**{**valid, "supervision_mode": "owner-will-fix-it"})
 
@@ -117,7 +123,7 @@ def test_normalize_evidence_cli_writes_github_outputs(tmp_path: Path) -> None:
     completed = subprocess.run(
         command,
         cwd=Path(__file__).parents[2],
-        env={"GITHUB_OUTPUT": str(output)},
+        env={**os.environ, "GITHUB_OUTPUT": str(output)},
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2752 -->
> **Source:** Issue #2752

Closes #2752

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- Extend the existing agent-runner output contract with optional, backwards-compatible capability/effect evidence.
- Add outputs for capability ID, effect fingerprint, evidence artifact reference, supervision mode, and terminal disposition/evidence status.
- Define strict formats, size bounds, absence semantics, and secret-safe handling.
- Wire the shared runner/orchestration summaries so existing runners can emit or omit these values uniformly.
- Adapt the evidence into Orchestrator's existing completion-event and capability ledger lifecycle.
- Preserve candidate/shadow gating, provenance, counterexamples, TTL, kill switch, and rollback evidence.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2750](https://github.com/stranske/Workflows/issues/2750)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Update the canonical runner-output contract and implementation guide.
- [ ] Add optional outputs to registry-backed runner surfaces without changing existing required-output semantics.
- [ ] Add shared validation/normalization tests.
- [ ] Extend Orchestrator's completion-event adapter rather than creating a new event store.
- [ ] Record idempotent capability/effect evidence and rejected-input diagnostics.
- [ ] Add deliberate-break fixtures for spoofed capability IDs, unstable fingerprints, oversized refs, and missing provenance.

#### Acceptance criteria
- [ ] Existing consumers remain compatible when every new field is absent.
- [ ] Present values are schema-validated, bounded, stable, and secret-safe.
- [ ] Replayed evidence is idempotent.
- [ ] Orchestrator links accepted evidence to an existing candidate/shadow capability and preserves counterexamples.
- [ ] Raw prompts or runner prose cannot activate, dispatch, or promote a capability.
- [ ] Invalid evidence is observable and cannot mutate capability state.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable Codex, Claude, Cursor, and Gemini workflows now accept optional provider-neutral “capability effect evidence” metadata and expose normalized/validated evidence via new standardized outputs.
* **Bug Fixes**
  * If evidence is invalid or incomplete, the workflows now skip the agent run and any subsequent commit/push to prevent unsafe execution.
* **Documentation**
  * Updated integration, workflow output references, runner implementation guidance, observability contract, and agent-runner output contract (v1.1) with the new optional fields and all-or-none validation rule.
* **Tests**
  * Added unit tests plus a CLI/subprocess integration test for normalization and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->