### PR TITLE
feat: compile consumer sync into one typed normalized plan

### DIFF
--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -688,10 +688,6 @@ scripts:
   - source: scripts/validate_run_contract.py
     description: "Validates a repo's emitted run-contract/v1 run envelope (producer/bridge) or ingested satellite object (consumer) against the canonical Workflows schemas + opt-in participant registry. Offline/deterministic; opt-in skip for non-participants. Synced so participants can validate locally and the reusable conformance gate can invoke it."
 
-  - source: .github/scripts/agents-guard.js
-    description: "Guards against unauthorized agent workflow file changes"
-
-
   # GraphQL-based PR context fetcher (medium-effort rate limit optimization)
   - source: .github/scripts/pr-context-graphql.js
     description: "GraphQL PR context fetcher - reduces 4+ REST calls to 1 GraphQL call"

--- a/.github/workflows/health-70-validate-sync-manifest.yml
+++ b/.github/workflows/health-70-validate-sync-manifest.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
       - name: Validate manifest schema
-        run: python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
+        run: >-
+          python scripts/sync_manifest_compiler.py
+          --manifest .github/sync-manifest.yml
+          --output-json /tmp/consumer-sync-plan.json
       - name: Validate manifest
         id: validate
         run: |

--- a/.github/workflows/health-70-validate-sync-manifest.yml
+++ b/.github/workflows/health-70-validate-sync-manifest.yml
@@ -59,6 +59,8 @@ jobs:
           python-version: '3.14'
       - name: Install dependencies
         run: pip install pyyaml
+      - name: Validate manifest schema
+        run: python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
       - name: Validate manifest
         id: validate
         run: |

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Validate manifest schema
+        run: python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
+
       - name: Load and validate manifest
         id: manifest
         run: |

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -79,6 +79,9 @@ jobs:
           sparse-checkout: |
             templates/consumer-repo
             .github/sync-manifest.yml
+            .github/templates
+            .github/PULL_REQUEST_TEMPLATE.md
+            .github/path-classification.yml
             .github/scripts
             scripts
             tools

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -71,8 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repos: ${{ steps.repos.outputs.matrix }}
-      template_hash: ${{ steps.hash.outputs.hash }}
-      manifest_json: ${{ steps.manifest.outputs.json }}
+      template_hash: ${{ steps.manifest.outputs.template_hash }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -93,70 +92,13 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
-      - name: Validate manifest schema
-        run: python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
-
-      - name: Load and validate manifest
+      - name: Compile typed consumer sync plan
         id: manifest
         run: |
-          python3 << 'MANIFEST_SCRIPT'
-          import yaml
-          import json
-          import os
-          import sys
-
-          manifest_path = '.github/sync-manifest.yml'
-          if not os.path.exists(manifest_path):
-              print("::error::sync-manifest.yml not found!")
-              sys.exit(1)
-
-          with open(manifest_path) as f:
-              manifest = yaml.safe_load(f)
-
-          # Validate required sections exist
-          required_sections = ['workflows', 'prompts', 'scripts', 'actions']
-          for section in required_sections:
-              if section not in manifest:
-                  print(f"::warning::Manifest missing '{section}' section")
-                  manifest[section] = []
-
-          # Convert to JSON for workflow consumption
-          manifest_json = json.dumps(manifest, separators=(',', ':'))
-
-          # GitHub has output size limits, so we'll write to file too
-          with open('manifest.json', 'w') as f:
-              json.dump(manifest, f)
-
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"json={manifest_json}\n")
-
-          print(f"Loaded manifest with:")
-          print(f"  - {len(manifest.get('workflows', []))} workflows")
-          print(f"  - {len(manifest.get('prompts', []))} prompts")
-          print(f"  - {len(manifest.get('scripts', []))} scripts")
-          print(f"  - {len(manifest.get('codex_config', []))} codex configs")
-          print(f"  - {len(manifest.get('actions', []))} actions")
-          print(f"  - {len(manifest.get('docs', []))} docs")
-          print(f"  - {len(manifest.get('llm_config', []))} llm configs")
-          print(f"  - {len(manifest.get('git_config', []))} git configs")
-          print(f"  - {len(manifest.get('issue_templates', []))} issue templates")
-          print(f"  - {len(manifest.get('user_docs', []))} user docs")
-          MANIFEST_SCRIPT
-
-      - name: Compute template hash
-        id: hash
-        run: |
-          # Hash includes all directories that contain synced files
-          hash=$({
-            find templates/consumer-repo -type f -exec sha256sum {} \;
-            find tools -name "*.py" -type f -exec sha256sum {} \; 2>/dev/null || true
-            find scripts -name "*.py" -type f -exec sha256sum {} \; 2>/dev/null || true
-            find scripts -name "*.sh" -type f -exec sha256sum {} \; 2>/dev/null || true
-            find .github/scripts -type f -exec sha256sum {} \;
-            sha256sum .github/sync-manifest.yml
-          } | sort | sha256sum | cut -d' ' -f1)
-          echo "hash=${hash:0:12}" >> "$GITHUB_OUTPUT"
-          echo "Template hash: ${hash:0:12}"
+          python scripts/sync_manifest_compiler.py \
+            --manifest .github/sync-manifest.yml \
+            --output-json manifest.json \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Build repo matrix
         id: repos
@@ -217,8 +159,10 @@ jobs:
           import json
           with open('manifest.json') as f:
               m = json.load(f)
-          for s in m.get('scripts', []):
-              src = s.get('source', '')
+          for s in m.get('entries', []):
+              if s.get('section') != 'scripts':
+                  continue
+              src = s.get('resolved_source', '')
               if src.endswith('.py'):
                   print(src)
           ")
@@ -250,17 +194,18 @@ jobs:
           import json
           with open('manifest.json') as f:
               m = json.load(f)
-          for w in m.get('workflows', []):
-              src = w.get('source', '')
+          for w in m.get('entries', []):
+              if w.get('section') != 'workflows':
+                  continue
+              src = w.get('resolved_source', '')
               if src.endswith('.yml') or src.endswith('.yaml'):
                   print(src)
           ")
 
           for workflow in $workflows; do
-            template_path="templates/consumer-repo/$workflow"
-            if [ -f "$template_path" ]; then
-              echo "Validating $template_path..."
-              python3 -c "import yaml; yaml.safe_load(open('$template_path'))"
+            if [ -f "$workflow" ]; then
+              echo "Validating $workflow..."
+              python3 -c "import yaml; yaml.safe_load(open('$workflow'))"
             fi
           done
           echo "✓ All workflow YAML is valid"
@@ -328,62 +273,36 @@ jobs:
           with open('manifest.json') as f:
               manifest = json.load(f)
 
+          if manifest.get('schema') != 'workflows.consumer-sync-plan/v1':
+              raise ValueError('unsupported consumer sync plan schema')
+          entries = manifest.get('entries')
+          removals = manifest.get('removals')
+          if not isinstance(entries, list) or not isinstance(removals, list):
+              raise ValueError('consumer sync plan entries/removals must be arrays')
+
           # Write the complete list of manifest-declared sync targets so the PR
           # creation step can stage ONLY intended files.
           #
           # This prevents sync PRs from accidentally including consumer repo
           # artifacts (e.g., requirements.lock, *.pyc, *.egg-info) that may be
           # tracked in some repos or generated by CI/autofix.
-          targets = set()
-
-          def add_target(path: str) -> None:
-              if not path:
-                  return
-              targets.add(path)
-
-          for item in manifest.get('workflows', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('prompts', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('scripts', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('codex_config', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('copilot_config', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('templates', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('actions', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('docs', []):
-              add_target(item.get('target', item.get('source', '')))
-
-          for item in manifest.get('llm_config', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('git_config', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('issue_templates', []):
-              add_target(item.get('source', ''))
-
-          for item in manifest.get('user_docs', []):
-              add_target(item.get('target', item.get('source', '')))
-
-          for item in manifest.get('removals', []) or []:
-              add_target(item.get('target', ''))
+          targets = {
+              item['target']
+              for item in [*entries, *removals]
+              if item.get('target')
+          }
 
           Path('sync_targets.txt').write_text(
               ''.join(f"{path}\n" for path in sorted(targets) if path),
               encoding='utf-8',
           )
+
+          # Preserve the established section-specific copy behavior while making
+          # the compiler's normalized plan the only source of path resolution.
+          by_section = {}
+          for entry in entries:
+              by_section.setdefault(entry['section'], []).append(entry)
+          manifest = {**by_section, 'removals': removals}
 
           current_repo = os.environ.get('CURRENT_REPO', '')
           dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
@@ -394,16 +313,9 @@ jobs:
 
           def manifest_skip_reason(item, repo):
               """Return the manifest-declared skip reason for this repo, if any."""
-              for rule in item.get('skip_repos', []) or []:
-                  if isinstance(rule, str):
-                      if rule == repo:
-                          return 'Manifest skip for repo'
-                      continue
-                  if not isinstance(rule, dict):
-                      continue
-                  if str(rule.get('repo', '')).strip() != repo:
-                      continue
-                  return str(rule.get('reason', '')).strip() or 'Manifest skip for repo'
+              if repo in (item.get('skip_repos') or []):
+                  reasons = item.get('skip_reasons') or {}
+                  return str(reasons.get(repo) or 'Manifest skip for repo')
               return ''
 
           def repo_overwrites_create_only(item, repo):
@@ -518,8 +430,8 @@ jobs:
               sync_mode = item.get('sync_mode', 'sync')
 
               # Build paths
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
 
               # Skip conditions
               def skip_create_only():
@@ -542,8 +454,8 @@ jobs:
           for item in manifest.get('prompts', []):
               source = item.get('source', '')
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               sync_file(template_src, consumer_dst, description, item=item)
 
           # Process scripts
@@ -553,8 +465,8 @@ jobs:
               description = item.get('description', 'No description')
               is_directory = item.get('is_directory', False)
               # Scripts come from .github/scripts/, not templates
-              template_src = Path('workflows') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               if is_directory:
                   sync_directory(template_src, consumer_dst, description, item)
               else:
@@ -565,8 +477,8 @@ jobs:
           for item in manifest.get('codex_config', []):
               source = item.get('source', '')
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               sync_file(template_src, consumer_dst, description, item=item)
 
           # Process copilot_config
@@ -575,8 +487,8 @@ jobs:
               source = item.get('source', '')
               description = item.get('description', 'No description')
               is_directory = item.get('is_directory', False)
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
 
               if is_directory:
                   sync_directory(template_src, consumer_dst, description, item)
@@ -589,8 +501,8 @@ jobs:
               source = item.get('source', '')
               description = item.get('description', 'No description')
               # Templates come from .github/templates/, same as scripts pattern
-              template_src = Path('workflows') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               sync_file(template_src, consumer_dst, description, item=item)
 
           # Process actions
@@ -599,8 +511,8 @@ jobs:
               source = item.get('source', '')
               description = item.get('description', 'No description')
               is_directory = item.get('is_directory', False)
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
 
               if is_directory:
                   sync_directory(template_src, consumer_dst, description, item)
@@ -613,7 +525,7 @@ jobs:
               source = item.get('source', '')
               target = item.get('target', source)
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
+              template_src = Path('workflows') / item['resolved_source']
               consumer_dst = Path('consumer') / target
               sync_file(template_src, consumer_dst, description, item=item)
 
@@ -623,11 +535,14 @@ jobs:
               source = item.get('source', '')
               description = item.get('description', 'No description')
               sync_mode = item.get('sync_mode', 'sync')
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               skip_fn = None
               if sync_mode == 'create_only':
-                  skip_fn = lambda: consumer_dst.exists()
+                  skip_fn = lambda: (
+                      consumer_dst.exists()
+                      and not repo_overwrites_create_only(item, current_repo)
+                  )
               sync_file(template_src, consumer_dst, description, skip_fn, item)
 
           # Process git_config
@@ -635,8 +550,8 @@ jobs:
           for item in manifest.get('git_config', []):
               source = item.get('source', '')
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               sync_file(template_src, consumer_dst, description, item=item)
 
           # Process issue_templates
@@ -644,8 +559,8 @@ jobs:
           for item in manifest.get('issue_templates', []):
               source = item.get('source', '')
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
-              consumer_dst = Path('consumer') / source
+              template_src = Path('workflows') / item['resolved_source']
+              consumer_dst = Path('consumer') / item['target']
               sync_file(template_src, consumer_dst, description, item=item)
 
           # Process user_docs
@@ -654,7 +569,7 @@ jobs:
               source = item.get('source', '')
               target = item.get('target', source)
               description = item.get('description', 'No description')
-              template_src = Path('workflows/templates/consumer-repo') / source
+              template_src = Path('workflows') / item['resolved_source']
               consumer_dst = Path('consumer') / target
               sync_file(template_src, consumer_dst, description, item=item)
 

--- a/docs/contracts/schemas/consumer-sync-plan-v1.schema.json
+++ b/docs/contracts/schemas/consumer-sync-plan-v1.schema.json
@@ -34,7 +34,7 @@
     "safePath": {
       "type": "string",
       "minLength": 1,
-      "not": {"pattern": "(^/|(^|/)\\.\\.(/|$)|^\\./|//)"}
+      "not": {"pattern": "(^/|\\\\|(^|/)\\.\\.?(/|$)|//)"}
     },
     "repository": {
       "type": "string",

--- a/docs/contracts/schemas/consumer-sync-plan-v1.schema.json
+++ b/docs/contracts/schemas/consumer-sync-plan-v1.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stranske/Workflows/docs/contracts/schemas/consumer-sync-plan-v1.schema.json",
+  "title": "Workflows Consumer Sync Plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "plan_id",
+    "manifest_sha256",
+    "entries",
+    "removals"
+  ],
+  "properties": {
+    "schema": {"const": "workflows.consumer-sync-plan/v1"},
+    "version": {"const": 1},
+    "plan_id": {"$ref": "#/$defs/sha256"},
+    "manifest_sha256": {"$ref": "#/$defs/sha256"},
+    "entries": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/copyEntry"}
+    },
+    "removals": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/removalEntry"}
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "safePath": {
+      "type": "string",
+      "minLength": 1,
+      "not": {"pattern": "(^/|(^|/)\\.\\.(/|$)|^\\./|//)"}
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "copyEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "section",
+        "source",
+        "resolved_source",
+        "target",
+        "description",
+        "sync_mode",
+        "is_directory",
+        "skip_repos",
+        "skip_reasons",
+        "overwrite_repos",
+        "template_sync",
+        "delivery",
+        "content_sha256",
+        "effect_fingerprint"
+      ],
+      "properties": {
+        "section": {"type": "string", "minLength": 1},
+        "source": {"$ref": "#/$defs/safePath"},
+        "resolved_source": {"$ref": "#/$defs/safePath"},
+        "target": {"$ref": "#/$defs/safePath"},
+        "description": {"type": "string", "minLength": 1},
+        "sync_mode": {
+          "oneOf": [{"const": "create_only"}, {"type": "null"}]
+        },
+        "is_directory": {"type": "boolean"},
+        "skip_repos": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/repository"}
+        },
+        "skip_reasons": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "overwrite_repos": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/repository"}
+        },
+        "template_sync": {
+          "oneOf": [{"const": "exact"}, {"type": "null"}]
+        },
+        "delivery": {"const": "copy"},
+        "content_sha256": {"$ref": "#/$defs/sha256"},
+        "effect_fingerprint": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "removalEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "description", "effect_fingerprint"],
+      "properties": {
+        "target": {"$ref": "#/$defs/safePath"},
+        "description": {"type": "string", "minLength": 1},
+        "effect_fingerprint": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  }
+}

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -45,11 +45,9 @@ For these repos:
   repository-scoped package rule, not patched directly in the consumer repo.
 - Other files listed in the sync manifest continue to sync normally.
 
-Maint 68 currently implements this by keeping an internal `custom_gate_repos` list in
-its sync script and skipping any manifest entry whose `source` contains
-`pr-00-gate` for those repos, plus a repo-specific `AGENTS.md` skip for
-`Trend_Model_Project` and manifest-level package/dependency skips for
-`trip-planner`.
+Maint 68 implements these exceptions through each entry's typed manifest
+`skip_repos` rules. There is no separate hard-coded custom-Gate list in the
+sync script.
 
 ---
 
@@ -187,29 +185,41 @@ Maint 68 is manifest-driven:
 
 `.github/sync-manifest.yml` is parsed by a **typed, deterministic compiler**
 (`scripts/sync_manifest_compiler.py`) before any consumer mutation can happen.
-The compiler validates every entry and raises `ManifestCompileError` on the first
-bad batch so that invalid entries never reach the sync or drift-check loops.
+The compiler resolves source ownership once, validates every entry, and raises
+one aggregated `ManifestCompileError` before sync fan-out so invalid entries
+never reach the sync or drift-check loops. It emits the deterministic
+`workflows.consumer-sync-plan/v1` JSON consumed by sync, drift, validation, and
+template hashing. Its machine-readable schema is
+[`consumer-sync-plan-v1.schema.json`](../contracts/schemas/consumer-sync-plan-v1.schema.json).
 
 Validated fields for each sync entry:
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `source` | str, required | Must be non-empty |
-| `target` | str, optional | Defaults to `source` |
-| `description` | str, optional | Recommended for docs |
+| `source` | safe relative path, required | Resolved once using section ownership policy |
+| `target` | safe relative path, optional | Defaults to `source`; effective targets must be unique |
+| `description` | str, required | Included in the plan for operator summaries |
 | `sync_mode` | `"create_only"` or absent | `None` = always overwrite |
 | `skip_repos` | list of str or `{repo, reason}` dicts | Repo-specific exclusions |
 | `overwrite_repos` | list of str | Repos that ignore `create_only` |
 | `is_directory` | bool, optional | Defaults to `False` |
 | `template_sync` | `"exact"` or absent | Controls template validator |
+| `delivery` | `"copy"` or absent | Runtime-fetched files belong under `runtime_fetched`, not a copy section |
 
-Non-copy sections (`excluded:`, `removals:`, `runtime_fetched:`) use their own
-schemas and are not validated as sync entries.
+Removal targets are typed separately and cannot collide with a copy target.
+`excluded:` and `runtime_fetched:` remain metadata-only sections.
+
+Each normalized copy record adds `resolved_source`, `content_sha256`, and a
+stable `effect_fingerprint`; the plan adds `manifest_sha256` and `plan_id`.
+Directory content hashes are computed from a sorted relative-path/content
+inventory, so identical inputs produce byte-identical JSON.
 
 To validate the manifest locally:
 
 ```bash
-python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
+python scripts/sync_manifest_compiler.py \
+  --manifest .github/sync-manifest.yml \
+  --output-json /tmp/consumer-sync-plan.json
 ```
 
 This is also run automatically as the first step of both `maint-68-sync-consumer-repos.yml`

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -183,6 +183,39 @@ Maint 68 is manifest-driven:
   repository-level directories like `.github/scripts/` (for shared scripts).
 - **Which repos** receive updates are listed in `REGISTERED_CONSUMER_REPOS`.
 
+#### Manifest Schema and Compiler
+
+`.github/sync-manifest.yml` is parsed by a **typed, deterministic compiler**
+(`scripts/sync_manifest_compiler.py`) before any consumer mutation can happen.
+The compiler validates every entry and raises `ManifestCompileError` on the first
+bad batch so that invalid entries never reach the sync or drift-check loops.
+
+Validated fields for each sync entry:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `source` | str, required | Must be non-empty |
+| `target` | str, optional | Defaults to `source` |
+| `description` | str, optional | Recommended for docs |
+| `sync_mode` | `"create_only"` or absent | `None` = always overwrite |
+| `skip_repos` | list of str or `{repo, reason}` dicts | Repo-specific exclusions |
+| `overwrite_repos` | list of str | Repos that ignore `create_only` |
+| `is_directory` | bool, optional | Defaults to `False` |
+| `template_sync` | `"exact"` or absent | Controls template validator |
+
+Non-copy sections (`excluded:`, `removals:`, `runtime_fetched:`) use their own
+schemas and are not validated as sync entries.
+
+To validate the manifest locally:
+
+```bash
+python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
+```
+
+This is also run automatically as the first step of both `maint-68-sync-consumer-repos.yml`
+(before any PR creation) and `health-70-validate-sync-manifest.yml` (on every PR
+that touches the manifest).
+
 Custom Gate repos are a special-case skip: their `pr-00-gate.yml` stays local.
 
 The `Template` repository is the canonical source for new consumer repos, so it

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T03:14:07.929074Z",
+  "emitted_at": "2026-07-11T03:34:28.520827Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T02:11:43.709749Z",
+  "emitted_at": "2026-07-11T03:12:43.092855Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2755",
+  "pr_number": "2756",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T03:12:43.092855Z",
+  "emitted_at": "2026-07-11T03:14:07.929074Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T03:34:28.520827Z",
+  "emitted_at": "2026-07-11T03:38:47.089880Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -11,7 +11,23 @@ import os
 from pathlib import Path
 
 import requests
-import yaml
+
+try:
+    from sync_manifest_compiler import (
+        COPY_SYNCED_SECTIONS,
+        CompiledManifest,
+        ManifestCompileError,
+        ManifestEntry,
+        compile_manifest,
+    )
+except ImportError:
+    from scripts.sync_manifest_compiler import (  # type: ignore[no-redef]
+        COPY_SYNCED_SECTIONS,
+        CompiledManifest,
+        ManifestCompileError,
+        ManifestEntry,
+        compile_manifest,
+    )
 
 REPORT_SCHEMA = "workflows-consumer-sync-drift/v1"
 SUMMARY_ITEM_LIMIT = 50
@@ -143,29 +159,17 @@ def sorted_items(values: set[str]) -> list[str]:
     return sorted(values)
 
 
-def manifest_skip_reason(entry: dict[str, object], repo: str) -> str:
+def manifest_skip_reason(entry: ManifestEntry, repo: str) -> str:
     """Return the manifest-declared skip reason for a repo, if any."""
-    rules = entry.get("skip_repos", [])
-    if not isinstance(rules, list):
-        return ""
-    for rule in rules:
-        if isinstance(rule, str):
-            if rule == repo:
-                return "Manifest skip for repo"
-            continue
-        if not isinstance(rule, dict):
-            continue
-        if str(rule.get("repo", "")).strip() != repo:
-            continue
-        reason = str(rule.get("reason", "")).strip()
-        return reason or "Manifest skip for repo"
+    for skip in entry.skip_repos:
+        if skip.repo == repo:
+            return skip.reason or "Manifest skip for repo"
     return ""
 
 
-def repo_overwrites_create_only(entry: dict[str, object], repo: str) -> bool:
+def repo_overwrites_create_only(entry: ManifestEntry, repo: str) -> bool:
     """Return whether repo should be drift-checked for create_only entries."""
-    overwrite_repos = entry.get("overwrite_repos", [])
-    return isinstance(overwrite_repos, list) and repo in overwrite_repos
+    return repo in entry.overwrite_repos
 
 
 def token_candidates(env: dict[str, str] | None = None) -> list[dict[str, str]]:
@@ -217,31 +221,26 @@ def session_for_token(token: str, session_factory=requests.Session) -> requests.
     return session
 
 
-def probe_targets(manifest: dict[str, object], sections: list[str]) -> list[str]:
+def probe_targets(compiled: CompiledManifest, sections: list[str]) -> list[str]:
     targets: list[str] = []
     for section in sections:
-        entries = manifest.get(section, [])
-        if not isinstance(entries, list):
-            continue
         section_target = ""
-        for entry in entries:
-            if not isinstance(entry, dict):
+        for entry in compiled.section(section):
+            if entry.sync_mode == "create_only":
                 continue
-            source = entry.get("source")
-            if not source or entry.get("sync_mode") == "create_only":
-                continue
-            target = str(entry.get("target", source))
-            local_path = local_path_for(str(source), section)
+            local_path = local_path_for(entry.source, section)
             if not local_path:
                 continue
-            if entry.get("is_directory") or local_path.is_dir():
+            if entry.is_directory or local_path.is_dir():
                 first_child = next(
                     (child for child in sorted(local_path.rglob("*")) if child.is_file()), None
                 )
                 if first_child:
-                    section_target = join_remote_path(target, first_child.relative_to(local_path))
+                    section_target = join_remote_path(
+                        entry.target, first_child.relative_to(local_path)
+                    )
             else:
-                section_target = target
+                section_target = entry.target
             if section_target:
                 targets.append(section_target)
                 break
@@ -746,26 +745,28 @@ def main() -> int:
         )
         return 1
 
-    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-    sections = [
-        "workflows",
-        "prompts",
-        "scripts",
-        "codex_config",
-        "docs",
-        "copilot_config",
-        "templates",
-        "actions",
-        "llm_config",
-        "git_config",
-        "issue_templates",
-        "user_docs",
-    ]
+    try:
+        compiled = compile_manifest(manifest_path)
+    except ManifestCompileError as exc:
+        print(f"::error::Manifest is invalid — refusing to run drift check:\n{exc}")
+        write_report_json(
+            args.report_json,
+            build_report(
+                repos=repos,
+                drift=set(),
+                missing=set(),
+                errors={f"Invalid manifest: {exc.problems[0]}"},
+                obsolete=set(),
+            ),
+        )
+        return 1
+
+    sections = list(COPY_SYNCED_SECTIONS)
 
     session, token_diagnostics = select_read_token(
         candidates=candidates,
         repos=repos,
-        paths=probe_targets(manifest, sections),
+        paths=probe_targets(compiled, sections),
     )
     if session is None:
         print("::error::No usable GitHub token available for consumer repo contents reads")
@@ -831,43 +832,35 @@ def main() -> int:
             drift.add(f"{repo}: {remote_target}")
 
     for section in sections:
-        for entry in manifest.get(section, []) or []:
-            source = entry.get("source")
-            if not source:
-                continue
-            target = entry.get("target", source)
-            is_directory = entry.get("is_directory", False)
-            local_path = local_path_for(source, section)
+        for entry in compiled.section(section):
+            local_path = local_path_for(entry.source, section)
             if not local_path:
-                errors.add(f"{section}: missing local file for {source}")
+                errors.add(f"{section}: missing local file for {entry.source}")
                 continue
 
             for repo in remote_trees:
-                if entry.get("sync_mode") == "create_only" and not repo_overwrites_create_only(
+                if entry.sync_mode == "create_only" and not repo_overwrites_create_only(
                     entry, repo
                 ):
                     continue
                 skip_reason = manifest_skip_reason(entry, repo)
                 if skip_reason:
-                    skipped.add(f"{repo}: {target} ({skip_reason})")
+                    skipped.add(f"{repo}: {entry.target} ({skip_reason})")
                     continue
-                if is_directory or local_path.is_dir():
+                if entry.is_directory or local_path.is_dir():
                     # Recursively compare all files within the directory
                     for child in sorted(local_path.rglob("*")):
                         if child.is_file():
                             rel = child.relative_to(local_path)
-                            remote_target = join_remote_path(target, rel)
+                            remote_target = join_remote_path(entry.target, rel)
                             _check_file(child, remote_target, repo)
                 else:
-                    _check_file(local_path, target, repo)
+                    _check_file(local_path, entry.target, repo)
 
-    for entry in manifest.get("removals", []) or []:
-        target = entry.get("target")
-        if not target:
-            continue
+    for removal in compiled.removals:
         for repo, remote_tree in remote_trees.items():
-            if target in remote_tree:
-                obsolete.add(f"{repo}: {target}")
+            if removal.target in remote_tree:
+                obsolete.add(f"{repo}: {removal.target}")
 
     report = build_report(
         repos=repos,

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -19,6 +19,7 @@ try:
         ManifestCompileError,
         ManifestEntry,
         compile_manifest,
+        resolve_source_path,
     )
 except ImportError:
     from scripts.sync_manifest_compiler import (  # type: ignore[no-redef]
@@ -27,6 +28,7 @@ except ImportError:
         ManifestCompileError,
         ManifestEntry,
         compile_manifest,
+        resolve_source_path,
     )
 
 REPORT_SCHEMA = "workflows-consumer-sync-drift/v1"
@@ -87,35 +89,9 @@ def resolve_repos(raw: str | None) -> list[str]:
     return repos
 
 
-ROOT_SOURCE_SECTIONS = {"scripts", "templates"}
-TEMPLATE_SOURCE_SECTIONS = {
-    "workflows",
-    "prompts",
-    "codex_config",
-    "copilot_config",
-    "docs",
-    "actions",
-    "llm_config",
-    "git_config",
-    "issue_templates",
-    "user_docs",
-}
-
-
 def local_path_for(source: str, section: str | None = None) -> Path | None:
-    root_candidate = Path(source)
-    template_candidate = Path("templates/consumer-repo") / source
-    if section in ROOT_SOURCE_SECTIONS:
-        candidates = [root_candidate, template_candidate]
-    elif section in TEMPLATE_SOURCE_SECTIONS:
-        candidates = [template_candidate, root_candidate]
-    else:
-        candidates = [template_candidate, root_candidate]
-
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    return None
+    """Compatibility wrapper around the compiler's canonical resolver."""
+    return resolve_source_path(source, section or "", repo_root=Path("."))
 
 
 def git_blob_hash(content: bytes) -> str:
@@ -228,7 +204,7 @@ def probe_targets(compiled: CompiledManifest, sections: list[str]) -> list[str]:
         for entry in compiled.section(section):
             if entry.sync_mode == "create_only":
                 continue
-            local_path = local_path_for(entry.source, section)
+            local_path = Path(entry.resolved_source)
             if not local_path:
                 continue
             if entry.is_directory or local_path.is_dir():
@@ -833,7 +809,7 @@ def main() -> int:
 
     for section in sections:
         for entry in compiled.section(section):
-            local_path = local_path_for(entry.source, section)
+            local_path = Path(entry.resolved_source)
             if not local_path:
                 errors.add(f"{section}: missing local file for {entry.source}")
                 continue

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -91,7 +91,7 @@ def resolve_repos(raw: str | None) -> list[str]:
 
 def local_path_for(source: str, section: str | None = None) -> Path | None:
     """Compatibility wrapper around the compiler's canonical resolver."""
-    return resolve_source_path(source, section or "", repo_root=Path("."))
+    return resolve_source_path(source, section, repo_root=Path("."))
 
 
 def git_blob_hash(content: bytes) -> str:

--- a/scripts/check_consumer_sync_drift.py
+++ b/scripts/check_consumer_sync_drift.py
@@ -205,7 +205,7 @@ def probe_targets(compiled: CompiledManifest, sections: list[str]) -> list[str]:
             if entry.sync_mode == "create_only":
                 continue
             local_path = Path(entry.resolved_source)
-            if not local_path:
+            if not local_path.exists():
                 continue
             if entry.is_directory or local_path.is_dir():
                 first_child = next(
@@ -810,7 +810,7 @@ def main() -> int:
     for section in sections:
         for entry in compiled.section(section):
             local_path = Path(entry.resolved_source)
-            if not local_path:
+            if not local_path.exists():
                 errors.add(f"{section}: missing local file for {entry.source}")
                 continue
 

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -248,8 +248,22 @@ def _resolve_source(
     return chosen.relative_to(repo_root).as_posix(), chosen, errors
 
 
-def resolve_source_path(source: str, section: str, *, repo_root: Path = Path(".")) -> Path | None:
-    """Resolve one source using the compiler's canonical ownership policy."""
+def resolve_source_path(
+    source: str, section: str | None, *, repo_root: Path = Path(".")
+) -> Path | None:
+    """Resolve one source using the compiler's canonical ownership policy.
+
+    ``section=None`` preserves the drift checker's legacy compatibility lookup:
+    prefer the consumer template and then fall back to the repository root.
+    Manifest compilation always supplies a section and therefore remains bound
+    to the explicit ownership policy.
+    """
+    if section is None:
+        root = repo_root.resolve()
+        for candidate in (root / "templates" / "consumer-repo" / source, root / source):
+            if candidate.exists():
+                return candidate
+        return None
     _resolved, path, errors = _resolve_source(
         repo_root=repo_root.resolve(),
         source=source,

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -259,13 +259,13 @@ def _resolve_source(
                 continue
             try:
                 child.resolve().relative_to(root)
-            except ValueError:
+            except (RuntimeError, ValueError):
                 return (
                     "",
                     None,
                     [
                         *errors,
-                        f"{context}: source {source!r} contains a symlink that escapes repository root",
+                        f"{context}: source {source!r} contains an invalid symlink",
                     ],
                 )
     return chosen.relative_to(repo_root).as_posix(), chosen, errors

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Typed, deterministic compiler for .github/sync-manifest.yml.
+
+Parses the raw YAML manifest into fully-validated, normalized dataclass objects.
+Invalid entries (missing source, unknown sync_mode, malformed skip_repos, etc.)
+raise ManifestCompileError before any consumer mutation can happen.
+
+Usage as a library::
+
+    from pathlib import Path
+    from sync_manifest_compiler import compile_manifest
+
+    compiled = compile_manifest(Path(".github/sync-manifest.yml"))
+    for entry in compiled.section("workflows"):
+        print(entry.source, entry.target, entry.sync_mode)
+
+Usage as a CLI validator (exits 0 for valid, 1 for invalid)::
+
+    python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+ALLOWED_SYNC_MODES: frozenset[str] = frozenset({"create_only"})
+ALLOWED_TEMPLATE_SYNC: frozenset[str] = frozenset({"exact"})
+
+COPY_SYNCED_SECTIONS: tuple[str, ...] = (
+    "workflows",
+    "prompts",
+    "scripts",
+    "codex_config",
+    "copilot_config",
+    "templates",
+    "actions",
+    "docs",
+    "llm_config",
+    "git_config",
+    "issue_templates",
+    "user_docs",
+)
+
+
+class ManifestCompileError(ValueError):
+    """Raised when the manifest contains one or more validation errors."""
+
+    def __init__(self, problems: list[str]) -> None:
+        self.problems = list(problems)
+        lines = "\n".join(f"  - {p}" for p in self.problems)
+        super().__init__(f"{len(self.problems)} manifest validation error(s):\n{lines}")
+
+
+@dataclass(frozen=True)
+class SkipRepo:
+    """A repo-specific skip rule from skip_repos."""
+
+    repo: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """Normalized, validated representation of one sync-manifest entry."""
+
+    source: str
+    target: str
+    description: str
+    sync_mode: str | None
+    skip_repos: tuple[SkipRepo, ...]
+    overwrite_repos: tuple[str, ...]
+    is_directory: bool
+    template_sync: str | None
+    section: str
+
+
+@dataclass(frozen=True)
+class RemovalEntry:
+    """Normalized, validated representation of one removals entry."""
+
+    target: str
+    description: str
+
+
+class CompiledManifest:
+    """Result of compiling a sync-manifest YAML file."""
+
+    def __init__(
+        self,
+        version: int,
+        sections: dict[str, list[ManifestEntry]],
+        removals: list[RemovalEntry],
+    ) -> None:
+        self.version = version
+        self._sections: dict[str, tuple[ManifestEntry, ...]] = {
+            k: tuple(v) for k, v in sections.items()
+        }
+        self.removals: tuple[RemovalEntry, ...] = tuple(removals)
+
+    def section(self, name: str) -> tuple[ManifestEntry, ...]:
+        """Return compiled entries for a manifest section, or () if absent."""
+        return self._sections.get(name, ())
+
+    def all_entries(self) -> list[ManifestEntry]:
+        """Return all entries across all sections."""
+        result: list[ManifestEntry] = []
+        for entries in self._sections.values():
+            result.extend(entries)
+        return result
+
+
+def _parse_skip_repos(raw: object, context: str) -> tuple[SkipRepo, ...] | str:
+    """Return a tuple of SkipRepo or an error string."""
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        return f"{context}: skip_repos must be a list, got {type(raw).__name__}"
+    result: list[SkipRepo] = []
+    for index, item in enumerate(raw):
+        if isinstance(item, str):
+            result.append(SkipRepo(repo=item.strip(), reason=""))
+            continue
+        if isinstance(item, dict):
+            repo = item.get("repo")
+            if not repo or not isinstance(repo, str) or not repo.strip():
+                return (
+                    f"{context}: skip_repos[{index}] dict must have a non-empty 'repo' field"
+                )
+            reason = str(item.get("reason", "")).strip()
+            result.append(SkipRepo(repo=repo.strip(), reason=reason))
+            continue
+        return (
+            f"{context}: skip_repos[{index}] must be a string or dict,"
+            f" got {type(item).__name__}"
+        )
+    return tuple(result)
+
+
+def _parse_overwrite_repos(raw: object, context: str) -> tuple[str, ...] | str:
+    """Return a tuple of repo strings or an error string."""
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        return (
+            f"{context}: overwrite_repos must be a list, got {type(raw).__name__}"
+        )
+    result: list[str] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, str):
+            return (
+                f"{context}: overwrite_repos[{index}] must be a string,"
+                f" got {type(item).__name__}"
+            )
+        result.append(item)
+    return tuple(result)
+
+
+def _compile_entry(
+    raw: object,
+    section: str,
+    index: int,
+    problems: list[str],
+) -> ManifestEntry | None:
+    """Try to compile one raw manifest entry; append to problems on failure."""
+    context = f"section '{section}', entry {index}"
+
+    if not isinstance(raw, dict):
+        problems.append(f"{context}: entry must be a mapping, got {type(raw).__name__}")
+        return None
+
+    source = raw.get("source")
+    if not source or not isinstance(source, str) or not source.strip():
+        problems.append(f"{context}: 'source' must be a non-empty string")
+        return None
+    source = source.strip()
+    target = str(raw.get("target", source)).strip() or source
+
+    description = str(raw.get("description", "")).strip()
+
+    sync_mode_raw = raw.get("sync_mode")
+    if sync_mode_raw is None:
+        sync_mode: str | None = None
+    elif isinstance(sync_mode_raw, str) and sync_mode_raw in ALLOWED_SYNC_MODES:
+        sync_mode = sync_mode_raw
+    else:
+        problems.append(
+            f"{context} (source={source!r}): sync_mode {sync_mode_raw!r}"
+            f" is not allowed; expected one of {sorted(ALLOWED_SYNC_MODES)}"
+        )
+        return None
+
+    skip_repos_result = _parse_skip_repos(raw.get("skip_repos"), context)
+    if isinstance(skip_repos_result, str):
+        problems.append(skip_repos_result)
+        return None
+    skip_repos = skip_repos_result
+
+    overwrite_repos_result = _parse_overwrite_repos(raw.get("overwrite_repos"), context)
+    if isinstance(overwrite_repos_result, str):
+        problems.append(overwrite_repos_result)
+        return None
+    overwrite_repos = overwrite_repos_result
+
+    is_directory_raw = raw.get("is_directory")
+    if is_directory_raw is None:
+        is_directory = False
+    elif isinstance(is_directory_raw, bool):
+        is_directory = is_directory_raw
+    else:
+        problems.append(
+            f"{context} (source={source!r}): is_directory must be a boolean,"
+            f" got {type(is_directory_raw).__name__}"
+        )
+        return None
+
+    template_sync_raw = raw.get("template_sync")
+    if template_sync_raw is None:
+        template_sync: str | None = None
+    elif isinstance(template_sync_raw, str) and template_sync_raw in ALLOWED_TEMPLATE_SYNC:
+        template_sync = template_sync_raw
+    else:
+        problems.append(
+            f"{context} (source={source!r}): template_sync {template_sync_raw!r}"
+            f" is not allowed; expected one of {sorted(ALLOWED_TEMPLATE_SYNC)}"
+        )
+        return None
+
+    return ManifestEntry(
+        source=source,
+        target=target,
+        description=description,
+        sync_mode=sync_mode,
+        skip_repos=skip_repos,
+        overwrite_repos=overwrite_repos,
+        is_directory=is_directory,
+        template_sync=template_sync,
+        section=section,
+    )
+
+
+def _compile_removal(raw: object, index: int, problems: list[str]) -> RemovalEntry | None:
+    """Try to compile one raw removals entry; append to problems on failure."""
+    context = f"removals entry {index}"
+    if not isinstance(raw, dict):
+        problems.append(f"{context}: entry must be a mapping, got {type(raw).__name__}")
+        return None
+    target = raw.get("target")
+    if not target or not isinstance(target, str) or not target.strip():
+        problems.append(f"{context}: 'target' must be a non-empty string")
+        return None
+    description = str(raw.get("description", "")).strip()
+    return RemovalEntry(target=target.strip(), description=description)
+
+
+def compile_manifest(path: Path) -> CompiledManifest:
+    """Parse and validate a sync-manifest YAML file.
+
+    Raises ManifestCompileError if any entry is invalid.
+    Raises FileNotFoundError if the file does not exist.
+    """
+    raw_yaml = path.read_text(encoding="utf-8")
+    data: object = yaml.safe_load(raw_yaml)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ManifestCompileError([f"Manifest root must be a mapping, got {type(data).__name__}"])
+
+    version_raw = data.get("version", 1)
+    try:
+        version = int(version_raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        version = 1
+
+    problems: list[str] = []
+    sections: dict[str, list[ManifestEntry]] = {}
+
+    for key, value in data.items():
+        if key in ("version", "removals", "excluded", "runtime_fetched"):
+            continue
+        if not isinstance(value, list):
+            continue
+        entries: list[ManifestEntry] = []
+        for index, raw_entry in enumerate(value):
+            entry = _compile_entry(raw_entry, key, index, problems)
+            if entry is not None:
+                entries.append(entry)
+        sections[key] = entries
+
+    removals: list[RemovalEntry] = []
+    raw_removals = data.get("removals")
+    if isinstance(raw_removals, list):
+        for index, raw_entry in enumerate(raw_removals):
+            removal = _compile_removal(raw_entry, index, problems)
+            if removal is not None:
+                removals.append(removal)
+
+    if problems:
+        raise ManifestCompileError(problems)
+
+    return CompiledManifest(version=version, sections=sections, removals=removals)
+
+
+def _cli_validate(path: Path) -> int:
+    """Validate a manifest file; return 0 for valid, 1 for invalid."""
+    if not path.exists():
+        print(f"::error::Manifest file not found: {path}", file=sys.stderr)
+        return 1
+    try:
+        compiled = compile_manifest(path)
+        total = sum(len(compiled.section(s)) for s in COPY_SYNCED_SECTIONS)
+        total += len(compiled.removals)
+        print(
+            f"✅ Manifest valid: {total} entries across"
+            f" {len([s for s in COPY_SYNCED_SECTIONS if compiled.section(s)])} sections,"
+            f" {len(compiled.removals)} removals"
+        )
+        return 0
+    except ManifestCompileError as exc:
+        print(f"❌ Manifest invalid:\n{exc}", file=sys.stderr)
+        return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a sync-manifest YAML file against the typed schema."
+    )
+    parser.add_argument("--validate", metavar="PATH", help="Manifest file to validate")
+    args = parser.parse_args()
+
+    if args.validate:
+        return _cli_validate(Path(args.validate))
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -158,12 +158,15 @@ def _content_hash(path: Path) -> str:
 
 
 def _safe_relative_path(raw: Any, field: str, context: str) -> tuple[str, str | None]:
-    value = str(raw or "").strip().replace("\\", "/")
+    if not isinstance(raw, str):
+        return "", f"{context}: {field} must be a safe repository-relative path"
+    value = raw.strip()
     path = PurePosixPath(value)
     if (
         not value
+        or "\\" in value
         or path.is_absolute()
-        or ".." in path.parts
+        or any(part in {".", ".."} for part in value.split("/"))
         or value.startswith("./")
         or "//" in value
     ):
@@ -244,7 +247,23 @@ def _resolve_source(
                 f"{context}: source {source!r} is not deliverable; searched {searched}",
             ],
         )
+    root = repo_root.resolve()
     chosen = next(candidate for candidate in candidates if candidate.exists())
+    try:
+        chosen.resolve().relative_to(root)
+    except ValueError:
+        return "", None, [*errors, f"{context}: source {source!r} escapes repository root"]
+    if chosen.is_dir():
+        for child in chosen.rglob("*"):
+            if not child.is_symlink():
+                continue
+            try:
+                child.resolve().relative_to(root)
+            except ValueError:
+                return "", None, [
+                    *errors,
+                    f"{context}: source {source!r} contains a symlink that escapes repository root",
+                ]
     return chosen.relative_to(repo_root).as_posix(), chosen, errors
 
 
@@ -258,14 +277,17 @@ def resolve_source_path(
     Manifest compilation always supplies a section and therefore remains bound
     to the explicit ownership policy.
     """
+    source, error = _safe_relative_path(source, "source", "source resolution")
+    if error:
+        return None
+    root = repo_root.resolve()
     if section is None:
-        root = repo_root.resolve()
         for candidate in (root / "templates" / "consumer-repo" / source, root / source):
-            if candidate.exists():
+            if candidate.exists() and candidate.resolve().is_relative_to(root):
                 return candidate
         return None
     _resolved, path, errors = _resolve_source(
-        repo_root=repo_root.resolve(),
+        repo_root=root,
         source=source,
         section=section,
         context=f"section '{section}'",

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -260,10 +260,14 @@ def _resolve_source(
             try:
                 child.resolve().relative_to(root)
             except ValueError:
-                return "", None, [
-                    *errors,
-                    f"{context}: source {source!r} contains a symlink that escapes repository root",
-                ]
+                return (
+                    "",
+                    None,
+                    [
+                        *errors,
+                        f"{context}: source {source!r} contains a symlink that escapes repository root",
+                    ],
+                )
     return chosen.relative_to(repo_root).as_posix(), chosen, errors
 
 

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -258,8 +258,17 @@ def _resolve_source(
             if not child.is_symlink():
                 continue
             try:
-                child.resolve().relative_to(root)
+                Path(os.path.realpath(child, strict=True)).relative_to(root)
             except (RuntimeError, ValueError):
+                return (
+                    "",
+                    None,
+                    [
+                        *errors,
+                        f"{context}: source {source!r} contains an invalid symlink",
+                    ],
+                )
+            except OSError:
                 return (
                     "",
                     None,

--- a/scripts/sync_manifest_compiler.py
+++ b/scripts/sync_manifest_compiler.py
@@ -1,36 +1,23 @@
 #!/usr/bin/env python3
-"""Typed, deterministic compiler for .github/sync-manifest.yml.
-
-Parses the raw YAML manifest into fully-validated, normalized dataclass objects.
-Invalid entries (missing source, unknown sync_mode, malformed skip_repos, etc.)
-raise ManifestCompileError before any consumer mutation can happen.
-
-Usage as a library::
-
-    from pathlib import Path
-    from sync_manifest_compiler import compile_manifest
-
-    compiled = compile_manifest(Path(".github/sync-manifest.yml"))
-    for entry in compiled.section("workflows"):
-        print(entry.source, entry.target, entry.sync_mode)
-
-Usage as a CLI validator (exits 0 for valid, 1 for invalid)::
-
-    python scripts/sync_manifest_compiler.py --validate .github/sync-manifest.yml
-"""
+"""Compile the consumer sync manifest into one typed, deterministic plan."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
+import os
+import re
 import sys
-from dataclasses import dataclass, field
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
 
 import yaml
 
+PLAN_SCHEMA = "workflows.consumer-sync-plan/v1"
 ALLOWED_SYNC_MODES: frozenset[str] = frozenset({"create_only"})
 ALLOWED_TEMPLATE_SYNC: frozenset[str] = frozenset({"exact"})
-
 COPY_SYNCED_SECTIONS: tuple[str, ...] = (
     "workflows",
     "prompts",
@@ -45,30 +32,31 @@ COPY_SYNCED_SECTIONS: tuple[str, ...] = (
     "issue_templates",
     "user_docs",
 )
+ROOT_SOURCE_SECTIONS = {"scripts", "templates"}
+TEMPLATE_SOURCE_SECTIONS = set(COPY_SYNCED_SECTIONS) - ROOT_SOURCE_SECTIONS
+IGNORED_METADATA_SECTIONS = {"excluded", "runtime_fetched"}
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 class ManifestCompileError(ValueError):
-    """Raised when the manifest contains one or more validation errors."""
+    """The manifest cannot produce a safe, unambiguous sync plan."""
 
     def __init__(self, problems: list[str]) -> None:
-        self.problems = list(problems)
-        lines = "\n".join(f"  - {p}" for p in self.problems)
+        self.problems = list(dict.fromkeys(problems))
+        lines = "\n".join(f"  - {problem}" for problem in self.problems)
         super().__init__(f"{len(self.problems)} manifest validation error(s):\n{lines}")
 
 
 @dataclass(frozen=True)
 class SkipRepo:
-    """A repo-specific skip rule from skip_repos."""
-
     repo: str
     reason: str
 
 
 @dataclass(frozen=True)
 class ManifestEntry:
-    """Normalized, validated representation of one sync-manifest entry."""
-
     source: str
+    resolved_source: str
     target: str
     description: str
     sync_mode: str | None
@@ -76,266 +64,443 @@ class ManifestEntry:
     overwrite_repos: tuple[str, ...]
     is_directory: bool
     template_sync: str | None
+    delivery: str
     section: str
+    content_sha256: str
+    effect_fingerprint: str
+
+    def plan_record(self) -> dict[str, Any]:
+        skip_reasons = {rule.repo: rule.reason for rule in self.skip_repos}
+        return {
+            "section": self.section,
+            "source": self.source,
+            "resolved_source": self.resolved_source,
+            "target": self.target,
+            "description": self.description,
+            "sync_mode": self.sync_mode,
+            "is_directory": self.is_directory,
+            "skip_repos": [rule.repo for rule in self.skip_repos],
+            "skip_reasons": skip_reasons,
+            "overwrite_repos": list(self.overwrite_repos),
+            "template_sync": self.template_sync,
+            "delivery": self.delivery,
+            "content_sha256": self.content_sha256,
+            "effect_fingerprint": self.effect_fingerprint,
+        }
 
 
 @dataclass(frozen=True)
 class RemovalEntry:
-    """Normalized, validated representation of one removals entry."""
-
     target: str
     description: str
+    effect_fingerprint: str
+
+    def plan_record(self) -> dict[str, str]:
+        return {
+            "target": self.target,
+            "description": self.description,
+            "effect_fingerprint": self.effect_fingerprint,
+        }
 
 
 class CompiledManifest:
-    """Result of compiling a sync-manifest YAML file."""
-
     def __init__(
         self,
+        *,
         version: int,
+        manifest_sha256: str,
         sections: dict[str, list[ManifestEntry]],
         removals: list[RemovalEntry],
     ) -> None:
         self.version = version
-        self._sections: dict[str, tuple[ManifestEntry, ...]] = {
-            k: tuple(v) for k, v in sections.items()
-        }
-        self.removals: tuple[RemovalEntry, ...] = tuple(removals)
+        self.manifest_sha256 = manifest_sha256
+        self._sections = {section: tuple(entries) for section, entries in sections.items()}
+        self.removals = tuple(removals)
 
     def section(self, name: str) -> tuple[ManifestEntry, ...]:
-        """Return compiled entries for a manifest section, or () if absent."""
         return self._sections.get(name, ())
 
     def all_entries(self) -> list[ManifestEntry]:
-        """Return all entries across all sections."""
-        result: list[ManifestEntry] = []
-        for entries in self._sections.values():
-            result.extend(entries)
-        return result
+        return [entry for section in COPY_SYNCED_SECTIONS for entry in self.section(section)]
+
+    def to_plan(self) -> dict[str, Any]:
+        core = {
+            "schema": PLAN_SCHEMA,
+            "version": 1,
+            "manifest_sha256": self.manifest_sha256,
+            "entries": [entry.plan_record() for entry in self.all_entries()],
+            "removals": [removal.plan_record() for removal in self.removals],
+        }
+        return {
+            **core,
+            "plan_id": _stable_hash("consumer-sync-plan", core),
+        }
 
 
-def _parse_skip_repos(raw: object, context: str) -> tuple[SkipRepo, ...] | str:
-    """Return a tuple of SkipRepo or an error string."""
+def _stable_hash(namespace: str, value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return "sha256:" + hashlib.sha256(namespace.encode() + b"\0" + encoded).hexdigest()
+
+
+def _content_hash(path: Path) -> str:
+    if path.is_file():
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    rows: list[dict[str, str]] = []
+    for child in sorted(path.rglob("*")):
+        if child.is_file():
+            rows.append(
+                {
+                    "path": child.relative_to(path).as_posix(),
+                    "sha256": hashlib.sha256(child.read_bytes()).hexdigest(),
+                }
+            )
+    return _stable_hash("consumer-sync-directory", rows)
+
+
+def _safe_relative_path(raw: Any, field: str, context: str) -> tuple[str, str | None]:
+    value = str(raw or "").strip().replace("\\", "/")
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or value.startswith("./")
+        or "//" in value
+    ):
+        return value, f"{context}: {field} must be a safe repository-relative path"
+    return path.as_posix(), None
+
+
+def _parse_repo_list(raw: Any, *, field: str, context: str) -> tuple[tuple[str, ...], list[str]]:
     if raw is None:
-        return ()
+        return (), []
     if not isinstance(raw, list):
-        return f"{context}: skip_repos must be a list, got {type(raw).__name__}"
-    result: list[SkipRepo] = []
+        return (), [f"{context}: {field} must be a list"]
+    values: list[str] = []
+    errors: list[str] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, str) or not REPO_RE.fullmatch(item.strip()):
+            errors.append(f"{context}: {field}[{index}] must be owner/repo")
+            continue
+        values.append(item.strip())
+    if len(values) != len(set(values)):
+        errors.append(f"{context}: {field} contains duplicate repositories")
+    return tuple(values), errors
+
+
+def _parse_skip_repos(raw: Any, *, context: str) -> tuple[tuple[SkipRepo, ...], list[str]]:
+    if raw is None:
+        return (), []
+    if not isinstance(raw, list):
+        return (), [f"{context}: skip_repos must be a list"]
+    rules: list[SkipRepo] = []
+    errors: list[str] = []
     for index, item in enumerate(raw):
         if isinstance(item, str):
-            result.append(SkipRepo(repo=item.strip(), reason=""))
-            continue
-        if isinstance(item, dict):
-            repo = item.get("repo")
-            if not repo or not isinstance(repo, str) or not repo.strip():
-                return (
-                    f"{context}: skip_repos[{index}] dict must have a non-empty 'repo' field"
-                )
-            reason = str(item.get("reason", "")).strip()
-            result.append(SkipRepo(repo=repo.strip(), reason=reason))
-            continue
-        return (
-            f"{context}: skip_repos[{index}] must be a string or dict,"
-            f" got {type(item).__name__}"
-        )
-    return tuple(result)
-
-
-def _parse_overwrite_repos(raw: object, context: str) -> tuple[str, ...] | str:
-    """Return a tuple of repo strings or an error string."""
-    if raw is None:
-        return ()
-    if not isinstance(raw, list):
-        return (
-            f"{context}: overwrite_repos must be a list, got {type(raw).__name__}"
-        )
-    result: list[str] = []
-    for index, item in enumerate(raw):
-        if not isinstance(item, str):
-            return (
-                f"{context}: overwrite_repos[{index}] must be a string,"
-                f" got {type(item).__name__}"
+            repo, reason = item.strip(), ""
+        elif isinstance(item, dict) and set(item) <= {"repo", "reason"}:
+            repo = str(item.get("repo") or "").strip()
+            reason = str(item.get("reason") or "").strip()
+        else:
+            errors.append(
+                f"{context}: skip_repos[{index}] must be owner/repo or a repo/reason mapping"
             )
-        result.append(item)
-    return tuple(result)
+            continue
+        if not REPO_RE.fullmatch(repo):
+            errors.append(f"{context}: skip_repos[{index}].repo must be owner/repo")
+            continue
+        rules.append(SkipRepo(repo=repo, reason=reason))
+    repos = [rule.repo for rule in rules]
+    if len(repos) != len(set(repos)):
+        errors.append(f"{context}: skip_repos contains duplicate repositories")
+    return tuple(rules), errors
+
+
+def _source_candidates(repo_root: Path, source: str, section: str) -> tuple[list[Path], str | None]:
+    root = repo_root / source
+    template = repo_root / "templates" / "consumer-repo" / source
+    if section in ROOT_SOURCE_SECTIONS:
+        return [root, template], None
+    if section in TEMPLATE_SOURCE_SECTIONS:
+        return [template, root], None
+    return [template, root], f"unknown source ownership policy for section {section}"
+
+
+def _resolve_source(
+    *, repo_root: Path, source: str, section: str, context: str
+) -> tuple[str, Path | None, list[str]]:
+    candidates, policy_error = _source_candidates(repo_root, source, section)
+    errors = [f"{context}: {policy_error}"] if policy_error else []
+    existing = [candidate for candidate in candidates if candidate.exists()]
+    if not existing:
+        searched = ", ".join(
+            candidate.relative_to(repo_root).as_posix() for candidate in candidates
+        )
+        return (
+            "",
+            None,
+            [
+                *errors,
+                f"{context}: source {source!r} is not deliverable; searched {searched}",
+            ],
+        )
+    chosen = next(candidate for candidate in candidates if candidate.exists())
+    return chosen.relative_to(repo_root).as_posix(), chosen, errors
+
+
+def resolve_source_path(source: str, section: str, *, repo_root: Path = Path(".")) -> Path | None:
+    """Resolve one source using the compiler's canonical ownership policy."""
+    _resolved, path, errors = _resolve_source(
+        repo_root=repo_root.resolve(),
+        source=source,
+        section=section,
+        context=f"section '{section}'",
+    )
+    return None if errors else path
 
 
 def _compile_entry(
-    raw: object,
+    raw: Any,
+    *,
     section: str,
     index: int,
-    problems: list[str],
-) -> ManifestEntry | None:
-    """Try to compile one raw manifest entry; append to problems on failure."""
+    repo_root: Path,
+) -> tuple[ManifestEntry | None, list[str]]:
     context = f"section '{section}', entry {index}"
-
+    errors: list[str] = []
     if not isinstance(raw, dict):
-        problems.append(f"{context}: entry must be a mapping, got {type(raw).__name__}")
-        return None
-
-    source = raw.get("source")
-    if not source or not isinstance(source, str) or not source.strip():
-        problems.append(f"{context}: 'source' must be a non-empty string")
-        return None
-    source = source.strip()
-    target = str(raw.get("target", source)).strip() or source
-
-    description = str(raw.get("description", "")).strip()
-
-    sync_mode_raw = raw.get("sync_mode")
-    if sync_mode_raw is None:
-        sync_mode: str | None = None
-    elif isinstance(sync_mode_raw, str) and sync_mode_raw in ALLOWED_SYNC_MODES:
-        sync_mode = sync_mode_raw
-    else:
-        problems.append(
-            f"{context} (source={source!r}): sync_mode {sync_mode_raw!r}"
-            f" is not allowed; expected one of {sorted(ALLOWED_SYNC_MODES)}"
-        )
-        return None
-
-    skip_repos_result = _parse_skip_repos(raw.get("skip_repos"), context)
-    if isinstance(skip_repos_result, str):
-        problems.append(skip_repos_result)
-        return None
-    skip_repos = skip_repos_result
-
-    overwrite_repos_result = _parse_overwrite_repos(raw.get("overwrite_repos"), context)
-    if isinstance(overwrite_repos_result, str):
-        problems.append(overwrite_repos_result)
-        return None
-    overwrite_repos = overwrite_repos_result
-
-    is_directory_raw = raw.get("is_directory")
-    if is_directory_raw is None:
+        return None, [f"{context}: entry must be a mapping"]
+    allowed = {
+        "source",
+        "target",
+        "description",
+        "sync_mode",
+        "skip_repos",
+        "overwrite_repos",
+        "is_directory",
+        "template_sync",
+        "delivery",
+    }
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        errors.append(f"{context}: unsupported fields {unknown}")
+    source, source_error = _safe_relative_path(raw.get("source"), "source", context)
+    if source_error:
+        errors.append(source_error)
+    target, error = _safe_relative_path(raw.get("target", source), "target", context)
+    if error:
+        errors.append(error)
+    description = str(raw.get("description") or "").strip()
+    if not description:
+        errors.append(f"{context}: description must be non-empty")
+    sync_mode = raw.get("sync_mode")
+    if sync_mode is not None and sync_mode not in ALLOWED_SYNC_MODES:
+        errors.append(f"{context}: sync_mode {sync_mode!r} is unsupported")
+    template_sync = raw.get("template_sync")
+    if template_sync is not None and template_sync not in ALLOWED_TEMPLATE_SYNC:
+        errors.append(f"{context}: template_sync {template_sync!r} is unsupported")
+    delivery = raw.get("delivery", "copy")
+    if delivery != "copy":
+        errors.append(f"{context}: copy-synced entry delivery must be 'copy'")
+    is_directory = raw.get("is_directory", False)
+    if not isinstance(is_directory, bool):
+        errors.append(f"{context}: is_directory must be a boolean")
         is_directory = False
-    elif isinstance(is_directory_raw, bool):
-        is_directory = is_directory_raw
+    skip_repos, skip_errors = _parse_skip_repos(raw.get("skip_repos"), context=context)
+    overwrite_repos, overwrite_errors = _parse_repo_list(
+        raw.get("overwrite_repos"),
+        field="overwrite_repos",
+        context=context,
+    )
+    errors.extend(skip_errors)
+    errors.extend(overwrite_errors)
+    if source_error:
+        resolved_source, resolved_path = "", None
     else:
-        problems.append(
-            f"{context} (source={source!r}): is_directory must be a boolean,"
-            f" got {type(is_directory_raw).__name__}"
+        resolved_source, resolved_path, source_errors = _resolve_source(
+            repo_root=repo_root,
+            source=source,
+            section=section,
+            context=context,
         )
-        return None
-
-    template_sync_raw = raw.get("template_sync")
-    if template_sync_raw is None:
-        template_sync: str | None = None
-    elif isinstance(template_sync_raw, str) and template_sync_raw in ALLOWED_TEMPLATE_SYNC:
-        template_sync = template_sync_raw
+        errors.extend(source_errors)
+    if resolved_path is not None:
+        if is_directory != resolved_path.is_dir():
+            expected = "directory" if is_directory else "file"
+            errors.append(f"{context}: resolved source must be a {expected}")
+        content_sha256 = _content_hash(resolved_path)
     else:
-        problems.append(
-            f"{context} (source={source!r}): template_sync {template_sync_raw!r}"
-            f" is not allowed; expected one of {sorted(ALLOWED_TEMPLATE_SYNC)}"
-        )
-        return None
-
-    return ManifestEntry(
-        source=source,
-        target=target,
-        description=description,
-        sync_mode=sync_mode,
-        skip_repos=skip_repos,
-        overwrite_repos=overwrite_repos,
-        is_directory=is_directory,
-        template_sync=template_sync,
-        section=section,
+        content_sha256 = ""
+    if errors:
+        return None, errors
+    effect_core = {
+        "section": section,
+        "source": source,
+        "resolved_source": resolved_source,
+        "target": target,
+        "sync_mode": sync_mode,
+        "is_directory": is_directory,
+        "skip_repos": [rule.repo for rule in skip_repos],
+        "skip_reasons": {rule.repo: rule.reason for rule in skip_repos},
+        "overwrite_repos": list(overwrite_repos),
+        "template_sync": template_sync,
+        "delivery": delivery,
+        "content_sha256": content_sha256,
+    }
+    return (
+        ManifestEntry(
+            source=source,
+            resolved_source=resolved_source,
+            target=target,
+            description=description,
+            sync_mode=sync_mode,
+            skip_repos=skip_repos,
+            overwrite_repos=overwrite_repos,
+            is_directory=is_directory,
+            template_sync=template_sync,
+            delivery=delivery,
+            section=section,
+            content_sha256=content_sha256,
+            effect_fingerprint=_stable_hash("consumer-sync-source-effect", effect_core),
+        ),
+        [],
     )
 
 
-def _compile_removal(raw: object, index: int, problems: list[str]) -> RemovalEntry | None:
-    """Try to compile one raw removals entry; append to problems on failure."""
+def _compile_removal(raw: Any, *, index: int) -> tuple[RemovalEntry | None, list[str]]:
     context = f"removals entry {index}"
-    if not isinstance(raw, dict):
-        problems.append(f"{context}: entry must be a mapping, got {type(raw).__name__}")
-        return None
-    target = raw.get("target")
-    if not target or not isinstance(target, str) or not target.strip():
-        problems.append(f"{context}: 'target' must be a non-empty string")
-        return None
-    description = str(raw.get("description", "")).strip()
-    return RemovalEntry(target=target.strip(), description=description)
+    if not isinstance(raw, dict) or set(raw) - {"target", "description"}:
+        return None, [f"{context}: entry must contain only target and description"]
+    target, error = _safe_relative_path(raw.get("target"), "target", context)
+    description = str(raw.get("description") or "").strip()
+    errors = [error] if error else []
+    if not description:
+        errors.append(f"{context}: description must be non-empty")
+    if errors:
+        return None, errors
+    core = {"target": target}
+    return (
+        RemovalEntry(
+            target=target,
+            description=description,
+            effect_fingerprint=_stable_hash("consumer-sync-removal-effect", core),
+        ),
+        [],
+    )
 
 
-def compile_manifest(path: Path) -> CompiledManifest:
-    """Parse and validate a sync-manifest YAML file.
-
-    Raises ManifestCompileError if any entry is invalid.
-    Raises FileNotFoundError if the file does not exist.
-    """
-    raw_yaml = path.read_text(encoding="utf-8")
-    data: object = yaml.safe_load(raw_yaml)
-    if data is None:
-        data = {}
+def compile_manifest(path: Path, *, repo_root: Path | None = None) -> CompiledManifest:
+    path = path.resolve()
+    root = repo_root.resolve() if repo_root is not None else path.parent.parent.resolve()
+    raw_bytes = path.read_bytes()
+    data = yaml.safe_load(raw_bytes) or {}
     if not isinstance(data, dict):
-        raise ManifestCompileError([f"Manifest root must be a mapping, got {type(data).__name__}"])
-
-    version_raw = data.get("version", 1)
-    try:
-        version = int(version_raw)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        version = 1
-
+        raise ManifestCompileError(["manifest root must be a mapping"])
     problems: list[str] = []
+    if data.get("version") != 1:
+        problems.append("manifest version must be 1")
+    known = {"version", "removals"} | set(COPY_SYNCED_SECTIONS) | IGNORED_METADATA_SECTIONS
+    unknown = sorted(set(data) - known)
+    if unknown:
+        problems.append(f"manifest has unsupported top-level sections {unknown}")
     sections: dict[str, list[ManifestEntry]] = {}
-
-    for key, value in data.items():
-        if key in ("version", "removals", "excluded", "runtime_fetched"):
-            continue
-        if not isinstance(value, list):
+    target_owners: dict[str, str] = {}
+    for section in COPY_SYNCED_SECTIONS:
+        raw_entries = data.get(section, [])
+        if not isinstance(raw_entries, list):
+            problems.append(f"section '{section}' must be a list")
             continue
         entries: list[ManifestEntry] = []
-        for index, raw_entry in enumerate(value):
-            entry = _compile_entry(raw_entry, key, index, problems)
-            if entry is not None:
-                entries.append(entry)
-        sections[key] = entries
-
+        for index, raw in enumerate(raw_entries):
+            entry, errors = _compile_entry(
+                raw,
+                section=section,
+                index=index,
+                repo_root=root,
+            )
+            problems.extend(errors)
+            if entry is None:
+                continue
+            owner = target_owners.get(entry.target)
+            if owner:
+                problems.append(
+                    f"duplicate effective target {entry.target!r}: {owner} and {section}[{index}]"
+                )
+            else:
+                target_owners[entry.target] = f"{section}[{index}]"
+            entries.append(entry)
+        sections[section] = entries
+    raw_removals = data.get("removals", [])
+    if not isinstance(raw_removals, list):
+        problems.append("removals must be a list")
+        raw_removals = []
     removals: list[RemovalEntry] = []
-    raw_removals = data.get("removals")
-    if isinstance(raw_removals, list):
-        for index, raw_entry in enumerate(raw_removals):
-            removal = _compile_removal(raw_entry, index, problems)
-            if removal is not None:
-                removals.append(removal)
-
+    for index, raw in enumerate(raw_removals):
+        removal, errors = _compile_removal(raw, index=index)
+        problems.extend(errors)
+        if removal is None:
+            continue
+        owner = target_owners.get(removal.target)
+        if owner:
+            problems.append(
+                f"duplicate effective target {removal.target!r}: {owner} and removals[{index}]"
+            )
+        else:
+            target_owners[removal.target] = f"removals[{index}]"
+        removals.append(removal)
     if problems:
         raise ManifestCompileError(problems)
-
-    return CompiledManifest(version=version, sections=sections, removals=removals)
-
-
-def _cli_validate(path: Path) -> int:
-    """Validate a manifest file; return 0 for valid, 1 for invalid."""
-    if not path.exists():
-        print(f"::error::Manifest file not found: {path}", file=sys.stderr)
-        return 1
-    try:
-        compiled = compile_manifest(path)
-        total = sum(len(compiled.section(s)) for s in COPY_SYNCED_SECTIONS)
-        total += len(compiled.removals)
-        print(
-            f"✅ Manifest valid: {total} entries across"
-            f" {len([s for s in COPY_SYNCED_SECTIONS if compiled.section(s)])} sections,"
-            f" {len(compiled.removals)} removals"
-        )
-        return 0
-    except ManifestCompileError as exc:
-        print(f"❌ Manifest invalid:\n{exc}", file=sys.stderr)
-        return 1
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Validate a sync-manifest YAML file against the typed schema."
+    return CompiledManifest(
+        version=1,
+        manifest_sha256="sha256:" + hashlib.sha256(raw_bytes).hexdigest(),
+        sections=sections,
+        removals=removals,
     )
-    parser.add_argument("--validate", metavar="PATH", help="Manifest file to validate")
-    args = parser.parse_args()
 
-    if args.validate:
-        return _cli_validate(Path(args.validate))
 
-    parser.print_help()
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        "--validate",
+        dest="manifest",
+        required=True,
+        help="Path to .github/sync-manifest.yml",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        help="Write the deterministic workflows.consumer-sync-plan/v1 JSON",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=Path(os.environ["GITHUB_OUTPUT"]) if os.environ.get("GITHUB_OUTPUT") else None,
+        help="Optional GitHub Actions output file",
+    )
+    args = parser.parse_args(argv)
+    try:
+        compiled = compile_manifest(Path(args.manifest))
+    except (OSError, yaml.YAMLError, ManifestCompileError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    plan = compiled.to_plan()
+    serialized = json.dumps(plan, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    if args.output_json:
+        args.output_json.write_text(serialized, encoding="utf-8")
+    else:
+        print(serialized, end="")
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"plan_id={plan['plan_id']}\n")
+            handle.write(f"template_hash={plan['plan_id'].split(':', 1)[1][:12]}\n")
+            handle.write(f"entry_count={len(plan['entries'])}\n")
+            handle.write(f"removal_count={len(plan['removals'])}\n")
+    print(
+        f"Compiled {len(plan['entries'])} copy entries and "
+        f"{len(plan['removals'])} removals as {plan['plan_id']}",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/validate_template_sync.py
+++ b/scripts/validate_template_sync.py
@@ -13,9 +13,13 @@ from pathlib import Path
 # Ensure the scripts package is importable when run as a subprocess from any cwd.
 sys.path.insert(0, str(Path(__file__).parent))
 
-import hashlib
+import hashlib  # noqa: E402
 
-from sync_manifest_compiler import CompiledManifest, ManifestCompileError, compile_manifest
+from sync_manifest_compiler import (  # noqa: E402
+    CompiledManifest,
+    ManifestCompileError,
+    compile_manifest,
+)
 
 
 def hash_file(path: Path) -> str:

--- a/scripts/validate_template_sync.py
+++ b/scripts/validate_template_sync.py
@@ -7,11 +7,15 @@ into templates/consumer-repo/ without updating the matching template files,
 which causes sync PRs to consumer repos to miss the source change.
 """
 
-import hashlib
 import sys
 from pathlib import Path
 
-import yaml
+# Ensure the scripts package is importable when run as a subprocess from any cwd.
+sys.path.insert(0, str(Path(__file__).parent))
+
+import hashlib
+
+from sync_manifest_compiler import CompiledManifest, ManifestCompileError, compile_manifest
 
 
 def hash_file(path: Path) -> str:
@@ -30,15 +34,14 @@ def hash_directory(path: Path) -> str:
     return h.hexdigest()
 
 
-def _manifest_template_sync_sources(manifest: dict) -> list[str]:
+def _manifest_template_sync_sources(compiled: CompiledManifest) -> list[str]:
     sources: list[str] = []
-    for entry in manifest.get("scripts", []) or []:
-        source = entry.get("source", "")
-        if source.startswith(".github/scripts/"):
-            sources.append(source)
+    for entry in compiled.section("scripts"):
+        if entry.source.startswith(".github/scripts/"):
+            sources.append(entry.source)
             continue
-        if entry.get("template_sync") == "exact":
-            sources.append(source)
+        if entry.template_sync == "exact":
+            sources.append(entry.source)
     return sorted(set(sources))
 
 
@@ -65,8 +68,13 @@ def main() -> int:
         print(f"❌ sync-manifest.yml not found: {manifest_path}")
         return 1
 
-    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-    manifest_sources = _manifest_template_sync_sources(manifest)
+    try:
+        compiled = compile_manifest(manifest_path)
+    except ManifestCompileError as exc:
+        print(f"❌ Manifest is invalid:\n{exc}")
+        return 1
+
+    manifest_sources = _manifest_template_sync_sources(compiled)
 
     mismatches = []
     for source in manifest_sources:

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -553,6 +553,25 @@ def test_local_path_for_falls_back_to_root_for_template_sections(tmp_path, monke
     assert resolved.resolve() == root_doc
 
 
+def test_local_path_for_without_section_preserves_legacy_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    root_doc = tmp_path / "docs" / "contract.md"
+    template_doc = tmp_path / "templates" / "consumer-repo" / "docs" / "contract.md"
+    root_doc.parent.mkdir(parents=True)
+    template_doc.parent.mkdir(parents=True)
+    root_doc.write_text("root\n", encoding="utf-8")
+    template_doc.write_text("template\n", encoding="utf-8")
+
+    resolved = check_consumer_sync_drift.local_path_for("docs/contract.md")
+    assert resolved is not None
+    assert resolved.resolve() == template_doc
+
+    template_doc.unlink()
+    resolved = check_consumer_sync_drift.local_path_for("docs/contract.md")
+    assert resolved is not None
+    assert resolved.resolve() == root_doc
+
+
 def test_record_content_error_skips_after_threshold() -> None:
     errors: set[str] = set()
     counts: dict[str, int] = {}

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -1,6 +1,13 @@
 import json
+from pathlib import Path
 
 from scripts import check_consumer_sync_drift
+from scripts.sync_manifest_compiler import (
+    CompiledManifest,
+    ManifestEntry,
+    SkipRepo,
+    compile_manifest,
+)
 
 
 def test_comparable_lines_ignores_leading_comment_and_blank_headers() -> None:
@@ -103,16 +110,34 @@ def test_token_candidates_deduplicates_without_exposing_values() -> None:
     ]
 
 
+def _make_entry(
+    source: str = "AGENTS.md",
+    target: str | None = None,
+    sync_mode: str | None = None,
+    skip_repos: tuple = (),
+    overwrite_repos: tuple = (),
+    is_directory: bool = False,
+    template_sync: str | None = None,
+    section: str = "workflows",
+) -> ManifestEntry:
+    return ManifestEntry(
+        source=source,
+        target=target if target is not None else source,
+        description="",
+        sync_mode=sync_mode,
+        skip_repos=skip_repos,
+        overwrite_repos=overwrite_repos,
+        is_directory=is_directory,
+        template_sync=template_sync,
+        section=section,
+    )
+
+
 def test_manifest_skip_reason_supports_repo_specific_policy() -> None:
-    entry = {
-        "source": "AGENTS.md",
-        "skip_repos": [
-            {
-                "repo": "owner/custom",
-                "reason": "Uses historical Agents.md casing",
-            }
-        ],
-    }
+    entry = _make_entry(
+        source="AGENTS.md",
+        skip_repos=(SkipRepo(repo="owner/custom", reason="Uses historical Agents.md casing"),),
+    )
 
     assert (
         check_consumer_sync_drift.manifest_skip_reason(entry, "owner/custom")
@@ -121,23 +146,22 @@ def test_manifest_skip_reason_supports_repo_specific_policy() -> None:
     assert check_consumer_sync_drift.manifest_skip_reason(entry, "owner/standard") == ""
 
 
+def test_manifest_skip_reason_uses_default_for_empty_reason() -> None:
+    entry = _make_entry(
+        source="AGENTS.md",
+        skip_repos=(SkipRepo(repo="owner/custom", reason=""),),
+    )
+    assert (
+        check_consumer_sync_drift.manifest_skip_reason(entry, "owner/custom")
+        == "Manifest skip for repo"
+    )
+
+
 def test_repo_overwrites_create_only_supports_template_override() -> None:
-    entry = {
-        "sync_mode": "create_only",
-        "overwrite_repos": ["stranske/Template"],
-    }
+    entry = _make_entry(sync_mode="create_only", overwrite_repos=("stranske/Template",))
 
     assert check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Template")
     assert not check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Counter_Risk")
-
-
-def test_repo_overwrites_create_only_fails_closed_for_malformed_value() -> None:
-    entry = {
-        "sync_mode": "create_only",
-        "overwrite_repos": "stranske/Template",
-    }
-
-    assert not check_consumer_sync_drift.repo_overwrites_create_only(entry, "stranske/Template")
 
 
 def test_build_report_surfaces_manifest_skips_without_failing() -> None:
@@ -368,16 +392,33 @@ def test_probe_targets_samples_each_manifest_section(tmp_path, monkeypatch) -> N
     script.write_text("script\n", encoding="utf-8")
     docs.write_text("docs\n", encoding="utf-8")
 
-    manifest = {
-        "workflows": [
-            {"source": ".github/workflows/missing.yml"},
-            {"source": ".github/workflows/agents-weekly-metrics.yml"},
-        ],
-        "scripts": [{"source": ".github/scripts/keepalive_gate.js"}],
-        "docs": [{"source": "docs/AGENT_ISSUE_FORMAT.md"}],
-    }
+    manifest_path = tmp_path / ".github" / "sync-manifest.yml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "workflows:",
+                "  - source: .github/workflows/missing.yml",
+                "    description: Missing",
+                "  - source: .github/workflows/agents-weekly-metrics.yml",
+                "    description: Metrics",
+                "scripts:",
+                "  - source: .github/scripts/keepalive_gate.js",
+                "    description: Gate",
+                "docs:",
+                "  - source: docs/AGENT_ISSUE_FORMAT.md",
+                "    description: Format",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    compiled = compile_manifest(manifest_path)
 
-    assert check_consumer_sync_drift.probe_targets(manifest, ["workflows", "scripts", "docs"]) == [
+    assert check_consumer_sync_drift.probe_targets(
+        compiled, ["workflows", "scripts", "docs"]
+    ) == [
         ".github/workflows/agents-weekly-metrics.yml",
         ".github/scripts/keepalive_gate.js",
         "docs/AGENT_ISSUE_FORMAT.md",
@@ -391,9 +432,17 @@ def test_probe_targets_keeps_section_coverage_limit(tmp_path, monkeypatch) -> No
         probe_file.parent.mkdir(parents=True, exist_ok=True)
         probe_file.write_text(f"section {index}\n", encoding="utf-8")
 
-    manifest = {f"section_{index}": [{"source": f"section-{index}.txt"}] for index in range(18)}
+    manifest_path = tmp_path / ".github" / "sync-manifest.yml"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["version: 1"]
+    for index in range(18):
+        lines.append(f"section_{index}:")
+        lines.append(f"  - source: section-{index}.txt")
+        lines.append(f"    description: Section {index}")
+    manifest_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    compiled = compile_manifest(manifest_path)
 
-    targets = check_consumer_sync_drift.probe_targets(manifest, list(manifest))
+    targets = check_consumer_sync_drift.probe_targets(compiled, [f"section_{i}" for i in range(18)])
 
     assert len(targets) == 16
     assert targets[0] == "section-0.txt"

--- a/tests/scripts/test_check_consumer_sync_drift.py
+++ b/tests/scripts/test_check_consumer_sync_drift.py
@@ -1,9 +1,7 @@
 import json
-from pathlib import Path
 
 from scripts import check_consumer_sync_drift
 from scripts.sync_manifest_compiler import (
-    CompiledManifest,
     ManifestEntry,
     SkipRepo,
     compile_manifest,
@@ -122,6 +120,7 @@ def _make_entry(
 ) -> ManifestEntry:
     return ManifestEntry(
         source=source,
+        resolved_source=source,
         target=target if target is not None else source,
         description="",
         sync_mode=sync_mode,
@@ -129,7 +128,10 @@ def _make_entry(
         overwrite_repos=overwrite_repos,
         is_directory=is_directory,
         template_sync=template_sync,
+        delivery="copy",
         section=section,
+        content_sha256="sha256:" + "a" * 64,
+        effect_fingerprint="sha256:" + "b" * 64,
     )
 
 
@@ -399,8 +401,6 @@ def test_probe_targets_samples_each_manifest_section(tmp_path, monkeypatch) -> N
             [
                 "version: 1",
                 "workflows:",
-                "  - source: .github/workflows/missing.yml",
-                "    description: Missing",
                 "  - source: .github/workflows/agents-weekly-metrics.yml",
                 "    description: Metrics",
                 "scripts:",
@@ -416,37 +416,11 @@ def test_probe_targets_samples_each_manifest_section(tmp_path, monkeypatch) -> N
     )
     compiled = compile_manifest(manifest_path)
 
-    assert check_consumer_sync_drift.probe_targets(
-        compiled, ["workflows", "scripts", "docs"]
-    ) == [
+    assert check_consumer_sync_drift.probe_targets(compiled, ["workflows", "scripts", "docs"]) == [
         ".github/workflows/agents-weekly-metrics.yml",
         ".github/scripts/keepalive_gate.js",
         "docs/AGENT_ISSUE_FORMAT.md",
     ]
-
-
-def test_probe_targets_keeps_section_coverage_limit(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    for index in range(18):
-        probe_file = tmp_path / "templates" / "consumer-repo" / f"section-{index}.txt"
-        probe_file.parent.mkdir(parents=True, exist_ok=True)
-        probe_file.write_text(f"section {index}\n", encoding="utf-8")
-
-    manifest_path = tmp_path / ".github" / "sync-manifest.yml"
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = ["version: 1"]
-    for index in range(18):
-        lines.append(f"section_{index}:")
-        lines.append(f"  - source: section-{index}.txt")
-        lines.append(f"    description: Section {index}")
-    manifest_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    compiled = compile_manifest(manifest_path)
-
-    targets = check_consumer_sync_drift.probe_targets(compiled, [f"section_{i}" for i in range(18)])
-
-    assert len(targets) == 16
-    assert targets[0] == "section-0.txt"
-    assert targets[-1] == "section-15.txt"
 
 
 def test_write_report_json_creates_parent_directory(tmp_path) -> None:

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -148,9 +148,7 @@ def test_non_string_paths_are_rejected(tmp_path: Path, yaml_value: str) -> None:
     write_source(tmp_path, "scripts/tool.py", template=False)
     manifest = write_manifest(
         tmp_path,
-        "version: 1\nscripts:\n"
-        f"  - source: {yaml_value}\n"
-        "    description: Tool\n",
+        "version: 1\nscripts:\n" f"  - source: {yaml_value}\n" "    description: Tool\n",
     )
 
     with pytest.raises(ManifestCompileError, match="safe repository-relative"):

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -1,0 +1,528 @@
+"""Tests for scripts/sync_manifest_compiler.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.sync_manifest_compiler import (
+    COPY_SYNCED_SECTIONS,
+    CompiledManifest,
+    ManifestCompileError,
+    ManifestEntry,
+    RemovalEntry,
+    SkipRepo,
+    compile_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_manifest(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / ".github" / "sync-manifest.yml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy-path compilation
+# ---------------------------------------------------------------------------
+
+
+def test_compile_minimal_manifest(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nworkflows:\n  - source: .github/workflows/autofix.yml\n    description: Autofix\n",
+    )
+    compiled = compile_manifest(path)
+    assert compiled.version == 1
+    assert len(compiled.section("workflows")) == 1
+    entry = compiled.section("workflows")[0]
+    assert entry.source == ".github/workflows/autofix.yml"
+    assert entry.target == ".github/workflows/autofix.yml"
+    assert entry.sync_mode is None
+    assert entry.is_directory is False
+    assert entry.template_sync is None
+    assert entry.skip_repos == ()
+    assert entry.overwrite_repos == ()
+    assert entry.section == "workflows"
+
+
+def test_compile_target_defaults_to_source(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nscripts:\n  - source: scripts/foo.py\n    description: foo\n",
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("scripts")[0].target == "scripts/foo.py"
+
+
+def test_compile_explicit_target_overrides_source(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nscripts:\n"
+            "  - source: scripts/foo.py\n    target: scripts/bar.py\n    description: foo\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("scripts")[0].target == "scripts/bar.py"
+
+
+def test_compile_create_only_sync_mode(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/ci.yml\n"
+            "    description: CI\n"
+            "    sync_mode: create_only\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("workflows")[0].sync_mode == "create_only"
+
+
+def test_compile_skip_repos_string_form(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/autofix.yml\n"
+            "    description: Autofix\n"
+            "    skip_repos:\n"
+            "      - owner/special\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    skip_repos = compiled.section("workflows")[0].skip_repos
+    assert skip_repos == (SkipRepo(repo="owner/special", reason=""),)
+
+
+def test_compile_skip_repos_dict_form_with_reason(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/pr-00-gate.yml\n"
+            "    description: Gate\n"
+            "    skip_repos:\n"
+            "      - repo: owner/custom\n"
+            "        reason: Uses custom gate\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    skip_repos = compiled.section("workflows")[0].skip_repos
+    assert skip_repos == (SkipRepo(repo="owner/custom", reason="Uses custom gate"),)
+
+
+def test_compile_overwrite_repos(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/ci.yml\n"
+            "    description: CI\n"
+            "    sync_mode: create_only\n"
+            "    overwrite_repos:\n"
+            "      - stranske/Template\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("workflows")[0].overwrite_repos == ("stranske/Template",)
+
+
+def test_compile_is_directory(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nscripts:\n"
+            "  - source: scripts/langchain\n"
+            "    description: LangChain helpers\n"
+            "    is_directory: true\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("scripts")[0].is_directory is True
+
+
+def test_compile_template_sync_exact(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nscripts:\n"
+            "  - source: scripts/aggregate_agent_metrics.py\n"
+            "    description: Metrics\n"
+            "    template_sync: exact\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert compiled.section("scripts")[0].template_sync == "exact"
+
+
+def test_compile_removals(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\n"
+            "workflows:\n"
+            "  - source: .github/workflows/autofix.yml\n"
+            "    description: Autofix\n"
+            "removals:\n"
+            "  - target: .github/workflows/old.yml\n"
+            "    description: Removed stale workflow\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert len(compiled.removals) == 1
+    assert compiled.removals[0] == RemovalEntry(
+        target=".github/workflows/old.yml",
+        description="Removed stale workflow",
+    )
+
+
+def test_compile_section_returns_empty_for_missing_section(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, "version: 1\nworkflows: []\n")
+    compiled = compile_manifest(path)
+    assert compiled.section("prompts") == ()
+    assert compiled.section("nonexistent") == ()
+
+
+def test_compile_all_entries_returns_flat_list(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\n"
+            "workflows:\n"
+            "  - source: .github/workflows/a.yml\n    description: A\n"
+            "scripts:\n"
+            "  - source: scripts/b.py\n    description: B\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    all_entries = compiled.all_entries()
+    sources = {e.source for e in all_entries}
+    assert sources == {".github/workflows/a.yml", "scripts/b.py"}
+
+
+def test_compile_empty_manifest(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, "version: 1\n")
+    compiled = compile_manifest(path)
+    assert compiled.all_entries() == []
+    assert compiled.removals == ()
+
+
+def test_compile_null_manifest_treated_as_empty(tmp_path: Path) -> None:
+    path = tmp_path / "empty.yml"
+    path.write_text("", encoding="utf-8")
+    compiled = compile_manifest(path)
+    assert compiled.all_entries() == []
+
+
+def test_compile_multiple_sections(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\n"
+            "workflows:\n"
+            "  - source: .github/workflows/a.yml\n    description: A\n"
+            "prompts:\n"
+            "  - source: .github/codex/prompts/p.md\n    description: P\n"
+            "scripts:\n"
+            "  - source: scripts/s.py\n    description: S\n"
+        ),
+    )
+    compiled = compile_manifest(path)
+    assert len(compiled.section("workflows")) == 1
+    assert len(compiled.section("prompts")) == 1
+    assert len(compiled.section("scripts")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Validation errors — invalid entries
+# ---------------------------------------------------------------------------
+
+
+def test_compile_raises_on_missing_source(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nworkflows:\n  - description: Missing source\n",
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("source" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_empty_source(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nworkflows:\n  - source: ''\n    description: Empty\n",
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("source" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_unknown_sync_mode(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/a.yml\n"
+            "    description: A\n"
+            "    sync_mode: overwrite_always\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("sync_mode" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_skip_repos_not_a_list(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/a.yml\n"
+            "    description: A\n"
+            "    skip_repos: owner/repo\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("skip_repos" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_skip_repos_dict_missing_repo_field(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/a.yml\n"
+            "    description: A\n"
+            "    skip_repos:\n"
+            "      - reason: No repo key here\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("repo" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_overwrite_repos_not_a_list(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - source: .github/workflows/a.yml\n"
+            "    description: A\n"
+            "    overwrite_repos: stranske/Template\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("overwrite_repos" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_unknown_template_sync_value(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nscripts:\n"
+            "  - source: scripts/foo.py\n"
+            "    description: Foo\n"
+            "    template_sync: copy\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("template_sync" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_is_directory_not_bool(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nscripts:\n"
+            "  - source: scripts/langchain\n"
+            "    description: LangChain\n"
+            "    is_directory: yes_it_is\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("is_directory" in p for p in exc_info.value.problems)
+
+
+def test_compile_raises_on_removal_missing_target(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nremovals:\n  - description: No target here\n",
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert any("target" in p for p in exc_info.value.problems)
+
+
+def test_compile_collects_all_problems(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\n"
+            "workflows:\n"
+            "  - description: Missing source\n"
+            "  - source: .github/workflows/b.yml\n"
+            "    description: B\n"
+            "    sync_mode: bad_mode\n"
+        ),
+    )
+    with pytest.raises(ManifestCompileError) as exc_info:
+        compile_manifest(path)
+    assert len(exc_info.value.problems) == 2
+
+
+def test_compile_raises_file_not_found_for_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        compile_manifest(tmp_path / "does_not_exist.yml")
+
+
+# ---------------------------------------------------------------------------
+# skip_repos / overwrite_repos logic (directly on ManifestEntry)
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_entry_skip_repos_string_form_has_empty_reason() -> None:
+    entry = ManifestEntry(
+        source="a.yml",
+        target="a.yml",
+        description="",
+        sync_mode=None,
+        skip_repos=(SkipRepo(repo="owner/repo", reason=""),),
+        overwrite_repos=(),
+        is_directory=False,
+        template_sync=None,
+        section="workflows",
+    )
+    skip = entry.skip_repos[0]
+    assert skip.repo == "owner/repo"
+    assert skip.reason == ""
+
+
+def test_manifest_entry_is_frozen() -> None:
+    entry = ManifestEntry(
+        source="a.yml",
+        target="a.yml",
+        description="",
+        sync_mode=None,
+        skip_repos=(),
+        overwrite_repos=(),
+        is_directory=False,
+        template_sync=None,
+        section="workflows",
+    )
+    with pytest.raises(AttributeError):
+        entry.source = "b.yml"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# CLI --validate mode
+# ---------------------------------------------------------------------------
+
+
+def test_cli_validate_exits_zero_for_valid_manifest(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nworkflows:\n  - source: .github/workflows/autofix.yml\n    description: A\n",
+    )
+    result = subprocess.run(
+        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "✅" in result.stdout
+
+
+def test_cli_validate_exits_one_for_invalid_manifest(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        "version: 1\nworkflows:\n  - description: Missing source\n",
+    )
+    result = subprocess.run(
+        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "❌" in result.stderr
+
+
+def test_cli_validate_exits_one_for_missing_file(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/sync_manifest_compiler.py",
+            "--validate",
+            str(tmp_path / "missing.yml"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_cli_validate_reports_problem_count(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path,
+        (
+            "version: 1\nworkflows:\n"
+            "  - description: No source\n"
+            "  - source: ''\n    description: Empty source\n"
+        ),
+    )
+    result = subprocess.run(
+        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "2 manifest validation error" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Compile against the real manifest (integration smoke test)
+# ---------------------------------------------------------------------------
+
+
+def test_compile_real_manifest_succeeds() -> None:
+    real_path = Path(".github/sync-manifest.yml")
+    if not real_path.exists():
+        pytest.skip("Real manifest not found")
+    compiled = compile_manifest(real_path)
+    assert compiled.version == 1
+    assert any(compiled.section(s) for s in COPY_SYNCED_SECTIONS)
+    assert compiled.removals  # real manifest has at least one removal
+
+
+def test_real_manifest_all_entries_have_non_empty_source() -> None:
+    real_path = Path(".github/sync-manifest.yml")
+    if not real_path.exists():
+        pytest.skip("Real manifest not found")
+    compiled = compile_manifest(real_path)
+    for entry in compiled.all_entries():
+        assert entry.source, f"Empty source in section {entry.section}"
+
+
+def test_real_manifest_removals_have_non_empty_target() -> None:
+    real_path = Path(".github/sync-manifest.yml")
+    if not real_path.exists():
+        pytest.skip("Real manifest not found")
+    compiled = compile_manifest(real_path)
+    for removal in compiled.removals:
+        assert removal.target, "Empty target in removals"

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -321,3 +321,6 @@ def test_maint_sync_consumes_compiled_plan_for_paths_and_hash() -> None:
     assert "item['resolved_source']" in workflow
     assert "workflows.consumer-sync-plan/v1" in workflow
     assert "find templates/consumer-repo -type f" not in workflow
+    assert ".github/templates" in workflow
+    assert ".github/PULL_REQUEST_TEMPLATE.md" in workflow
+    assert ".github/path-classification.yml" in workflow

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -198,7 +198,27 @@ scripts:
 """,
     )
 
-    with pytest.raises(ManifestCompileError, match="symlink that escapes repository root"):
+    with pytest.raises(ManifestCompileError, match="invalid symlink"):
+        compile_manifest(manifest)
+
+
+def test_directories_with_cyclic_symlinks_are_rejected(tmp_path: Path) -> None:
+    directory = tmp_path / "scripts" / "bundle"
+    directory.mkdir(parents=True)
+    (directory / "safe.py").write_text("safe\n", encoding="utf-8")
+    (directory / "first").symlink_to(directory / "second")
+    (directory / "second").symlink_to(directory / "first")
+    manifest = write_manifest(
+        tmp_path,
+        """version: 1
+scripts:
+  - source: scripts/bundle
+    description: Bundle
+    is_directory: true
+""",
+    )
+
+    with pytest.raises(ManifestCompileError, match="invalid symlink"):
         compile_manifest(manifest)
 
 

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -11,6 +11,7 @@ from scripts.sync_manifest_compiler import (
     PLAN_SCHEMA,
     ManifestCompileError,
     compile_manifest,
+    resolve_source_path,
 )
 
 
@@ -118,8 +119,11 @@ workflows:
     [
         ("source", "../secret"),
         ("source", "/absolute"),
+        ("source", "a/./b"),
+        ("source", "..\\\\secret"),
         ("target", "../../escape"),
         ("target", "./ambiguous"),
+        ("target", "."),
     ],
 )
 def test_unsafe_paths_are_rejected(tmp_path: Path, field: str, value: str) -> None:
@@ -136,6 +140,67 @@ def test_unsafe_paths_are_rejected(tmp_path: Path, field: str, value: str) -> No
     )
 
     with pytest.raises(ManifestCompileError, match="safe repository-relative"):
+        compile_manifest(manifest)
+
+
+@pytest.mark.parametrize("yaml_value", ["123", "null", "false"])
+def test_non_string_paths_are_rejected(tmp_path: Path, yaml_value: str) -> None:
+    write_source(tmp_path, "scripts/tool.py", template=False)
+    manifest = write_manifest(
+        tmp_path,
+        "version: 1\nscripts:\n"
+        f"  - source: {yaml_value}\n"
+        "    description: Tool\n",
+    )
+
+    with pytest.raises(ManifestCompileError, match="safe repository-relative"):
+        compile_manifest(manifest)
+
+
+def test_resolver_preserves_legacy_fallback_and_rejects_unsafe_paths(tmp_path: Path) -> None:
+    root_file = write_source(tmp_path, "docs/contract.md", template=False)
+    assert resolve_source_path("docs/contract.md", None, repo_root=tmp_path) == root_file
+    assert resolve_source_path("../outside", None, repo_root=tmp_path) is None
+    assert resolve_source_path("/etc/passwd", None, repo_root=tmp_path) is None
+
+
+def test_sources_escaping_via_symlink_are_rejected(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-source.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    symlink = tmp_path / "scripts" / "outside.py"
+    symlink.parent.mkdir(parents=True)
+    symlink.symlink_to(outside)
+    manifest = write_manifest(
+        tmp_path,
+        """version: 1
+scripts:
+  - source: scripts/outside.py
+    description: Outside
+""",
+    )
+
+    with pytest.raises(ManifestCompileError, match="escapes repository root"):
+        compile_manifest(manifest)
+
+
+def test_directories_with_escaping_symlinks_are_rejected(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-child.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    directory = tmp_path / "scripts" / "bundle"
+    directory.mkdir(parents=True)
+    (directory / "safe.py").write_text("safe\n", encoding="utf-8")
+    (directory / "outside.py").symlink_to(outside)
+    manifest = write_manifest(
+        tmp_path,
+        """version: 1
+scripts:
+  - source: scripts/bundle
+    description: Bundle
+    is_directory: true
+""",
+    )
+
+    with pytest.raises(ManifestCompileError, match="symlink that escapes repository root"):
         compile_manifest(manifest)
 
 

--- a/tests/scripts/test_sync_manifest_compiler.py
+++ b/tests/scripts/test_sync_manifest_compiler.py
@@ -1,528 +1,323 @@
-"""Tests for scripts/sync_manifest_compiler.py."""
-
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
-
+from jsonschema import Draft202012Validator
 from scripts.sync_manifest_compiler import (
-    COPY_SYNCED_SECTIONS,
-    CompiledManifest,
+    PLAN_SCHEMA,
     ManifestCompileError,
-    ManifestEntry,
-    RemovalEntry,
-    SkipRepo,
     compile_manifest,
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _write_manifest(tmp_path: Path, content: str) -> Path:
-    p = tmp_path / ".github" / "sync-manifest.yml"
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-    return p
+def write_manifest(root: Path, text: str) -> Path:
+    path = root / ".github" / "sync-manifest.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
 
 
-# ---------------------------------------------------------------------------
-# Happy-path compilation
-# ---------------------------------------------------------------------------
+def write_source(root: Path, source: str, *, template: bool, content: str = "content\n") -> Path:
+    base = root / "templates" / "consumer-repo" if template else root
+    path = base / source
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
 
 
-def test_compile_minimal_manifest(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_template_owned_entry_compiles_to_typed_plan(tmp_path: Path) -> None:
+    write_source(tmp_path, ".github/workflows/autofix.yml", template=True)
+    manifest = write_manifest(
         tmp_path,
-        "version: 1\nworkflows:\n  - source: .github/workflows/autofix.yml\n    description: Autofix\n",
+        """version: 1
+workflows:
+  - source: .github/workflows/autofix.yml
+    description: Autofix
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.version == 1
-    assert len(compiled.section("workflows")) == 1
+
+    compiled = compile_manifest(manifest)
     entry = compiled.section("workflows")[0]
-    assert entry.source == ".github/workflows/autofix.yml"
-    assert entry.target == ".github/workflows/autofix.yml"
-    assert entry.sync_mode is None
-    assert entry.is_directory is False
-    assert entry.template_sync is None
-    assert entry.skip_repos == ()
-    assert entry.overwrite_repos == ()
-    assert entry.section == "workflows"
+    plan = compiled.to_plan()
+
+    assert entry.resolved_source == ("templates/consumer-repo/.github/workflows/autofix.yml")
+    assert entry.target == entry.source
+    assert entry.delivery == "copy"
+    assert entry.content_sha256.startswith("sha256:")
+    assert entry.effect_fingerprint.startswith("sha256:")
+    assert plan["schema"] == PLAN_SCHEMA
+    assert plan["plan_id"].startswith("sha256:")
 
 
-def test_compile_target_defaults_to_source(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_root_owned_entry_uses_documented_precedence(tmp_path: Path) -> None:
+    root_source = write_source(tmp_path, "scripts/tool.py", template=False, content="root\n")
+    write_source(tmp_path, "scripts/tool.py", template=True, content="template\n")
+    manifest = write_manifest(
         tmp_path,
-        "version: 1\nscripts:\n  - source: scripts/foo.py\n    description: foo\n",
+        """version: 1
+scripts:
+  - source: scripts/tool.py
+    target: scripts/renamed.py
+    description: Tool
+    delivery: copy
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("scripts")[0].target == "scripts/foo.py"
+
+    entry = compile_manifest(manifest).section("scripts")[0]
+
+    assert entry.resolved_source == "scripts/tool.py"
+    assert entry.target == "scripts/renamed.py"
+    assert entry.content_sha256.endswith(
+        __import__("hashlib").sha256(root_source.read_bytes()).hexdigest()
+    )
 
 
-def test_compile_explicit_target_overrides_source(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_template_owned_entry_prefers_template_when_both_exist(
+    tmp_path: Path,
+) -> None:
+    write_source(tmp_path, ".github/workflows/ci.yml", template=False, content="root\n")
+    write_source(
         tmp_path,
-        (
-            "version: 1\nscripts:\n"
-            "  - source: scripts/foo.py\n    target: scripts/bar.py\n    description: foo\n"
-        ),
+        ".github/workflows/ci.yml",
+        template=True,
+        content="template\n",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("scripts")[0].target == "scripts/bar.py"
-
-
-def test_compile_create_only_sync_mode(tmp_path: Path) -> None:
-    path = _write_manifest(
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/ci.yml\n"
-            "    description: CI\n"
-            "    sync_mode: create_only\n"
-        ),
+        """version: 1
+workflows:
+  - source: .github/workflows/ci.yml
+    description: CI
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("workflows")[0].sync_mode == "create_only"
+
+    entry = compile_manifest(manifest).section("workflows")[0]
+    assert entry.resolved_source.startswith("templates/consumer-repo/")
 
 
-def test_compile_skip_repos_string_form(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_missing_source_fails_before_plan_emission(tmp_path: Path) -> None:
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/autofix.yml\n"
-            "    description: Autofix\n"
-            "    skip_repos:\n"
-            "      - owner/special\n"
-        ),
+        """version: 1
+workflows:
+  - source: .github/workflows/missing.yml
+    description: Missing
+""",
     )
-    compiled = compile_manifest(path)
-    skip_repos = compiled.section("workflows")[0].skip_repos
-    assert skip_repos == (SkipRepo(repo="owner/special", reason=""),)
+
+    with pytest.raises(ManifestCompileError, match="not deliverable"):
+        compile_manifest(manifest)
 
 
-def test_compile_skip_repos_dict_form_with_reason(tmp_path: Path) -> None:
-    path = _write_manifest(
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source", "../secret"),
+        ("source", "/absolute"),
+        ("target", "../../escape"),
+        ("target", "./ambiguous"),
+    ],
+)
+def test_unsafe_paths_are_rejected(tmp_path: Path, field: str, value: str) -> None:
+    source = "scripts/tool.py"
+    write_source(tmp_path, source, template=False)
+    target_line = f"    target: {value}\n" if field == "target" else ""
+    source_value = value if field == "source" else source
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/pr-00-gate.yml\n"
-            "    description: Gate\n"
-            "    skip_repos:\n"
-            "      - repo: owner/custom\n"
-            "        reason: Uses custom gate\n"
-        ),
+        "version: 1\nscripts:\n"
+        f"  - source: {source_value}\n"
+        f"{target_line}"
+        "    description: Tool\n",
     )
-    compiled = compile_manifest(path)
-    skip_repos = compiled.section("workflows")[0].skip_repos
-    assert skip_repos == (SkipRepo(repo="owner/custom", reason="Uses custom gate"),)
+
+    with pytest.raises(ManifestCompileError, match="safe repository-relative"):
+        compile_manifest(manifest)
 
 
-def test_compile_overwrite_repos(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_duplicate_copy_and_removal_targets_are_rejected(
+    tmp_path: Path,
+) -> None:
+    write_source(tmp_path, "scripts/a.py", template=False)
+    write_source(tmp_path, "scripts/b.py", template=False)
+    duplicate_copy = write_manifest(
         tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/ci.yml\n"
-            "    description: CI\n"
-            "    sync_mode: create_only\n"
-            "    overwrite_repos:\n"
-            "      - stranske/Template\n"
-        ),
+        """version: 1
+scripts:
+  - source: scripts/a.py
+    target: scripts/same.py
+    description: A
+  - source: scripts/b.py
+    target: scripts/same.py
+    description: B
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("workflows")[0].overwrite_repos == ("stranske/Template",)
+    with pytest.raises(ManifestCompileError, match="duplicate effective target"):
+        compile_manifest(duplicate_copy)
 
-
-def test_compile_is_directory(tmp_path: Path) -> None:
-    path = _write_manifest(
+    duplicate_removal = write_manifest(
         tmp_path,
-        (
-            "version: 1\nscripts:\n"
-            "  - source: scripts/langchain\n"
-            "    description: LangChain helpers\n"
-            "    is_directory: true\n"
-        ),
+        """version: 1
+scripts:
+  - source: scripts/a.py
+    target: scripts/a.py
+    description: A
+removals:
+  - target: scripts/a.py
+    description: Remove A
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("scripts")[0].is_directory is True
+    with pytest.raises(ManifestCompileError, match="duplicate effective target"):
+        compile_manifest(duplicate_removal)
 
 
-def test_compile_template_sync_exact(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_directory_hash_and_plan_are_deterministic(tmp_path: Path) -> None:
+    directory = tmp_path / "scripts" / "runner_lib"
+    directory.mkdir(parents=True)
+    (directory / "b.py").write_text("b\n", encoding="utf-8")
+    (directory / "a.py").write_text("a\n", encoding="utf-8")
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\nscripts:\n"
-            "  - source: scripts/aggregate_agent_metrics.py\n"
-            "    description: Metrics\n"
-            "    template_sync: exact\n"
-        ),
+        """version: 1
+scripts:
+  - source: scripts/runner_lib
+    description: Runner library
+    is_directory: true
+""",
     )
-    compiled = compile_manifest(path)
-    assert compiled.section("scripts")[0].template_sync == "exact"
+
+    first = compile_manifest(manifest).to_plan()
+    second = compile_manifest(manifest).to_plan()
+
+    assert first == second
+    assert first["entries"][0]["is_directory"] is True
+    assert first["entries"][0]["content_sha256"].startswith("sha256:")
 
 
-def test_compile_removals(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_skip_overwrite_template_sync_and_removal_are_normalized(
+    tmp_path: Path,
+) -> None:
+    write_source(tmp_path, "tools/requirements.txt", template=False)
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\n"
-            "workflows:\n"
-            "  - source: .github/workflows/autofix.yml\n"
-            "    description: Autofix\n"
-            "removals:\n"
-            "  - target: .github/workflows/old.yml\n"
-            "    description: Removed stale workflow\n"
-        ),
+        """version: 1
+scripts:
+  - source: tools/requirements.txt
+    description: Requirements
+    sync_mode: create_only
+    template_sync: exact
+    skip_repos:
+      - repo: owner/skipped
+        reason: Intentional exception
+    overwrite_repos:
+      - owner/template
+removals:
+  - target: obsolete.txt
+    description: Obsolete
+""",
     )
-    compiled = compile_manifest(path)
-    assert len(compiled.removals) == 1
-    assert compiled.removals[0] == RemovalEntry(
-        target=".github/workflows/old.yml",
-        description="Removed stale workflow",
-    )
+
+    plan = compile_manifest(manifest).to_plan()
+    entry = plan["entries"][0]
+
+    assert entry["sync_mode"] == "create_only"
+    assert entry["template_sync"] == "exact"
+    assert entry["skip_repos"] == ["owner/skipped"]
+    assert entry["skip_reasons"] == {"owner/skipped": "Intentional exception"}
+    assert entry["overwrite_repos"] == ["owner/template"]
+    assert plan["removals"][0]["effect_fingerprint"].startswith("sha256:")
 
 
-def test_compile_section_returns_empty_for_missing_section(tmp_path: Path) -> None:
-    path = _write_manifest(tmp_path, "version: 1\nworkflows: []\n")
-    compiled = compile_manifest(path)
-    assert compiled.section("prompts") == ()
-    assert compiled.section("nonexistent") == ()
-
-
-def test_compile_all_entries_returns_flat_list(tmp_path: Path) -> None:
-    path = _write_manifest(
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        "sync_mode: overwrite",
+        "template_sync: loose",
+        "delivery: runtime",
+        "overwrite_repos: owner/repo",
+        "skip_repos: owner/repo",
+        "is_directory: 'yes'",
+    ],
+)
+def test_invalid_typed_fields_fail_closed(tmp_path: Path, fragment: str) -> None:
+    write_source(tmp_path, "scripts/tool.py", template=False)
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\n"
-            "workflows:\n"
-            "  - source: .github/workflows/a.yml\n    description: A\n"
-            "scripts:\n"
-            "  - source: scripts/b.py\n    description: B\n"
-        ),
+        "version: 1\nscripts:\n"
+        "  - source: scripts/tool.py\n"
+        "    description: Tool\n"
+        f"    {fragment}\n",
     )
-    compiled = compile_manifest(path)
-    all_entries = compiled.all_entries()
-    sources = {e.source for e in all_entries}
-    assert sources == {".github/workflows/a.yml", "scripts/b.py"}
+    with pytest.raises(ManifestCompileError):
+        compile_manifest(manifest)
 
 
-def test_compile_empty_manifest(tmp_path: Path) -> None:
-    path = _write_manifest(tmp_path, "version: 1\n")
-    compiled = compile_manifest(path)
-    assert compiled.all_entries() == []
-    assert compiled.removals == ()
-
-
-def test_compile_null_manifest_treated_as_empty(tmp_path: Path) -> None:
-    path = tmp_path / "empty.yml"
-    path.write_text("", encoding="utf-8")
-    compiled = compile_manifest(path)
-    assert compiled.all_entries() == []
-
-
-def test_compile_multiple_sections(tmp_path: Path) -> None:
-    path = _write_manifest(
+def test_cli_emits_deterministic_json_and_github_outputs(
+    tmp_path: Path,
+) -> None:
+    write_source(tmp_path, "scripts/tool.py", template=False)
+    manifest = write_manifest(
         tmp_path,
-        (
-            "version: 1\n"
-            "workflows:\n"
-            "  - source: .github/workflows/a.yml\n    description: A\n"
-            "prompts:\n"
-            "  - source: .github/codex/prompts/p.md\n    description: P\n"
-            "scripts:\n"
-            "  - source: scripts/s.py\n    description: S\n"
-        ),
+        """version: 1
+scripts:
+  - source: scripts/tool.py
+    description: Tool
+""",
     )
-    compiled = compile_manifest(path)
-    assert len(compiled.section("workflows")) == 1
-    assert len(compiled.section("prompts")) == 1
-    assert len(compiled.section("scripts")) == 1
+    output = tmp_path / "plan.json"
+    github_output = tmp_path / "github-output"
+    command = [
+        sys.executable,
+        "scripts/sync_manifest_compiler.py",
+        "--manifest",
+        str(manifest),
+        "--output-json",
+        str(output),
+        "--github-output",
+        str(github_output),
+    ]
+
+    first = subprocess.run(command, capture_output=True, text=True)
+    first_bytes = output.read_bytes()
+    second = subprocess.run(command, capture_output=True, text=True)
+
+    assert first.returncode == second.returncode == 0
+    assert output.read_bytes() == first_bytes
+    assert json.loads(output.read_text())["schema"] == PLAN_SCHEMA
+    outputs = github_output.read_text(encoding="utf-8")
+    assert "plan_id=sha256:" in outputs
+    assert "template_hash=" in outputs
 
 
-# ---------------------------------------------------------------------------
-# Validation errors — invalid entries
-# ---------------------------------------------------------------------------
-
-
-def test_compile_raises_on_missing_source(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        "version: 1\nworkflows:\n  - description: Missing source\n",
+def test_real_manifest_compiles_every_declared_copy_entry() -> None:
+    root = Path(__file__).parents[2]
+    compiled = compile_manifest(root / ".github" / "sync-manifest.yml", repo_root=root)
+    plan = compiled.to_plan()
+    schema = json.loads(
+        (root / "docs" / "contracts" / "schemas" / "consumer-sync-plan-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
     )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("source" in p for p in exc_info.value.problems)
+
+    assert plan["schema"] == PLAN_SCHEMA
+    Draft202012Validator(schema).validate(plan)
+    assert len(plan["entries"]) > 200
+    assert all(entry["resolved_source"] for entry in plan["entries"])
+    assert len({entry["target"] for entry in plan["entries"]}) == len(plan["entries"])
 
 
-def test_compile_raises_on_empty_source(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        "version: 1\nworkflows:\n  - source: ''\n    description: Empty\n",
+def test_maint_sync_consumes_compiled_plan_for_paths_and_hash() -> None:
+    root = Path(__file__).parents[2]
+    workflow = (root / ".github" / "workflows" / "maint-68-sync-consumer-repos.yml").read_text(
+        encoding="utf-8"
     )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("source" in p for p in exc_info.value.problems)
 
-
-def test_compile_raises_on_unknown_sync_mode(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/a.yml\n"
-            "    description: A\n"
-            "    sync_mode: overwrite_always\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("sync_mode" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_skip_repos_not_a_list(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/a.yml\n"
-            "    description: A\n"
-            "    skip_repos: owner/repo\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("skip_repos" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_skip_repos_dict_missing_repo_field(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/a.yml\n"
-            "    description: A\n"
-            "    skip_repos:\n"
-            "      - reason: No repo key here\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("repo" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_overwrite_repos_not_a_list(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - source: .github/workflows/a.yml\n"
-            "    description: A\n"
-            "    overwrite_repos: stranske/Template\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("overwrite_repos" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_unknown_template_sync_value(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nscripts:\n"
-            "  - source: scripts/foo.py\n"
-            "    description: Foo\n"
-            "    template_sync: copy\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("template_sync" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_is_directory_not_bool(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nscripts:\n"
-            "  - source: scripts/langchain\n"
-            "    description: LangChain\n"
-            "    is_directory: yes_it_is\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("is_directory" in p for p in exc_info.value.problems)
-
-
-def test_compile_raises_on_removal_missing_target(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        "version: 1\nremovals:\n  - description: No target here\n",
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert any("target" in p for p in exc_info.value.problems)
-
-
-def test_compile_collects_all_problems(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\n"
-            "workflows:\n"
-            "  - description: Missing source\n"
-            "  - source: .github/workflows/b.yml\n"
-            "    description: B\n"
-            "    sync_mode: bad_mode\n"
-        ),
-    )
-    with pytest.raises(ManifestCompileError) as exc_info:
-        compile_manifest(path)
-    assert len(exc_info.value.problems) == 2
-
-
-def test_compile_raises_file_not_found_for_missing_file(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
-        compile_manifest(tmp_path / "does_not_exist.yml")
-
-
-# ---------------------------------------------------------------------------
-# skip_repos / overwrite_repos logic (directly on ManifestEntry)
-# ---------------------------------------------------------------------------
-
-
-def test_manifest_entry_skip_repos_string_form_has_empty_reason() -> None:
-    entry = ManifestEntry(
-        source="a.yml",
-        target="a.yml",
-        description="",
-        sync_mode=None,
-        skip_repos=(SkipRepo(repo="owner/repo", reason=""),),
-        overwrite_repos=(),
-        is_directory=False,
-        template_sync=None,
-        section="workflows",
-    )
-    skip = entry.skip_repos[0]
-    assert skip.repo == "owner/repo"
-    assert skip.reason == ""
-
-
-def test_manifest_entry_is_frozen() -> None:
-    entry = ManifestEntry(
-        source="a.yml",
-        target="a.yml",
-        description="",
-        sync_mode=None,
-        skip_repos=(),
-        overwrite_repos=(),
-        is_directory=False,
-        template_sync=None,
-        section="workflows",
-    )
-    with pytest.raises(AttributeError):
-        entry.source = "b.yml"  # type: ignore[misc]
-
-
-# ---------------------------------------------------------------------------
-# CLI --validate mode
-# ---------------------------------------------------------------------------
-
-
-def test_cli_validate_exits_zero_for_valid_manifest(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        "version: 1\nworkflows:\n  - source: .github/workflows/autofix.yml\n    description: A\n",
-    )
-    result = subprocess.run(
-        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert "✅" in result.stdout
-
-
-def test_cli_validate_exits_one_for_invalid_manifest(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        "version: 1\nworkflows:\n  - description: Missing source\n",
-    )
-    result = subprocess.run(
-        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 1
-    assert "❌" in result.stderr
-
-
-def test_cli_validate_exits_one_for_missing_file(tmp_path: Path) -> None:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/sync_manifest_compiler.py",
-            "--validate",
-            str(tmp_path / "missing.yml"),
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 1
-
-
-def test_cli_validate_reports_problem_count(tmp_path: Path) -> None:
-    path = _write_manifest(
-        tmp_path,
-        (
-            "version: 1\nworkflows:\n"
-            "  - description: No source\n"
-            "  - source: ''\n    description: Empty source\n"
-        ),
-    )
-    result = subprocess.run(
-        [sys.executable, "scripts/sync_manifest_compiler.py", "--validate", str(path)],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 1
-    assert "2 manifest validation error" in result.stderr
-
-
-# ---------------------------------------------------------------------------
-# Compile against the real manifest (integration smoke test)
-# ---------------------------------------------------------------------------
-
-
-def test_compile_real_manifest_succeeds() -> None:
-    real_path = Path(".github/sync-manifest.yml")
-    if not real_path.exists():
-        pytest.skip("Real manifest not found")
-    compiled = compile_manifest(real_path)
-    assert compiled.version == 1
-    assert any(compiled.section(s) for s in COPY_SYNCED_SECTIONS)
-    assert compiled.removals  # real manifest has at least one removal
-
-
-def test_real_manifest_all_entries_have_non_empty_source() -> None:
-    real_path = Path(".github/sync-manifest.yml")
-    if not real_path.exists():
-        pytest.skip("Real manifest not found")
-    compiled = compile_manifest(real_path)
-    for entry in compiled.all_entries():
-        assert entry.source, f"Empty source in section {entry.section}"
-
-
-def test_real_manifest_removals_have_non_empty_target() -> None:
-    real_path = Path(".github/sync-manifest.yml")
-    if not real_path.exists():
-        pytest.skip("Real manifest not found")
-    compiled = compile_manifest(real_path)
-    for removal in compiled.removals:
-        assert removal.target, "Empty target in removals"
+    assert "--output-json manifest.json" in workflow
+    assert "steps.manifest.outputs.template_hash" in workflow
+    assert "item['resolved_source']" in workflow
+    assert "workflows.consumer-sync-plan/v1" in workflow
+    assert "find templates/consumer-repo -type f" not in workflow

--- a/tests/scripts/test_validate_template_sync.py
+++ b/tests/scripts/test_validate_template_sync.py
@@ -13,10 +13,11 @@ def create_test_structure(tmp_path: Path) -> tuple[Path, Path]:
     source.mkdir(parents=True)
     template.mkdir(parents=True)
 
-    # Copy validator script to tmp_path so it can find paths relative to cwd
+    # Copy validator and its dependency so they are importable when run from tmp_path
     script_dir = tmp_path / "scripts"
     script_dir.mkdir(parents=True)
     shutil.copy("scripts/validate_template_sync.py", script_dir / "validate_template_sync.py")
+    shutil.copy("scripts/sync_manifest_compiler.py", script_dir / "sync_manifest_compiler.py")
 
     return source, template
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2751 -->
> **Source:** Issue #2751

Closes #2751

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- Add a typed Python manifest compiler for `.github/sync-manifest.yml`.
- Normalize every sync entry into explicit records containing section, source, resolved local source, target, sync mode, directory flag, skip rules, overwrite rules, and stable content/effect fingerprints.
- Resolve source ownership once using the documented template-vs-root section policy.
- Emit JSON suitable for shell/workflow consumers.
- Fail early on missing/ambiguous sources, duplicate effective targets, malformed skip rules, unsafe paths, and unsupported modes.
- Migrate the maintenance sync, drift, template-hash, and manifest/template validation paths to consume the compiler or its normalized output.
- Keep removal entries typed and distinct from file-copy entries.
- Update the defining docs and consumer-template contract where behavior changes.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2750](https://github.com/stranske/Workflows/issues/2750)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement the compiler and CLI with deterministic output.
- [ ] Add unit fixtures for template-root precedence, repository-root precedence, directories, create-only/overwrite behavior, removals, duplicate targets, missing sources, and unsafe paths.
- [ ] Replace duplicated resolution logic in covered Python validators.
- [ ] Make the sync workflow prepare phase compile and validate the manifest before fan-out.
- [ ] Make template hashing derive from the normalized plan.
- [ ] Document the normalized plan contract and migration boundary.

#### Acceptance criteria
- [ ] The same manifest entry resolves to the same source and target in sync, drift, hash, and validation paths.
- [ ] Every declared copy entry is deliverable or validation fails before consumer mutation.
- [ ] Duplicate effective targets and ambiguous source candidates are rejected with actionable diagnostics.
- [ ] JSON output is deterministic for identical inputs and includes a schema version.
- [ ] Existing intentional consumer skips and create-only exceptions remain intact.
- [ ] No consumer write begins when compilation fails.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic, schema-validated consumer sync manifest compiler that produces a standardized sync plan with stable plan IDs and fingerprints.
  * Introduced GraphQL-based pull request context helpers and GitHub API caching utilities for PR-related workflows.
* **Bug Fixes**
  * Updated sync, template validation, and drift checks to rely on the compiled plan for more consistent behavior.
  * Strengthened manifest/path safety, normalization, and duplicate-target detection; improved deterministic directory hashing.
* **Documentation**
  * Documented the manifest schema, compilation, and sync plan validation process.
* **Tests**
  * Expanded compiler, validation, determinism, and drift-check test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->