### PR TITLE
fix: restore backplane reference artifact

### DIFF
--- a/.github/workflows/reusable-backplane-conformance.yml
+++ b/.github/workflows/reusable-backplane-conformance.yml
@@ -74,8 +74,11 @@ jobs:
         uses: actions/checkout@v7
 
       # A reusable workflow runs in a fresh job. Restore the caller's emitted
-      # reference-run artifact before validating its configured paths.
+      # reference-run artifact before validating its configured paths. Some
+      # planned/non-emitting participants intentionally have no artifact; let
+      # the validator apply its existing opt-in skip policy in that case.
       - name: Restore emitted reference run
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.reference_artifact_name }}

--- a/.github/workflows/reusable-backplane-conformance.yml
+++ b/.github/workflows/reusable-backplane-conformance.yml
@@ -19,13 +19,20 @@ on:
   workflow_call:
     inputs:
       run_json_path:
-        description: 'Path to the emitted run.json (producer/bridge) or ingested object (consumer) to validate'
+        description: >-
+          Path to the emitted run.json (producer/bridge) or ingested object
+          (consumer) to validate
         required: true
         type: string
       manifest_path:
         description: 'Path to the run manifest.json (enables artifact cross-check; producers only)'
         required: false
         default: ''
+        type: string
+      reference_artifact_name:
+        description: 'Caller-workflow artifact containing the emitted run envelope and manifest'
+        required: false
+        default: 'reference-run'
         type: string
       repo:
         description: 'Participant repo slug (defaults to calling repo)'
@@ -65,6 +72,14 @@ jobs:
       # The participant's own checkout (carries the emitted run.json/manifest).
       - name: Checkout participant
         uses: actions/checkout@v7
+
+      # A reusable workflow runs in a fresh job. Restore the caller's emitted
+      # reference-run artifact before validating its configured paths.
+      - name: Restore emitted reference run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.reference_artifact_name }}
+          path: artifacts/reference
 
       - name: Setup API client
         uses: ./.github/actions/setup-api-client
@@ -137,7 +152,9 @@ jobs:
             let detail = '(no machine-readable report produced)';
             try {
               const r = JSON.parse(fs.readFileSync('conformance-report.json', 'utf8'));
-              detail = (r.violations || []).map((v) => `- \`${v.path || ''}\` ${v.message}`).join('\n');
+              detail = (r.violations || [])
+                .map((v) => `- \`${v.path || ''}\` ${v.message}`)
+                .join('\n');
             } catch (e) { /* leave default */ }
             const body = [
               '## Backplane Conformance Failed',

--- a/docs/contracts/research-backplane-contract.md
+++ b/docs/contracts/research-backplane-contract.md
@@ -44,6 +44,14 @@ Participating repos own:
   `run.json` (+ `manifest.json`), and/or their ingest adapter,
 - their entity-resolution algorithm (for identity-authoritative repos).
 
+## Reference-run artifact handoff
+
+A participant caller emits its reference `run.json` and `manifest.json` in one
+job, uploads them as the `reference-run` artifact, and then invokes the reusable
+conformance workflow. The reusable workflow restores that artifact to
+`artifacts/reference` before running the canonical validator. Callers that use
+a different artifact name must pass it through `reference_artifact_name`.
+
 ## Roles: producer / consumer / bridge
 
 Participation is **not binary in/out**. Each registry entry declares a `role`, and

--- a/docs/contracts/research-backplane-contract.md
+++ b/docs/contracts/research-backplane-contract.md
@@ -50,7 +50,10 @@ A participant caller emits its reference `run.json` and `manifest.json` in one
 job, uploads them as the `reference-run` artifact, and then invokes the reusable
 conformance workflow. The reusable workflow restores that artifact to
 `artifacts/reference` before running the canonical validator. Callers that use
-a different artifact name must pass it through `reference_artifact_name`.
+a different artifact name must pass it through `reference_artifact_name`. A
+caller that intentionally has no emitted artifact remains an opt-in skip: the
+restore failure is non-fatal and the validator decides whether that participant
+is absent/planned or should fail for a missing required envelope.
 
 ## Roles: producer / consumer / bridge
 

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T23:07:52.369708Z",
+  "emitted_at": "2026-07-11T23:15:22.872166Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:41:57.530023Z",
+  "emitted_at": "2026-07-11T22:50:10.621550Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:50:10.621550Z",
+  "emitted_at": "2026-07-11T22:59:43.965511Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:59:43.965511Z",
+  "emitted_at": "2026-07-11T23:07:52.369708Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T05:26:17.399554Z",
+  "emitted_at": "2026-07-11T22:41:57.530023Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2757",
+  "pr_number": "2763",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/tests/workflows/test_backplane_conformance_artifact_handoff.py
+++ b/tests/workflows/test_backplane_conformance_artifact_handoff.py
@@ -16,6 +16,7 @@ def test_reusable_backplane_conformance_restores_caller_reference_artifact() -> 
     assert "reference_artifact_name:" in workflow
     assert "default: 'reference-run'" in workflow
     assert "name: Restore emitted reference run" in workflow
+    assert "continue-on-error: true" in workflow
     assert "uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" in workflow
     assert "name: ${{ inputs.reference_artifact_name }}" in workflow
     assert "path: artifacts/reference" in workflow

--- a/tests/workflows/test_backplane_conformance_artifact_handoff.py
+++ b/tests/workflows/test_backplane_conformance_artifact_handoff.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_reusable_backplane_conformance_restores_caller_reference_artifact() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "reusable-backplane-conformance.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "reference_artifact_name:" in workflow
+    assert "default: 'reference-run'" in workflow
+    assert "name: Restore emitted reference run" in workflow
+    assert "uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" in workflow
+    assert "name: ${{ inputs.reference_artifact_name }}" in workflow
+    assert "path: artifacts/reference" in workflow

--- a/tests/workflows/test_backplane_conformance_artifact_handoff.py
+++ b/tests/workflows/test_backplane_conformance_artifact_handoff.py
@@ -8,6 +8,11 @@ def test_reusable_backplane_conformance_restores_caller_reference_artifact() -> 
         encoding="utf-8"
     )
 
+    # The contract exposes exactly one caller-configurable artifact name and
+    # exactly one restore step; duplicate declarations would make the handoff
+    # ambiguous even if the expected strings were still present somewhere.
+    assert workflow.count("reference_artifact_name:") == 1
+    assert workflow.count("name: Restore emitted reference run") == 1
     assert "reference_artifact_name:" in workflow
     assert "default: 'reference-run'" in workflow
     assert "name: Restore emitted reference run" in workflow


### PR DESCRIPTION
## Summary
- restore the caller-emitted `reference-run` artifact before reusable conformance validation
- make the artifact name configurable, defaulting to the existing caller contract
- document and test the cross-job handoff

## Root cause
Pension-Data #712 emitted a valid run envelope and manifest, but the reusable workflow runs in a fresh job and previously validated paths that were never downloaded.

## Validation
- `python scripts/validate_workflow_yaml.py .github/workflows/reusable-backplane-conformance.yml`
- focused workflow and backplane-contract tests (30 passed)
- Ruff, Black, and `git diff --check`

Unblocks the retry path for stranske/Pension-Data#712.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restoring a configurable reference-run artifact during conformance validation.
  * The reference artifact name is now optional/configurable, defaulting to `reference-run`.
* **Documentation**
  * Added a “Reference-run artifact handoff” guide covering how to package, upload, restore, and validate reference-run artifacts.
* **Tests**
  * Added tests that verify the reusable workflow’s configuration for restoring the reference run into `artifacts/reference`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->