### PR TITLE
fix(llm): run model evaluation pilot as a module

### DIFF
--- a/.github/workflows/maint-78-model-evaluation-pilot.yml
+++ b/.github/workflows/maint-78-model-evaluation-pilot.yml
@@ -24,10 +24,16 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
         run: |
-          uv run --extra dev python tools/run_model_eval_pilot.py --output pilot-results.json
+          uv run --extra dev python -m tools.run_model_eval_pilot --output pilot-results.json
       - name: Summarize pilot
         if: always()
         run: |
+          if [ ! -f pilot-results.json ]; then
+            echo '## Verifier model pilot' >> "$GITHUB_STEP_SUMMARY"
+            echo 'The pilot failed before producing a results artifact; inspect the run step.' \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           {
             echo '## Verifier model pilot'
             echo 'The pilot narrows candidates only; approval still requires the 75-case corpus.'
@@ -43,4 +49,4 @@ jobs:
           name: verifier-model-pilot-${{ github.run_id }}
           path: |
             pilot-results.json
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/tests/workflows/test_model_eval_pilot_workflow.py
+++ b/tests/workflows/test_model_eval_pilot_workflow.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_model_eval_pilot_runs_as_importable_module() -> None:
+    root = Path(__file__).resolve().parents[2]
+    workflow = (root / ".github/workflows/maint-78-model-evaluation-pilot.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "python -m tools.run_model_eval_pilot" in workflow
+    assert "python tools/run_model_eval_pilot.py" not in workflow
+    assert "if [ ! -f pilot-results.json ]" in workflow
+    assert "if-no-files-found: warn" in workflow

--- a/tests/workflows/test_model_eval_pilot_workflow.py
+++ b/tests/workflows/test_model_eval_pilot_workflow.py
@@ -1,13 +1,21 @@
 from pathlib import Path
 
+import yaml
+
 
 def test_model_eval_pilot_runs_as_importable_module() -> None:
     root = Path(__file__).resolve().parents[2]
-    workflow = (root / ".github/workflows/maint-78-model-evaluation-pilot.yml").read_text(
-        encoding="utf-8"
+    workflow = yaml.safe_load(
+        (root / ".github/workflows/maint-78-model-evaluation-pilot.yml").read_text(encoding="utf-8")
     )
+    steps = workflow["jobs"]["pilot"]["steps"]
+    pilot = next(step for step in steps if step.get("name") == "Run paired 30-case pilot")
+    summary = next(step for step in steps if step.get("name") == "Summarize pilot")
+    upload = next(step for step in steps if "actions/upload-artifact@" in step.get("uses", ""))
 
-    assert workflow.count("python -m tools.run_model_eval_pilot") == 1
-    assert "python tools/run_model_eval_pilot.py" not in workflow
-    assert "if [ ! -f pilot-results.json ]" in workflow
-    assert "if-no-files-found: warn" in workflow
+    assert pilot["run"].count("python -m tools.run_model_eval_pilot") == 1
+    assert "python tools/run_model_eval_pilot.py" not in pilot["run"]
+    assert summary["if"] == "always()"
+    assert "if [ ! -f pilot-results.json ]" in summary["run"]
+    assert upload["if"] == "always()"
+    assert upload["with"]["if-no-files-found"] == "warn"

--- a/tests/workflows/test_model_eval_pilot_workflow.py
+++ b/tests/workflows/test_model_eval_pilot_workflow.py
@@ -7,7 +7,7 @@ def test_model_eval_pilot_runs_as_importable_module() -> None:
         encoding="utf-8"
     )
 
-    assert "python -m tools.run_model_eval_pilot" in workflow
+    assert workflow.count("python -m tools.run_model_eval_pilot") == 1
     assert "python tools/run_model_eval_pilot.py" not in workflow
     assert "if [ ! -f pilot-results.json ]" in workflow
     assert "if-no-files-found: warn" in workflow


### PR DESCRIPTION
Follow-up to #2740 and failed pilot run #29220735966.

The workflow invoked `tools/run_model_eval_pilot.py` as a file, which placed `tools/` rather than the repository root on `sys.path` and caused `ModuleNotFoundError: scripts`. This changes the command to `python -m tools.run_model_eval_pilot`, adds a workflow contract test, and makes the always-run summary/upload steps report a missing result artifact without masking the root execution failure.

Validation:
- `3 passed` for the workflow contract and pilot runner tests
- workflow YAML validation passed
- Ruff, Black, and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model evaluation pilot workflow handling when results are not produced.
  * Workflow summaries now clearly indicate when a pilot run finishes without generating results.
  * Missing result artifacts now emit a warning instead of failing the workflow.

* **Tests**
  * Added coverage to ensure the pilot runs as an importable module and validates the missing-results shell guard and artifact warning configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->