### PR TITLE
feat(llm): preflight model pilot candidates

### DIFF
--- a/.github/workflows/maint-78-model-evaluation-pilot.yml
+++ b/.github/workflows/maint-78-model-evaluation-pilot.yml
@@ -41,7 +41,8 @@ jobs:
             echo 'The pilot narrows candidates only; approval still requires the 75-case corpus.'
             echo '```json'
             jq '{schema, corpus_version, rows:(.results|length),
-              errors:([.results[]|select(.schema_valid == false)]|length)}' \
+              errors:([.results[]|select(.schema_valid == false)]|length),
+              category_report:.summary.candidates}' \
               pilot-results.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
@@ -51,4 +52,5 @@ jobs:
           name: verifier-model-pilot-${{ github.run_id }}
           path: |
             pilot-results.json
+            pilot-preflight.json
           if-no-files-found: warn

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T07:26:29.245330Z",
+  "emitted_at": "2026-07-13T07:28:14.295050Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T05:25:54.260984Z",
+  "emitted_at": "2026-07-13T05:27:22.385401Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T06:30:29.885543Z",
+  "emitted_at": "2026-07-13T07:09:13.458799Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T05:19:36.404745Z",
+  "emitted_at": "2026-07-13T05:25:54.260984Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T23:15:22.872166Z",
+  "emitted_at": "2026-07-13T05:11:52.501042Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2763",
+  "pr_number": "2769",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T07:28:14.295050Z",
+  "emitted_at": "2026-07-13T08:04:39.361262Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T05:11:52.501042Z",
+  "emitted_at": "2026-07-13T05:15:54.109949Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T06:10:14.854898Z",
+  "emitted_at": "2026-07-13T06:30:29.885543Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T07:13:40.819647Z",
+  "emitted_at": "2026-07-13T07:26:29.245330Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T05:15:54.109949Z",
+  "emitted_at": "2026-07-13T05:19:36.404745Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T05:27:22.385401Z",
+  "emitted_at": "2026-07-13T06:08:40.400136Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T06:08:40.400136Z",
+  "emitted_at": "2026-07-13T06:10:14.854898Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T07:09:13.458799Z",
+  "emitted_at": "2026-07-13T07:13:40.819647Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/tests/tools/test_run_model_eval_pilot.py
+++ b/tests/tools/test_run_model_eval_pilot.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from tools import run_model_eval_pilot as pilot
@@ -88,9 +89,15 @@ def test_run_pilot_captures_failure_with_case_and_candidate_metadata() -> None:
 def test_unusable_candidates_requires_valid_evidence_per_candidate() -> None:
     report = {
         "results": [
-            {"provider": "openai", "model_id": "working", "schema_valid": True},
-            {"provider": "openai", "model_id": "working", "schema_valid": False},
-            {"provider": "anthropic", "model_id": "broken", "schema_valid": False},
+            {"case_id": "one", "provider": "openai", "model_id": "working", "schema_valid": True},
+            {"case_id": "two", "provider": "openai", "model_id": "working", "schema_valid": True},
+            {"case_id": "one", "provider": "anthropic", "model_id": "broken", "schema_valid": True},
+            {
+                "case_id": "two",
+                "provider": "anthropic",
+                "model_id": "broken",
+                "schema_valid": False,
+            },
         ]
     }
 
@@ -122,6 +129,56 @@ def test_fetch_pr_includes_linked_source_issue_context(monkeypatch) -> None:
     assert "acceptance context" in context
     assert "Verifier disposition: PASS after comparison." in context
     assert diff == "diff"
+
+
+def test_fetch_pr_skips_inaccessible_linked_issue(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_pull_request",
+        lambda *_: {"title": "PR", "body": "Closes #12"},
+    )
+    monkeypatch.setattr(pilot.api_client, "fetch_pull_request_diff", lambda *_: "diff")
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_issue",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("forbidden")),
+    )
+
+    context, _ = pilot.fetch_pr("owner/repo", 13, "token")
+
+    assert "Repository: owner/repo" in context
+    assert "Linked source issues" not in context
+
+
+def test_linked_issue_numbers_accepts_inline_references_and_deduplicates() -> None:
+    assert pilot._linked_issue_numbers(
+        "This closes #12; related to: #12 and fixes #13. Resolves #99.", pr_number=99
+    ) == [12, 13]
+
+
+def test_fetch_pr_bounds_and_guards_linked_issue_text(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_pull_request",
+        lambda *_: {"title": "PR", "body": "Closes #12"},
+    )
+    monkeypatch.setattr(pilot.api_client, "fetch_pull_request_diff", lambda *_: "diff")
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_issue",
+        lambda *_: {"title": "Source", "body": "unsafe body"},
+    )
+    monkeypatch.setattr(pilot.api_client, "fetch_issue_comments", lambda *_: [])
+    monkeypatch.setattr(
+        pilot,
+        "check_prompt_injection",
+        lambda text: {"blocked": text == "unsafe body", "code": "INSTRUCTION_OVERRIDE"},
+    )
+
+    context, _ = pilot.fetch_pr("owner/repo", 13, "token")
+
+    assert "unsafe body" not in context
+    assert "INSTRUCTION_OVERRIDE" in context
 
 
 def test_preflight_uses_one_case_per_candidate_and_stops_unusable_candidate() -> None:
@@ -228,4 +285,32 @@ def test_summary_reports_category_agreement_errors_and_latency() -> None:
         "false_pass": 1,
         "false_fail": 0,
         "schema_errors": 1,
+        "latency_ms": 5.0,
     }
+
+
+def test_main_reports_malformed_corpus_without_traceback(monkeypatch, tmp_path, capsys) -> None:
+    corpus = tmp_path / "corpus.json"
+    candidates = tmp_path / "candidates.json"
+    output = tmp_path / "report.json"
+    corpus.write_text(json.dumps({"corpus_version": "v1", "cases": []}))
+    candidates.write_text(json.dumps({"candidates": []}))
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(
+        pilot.sys,
+        "argv",
+        [
+            "run_model_eval_pilot.py",
+            "--corpus",
+            str(corpus),
+            "--candidates",
+            str(candidates),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert pilot.main() == 1
+    assert (
+        "pilot preflight error: pilot corpus requires at least one case" in capsys.readouterr().err
+    )

--- a/tests/tools/test_run_model_eval_pilot.py
+++ b/tests/tools/test_run_model_eval_pilot.py
@@ -131,7 +131,7 @@ def test_fetch_pr_includes_linked_source_issue_context(monkeypatch) -> None:
     assert diff == "diff"
 
 
-def test_fetch_pr_skips_inaccessible_linked_issue(monkeypatch) -> None:
+def test_fetch_pr_skips_inaccessible_linked_issue(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         pilot.api_client,
         "fetch_pull_request",
@@ -148,6 +148,7 @@ def test_fetch_pr_skips_inaccessible_linked_issue(monkeypatch) -> None:
 
     assert "Repository: owner/repo" in context
     assert "Linked source issues" not in context
+    assert "pilot: skipping linked issue #12: forbidden" in capsys.readouterr().err
 
 
 def test_linked_issue_numbers_accepts_inline_references_and_deduplicates() -> None:

--- a/tests/tools/test_run_model_eval_pilot.py
+++ b/tests/tools/test_run_model_eval_pilot.py
@@ -1,6 +1,12 @@
 from types import SimpleNamespace
 
-from tools.run_model_eval_pilot import run_pilot, unusable_candidates
+from tools import run_model_eval_pilot as pilot
+from tools.run_model_eval_pilot import (
+    run_pilot,
+    run_preflight,
+    summarize_results,
+    unusable_candidates,
+)
 
 
 def test_run_pilot_records_paired_verdicts() -> None:
@@ -90,3 +96,136 @@ def test_unusable_candidates_requires_valid_evidence_per_candidate() -> None:
 
     assert unusable_candidates(report) == ["anthropic/broken"]
     assert unusable_candidates({"results": []}) == ["<no-results>"]
+
+
+def test_fetch_pr_includes_linked_source_issue_context(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_pull_request",
+        lambda *_: {"title": "PR", "body": "Closes #12"},
+    )
+    monkeypatch.setattr(pilot.api_client, "fetch_pull_request_diff", lambda *_: "diff")
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_issue",
+        lambda *_: {"title": "Source", "body": "- [ ] acceptance context"},
+    )
+    monkeypatch.setattr(
+        pilot.api_client,
+        "fetch_issue_comments",
+        lambda *_: [{"body": "Verifier disposition: PASS after comparison."}],
+    )
+
+    context, diff = pilot.fetch_pr("owner/repo", 13, "token")
+
+    assert "Source issue: #12 — Source" in context
+    assert "acceptance context" in context
+    assert "Verifier disposition: PASS after comparison." in context
+    assert diff == "diff"
+
+
+def test_preflight_uses_one_case_per_candidate_and_stops_unusable_candidate() -> None:
+    corpus = {
+        "corpus_version": "v1",
+        "cases": [
+            {
+                "case_id": "representative",
+                "repo": "o/r",
+                "pr": 1,
+                "category": "clean",
+                "expected_verdict": "PASS",
+            },
+            {
+                "case_id": "later",
+                "repo": "o/r",
+                "pr": 2,
+                "category": "clean",
+                "expected_verdict": "PASS",
+            },
+        ],
+    }
+    candidates = {"candidates": [{"provider": "openai", "model_id": "model-a"}]}
+    report = run_preflight(
+        corpus,
+        candidates,
+        token="token",
+        fetcher=lambda *_: ("PR #1", "diff"),
+        evaluator=lambda *_args, **_kwargs: SimpleNamespace(
+            verdict="PASS", confidence=1, error=None
+        ),
+    )
+
+    assert report["stage"] == "candidate-preflight"
+    assert [row["case_id"] for row in report["results"]] == ["representative"]
+    assert unusable_candidates(report) == []
+
+
+def test_run_pilot_fetches_each_case_once_for_all_candidates() -> None:
+    corpus = {
+        "corpus_version": "v1",
+        "cases": [
+            {
+                "case_id": "one",
+                "repo": "o/r",
+                "pr": 1,
+                "category": "clean",
+                "expected_verdict": "PASS",
+            }
+        ],
+    }
+    candidates = {
+        "candidates": [
+            {"provider": "openai", "model_id": "model-a"},
+            {"provider": "openai", "model_id": "model-b"},
+        ]
+    }
+    calls = []
+
+    report = run_pilot(
+        corpus,
+        candidates,
+        token="token",
+        fetcher=lambda *args: (calls.append(args), ("PR #1", "diff"))[1],
+        evaluator=lambda *_args, **_kwargs: SimpleNamespace(
+            verdict="PASS", confidence=1, error=None
+        ),
+    )
+
+    assert len(calls) == 1
+    assert len(report["results"]) == 2
+
+
+def test_summary_reports_category_agreement_errors_and_latency() -> None:
+    summary = summarize_results(
+        [
+            {
+                "provider": "openai",
+                "model_id": "model-a",
+                "category": "clean",
+                "expected_verdict": "PASS",
+                "actual_verdict": "PASS",
+                "schema_valid": True,
+                "latency_ms": 2,
+            },
+            {
+                "provider": "openai",
+                "model_id": "model-a",
+                "category": "clean",
+                "expected_verdict": "NON_PASS",
+                "actual_verdict": "PASS",
+                "schema_valid": False,
+                "latency_ms": 3,
+            },
+        ]
+    )
+
+    candidate = summary["candidates"][0]
+    assert candidate["latency_ms"] == 5.0
+    assert candidate["schema_errors"] == 1
+    assert candidate["categories"]["clean"] == {
+        "rows": 2,
+        "agreement": 1,
+        "false_pass": 1,
+        "false_fail": 0,
+        "schema_errors": 1,
+    }

--- a/tools/run_model_eval_pilot.py
+++ b/tools/run_model_eval_pilot.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from collections.abc import Callable
@@ -14,19 +15,34 @@ from typing import Any
 
 from scripts import api_client
 from scripts.langchain import pr_verifier
+from scripts.langchain.injection_guard import check_prompt_injection
 
 ROOT = Path(__file__).resolve().parent.parent
+MAX_LINKED_ISSUE_BODY_CHARS = 4_000
+MAX_LINKED_ISSUE_COMMENT_CHARS = 1_200
+MAX_LINKED_ISSUE_CONTEXT_CHARS = 8_000
 
 
 def _linked_issue_numbers(body: str, *, pr_number: int) -> list[int]:
     """Return issue references that state an explicit PR-to-issue relationship."""
-    import re
-
     numbers = [
         int(match.group(1))
-        for match in re.finditer(r"(?im)^\s*(?:closes|fixes|resolves|related to)\s+#(\d+)\b", body)
+        for match in re.finditer(
+            r"(?i)\b(?:closes|fixes|resolves|related to)\s*:?\s+#(\d+)\b", body
+        )
     ]
     return [number for number in dict.fromkeys(numbers) if number != pr_number]
+
+
+def _bounded_linked_issue_text(value: object, *, limit: int) -> str:
+    """Keep untrusted linked-issue text safe and bounded for verifier context."""
+    text = str(value or "").strip()
+    guard = check_prompt_injection(text)
+    if guard["blocked"]:
+        return f"[linked issue text omitted by prompt-injection guard: {guard['code']}]"
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "\n[truncated linked issue context]"
 
 
 def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
@@ -34,21 +50,28 @@ def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
     diff = api_client.fetch_pull_request_diff(repo, number, token)
     pr_body = str(payload.get("body") or "")
     source_issues: list[str] = []
+    remaining_context = MAX_LINKED_ISSUE_CONTEXT_CHARS
     for issue_number in _linked_issue_numbers(pr_body, pr_number=number):
-        issue = api_client.fetch_issue(repo, issue_number, token)
-        disposition_comments = [
-            str(comment.get("body") or "")
-            for comment in api_client.fetch_issue_comments(repo, issue_number, token)
-            if any(
-                marker in str(comment.get("body") or "").casefold()
-                for marker in ("verifier", "verify:compare", "disposition", "terminal")
-            )
-        ][-3:]
-        source_issues.append(
-            "\n".join(
+        try:
+            issue = api_client.fetch_issue(repo, issue_number, token)
+            disposition_comments = [
+                _bounded_linked_issue_text(
+                    comment.get("body"), limit=MAX_LINKED_ISSUE_COMMENT_CHARS
+                )
+                for comment in api_client.fetch_issue_comments(repo, issue_number, token)
+                if any(
+                    marker in str(comment.get("body") or "").casefold()
+                    for marker in ("verifier", "verify:compare", "disposition", "terminal")
+                )
+            ][-3:]
+            source_issue = "\n".join(
                 (
-                    f"Source issue: #{issue_number} — {issue.get('title') or ''}",
-                    str(issue.get("body") or ""),
+                    "Source issue: "
+                    f"#{issue_number} — "
+                    + _bounded_linked_issue_text(issue.get("title"), limit=300),
+                    _bounded_linked_issue_text(
+                        issue.get("body"), limit=MAX_LINKED_ISSUE_BODY_CHARS
+                    ),
                     "## Durable verifier/disposition context",
                     (
                         "\n\n---\n\n".join(disposition_comments)
@@ -57,7 +80,12 @@ def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
                     ),
                 )
             )
-        )
+        except Exception:
+            continue
+        if remaining_context <= 0:
+            break
+        source_issues.append(source_issue[:remaining_context])
+        remaining_context -= len(source_issues[-1])
     context = "\n\n".join(
         part
         for part in (
@@ -153,7 +181,14 @@ def summarize_results(results: list[dict[str, Any]]) -> dict[str, Any]:
         )
         category = candidate["categories"].setdefault(
             row["category"],
-            {"rows": 0, "agreement": 0, "false_pass": 0, "false_fail": 0, "schema_errors": 0},
+            {
+                "rows": 0,
+                "agreement": 0,
+                "false_pass": 0,
+                "false_fail": 0,
+                "schema_errors": 0,
+                "latency_ms": 0.0,
+            },
         )
         expected = row["expected_verdict"]
         actual = row["actual_verdict"]
@@ -166,8 +201,11 @@ def summarize_results(results: list[dict[str, Any]]) -> dict[str, Any]:
         category["false_pass"] += int(expected == "NON_PASS" and actual == "PASS")
         category["false_fail"] += int(expected == "PASS" and actual == "NON_PASS")
         category["schema_errors"] += int(not schema_valid)
+        category["latency_ms"] += float(row["latency_ms"])
     for candidate in candidates.values():
         candidate["latency_ms"] = round(candidate["latency_ms"], 3)
+        for category in candidate["categories"].values():
+            category["latency_ms"] = round(category["latency_ms"], 3)
     return {"candidates": list(candidates.values())}
 
 
@@ -196,16 +234,23 @@ def run_preflight(
 
 
 def unusable_candidates(report: dict[str, Any]) -> list[str]:
-    """Return candidates that produced no schema-valid evaluation row."""
-    if not report.get("results"):
+    """Return candidates without a schema-valid row for every corpus case."""
+    results = [row for row in report.get("results", []) if isinstance(row, dict)]
+    if not results:
         return ["<no-results>"]
-    health: dict[tuple[str, str], bool] = {}
-    for row in report.get("results", []):
-        if not isinstance(row, dict):
-            continue
+    expected_case_ids = {str(row.get("case_id", "")) for row in results}
+    valid_case_ids: dict[tuple[str, str], set[str]] = {}
+    candidates: set[tuple[str, str]] = set()
+    for row in results:
         key = (str(row.get("provider", "")), str(row.get("model_id", "")))
-        health[key] = health.get(key, False) or row.get("schema_valid") is True
-    return [f"{provider}/{model}" for (provider, model), usable in health.items() if not usable]
+        candidates.add(key)
+        if row.get("schema_valid") is True:
+            valid_case_ids.setdefault(key, set()).add(str(row.get("case_id", "")))
+    return [
+        f"{provider}/{model}"
+        for provider, model in sorted(candidates)
+        if valid_case_ids.get((provider, model), set()) != expected_case_ids
+    ]
 
 
 def main() -> int:
@@ -222,11 +267,15 @@ def main() -> int:
         raise SystemExit("GITHUB_TOKEN is required")
     corpus = json.loads(args.corpus.read_text())
     candidates = json.loads(args.candidates.read_text())
-    preflight = run_preflight(
-        corpus,
-        candidates,
-        token=token,
-    )
+    try:
+        preflight = run_preflight(
+            corpus,
+            candidates,
+            token=token,
+        )
+    except ValueError as exc:
+        print(f"pilot preflight error: {exc}", file=sys.stderr)
+        return 1
     preflight_output = args.preflight_output or args.output.with_name("pilot-preflight.json")
     preflight_output.write_text(json.dumps(preflight, indent=2) + "\n")
     unusable = unusable_candidates(preflight)

--- a/tools/run_model_eval_pilot.py
+++ b/tools/run_model_eval_pilot.py
@@ -52,6 +52,8 @@ def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
     source_issues: list[str] = []
     remaining_context = MAX_LINKED_ISSUE_CONTEXT_CHARS
     for issue_number in _linked_issue_numbers(pr_body, pr_number=number):
+        if remaining_context <= 0:
+            break
         try:
             issue = api_client.fetch_issue(repo, issue_number, token)
             disposition_comments = [
@@ -80,10 +82,9 @@ def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
                     ),
                 )
             )
-        except Exception:
+        except Exception as exc:
+            print(f"pilot: skipping linked issue #{issue_number}: {exc}", file=sys.stderr)
             continue
-        if remaining_context <= 0:
-            break
         source_issues.append(source_issue[:remaining_context])
         remaining_context -= len(source_issues[-1])
     context = "\n\n".join(

--- a/tools/run_model_eval_pilot.py
+++ b/tools/run_model_eval_pilot.py
@@ -18,10 +18,58 @@ from scripts.langchain import pr_verifier
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def _linked_issue_numbers(body: str, *, pr_number: int) -> list[int]:
+    """Return issue references that state an explicit PR-to-issue relationship."""
+    import re
+
+    numbers = [
+        int(match.group(1))
+        for match in re.finditer(r"(?im)^\s*(?:closes|fixes|resolves|related to)\s+#(\d+)\b", body)
+    ]
+    return [number for number in dict.fromkeys(numbers) if number != pr_number]
+
+
 def fetch_pr(repo: str, number: int, token: str) -> tuple[str, str]:
     payload = api_client.fetch_pull_request(repo, number, token)
     diff = api_client.fetch_pull_request_diff(repo, number, token)
-    context = f"Repository: {repo}\nPR: #{number}\nTitle: {payload['title']}\n\n{payload.get('body') or ''}"
+    pr_body = str(payload.get("body") or "")
+    source_issues: list[str] = []
+    for issue_number in _linked_issue_numbers(pr_body, pr_number=number):
+        issue = api_client.fetch_issue(repo, issue_number, token)
+        disposition_comments = [
+            str(comment.get("body") or "")
+            for comment in api_client.fetch_issue_comments(repo, issue_number, token)
+            if any(
+                marker in str(comment.get("body") or "").casefold()
+                for marker in ("verifier", "verify:compare", "disposition", "terminal")
+            )
+        ][-3:]
+        source_issues.append(
+            "\n".join(
+                (
+                    f"Source issue: #{issue_number} — {issue.get('title') or ''}",
+                    str(issue.get("body") or ""),
+                    "## Durable verifier/disposition context",
+                    (
+                        "\n\n---\n\n".join(disposition_comments)
+                        if disposition_comments
+                        else "No matching source-issue verifier or disposition comments were found."
+                    ),
+                )
+            )
+        )
+    context = "\n\n".join(
+        part
+        for part in (
+            f"Repository: {repo}\nPR: #{number}\nTitle: {payload['title']}\n\n{pr_body}",
+            (
+                "## Linked source issues\n\n" + "\n\n---\n\n".join(source_issues)
+                if source_issues
+                else ""
+            ),
+        )
+        if part
+    )
     return context, diff
 
 
@@ -34,13 +82,23 @@ def run_pilot(
     evaluator: Callable[..., Any] = pr_verifier.evaluate_pr,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
+    prepared_cases: dict[str, tuple[str, str] | Exception] = {}
+    for case in corpus["cases"]:
+        case_id = str(case["case_id"])
+        try:
+            prepared_cases[case_id] = fetcher(case["repo"], case["pr"], token)
+        except Exception as exc:  # preserve a shared GitHub read failure for every candidate
+            prepared_cases[case_id] = exc
     for candidate in candidates["candidates"]:
         provider = candidate["provider"]
         model = candidate["model_id"]
         for case in corpus["cases"]:
             started = time.perf_counter()
             try:
-                context, diff = fetcher(case["repo"], case["pr"], token)
+                prepared = prepared_cases[str(case["case_id"])]
+                if isinstance(prepared, Exception):
+                    raise prepared
+                context, diff = prepared
                 result = evaluator(context, diff=diff, model=model, provider=provider)
                 actual = "PASS" if result.verdict == "PASS" else "NON_PASS"
                 row = {
@@ -73,7 +131,68 @@ def run_pilot(
         "schema": "workflows-verifier-pilot-results/v1",
         "corpus_version": corpus["corpus_version"],
         "results": results,
+        "summary": summarize_results(results),
     }
+
+
+def summarize_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Produce durable, category-level evidence without selecting a model."""
+    candidates: dict[str, dict[str, Any]] = {}
+    for row in results:
+        candidate_key = f"{row['provider']}/{row['model_id']}"
+        candidate = candidates.setdefault(
+            candidate_key,
+            {
+                "provider": row["provider"],
+                "model_id": row["model_id"],
+                "rows": 0,
+                "schema_errors": 0,
+                "latency_ms": 0.0,
+                "categories": {},
+            },
+        )
+        category = candidate["categories"].setdefault(
+            row["category"],
+            {"rows": 0, "agreement": 0, "false_pass": 0, "false_fail": 0, "schema_errors": 0},
+        )
+        expected = row["expected_verdict"]
+        actual = row["actual_verdict"]
+        schema_valid = row["schema_valid"] is True
+        candidate["rows"] += 1
+        candidate["schema_errors"] += int(not schema_valid)
+        candidate["latency_ms"] += float(row["latency_ms"])
+        category["rows"] += 1
+        category["agreement"] += int(schema_valid and expected == actual)
+        category["false_pass"] += int(expected == "NON_PASS" and actual == "PASS")
+        category["false_fail"] += int(expected == "PASS" and actual == "NON_PASS")
+        category["schema_errors"] += int(not schema_valid)
+    for candidate in candidates.values():
+        candidate["latency_ms"] = round(candidate["latency_ms"], 3)
+    return {"candidates": list(candidates.values())}
+
+
+def run_preflight(
+    corpus: dict[str, Any],
+    candidates: dict[str, Any],
+    *,
+    token: str,
+    fetcher: Callable[[str, int, str], tuple[str, str]] = fetch_pr,
+    evaluator: Callable[..., Any] = pr_verifier.evaluate_pr,
+) -> dict[str, Any]:
+    """Run one representative case per candidate before the full paired pilot."""
+    cases = corpus.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("pilot corpus requires at least one case for preflight")
+    preflight_corpus = {**corpus, "cases": [cases[0]]}
+    report = run_pilot(
+        preflight_corpus,
+        candidates,
+        token=token,
+        fetcher=fetcher,
+        evaluator=evaluator,
+    )
+    report["stage"] = "candidate-preflight"
+    return report
 
 
 def unusable_candidates(report: dict[str, Any]) -> list[str]:
@@ -96,15 +215,29 @@ def main() -> int:
         "--candidates", type=Path, default=ROOT / "config/model_eval_candidates.json"
     )
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--preflight-output", type=Path)
     args = parser.parse_args()
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
     if not token:
         raise SystemExit("GITHUB_TOKEN is required")
-    payload = run_pilot(
-        json.loads(args.corpus.read_text()),
-        json.loads(args.candidates.read_text()),
+    corpus = json.loads(args.corpus.read_text())
+    candidates = json.loads(args.candidates.read_text())
+    preflight = run_preflight(
+        corpus,
+        candidates,
         token=token,
     )
+    preflight_output = args.preflight_output or args.output.with_name("pilot-preflight.json")
+    preflight_output.write_text(json.dumps(preflight, indent=2) + "\n")
+    unusable = unusable_candidates(preflight)
+    if unusable:
+        print(
+            "pilot preflight error: candidates produced no schema-valid rows: "
+            + ", ".join(unusable),
+            file=sys.stderr,
+        )
+        return 1
+    payload = run_pilot(corpus, candidates, token=token)
     args.output.write_text(json.dumps(payload, indent=2) + "\n")
     unusable = unusable_candidates(payload)
     if unusable:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2768 -->
> **Source:** Issue #2768

Closes #2768

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2710](https://github.com/stranske/Workflows/issues/2710)
- [#2740](https://github.com/stranske/Workflows/issues/2740)
- [#2766](https://github.com/stranske/Workflows/issues/2766)
- [#2767](https://github.com/stranske/Workflows/issues/2767)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Enrich each case input with the linked source issue body, acceptance checklist, and durable verifier/disposition context instead of PR body/diff alone.
- [x] Re-adjudicate and rebalance the frozen screening corpus. The current labels are 26 PASS / 4 NON_PASS and 19/30 cases are clean-pass.
- [x] Add a candidate preflight using one representative case before the full run.
- [ ] Replace or repair GitHub Models codex-mini-latest; run 29221999718 returned 404 for all 30 rows.
- [x] Resolve the six 401 insufficient-permission rows for each gpt-5.6 candidate, or remove those candidates from the API benchmark until their access path is stable.
- [x] Require fully paired, schema-valid rows for every candidate before computing comparisons.
- [ ] Rerun the 30-case pilot and attach a durable, category-level report.

#### Acceptance criteria
- [x] Every candidate has the same complete set of schema-valid case IDs.
- [ ] No candidate has auth, permission, model-not-found, or endpoint errors.
- [x] Corpus class/category distribution is documented and defensible.
- [ ] The rerun report includes agreement, false-pass, false-fail, schema-error, and latency by category.
- [x] A recorded decision explicitly either narrows candidates for the 75-case approval benchmark or retains incumbents with evidence.
- [x] No runtime selection or consumer migration occurs before a candidate passes the documented approval stage.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preflight stage that runs first, emits a separate preflight JSON report, and stops early if candidates produce no schema-valid results for the expected cases.
  * Enhanced PR context using explicitly linked source issues, with bounded/truncated text and prompt-injection guarding.
  * Added an aggregated pilot summary including latency and per-category agreement/false pass-fail details.
* **Bug Fixes**
  * Improved evaluation consistency by caching corpus case fetch results and reusing them across all provider/model candidates.
* **Tests**
  * Expanded coverage for context enrichment, preflight selection, deduped linked issue extraction, summary aggregation, and graceful handling of malformed input.
* **Chores**
  * Updated the pilot workflow to upload the new preflight artifact and include a category report in the summarized JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->