### PR TITLE
fix: include manifest sources in sync sparse checkout

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -80,9 +80,12 @@ jobs:
             templates/consumer-repo
             .github/sync-manifest.yml
             .github/templates
+            .github/actions
             .github/PULL_REQUEST_TEMPLATE.md
             .github/path-classification.yml
             .github/scripts
+            config
+            docs
             scripts
             tools
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
Fixes the Maint 68 typed-plan failure by checking out every manifest-supported source root before compiling the consumer sync plan.\n\nValidation:\n- `python3 scripts/sync_manifest_compiler.py --manifest .github/sync-manifest.yml --output-json /tmp/manifest.json`\n- `git diff --check`\n- Focused compiler tests: 28 passed; 2 unrelated failures because local Python 3.12 lacks `os.path.realpath(strict=...)`, while CI uses Python 3.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow setup by including shared automation actions during repository synchronization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->