### PR TITLE
fix: include agent registry in maint 68 checkout

### DIFF
--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -81,6 +81,7 @@ jobs:
             .github/sync-manifest.yml
             .github/templates
             .github/actions
+            .github/agents
             .github/PULL_REQUEST_TEMPLATE.md
             .github/path-classification.yml
             .github/scripts

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -190,3 +190,16 @@ def test_runtime_fetched_section_is_not_copy_processed() -> None:
     assert (
         "runtime_fetched" not in drift_text
     ), "check_consumer_sync_drift must not probe the runtime_fetched section"
+
+
+def test_prepare_checkout_includes_manifest_owned_github_roots() -> None:
+    """Maint-68 must hash root-owned manifest sources, not stale template copies."""
+    workflow = yaml.safe_load(SYNC_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["prepare"]["steps"]
+    checkout = next(step for step in steps if step.get("name") == "Checkout")
+    sparse_checkout = checkout["with"]["sparse-checkout"]
+
+    # The registry is owned at the Workflows root even though a consumer template
+    # copy also exists. Without this root, the manifest compiler silently reads
+    # the stale template copy during a sync run.
+    assert ".github/agents" in sparse_checkout


### PR DESCRIPTION
Fixes the remaining manifest-owned source omission in Maint 68 sparse checkout.

`.github/agents/registry.yml` is declared as a root-owned manifest source; without `.github/agents` in the checkout, the compiler can silently hash the stale template copy instead.

Validation: `python3 -m pytest tests/workflows/test_sync_manifest_delivery.py -q` (7 passed) and `git diff --check`.