### PR TITLE
fix: address shared sync review blockers

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -66,7 +66,7 @@ runs:
     - name: Mint GitHub App token
       id: app_token
       continue-on-error: true
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: ${{ inputs.workflows_app_id || '0' }}
         private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
@@ -109,7 +109,7 @@ runs:
         printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
 
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout_ref || github.ref }}
@@ -132,7 +132,7 @@ runs:
         github_token: ${{ inputs.github_token }}
 
     - name: Checkout Workflows scripts
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: stranske/Workflows
         ref: ${{ inputs.workflows_ref }}

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T05:06:39.179613Z",
+  "emitted_at": "2026-07-15T05:15:09.843438Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T04:49:25.120890Z",
+  "emitted_at": "2026-07-15T04:57:55.169798Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-14T22:27:32.986055Z",
+  "emitted_at": "2026-07-15T04:49:25.120890Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2775",
+  "pr_number": "2778",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T04:57:55.169798Z",
+  "emitted_at": "2026-07-15T05:06:39.179613Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -43,7 +43,7 @@ SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
 SECRET_LIKE_EVIDENCE_SEGMENT_RE = re.compile(
-    r"(?:^|[:/])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
+    r"(?:^|[:/#@])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
     re.IGNORECASE,
 )
 SUPERVISION_MODES = {

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -286,7 +286,9 @@ def configured_model_for_provider(
                     slot_profile,
                     slot_provider,
                 )
-                return ""
+                # A malformed slot must not mask a later valid slot or the
+                # provider-level reviewed selection/fallback.
+                continue
             if explicit_model and explicit_model != model:
                 logger.warning(
                     "Ignoring slot model pin %s/%s; reviewed %s selection is %s",

--- a/tests/tools/test_discover_model_catalog.py
+++ b/tests/tools/test_discover_model_catalog.py
@@ -1,32 +1,27 @@
 from __future__ import annotations
 
 import datetime as dt
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 from tools import discover_model_catalog as discovery
 
 
 def test_request_json_uses_http_only_client(monkeypatch):
-    response = SimpleNamespace(
-        raise_for_status=lambda: None,
-        json=lambda: {"data": []},
-    )
+    response = SimpleNamespace(read=lambda: b'{"data": []}')
     calls = []
     monkeypatch.setattr(
-        discovery.requests,
-        "get",
-        lambda url, **kwargs: calls.append((url, kwargs)) or response,
+        discovery,
+        "urlopen",
+        lambda request, **kwargs: calls.append((request, kwargs)) or nullcontext(response),
     )
 
     assert discovery._request_json("https://provider.example/models", {"X-Test": "yes"}) == {
         "data": []
     }
-    assert calls == [
-        (
-            "https://provider.example/models",
-            {"headers": {"X-Test": "yes"}, "timeout": 30},
-        )
-    ]
+    assert calls[0][0].full_url == "https://provider.example/models"
+    assert calls[0][0].headers["X-test"] == "yes"
+    assert calls[0][1] == {"timeout": 30}
 
 
 def test_github_catalog_parser_filters_non_chat_entries():

--- a/tests/tools/test_discover_model_catalog.py
+++ b/tests/tools/test_discover_model_catalog.py
@@ -16,10 +16,10 @@ def test_request_json_uses_http_only_client(monkeypatch):
         lambda request, **kwargs: calls.append((request, kwargs)) or nullcontext(response),
     )
 
-    assert discovery._request_json("https://provider.example/models", {"X-Test": "yes"}) == {
+    assert discovery._request_json("https://models.github.ai/catalog/models", {"X-Test": "yes"}) == {
         "data": []
     }
-    assert calls[0][0].full_url == "https://provider.example/models"
+    assert calls[0][0].full_url == "https://models.github.ai/catalog/models"
     assert calls[0][0].headers["X-test"] == "yes"
     assert calls[0][1] == {"timeout": 30}
 

--- a/tests/tools/test_discover_model_catalog.py
+++ b/tests/tools/test_discover_model_catalog.py
@@ -16,9 +16,9 @@ def test_request_json_uses_http_only_client(monkeypatch):
         lambda request, **kwargs: calls.append((request, kwargs)) or nullcontext(response),
     )
 
-    assert discovery._request_json("https://models.github.ai/catalog/models", {"X-Test": "yes"}) == {
-        "data": []
-    }
+    assert discovery._request_json(
+        "https://models.github.ai/catalog/models", {"X-Test": "yes"}
+    ) == {"data": []}
     assert calls[0][0].full_url == "https://models.github.ai/catalog/models"
     assert calls[0][0].headers["X-test"] == "yes"
     assert calls[0][1] == {"timeout": 30}

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -127,7 +127,9 @@ def test_unknown_explicit_profile_fails_closed(
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
     assert registry.load_slot_config() == []
-    assert registry.configured_model_for_provider("openai") == ""
+    # An unresolved slot profile must not mask the provider-level reviewed
+    # selection used as the compatibility fallback.
+    assert registry.configured_model_for_provider("openai") == "model-balanced"
 
 
 def test_noncurrent_selected_model_fails_closed(

--- a/tests/workflows/test_reusable_run_shared_base.py
+++ b/tests/workflows/test_reusable_run_shared_base.py
@@ -146,13 +146,7 @@ def test_extracted_setup_steps_not_duplicated_in_runners(workflow_rel: str) -> N
     # the composite; only the pre-checkout for the composite definition remains
     # in the runners.
     assert "repository: stranske/Workflows" in src
-    assert (
-        sum(
-            _uses_base(step) == "actions/create-github-app-token"
-            for step in steps
-        )
-        == 1
-    ), (
+    assert sum(_uses_base(step) == "actions/create-github-app-token" for step in steps) == 1, (
         f"{workflow_rel}: only the run-base bootstrap checkout may mint an App "
         "token in the runner; shared runtime auth still belongs in "
         f"{RUN_BASE_ACTION}"

--- a/tests/workflows/test_reusable_run_shared_base.py
+++ b/tests/workflows/test_reusable_run_shared_base.py
@@ -84,7 +84,8 @@ def test_run_base_action_exists_and_parses() -> None:
     # The shared block must still reach setup-api-client and the sparse
     # Workflows scripts checkout — the whole point of the extraction.
     src = path.read_text()
-    assert "uses: actions/create-github-app-token@v3" in src
+    app_token_step = next(s for s in steps if s.get("name") == "Mint GitHub App token")
+    assert _uses_base(app_token_step) == "actions/create-github-app-token"
     assert "push_allowed" in src
     assert "uses: ./.github/actions/setup-api-client" in src
     assert "sparse-checkout" in src
@@ -145,7 +146,13 @@ def test_extracted_setup_steps_not_duplicated_in_runners(workflow_rel: str) -> N
     # the composite; only the pre-checkout for the composite definition remains
     # in the runners.
     assert "repository: stranske/Workflows" in src
-    assert src.count("uses: actions/create-github-app-token@v3") == 1, (
+    assert (
+        sum(
+            _uses_base(step) == "actions/create-github-app-token"
+            for step in steps
+        )
+        == 1
+    ), (
         f"{workflow_rel}: only the run-base bootstrap checkout may mint an App "
         "token in the runner; shared runtime auth still belongs in "
         f"{RUN_BASE_ACTION}"

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -22,6 +22,13 @@ from urllib.request import Request, urlopen
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 PROVIDERS = ("openai", "anthropic", "github-models")
+CATALOG_URLS = frozenset(
+    {
+        "https://models.github.ai/catalog/models",
+        "https://api.openai.com/v1/models",
+        "https://api.anthropic.com/v1/models?limit=1000",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -31,8 +38,10 @@ class CatalogModel:
 
 
 def _request_json(url: str, headers: dict[str, str]) -> Any:
+    if url not in CATALOG_URLS:
+        raise ValueError(f"unsupported catalog URL: {url}")
     request = Request(url, headers=headers)
-    with urlopen(request, timeout=30) as response:  # noqa: S310 - caller URLs are fixed
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - validated static catalog URL
         return json.load(response)
 
 

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -16,8 +16,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-import requests
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
@@ -31,9 +31,9 @@ class CatalogModel:
 
 
 def _request_json(url: str, headers: dict[str, str]) -> Any:
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - caller URLs are fixed
+        return json.load(response)
 
 
 def _parse_timestamp(value: object) -> dt.datetime | None:
@@ -131,7 +131,7 @@ def fetch_provider(provider: str) -> tuple[list[CatalogModel] | None, str | None
         else:  # pragma: no cover - argparse constrains values
             raise ValueError(f"unsupported provider: {provider}")
         return parse_catalog(provider, payload), None
-    except (OSError, ValueError, requests.RequestException) as exc:
+    except (OSError, URLError, ValueError) as exc:
         return None, str(exc)
 
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -286,7 +286,9 @@ def configured_model_for_provider(
                     slot_profile,
                     slot_provider,
                 )
-                return ""
+                # A malformed slot must not mask a later valid slot or the
+                # provider-level reviewed selection/fallback.
+                continue
             if explicit_model and explicit_model != model:
                 logger.warning(
                     "Ignoring slot model pin %s/%s; reviewed %s selection is %s",


### PR DESCRIPTION
Addresses active non-outdated review feedback on the current consumer sync wave at its source of truth.

- allow unresolved slot profiles to continue to provider-level reviewed selection
- avoid a fragile direct requests import in catalog discovery
- reject credential-like evidence segments after # or @
- pin the agent-run base actions to immutable commits

Validated: focused pytest (62 passed), template sync/completeness, and git diff --check.