### PR TITLE
fix: preserve reviewed model fallback

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T05:15:09.843438Z",
+  "emitted_at": "2026-07-15T14:46:51.200865Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2778",
+  "pr_number": "2779",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -292,14 +292,18 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
     if not github_token and not openai_token:
         return None
 
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+    from tools.llm_provider import GITHUB_MODELS_BASE_URL
+    from tools.llm_registry import configured_model_for_provider
 
     if github_token:
+        model = configured_model_for_provider("github-models")
+        if not model:
+            return None
         return (
             cast(
                 _LLMClient,
                 ChatOpenAI(
-                    model=DEFAULT_MODEL,
+                    model=model,
                     base_url=GITHUB_MODELS_BASE_URL,
                     api_key=cast(Any, github_token),
                     temperature=0.1,
@@ -309,11 +313,14 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
         )
     if openai_token is None:
         return None
+    model = configured_model_for_provider("openai")
+    if not model:
+        return None
     return (
         cast(
             _LLMClient,
             ChatOpenAI(
-                model=DEFAULT_MODEL,
+                model=model,
                 api_key=cast(Any, openai_token),
                 temperature=0.1,
             ),

--- a/templates/consumer-repo/tools/llm_provider.py
+++ b/templates/consumer-repo/tools/llm_provider.py
@@ -351,6 +351,7 @@ class GitHubModelsProvider(LLMProvider):
 
         model_name = _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
         if not model_name:
+            logger.warning("No reviewed GitHub Models selection is configured")
             return None
         self._model_name = model_name
         return ChatOpenAI(

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -379,7 +379,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    return slots if slot_entries else fallback_slots
+    # A syntactically valid config can still yield no usable entries (for
+    # example, every profile was retired or every model was blocked).  That is
+    # equivalent to no usable slot configuration; retain the reviewed defaults
+    # instead of silently disabling every provider.
+    return slots or fallback_slots
 
 
 def apply_slot_env_overrides(

--- a/tests/tools/test_evaluate_model_benchmark.py
+++ b/tests/tools/test_evaluate_model_benchmark.py
@@ -21,6 +21,7 @@ def _policy():
             "verifier-balanced": {
                 "candidate_stage": {"required_case_categories": CATEGORIES},
                 "approval_stage": {
+                    "confidence_level": 0.95,
                     "minimum_adjudicated_cases": 75,
                     "minimum_cases_per_category": 10,
                     "quality_gates": {
@@ -95,6 +96,13 @@ def test_wilson_interval_is_conservative_for_zero_errors():
     lower, upper = evaluator.wilson_interval(0, 80)
     assert lower == 0.0
     assert 0.04 < upper < 0.05
+
+
+def test_invalid_confidence_level_is_rejected():
+    policy = _policy()
+    policy["profiles"]["verifier-balanced"]["approval_stage"]["confidence_level"] = 1.0
+    with pytest.raises(ValueError, match="confidence_level"):
+        evaluator.evaluate_benchmark(_payload(), policy)
 
 
 def test_passing_models_rank_by_cost_after_quality_gates():

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -126,10 +126,23 @@ def test_unknown_explicit_profile_fails_closed(
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
-    assert registry.load_slot_config() == []
-    # An unresolved slot profile must not mask the provider-level reviewed
-    # selection used as the compatibility fallback.
+    # An unresolved slot profile must not disable the provider-level reviewed
+    # selection used as the safe fallback.
+    assert registry.load_slot_config()[0].model == "model-balanced"
     assert registry.configured_model_for_provider("openai") == "model-balanced"
+
+
+def test_all_unusable_slot_entries_fall_back_to_reviewed_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    _write_slots(slots_path, profile="misspelled-profile")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config()[0].model == "model-balanced"
 
 
 def test_noncurrent_selected_model_fails_closed(

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -292,14 +292,18 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
     if not github_token and not openai_token:
         return None
 
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+    from tools.llm_provider import GITHUB_MODELS_BASE_URL
+    from tools.llm_registry import configured_model_for_provider
 
     if github_token:
+        model = configured_model_for_provider("github-models")
+        if not model:
+            return None
         return (
             cast(
                 _LLMClient,
                 ChatOpenAI(
-                    model=DEFAULT_MODEL,
+                    model=model,
                     base_url=GITHUB_MODELS_BASE_URL,
                     api_key=cast(Any, github_token),
                     temperature=0.1,
@@ -309,11 +313,14 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
         )
     if openai_token is None:
         return None
+    model = configured_model_for_provider("openai")
+    if not model:
+        return None
     return (
         cast(
             _LLMClient,
             ChatOpenAI(
-                model=DEFAULT_MODEL,
+                model=model,
                 api_key=cast(Any, openai_token),
                 temperature=0.1,
             ),

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import math
-from statistics import NormalDist
 import sys
 from pathlib import Path
+from statistics import NormalDist
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+from statistics import NormalDist
 import sys
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,7 @@ def _case_outcome(case: dict[str, Any]) -> tuple[str, str, bool]:
     return expected, actual, schema_valid
 
 
-def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
+def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
     success = false_pass = false_fail = schema_error = 0
     expected_pass = expected_non_pass = 0
     categories: dict[str, int] = {}
@@ -77,10 +78,10 @@ def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
         latencies.append(latency)
 
     count = len(cases)
-    success_interval = wilson_interval(success, count)
-    false_pass_interval = wilson_interval(false_pass, expected_non_pass)
-    false_fail_interval = wilson_interval(false_fail, expected_pass)
-    schema_interval = wilson_interval(schema_error, count)
+    success_interval = wilson_interval(success, count, z=z)
+    false_pass_interval = wilson_interval(false_pass, expected_non_pass, z=z)
+    false_fail_interval = wilson_interval(false_fail, expected_pass, z=z)
+    schema_interval = wilson_interval(schema_error, count, z=z)
     return {
         "sample_count": count,
         "category_counts": categories,
@@ -124,6 +125,10 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     profile_policy = profiles[profile]
     approval = profile_policy["approval_stage"]
     gates = approval["quality_gates"]
+    confidence_level = float(approval.get("confidence_level", 0.95))
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("approval_stage.confidence_level must be between 0 and 1")
+    z = NormalDist().inv_cdf((1.0 + confidence_level) / 2.0)
     candidates = payload.get("candidates")
     if not isinstance(candidates, list) or len(candidates) < 2:
         raise ValueError("benchmark requires a baseline and at least one candidate")
@@ -137,7 +142,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
         provider = str(candidate.get("provider", "")).strip()
         if not model_id or not provider or model_id in metrics_by_model:
             raise ValueError("candidate provider/model_id values must be non-empty and unique")
-        metrics_by_model[model_id] = _metrics(candidate["cases"])
+        metrics_by_model[model_id] = _metrics(candidate["cases"], z=z)
     if baseline_model not in metrics_by_model:
         raise ValueError("baseline_model_id must identify one candidate")
 

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -351,6 +351,7 @@ class GitHubModelsProvider(LLMProvider):
 
         model_name = _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
         if not model_name:
+            logger.warning("No reviewed GitHub Models selection is configured")
             return None
         self._model_name = model_name
         return ChatOpenAI(
@@ -369,7 +370,7 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("LangChain OpenAI not available")
+            raise RuntimeError("GitHub Models client unavailable or no reviewed model is configured")
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -370,7 +370,9 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("GitHub Models client unavailable or no reviewed model is configured")
+            raise RuntimeError(
+                "GitHub Models client unavailable or no reviewed model is configured"
+            )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -379,7 +379,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    return slots if slot_entries else fallback_slots
+    # A syntactically valid config can still yield no usable entries (for
+    # example, every profile was retired or every model was blocked).  That is
+    # equivalent to no usable slot configuration; retain the reviewed defaults
+    # instead of silently disabling every provider.
+    return slots or fallback_slots
 
 
 def apply_slot_env_overrides(


### PR DESCRIPTION
Fixes review-backed regressions surfaced by the current consumer sync wave.\n\n- falls back to reviewed slots when configured entries are all unusable\n- resolves CI-triage models through the reviewed registry\n- clarifies missing GitHub Models configuration\n- applies the policy confidence level to Wilson intervals\n\nValidation: focused pytest suite (113 passed), template sync/completeness, and diff check.