### PR TITLE
fix: close model registry review gaps

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -229,6 +229,13 @@ def select_model_for_profile(
             )
         return None
     decision = matches[0]
+    if not decision.evidence_ids:
+        logger.warning(
+            "Model selection %s/%s has no evidence; refusing to use it",
+            normalized_provider,
+            profile,
+        )
+        return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
     if entry is None or entry.blocked or entry.lifecycle != "current":
         return None
@@ -263,42 +270,13 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    path = _slot_path()
-    payload = _load_object(path, label="slot config")
-    if payload is not None:
-        for slot in _slot_entries(payload, path):
-            slot_provider = normalize_provider(str(slot.get("provider", "")))
-            if slot_provider != normalized_provider:
-                continue
-            explicit_model = str(slot.get("model", "")).strip()
-            slot_profile = str(slot.get("profile") or profile).strip()
-            model = (
-                select_model_for_profile(
-                    provider=slot_provider or "",
-                    profile=slot_profile,
-                    registry=entries,
-                )
-                or ""
-            )
-            if not model:
-                logger.warning(
-                    "No reviewed model selection for slot profile %s/%s",
-                    slot_profile,
-                    slot_provider,
-                )
-                # A malformed slot must not mask a later valid slot or the
-                # provider-level reviewed selection/fallback.
-                continue
-            if explicit_model and explicit_model != model:
-                logger.warning(
-                    "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
-                    slot_provider,
-                    explicit_model,
-                    slot_profile,
-                    model or "unavailable",
-                )
-            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
-                return model
+    # Use the same resolution path as runtime callers so emergency environment
+    # overrides cannot be ignored by this convenience helper.
+    for slot in resolve_slots():
+        if slot.provider == normalized_provider and not is_model_blocked(
+            slot.provider, slot.model, registry=entries
+        ):
+            return slot.model
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -150,6 +150,20 @@ def test_explicit_old_pin_is_flagged_against_reviewed_selection():
     assert "selection_override" in _kinds(findings)
 
 
+def test_explicit_pin_without_profile_is_flagged_against_default_selection():
+    registry = _registry()
+    registry["models"].append(
+        {"model_id": "model-old", "provider": "openai", "lifecycle": "compatibility"}
+    )
+    findings = gate.evaluate(
+        registry,
+        {"slots": [{"name": "slot1", "provider": "openai", "model": "model-old"}]},
+        today=TODAY,
+        policy=_policy(),
+    )
+    assert "selection_override" in _kinds(findings)
+
+
 def test_slot_requires_profile_selection():
     findings = gate.evaluate(
         _registry(),

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -173,6 +173,33 @@ def test_duplicate_profile_decisions_fail_closed(
     assert registry.select_model_for_profile(provider="openai") is None
 
 
+def test_selection_without_evidence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    payload["selections"][0]["evidence_ids"] = []
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    assert registry.select_model_for_profile(provider="openai") is None
+
+
+def test_configured_model_honors_runtime_slot_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    _write_slots(slots_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+    monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
+
+    assert registry.configured_model_for_provider("openai") == "emergency-model"
+
+
 def test_runtime_helpers_contain_no_model_version_literals() -> None:
     root = Path(__file__).resolve().parents[2]
     for relative in ("tools/llm_registry.py", "tools/llm_provider.py"):

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -318,13 +318,17 @@ def evaluate(
             findings.append(_finding("invalid_slot", f"slot {name!r} has no provider."))
             continue
         if explicit_model:
-            selected = selection_by_key.get((profile, provider)) if profile else None
+            # A slot without an explicit profile still resolves through the
+            # default reviewed profile at runtime. Compare it against that
+            # decision so an old model pin cannot silently bypass review.
+            effective_profile = profile or "verifier-balanced"
+            selected = selection_by_key.get((effective_profile, provider))
             if selected and selected.get("model_id") != explicit_model:
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')}.",
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
             model = model_by_key.get((provider, explicit_model))

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -229,6 +229,13 @@ def select_model_for_profile(
             )
         return None
     decision = matches[0]
+    if not decision.evidence_ids:
+        logger.warning(
+            "Model selection %s/%s has no evidence; refusing to use it",
+            normalized_provider,
+            profile,
+        )
+        return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
     if entry is None or entry.blocked or entry.lifecycle != "current":
         return None
@@ -263,42 +270,13 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    path = _slot_path()
-    payload = _load_object(path, label="slot config")
-    if payload is not None:
-        for slot in _slot_entries(payload, path):
-            slot_provider = normalize_provider(str(slot.get("provider", "")))
-            if slot_provider != normalized_provider:
-                continue
-            explicit_model = str(slot.get("model", "")).strip()
-            slot_profile = str(slot.get("profile") or profile).strip()
-            model = (
-                select_model_for_profile(
-                    provider=slot_provider or "",
-                    profile=slot_profile,
-                    registry=entries,
-                )
-                or ""
-            )
-            if not model:
-                logger.warning(
-                    "No reviewed model selection for slot profile %s/%s",
-                    slot_profile,
-                    slot_provider,
-                )
-                # A malformed slot must not mask a later valid slot or the
-                # provider-level reviewed selection/fallback.
-                continue
-            if explicit_model and explicit_model != model:
-                logger.warning(
-                    "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
-                    slot_provider,
-                    explicit_model,
-                    slot_profile,
-                    model or "unavailable",
-                )
-            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
-                return model
+    # Use the same resolution path as runtime callers so emergency environment
+    # overrides cannot be ignored by this convenience helper.
+    for slot in resolve_slots():
+        if slot.provider == normalized_provider and not is_model_blocked(
+            slot.provider, slot.model, registry=entries
+        ):
+            return slot.model
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:


### PR DESCRIPTION
Addresses active sync-wave review debt in the shared source of truth.\n\n- reject evidence-free reviewed selections\n- honor runtime slot environment overrides in configured model lookup\n- flag model pins without a profile against the default reviewed profile\n\nValidated: Python 3.12 focused registry/freshness tests; template sync/completeness; diff check.