### PR TITLE
fix: preserve consumer slot compatibility

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T20:46:44.622969Z",
+  "emitted_at": "2026-07-15T21:30:40.959289Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T14:46:51.200865Z",
+  "emitted_at": "2026-07-15T20:46:44.622969Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2779",
+  "pr_number": "2781",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -199,7 +199,7 @@ def fetch_pull_request_diff(
         url,
         token,
         payload=None,
-        accept="application/vnd.github.diff",
+        accept="application/vnd.github.v3.diff",
         **_retry_kwargs(retry_attempts, retry_backoff),
     )
     return response.text

--- a/templates/consumer-repo/scripts/api_client.py
+++ b/templates/consumer-repo/scripts/api_client.py
@@ -199,7 +199,7 @@ def fetch_pull_request_diff(
         url,
         token,
         payload=None,
-        accept="application/vnd.github.diff",
+        accept="application/vnd.github.v3.diff",
         **_retry_kwargs(retry_attempts, retry_backoff),
     )
     return response.text

--- a/templates/consumer-repo/tools/ci_failure_triage.py
+++ b/templates/consumer-repo/tools/ci_failure_triage.py
@@ -297,20 +297,19 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
 
     if github_token:
         model = configured_model_for_provider("github-models")
-        if not model:
-            return None
-        return (
-            cast(
-                _LLMClient,
-                ChatOpenAI(
-                    model=model,
-                    base_url=GITHUB_MODELS_BASE_URL,
-                    api_key=cast(Any, github_token),
-                    temperature=0.1,
+        if model:
+            return (
+                cast(
+                    _LLMClient,
+                    ChatOpenAI(
+                        model=model,
+                        base_url=GITHUB_MODELS_BASE_URL,
+                        api_key=cast(Any, github_token),
+                        temperature=0.1,
+                    ),
                 ),
-            ),
-            "github-models",
-        )
+                "github-models",
+            )
     if openai_token is None:
         return None
     model = configured_model_for_provider("openai")

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -332,7 +332,12 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        if provider and explicit_model and explicit_model != model:
+        explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
+        if provider and explicit_model and not configured_profile and explicit_entry and not (
+            explicit_entry.blocked or explicit_entry.lifecycle != "current"
+        ):
+            model = explicit_model
+        elif provider and explicit_model and explicit_model != model:
             logger.warning(
                 "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
@@ -357,11 +362,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    # A syntactically valid config can still yield no usable entries (for
-    # example, every profile was retired or every model was blocked).  That is
-    # equivalent to no usable slot configuration; retain the reviewed defaults
-    # instead of silently disabling every provider.
-    return slots or fallback_slots
+    # A present slot file is an allowlist.  If every configured slot is
+    # unusable, fail closed instead of broadening execution to default providers.
+    return slots if slot_entries else fallback_slots
 
 
 def apply_slot_env_overrides(

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -278,6 +278,12 @@ def configured_model_for_provider(
         ):
             return slot.model
 
+    # A readable slot config is an execution allowlist.  Do not broaden to a
+    # provider-level registry decision when that config has no usable slot for
+    # this provider (including an empty or invalid-only slots list).
+    if _load_object(_slot_path(), label="slot config") is not None:
+        return ""
+
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:
         return selected
@@ -368,7 +374,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
     # A present slot file is an allowlist.  If every configured slot is
     # unusable, fail closed instead of broadening execution to default providers.
-    return slots if slot_entries else fallback_slots
+    return slots
 
 
 def apply_slot_env_overrides(

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -333,8 +333,12 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 or ""
             )
         explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
-        if provider and explicit_model and not configured_profile and explicit_entry and not (
-            explicit_entry.blocked or explicit_entry.lifecycle != "current"
+        if (
+            provider
+            and explicit_model
+            and not configured_profile
+            and explicit_entry
+            and not (explicit_entry.blocked or explicit_entry.lifecycle != "current")
         ):
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:

--- a/tests/scripts/test_api_client.py
+++ b/tests/scripts/test_api_client.py
@@ -215,7 +215,7 @@ def test_fetch_pull_request_and_diff_use_shared_client(monkeypatch: pytest.Monke
 
     assert api_client.fetch_pull_request("owner/repo", 7, "tok") == {"title": "PR"}
     assert api_client.fetch_pull_request_diff("owner/repo", 7, "tok") == response.text
-    assert calls == [{"payload": None, "accept": "application/vnd.github.diff"}]
+    assert calls == [{"payload": None, "accept": "application/vnd.github.v3.diff"}]
 
 
 def test_fetch_pull_request_rejects_nonobject_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -164,6 +164,26 @@ def test_explicit_pin_without_profile_is_flagged_against_default_selection():
     assert "selection_override" in _kinds(findings)
 
 
+def test_current_unblocked_legacy_pin_is_compatible_with_default_selection():
+    registry = _registry()
+    registry["models"].append(
+        {
+            "model_id": "model-frontier",
+            "provider": "openai",
+            "lifecycle": "current",
+            "source_ids": ["models-1"],
+            "pricing": {"as_of": "2026-07-10"},
+        }
+    )
+    findings = gate.evaluate(
+        registry,
+        {"slots": [{"name": "slot1", "provider": "openai", "model": "model-frontier"}]},
+        today=TODAY,
+        policy=_policy(),
+    )
+    assert "selection_override" not in _kinds(findings)
+
+
 def test_slot_requires_profile_selection():
     findings = gate.evaluate(
         _registry(),

--- a/tests/tools/test_ci_failure_triage.py
+++ b/tests/tools/test_ci_failure_triage.py
@@ -1,4 +1,7 @@
-from tools import ci_failure_triage
+import sys
+import types
+
+from tools import ci_failure_triage, llm_registry
 
 
 def test_extract_pytest_failures_parses_unique() -> None:
@@ -32,3 +35,23 @@ def test_triage_report_includes_failed_tests() -> None:
         "tests/workflows/test_keepalive_workflow.py::test_keepalive_requires_dispatch_token"
     ]
     assert "Pytest failures: 1" in report.summary
+
+
+def test_llm_triage_does_not_fall_back_outside_slot_allowlist(monkeypatch) -> None:
+    created: list[object] = []
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            created.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules, "langchain_openai", types.SimpleNamespace(ChatOpenAI=FakeChatOpenAI)
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
+    monkeypatch.setattr(
+        llm_registry, "configured_model_for_provider", lambda _provider: ""
+    )
+
+    assert ci_failure_triage._get_llm_client() is None
+    assert created == []

--- a/tests/tools/test_ci_failure_triage.py
+++ b/tests/tools/test_ci_failure_triage.py
@@ -49,9 +49,7 @@ def test_llm_triage_does_not_fall_back_outside_slot_allowlist(monkeypatch) -> No
     )
     monkeypatch.setenv("GITHUB_TOKEN", "github-token")
     monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
-    monkeypatch.setattr(
-        llm_registry, "configured_model_for_provider", lambda _provider: ""
-    )
+    monkeypatch.setattr(llm_registry, "configured_model_for_provider", lambda _provider: "")
 
     assert ci_failure_triage._get_llm_client() is None
     assert created == []

--- a/tests/tools/test_ci_failure_triage.py
+++ b/tests/tools/test_ci_failure_triage.py
@@ -53,3 +53,30 @@ def test_llm_triage_does_not_fall_back_outside_slot_allowlist(monkeypatch) -> No
 
     assert ci_failure_triage._get_llm_client() is None
     assert created == []
+
+
+def test_llm_triage_falls_back_from_github_models_to_openai(monkeypatch) -> None:
+    created: list[dict[str, object]] = []
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            created.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules, "langchain_openai", types.SimpleNamespace(ChatOpenAI=FakeChatOpenAI)
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-token")
+    monkeypatch.setattr(
+        llm_registry,
+        "configured_model_for_provider",
+        lambda provider: "" if provider == "github-models" else "gpt-5-mini",
+    )
+
+    client_and_provider = ci_failure_triage._get_llm_client()
+
+    assert client_and_provider is not None
+    client, provider = client_and_provider
+    assert provider == "openai"
+    assert isinstance(client, FakeChatOpenAI)
+    assert created == [{"model": "gpt-5-mini", "api_key": "openai-token", "temperature": 0.1}]

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -102,18 +102,18 @@ def test_registry_decision_update_changes_slot_without_slot_edit(
     assert "model" not in json.loads(slots_path.read_text())["slots"][0]
 
 
-def test_legacy_slot_pin_cannot_override_reviewed_selection(
+def test_legacy_slot_pin_is_honored_when_current_and_unblocked(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registry_path = tmp_path / "registry.json"
     slots_path = tmp_path / "slots.json"
     _write_registry(registry_path)
-    _write_slots(slots_path, model="model-frontier")
+    _write_slots(slots_path, model="model-frontier", profile="")
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
-    assert registry.load_slot_config()[0].model == "model-balanced"
-    assert registry.configured_model_for_provider("openai") == "model-balanced"
+    assert registry.load_slot_config()[0].model == "model-frontier"
+    assert registry.configured_model_for_provider("openai") == "model-frontier"
 
 
 def test_unknown_explicit_profile_fails_closed(
@@ -126,13 +126,12 @@ def test_unknown_explicit_profile_fails_closed(
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
-    # An unresolved slot profile must not disable the provider-level reviewed
-    # selection used as the safe fallback.
-    assert registry.load_slot_config()[0].model == "model-balanced"
+    # A present slot config is an allowlist; an unresolved profile fails closed.
+    assert registry.load_slot_config() == []
     assert registry.configured_model_for_provider("openai") == "model-balanced"
 
 
-def test_all_unusable_slot_entries_fall_back_to_reviewed_defaults(
+def test_all_unusable_slot_entries_fail_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registry_path = tmp_path / "registry.json"
@@ -142,7 +141,7 @@ def test_all_unusable_slot_entries_fall_back_to_reviewed_defaults(
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
-    assert registry.load_slot_config()[0].model == "model-balanced"
+    assert registry.load_slot_config() == []
 
 
 def test_noncurrent_selected_model_fails_closed(

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -128,7 +128,7 @@ def test_unknown_explicit_profile_fails_closed(
 
     # A present slot config is an allowlist; an unresolved profile fails closed.
     assert registry.load_slot_config() == []
-    assert registry.configured_model_for_provider("openai") == "model-balanced"
+    assert registry.configured_model_for_provider("openai") == ""
 
 
 def test_all_unusable_slot_entries_fail_closed(
@@ -142,6 +142,20 @@ def test_all_unusable_slot_entries_fail_closed(
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
     assert registry.load_slot_config() == []
+
+
+def test_empty_slot_config_does_not_broaden_to_default_providers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    slots_path.write_text(json.dumps({"slots": []}), encoding="utf-8")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config() == []
+    assert registry.configured_model_for_provider("openai") == ""
 
 
 def test_noncurrent_selected_model_fails_closed(

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -318,12 +318,23 @@ def evaluate(
             findings.append(_finding("invalid_slot", f"slot {name!r} has no provider."))
             continue
         if explicit_model:
-            # A slot without an explicit profile still resolves through the
-            # default reviewed profile at runtime. Compare it against that
-            # decision so an old model pin cannot silently bypass review.
+            model = model_by_key.get((provider, explicit_model))
+            # Explicit-profile pins must match their reviewed decision.  A
+            # legacy pin without a profile is also valid at runtime when the
+            # pin is a current, unblocked catalog model.
             effective_profile = profile or "verifier-balanced"
             selected = selection_by_key.get((effective_profile, provider))
-            if selected and selected.get("model_id") != explicit_model:
+            legacy_pin_is_current = bool(
+                not profile
+                and model is not None
+                and not model.get("blocked")
+                and str(model.get("lifecycle", "")).strip().lower() == "current"
+            )
+            if (
+                selected
+                and selected.get("model_id") != explicit_model
+                and not legacy_pin_is_current
+            ):
                 findings.append(
                     _finding(
                         "selection_override",
@@ -331,7 +342,6 @@ def evaluate(
                         f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
-            model = model_by_key.get((provider, explicit_model))
             if model is None:
                 findings.append(
                     _finding(

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -297,20 +297,19 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
 
     if github_token:
         model = configured_model_for_provider("github-models")
-        if not model:
-            return None
-        return (
-            cast(
-                _LLMClient,
-                ChatOpenAI(
-                    model=model,
-                    base_url=GITHUB_MODELS_BASE_URL,
-                    api_key=cast(Any, github_token),
-                    temperature=0.1,
+        if model:
+            return (
+                cast(
+                    _LLMClient,
+                    ChatOpenAI(
+                        model=model,
+                        base_url=GITHUB_MODELS_BASE_URL,
+                        api_key=cast(Any, github_token),
+                        temperature=0.1,
+                    ),
                 ),
-            ),
-            "github-models",
-        )
+                "github-models",
+            )
     if openai_token is None:
         return None
     model = configured_model_for_provider("openai")

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -153,7 +153,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     noninferiority_margin = float(gates["paired_success_noninferiority_margin"])
 
     for candidate in candidates:
-        model_id = str(candidate["model_id"])
+        model_id = str(candidate["model_id"]).strip()
         metrics = metrics_by_model[model_id]
         gate_results = {
             "minimum_adjudicated_cases": metrics["sample_count"] >= minimum_cases,

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -332,7 +332,12 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        if provider and explicit_model and explicit_model != model:
+        explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
+        if provider and explicit_model and not configured_profile and explicit_entry and not (
+            explicit_entry.blocked or explicit_entry.lifecycle != "current"
+        ):
+            model = explicit_model
+        elif provider and explicit_model and explicit_model != model:
             logger.warning(
                 "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
@@ -357,11 +362,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    # A syntactically valid config can still yield no usable entries (for
-    # example, every profile was retired or every model was blocked).  That is
-    # equivalent to no usable slot configuration; retain the reviewed defaults
-    # instead of silently disabling every provider.
-    return slots or fallback_slots
+    # A present slot file is an allowlist.  If every configured slot is
+    # unusable, fail closed instead of broadening execution to default providers.
+    return slots if slot_entries else fallback_slots
 
 
 def apply_slot_env_overrides(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -278,6 +278,12 @@ def configured_model_for_provider(
         ):
             return slot.model
 
+    # A readable slot config is an execution allowlist.  Do not broaden to a
+    # provider-level registry decision when that config has no usable slot for
+    # this provider (including an empty or invalid-only slots list).
+    if _load_object(_slot_path(), label="slot config") is not None:
+        return ""
+
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:
         return selected
@@ -368,7 +374,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
     # A present slot file is an allowlist.  If every configured slot is
     # unusable, fail closed instead of broadening execution to default providers.
-    return slots if slot_entries else fallback_slots
+    return slots
 
 
 def apply_slot_env_overrides(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -333,8 +333,12 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 or ""
             )
         explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
-        if provider and explicit_model and not configured_profile and explicit_entry and not (
-            explicit_entry.blocked or explicit_entry.lifecycle != "current"
+        if (
+            provider
+            and explicit_model
+            and not configured_profile
+            and explicit_entry
+            and not (explicit_entry.blocked or explicit_entry.lifecycle != "current")
         ):
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:


### PR DESCRIPTION
Fix shared review debt from the current consumer sync wave. Preserves current, unblocked legacy model pins when no profile is declared; treats a present slot config as an allowlist; falls through from unavailable GitHub Models to OpenAI; normalizes benchmark model IDs; and uses GitHub v3 diff media type.\n\nValidation: `python3.12 -m pytest -q tests/tools/test_llm_registry_selection.py tests/tools/test_langchain_client.py tests/tools/test_ci_failure_triage.py tests/tools/test_evaluate_model_benchmark.py tests/scripts/test_api_client.py` (110 passed); template sync and completeness checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request diff downloads by requesting the correct GitHub v3 diff content type.
  - Updated CI failure triage so provider selection no longer stops prematurely when GitHub is partially configured.
  - Trimmed model IDs during benchmark evaluation to prevent whitespace-related mismatches.
- **Model Selection**
  - Honored explicitly pinned models only when they’re current and unblocked.
  - Treated slot configuration as a fail-closed allowlist (no fallback when slots resolve empty/invalid).
  - Adjusted legacy (profile-less) pin override detection for better compatibility.
- **Tests**
  - Updated and expanded coverage for diff media type, provider fallback behavior, and slot/pin override rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->