### PR TITLE
fix: harden consumer model slot resolution

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T06:21:23.508156Z",
+  "emitted_at": "2026-07-16T06:27:48.218526Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T05:34:21.126471Z",
+  "emitted_at": "2026-07-16T05:42:37.389192Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T05:51:34.555827Z",
+  "emitted_at": "2026-07-16T06:03:58.521954Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T06:03:58.521954Z",
+  "emitted_at": "2026-07-16T06:12:51.045340Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T06:12:51.045340Z",
+  "emitted_at": "2026-07-16T06:21:23.508156Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-15T21:30:40.959289Z",
+  "emitted_at": "2026-07-16T04:51:00.892103Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2781",
+  "pr_number": "2785",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T05:42:37.389192Z",
+  "emitted_at": "2026-07-16T05:51:34.555827Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
@@ -11,6 +11,6 @@
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T04:51:00.892103Z",
+  "emitted_at": "2026-07-16T05:34:21.126471Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/templates/consumer-repo/tools/llm_provider.py
+++ b/templates/consumer-repo/tools/llm_provider.py
@@ -370,7 +370,9 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("LangChain OpenAI not available")
+            raise RuntimeError(
+                "GitHub Models client unavailable: install langchain-openai or configure a reviewed model"
+            )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -271,11 +271,14 @@ def configured_model_for_provider(
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     slot_path = _slot_path()
-    # A present slot config is an execution allowlist, including one that is
-    # malformed. Never broaden execution because a configured allowlist cannot
-    # be read or does not contain this provider.
-    if slot_path.is_file():
-        for slot in resolve_slots():
+    # An explicit slot config is an execution allowlist, including when its
+    # path is missing or malformed. Never broaden execution because a
+    # configured allowlist cannot be read or does not contain this provider.
+    if os.environ.get(ENV_SLOT_CONFIG):
+        configured_slots = load_slot_config()
+        if not configured_slots:
+            return ""
+        for slot in apply_slot_env_overrides(configured_slots):
             if (
                 slot.provider == normalized_provider
                 and slot.model
@@ -311,9 +314,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
     if payload is None:
-        # An unreadable configured slot file must fail closed. Only a missing
-        # file means no allowlist was configured and permits default slots.
-        if path.is_file():
+        # An unreadable or missing explicitly configured slot file must fail
+        # closed. Only an unconfigured default path permits default slots.
+        if os.environ.get(ENV_SLOT_CONFIG):
             return []
         return fallback_slots
 
@@ -425,7 +428,7 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and os.environ.get(env_model_name):
+    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -85,7 +85,7 @@ def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         logger.warning("Could not read %s %s", label, path)
         return None
     if not isinstance(payload, dict):
@@ -270,7 +270,6 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    slot_path = _slot_path()
     # An explicit slot config is an execution allowlist, including when its
     # path is missing or malformed. Never broaden execution because a
     # configured allowlist cannot be read or does not contain this provider.
@@ -330,7 +329,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return fallback_slots
+        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -270,18 +270,18 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    # Use the same resolution path as runtime callers so emergency environment
-    # overrides cannot be ignored by this convenience helper.
-    for slot in resolve_slots():
-        if slot.provider == normalized_provider and not is_model_blocked(
-            slot.provider, slot.model, registry=entries
-        ):
-            return slot.model
-
-    # A readable slot config is an execution allowlist.  Do not broaden to a
-    # provider-level registry decision when that config has no usable slot for
-    # this provider (including an empty or invalid-only slots list).
-    if _load_object(_slot_path(), label="slot config") is not None:
+    slot_path = _slot_path()
+    # A present slot config is an execution allowlist, including one that is
+    # malformed. Never broaden execution because a configured allowlist cannot
+    # be read or does not contain this provider.
+    if slot_path.is_file():
+        for slot in resolve_slots():
+            if (
+                slot.provider == normalized_provider
+                and slot.model
+                and not is_model_blocked(slot.provider, slot.model, registry=entries)
+            ):
+                return slot.model
         return ""
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
@@ -311,6 +311,10 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
     if payload is None:
+        # An unreadable configured slot file must fail closed. Only a missing
+        # file means no allowlist was configured and permits default slots.
+        if path.is_file():
+            return []
         return fallback_slots
 
     registry = load_model_registry()
@@ -338,7 +342,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
+        explicit_entry = (
+            registry_entry_for(provider, explicit_model, registry=registry)
+            if provider and explicit_model
+            else None
+        )
         if (
             provider
             and explicit_model
@@ -349,12 +357,15 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
             logger.warning(
-                "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
+                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
+            # An explicit legacy pin is also an allowlist decision. Do not
+            # silently substitute a newer reviewed selection for it.
+            continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",

--- a/tests/tools/test_evaluate_model_benchmark.py
+++ b/tests/tools/test_evaluate_model_benchmark.py
@@ -111,8 +111,16 @@ def test_near_one_confidence_level_has_finite_interval():
         1.0, 0.0
     )
     report = evaluator.evaluate_benchmark(_payload(), policy)
+    wilson_metrics = (
+        "task_success_rate_wilson_lower_bound",
+        "false_pass_rate_wilson_upper_bound",
+        "false_fail_rate_wilson_upper_bound",
+        "schema_error_rate_wilson_upper_bound",
+    )
     assert all(
-        math.isfinite(result["metrics"]["task_success_rate"]) for result in report["results"]
+        math.isfinite(result["metrics"][metric])
+        for result in report["results"]
+        for metric in wilson_metrics
     )
 
 

--- a/tests/tools/test_evaluate_model_benchmark.py
+++ b/tests/tools/test_evaluate_model_benchmark.py
@@ -107,9 +107,13 @@ def test_invalid_confidence_level_is_rejected():
 
 def test_near_one_confidence_level_has_finite_interval():
     policy = _policy()
-    policy["profiles"]["verifier-balanced"]["approval_stage"]["confidence_level"] = math.nextafter(1.0, 0.0)
+    policy["profiles"]["verifier-balanced"]["approval_stage"]["confidence_level"] = math.nextafter(
+        1.0, 0.0
+    )
     report = evaluator.evaluate_benchmark(_payload(), policy)
-    assert all(math.isfinite(result["metrics"]["task_success_rate"]) for result in report["results"])
+    assert all(
+        math.isfinite(result["metrics"]["task_success_rate"]) for result in report["results"]
+    )
 
 
 def test_passing_models_rank_by_cost_after_quality_gates():

--- a/tests/tools/test_evaluate_model_benchmark.py
+++ b/tests/tools/test_evaluate_model_benchmark.py
@@ -105,6 +105,13 @@ def test_invalid_confidence_level_is_rejected():
         evaluator.evaluate_benchmark(_payload(), policy)
 
 
+def test_near_one_confidence_level_has_finite_interval():
+    policy = _policy()
+    policy["profiles"]["verifier-balanced"]["approval_stage"]["confidence_level"] = math.nextafter(1.0, 0.0)
+    report = evaluator.evaluate_benchmark(_payload(), policy)
+    assert all(math.isfinite(result["metrics"]["task_success_rate"]) for result in report["results"])
+
+
 def test_passing_models_rank_by_cost_after_quality_gates():
     report = evaluator.evaluate_benchmark(_payload(), _policy())
     assert all(result["status"] == "passed" for result in report["results"])

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -158,6 +158,34 @@ def test_empty_slot_config_does_not_broaden_to_default_providers(
     assert registry.configured_model_for_provider("openai") == ""
 
 
+def test_invalid_slot_config_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    slots_path.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config() == []
+    assert registry.configured_model_for_provider("openai") == ""
+
+
+def test_unresolved_explicit_slot_pin_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    _write_slots(slots_path, model="retired-model", profile="")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config() == []
+    assert registry.configured_model_for_provider("openai") == ""
+
+
 def test_noncurrent_selected_model_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -170,6 +170,19 @@ def test_invalid_slot_config_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert registry.configured_model_for_provider("openai") == ""
 
 
+def test_missing_explicit_slot_config_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(tmp_path / "missing-slots.json"))
+    monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
+
+    assert registry.load_slot_config() == []
+    assert registry.configured_model_for_provider("openai") == ""
+
+
 def test_unresolved_explicit_slot_pin_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -158,9 +158,7 @@ def test_empty_slot_config_does_not_broaden_to_default_providers(
     assert registry.configured_model_for_provider("openai") == ""
 
 
-def test_invalid_slot_config_fails_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_invalid_slot_config_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     registry_path = tmp_path / "registry.json"
     slots_path = tmp_path / "slots.json"
     _write_registry(registry_path)

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -127,7 +127,7 @@ def test_unknown_explicit_profile_fails_closed(
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
 
     # A present slot config is an allowlist; an unresolved profile fails closed.
-    assert registry.load_slot_config() == []
+    assert registry.load_slot_config(github_default_model="fallback-github-model") == []
     assert registry.configured_model_for_provider("openai") == ""
 
 
@@ -170,6 +170,19 @@ def test_invalid_slot_config_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert registry.configured_model_for_provider("openai") == ""
 
 
+def test_undecodable_explicit_slot_config_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    slots_path.write_bytes(b"\xff")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config() == []
+
+
 def test_missing_explicit_slot_config_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -180,7 +193,21 @@ def test_missing_explicit_slot_config_fails_closed(
     monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
 
     assert registry.load_slot_config() == []
+    assert registry.resolve_slots() == []
     assert registry.configured_model_for_provider("openai") == ""
+
+
+def test_invalid_registry_with_explicit_profile_slot_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    registry_path.write_text("{}", encoding="utf-8")
+    _write_slots(slots_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, str(slots_path))
+
+    assert registry.load_slot_config(github_default_model="fallback-github-model") == []
 
 
 def test_unresolved_explicit_slot_pin_fails_closed(

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -128,7 +128,10 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     confidence_level = float(approval.get("confidence_level", 0.95))
     if not 0.0 < confidence_level < 1.0:
         raise ValueError("approval_stage.confidence_level must be between 0 and 1")
-    z = NormalDist().inv_cdf((1.0 + confidence_level) / 2.0)
+    # Keep the inverse CDF strictly inside its finite domain even when a
+    # valid float extremely close to 0 or 1 rounds at machine precision.
+    probability = min(1.0 - 1e-15, max(1e-15, (1.0 + confidence_level) / 2.0))
+    z = NormalDist().inv_cdf(probability)
     candidates = payload.get("candidates")
     if not isinstance(candidates, list) or len(candidates) < 2:
         raise ValueError("benchmark requires a baseline and at least one candidate")

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -371,7 +371,7 @@ class GitHubModelsProvider(LLMProvider):
         client = self._get_client()
         if not client:
             raise RuntimeError(
-                "GitHub Models client unavailable or no reviewed model is configured"
+                "GitHub Models client unavailable: install langchain-openai or configure a reviewed model"
             )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -271,11 +271,14 @@ def configured_model_for_provider(
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     slot_path = _slot_path()
-    # A present slot config is an execution allowlist, including one that is
-    # malformed. Never broaden execution because a configured allowlist cannot
-    # be read or does not contain this provider.
-    if slot_path.is_file():
-        for slot in resolve_slots():
+    # An explicit slot config is an execution allowlist, including when its
+    # path is missing or malformed. Never broaden execution because a
+    # configured allowlist cannot be read or does not contain this provider.
+    if os.environ.get(ENV_SLOT_CONFIG):
+        configured_slots = load_slot_config()
+        if not configured_slots:
+            return ""
+        for slot in apply_slot_env_overrides(configured_slots):
             if (
                 slot.provider == normalized_provider
                 and slot.model
@@ -311,9 +314,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
     if payload is None:
-        # An unreadable configured slot file must fail closed. Only a missing
-        # file means no allowlist was configured and permits default slots.
-        if path.is_file():
+        # An unreadable or missing explicitly configured slot file must fail
+        # closed. Only an unconfigured default path permits default slots.
+        if os.environ.get(ENV_SLOT_CONFIG):
             return []
         return fallback_slots
 
@@ -425,7 +428,7 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and os.environ.get(env_model_name):
+    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -85,7 +85,7 @@ def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         logger.warning("Could not read %s %s", label, path)
         return None
     if not isinstance(payload, dict):
@@ -270,7 +270,6 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    slot_path = _slot_path()
     # An explicit slot config is an execution allowlist, including when its
     # path is missing or malformed. Never broaden execution because a
     # configured allowlist cannot be read or does not contain this provider.
@@ -330,7 +329,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return fallback_slots
+        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -270,18 +270,18 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    # Use the same resolution path as runtime callers so emergency environment
-    # overrides cannot be ignored by this convenience helper.
-    for slot in resolve_slots():
-        if slot.provider == normalized_provider and not is_model_blocked(
-            slot.provider, slot.model, registry=entries
-        ):
-            return slot.model
-
-    # A readable slot config is an execution allowlist.  Do not broaden to a
-    # provider-level registry decision when that config has no usable slot for
-    # this provider (including an empty or invalid-only slots list).
-    if _load_object(_slot_path(), label="slot config") is not None:
+    slot_path = _slot_path()
+    # A present slot config is an execution allowlist, including one that is
+    # malformed. Never broaden execution because a configured allowlist cannot
+    # be read or does not contain this provider.
+    if slot_path.is_file():
+        for slot in resolve_slots():
+            if (
+                slot.provider == normalized_provider
+                and slot.model
+                and not is_model_blocked(slot.provider, slot.model, registry=entries)
+            ):
+                return slot.model
         return ""
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
@@ -311,6 +311,10 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
     if payload is None:
+        # An unreadable configured slot file must fail closed. Only a missing
+        # file means no allowlist was configured and permits default slots.
+        if path.is_file():
+            return []
         return fallback_slots
 
     registry = load_model_registry()
@@ -338,7 +342,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
+        explicit_entry = (
+            registry_entry_for(provider, explicit_model, registry=registry)
+            if provider and explicit_model
+            else None
+        )
         if (
             provider
             and explicit_model
@@ -349,12 +357,15 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
             logger.warning(
-                "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
+                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
+            # An explicit legacy pin is also an allowlist decision. Do not
+            # silently substitute a newer reviewed selection for it.
+            continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",


### PR DESCRIPTION
## Summary
- fail closed when a configured consumer slot allowlist is unreadable or lacks an explicit pinned model
- prevent empty placeholder models from short-circuiting provider resolution
- clarify the GitHub Models unavailable error and keep benchmark confidence bounds finite

## Validation
- `/opt/anaconda3/bin/python3.12 -m pytest tests/tools/test_llm_registry_selection.py tests/tools/test_llm_provider.py tests/tools/test_evaluate_model_benchmark.py tests/workflows/test_sync_manifest_delivery.py -q` (119 passed)
- `/opt/anaconda3/bin/python3.12 scripts/validate_template_sync.py`
- `git diff --check`

This is source-first remediation for the active `sync/workflows-7a590071b52b` consumer review threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error shown when GitHub Models can’t be initialized, with clearer install/config guidance.
  * Slot-based model selection now treats explicitly provided slot config as an allowlist and “fails closed” on unreadable/missing configs or unresolved pinned models, preventing unintended fallbacks (including when emergency bootstrap would otherwise apply).
  * Benchmark confidence-interval calculations stay finite when confidence is extremely close to 100% (avoids NaN/Inf edge effects).

* **Tests**
  * Added coverage for fail-closed slot config scenarios and near-100%-confidence finiteness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->