### PR TITLE
fix: harden synced registry and keepalive helpers

### DIFF
--- a/.github/scripts/__tests__/capability-bundle-contract.test.js
+++ b/.github/scripts/__tests__/capability-bundle-contract.test.js
@@ -205,6 +205,25 @@ test('keepalive metrics carry applied bundle metadata and rejection reasons', ()
   assert.deepEqual(record.capability_rejection_reasons, ['repo']);
 });
 
+test('keepalive metrics ignore malformed capability bundle entries', () => {
+  const record = buildMetricsRecord({
+    prNumber: 123,
+    iteration: 2,
+    action: 'run',
+    errorCategory: 'none',
+    durationMs: 10,
+    tasksTotal: 3,
+    tasksComplete: 1,
+    capabilityBundles: {
+      applied: [null, 'invalid', [], { capability_id: 'keepalive/static-spa' }],
+      rejected: [null, 'invalid', [], { reason: 'repo' }],
+    },
+  });
+
+  assert.deepEqual(record.capability_bundle_ids, ['keepalive/static-spa']);
+  assert.deepEqual(record.capability_rejection_reasons, ['repo']);
+});
+
 test('capability bundle metrics input parser preserves applied and rejected arrays', () => {
   const parsed = parseCapabilityBundlesInput(JSON.stringify({
     applied: [{ capability_id: 'keepalive/static-spa' }],

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -801,8 +801,12 @@ function buildMetricsRecord({
   const capabilityResult = capabilityBundles && typeof capabilityBundles === 'object'
     ? capabilityBundles
     : { applied: [], rejected: [] };
-  const applied = Array.isArray(capabilityResult.applied) ? capabilityResult.applied : [];
-  const rejected = Array.isArray(capabilityResult.rejected) ? capabilityResult.rejected : [];
+  const applied = Array.isArray(capabilityResult.applied)
+    ? capabilityResult.applied.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
+  const rejected = Array.isArray(capabilityResult.rejected)
+    ? capabilityResult.rejected.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
   return {
     pr_number: toNumber(prNumber, 0),
     iteration: Math.max(1, toNumber(iteration, 0)),

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -677,6 +677,7 @@ scripts:
 
   - source: tools/llm_registry.py
     description: "LLM model registry helper - shared slot/model selection and blocked-model enforcement"
+    template_sync: exact
 
   - source: tools/embedding_provider.py
     description: "Embedding provider registry used by synced semantic matching helpers"

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -801,8 +801,12 @@ function buildMetricsRecord({
   const capabilityResult = capabilityBundles && typeof capabilityBundles === 'object'
     ? capabilityBundles
     : { applied: [], rejected: [] };
-  const applied = Array.isArray(capabilityResult.applied) ? capabilityResult.applied : [];
-  const rejected = Array.isArray(capabilityResult.rejected) ? capabilityResult.rejected : [];
+  const applied = Array.isArray(capabilityResult.applied)
+    ? capabilityResult.applied.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
+  const rejected = Array.isArray(capabilityResult.rejected)
+    ? capabilityResult.rejected.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
   return {
     pr_number: toNumber(prNumber, 0),
     iteration: Math.max(1, toNumber(iteration, 0)),

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -358,16 +358,25 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ):
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
-            logger.warning(
-                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+            # A caller-supplied slot file is an allowlist and must fail closed.
+            # The repository's bundled legacy file is advisory: ignore a stale
+            # pin and retain the reviewed registry selection for that provider.
+            if os.environ.get(ENV_SLOT_CONFIG):
+                logger.warning(
+                    "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+                    provider,
+                    explicit_model,
+                    profile,
+                    model or "unavailable",
+                )
+                continue
+            logger.debug(
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
-            # An explicit legacy pin is also an allowlist decision. Do not
-            # silently substitute a newer reviewed selection for it.
-            continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -166,7 +166,7 @@ def load_selection_decisions() -> list[SelectionDecision]:
                 model=model,
                 status=str(raw.get("status", "")).strip().lower(),
                 review_by=str(raw.get("review_by", "")).strip(),
-                evidence_ids=tuple(str(item) for item in evidence if str(item).strip()),
+                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
             )
         )
     return decisions
@@ -303,8 +303,7 @@ def default_slots(*, github_default_model: str = "") -> list[SlotDefinition]:
         model = select_model_for_profile(provider=provider)
         if not model and provider == PROVIDER_GITHUB:
             model = github_default_model.strip()
-        if model:
-            slots.append(SlotDefinition(name=f"slot{index}", provider=provider, model=model))
+        slots.append(SlotDefinition(name=f"slot{index}", provider=provider, model=model or ""))
     return slots
 
 

--- a/tests/scripts/test_validate_template_sync.py
+++ b/tests/scripts/test_validate_template_sync.py
@@ -232,3 +232,39 @@ def test_validator_checks_exact_template_sync_script_entries(tmp_path):
     assert result.returncode == 1
     assert "scripts/aggregate_agent_metrics.py" in result.stdout
     assert "git add templates/consumer-repo/scripts/aggregate_agent_metrics.py" in result.stdout
+
+
+def test_validator_checks_exact_template_sync_tool_entries(tmp_path):
+    """Validator should detect drift in exact-synced consumer tools."""
+    create_test_structure(tmp_path)
+    source = tmp_path / "tools"
+    template = tmp_path / "templates" / "consumer-repo" / "tools"
+    source.mkdir(parents=True, exist_ok=True)
+    template.mkdir(parents=True, exist_ok=True)
+
+    (source / "llm_registry.py").write_text("MODEL = 'reviewed'\n", encoding="utf-8")
+    (template / "llm_registry.py").write_text("MODEL = 'stale'\n", encoding="utf-8")
+    write_raw_manifest(
+        tmp_path,
+        "\n".join(
+            [
+                "version: 1",
+                "scripts:",
+                "  - source: tools/llm_registry.py",
+                "    description: test",
+                "    template_sync: exact",
+                "",
+            ]
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_template_sync.py"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "tools/llm_registry.py" in result.stdout
+    assert "git add templates/consumer-repo/tools/llm_registry.py" in result.stdout

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -257,9 +257,10 @@ def test_bundled_stale_slot_pin_is_debug_only(
     monkeypatch.delenv(registry.ENV_SLOT_CONFIG, raising=False)
     monkeypatch.setattr(registry, "DEFAULT_SLOT_CONFIG_PATH", slots_path)
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
         registry.load_slot_config()
 
+    assert "Ignoring advisory bundled slot model pin" in caplog.text
     assert "Skipping unresolved slot model pin" not in caplog.text
 
 

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -246,6 +246,23 @@ def test_bundled_stale_slot_pin_uses_reviewed_registry_selection(
     ]
 
 
+def test_bundled_stale_slot_pin_is_debug_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    _write_slots(slots_path, model="retired-model", profile="")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.delenv(registry.ENV_SLOT_CONFIG, raising=False)
+    monkeypatch.setattr(registry, "DEFAULT_SLOT_CONFIG_PATH", slots_path)
+
+    with caplog.at_level("WARNING"):
+        registry.load_slot_config()
+
+    assert "Skipping unresolved slot model pin" not in caplog.text
+
+
 def test_noncurrent_selected_model_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -357,18 +357,25 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ):
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
-            logger.warning(
-                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+            # A caller-supplied slot file is an allowlist and must fail closed.
+            # The repository's bundled legacy file is advisory: ignore a stale
+            # pin and retain the reviewed registry selection for that provider.
+            if os.environ.get(ENV_SLOT_CONFIG):
+                logger.warning(
+                    "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+                    provider,
+                    explicit_model,
+                    profile,
+                    model or "unavailable",
+                )
+                continue
+            logger.debug(
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
-            # A caller-supplied slot file is an allowlist and must fail closed.
-            # The repository's bundled legacy file is advisory: ignore a stale
-            # pin and retain the reviewed registry selection for that provider.
-            if os.environ.get(ENV_SLOT_CONFIG):
-                continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",


### PR DESCRIPTION
Fixes the source-of-truth review debt found in the current consumer sync wave.

- Treat bundled stale LLM slot pins as debug-only while retaining warnings and fail-closed behavior for explicit allowlists.
- Ignore malformed capability bundle entries before producing keepalive metrics.

Validated with `python -m pytest tests/tools/test_llm_registry_selection.py -q` and `node --test .github/scripts/__tests__/capability-bundle-contract.test.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capability metrics handling by ignoring malformed capability bundle entries and only recording well-formed capability data.
  * Normalized slot conflict messaging: bundled legacy model pin conflicts are treated as advisory (debug-only) when no explicit slot configuration is set; explicit mismatches still warn and fail safely.
  * Improved selection and slot loading by normalizing evidence IDs and always emitting slot definitions per provider index.

* **Tests**
  * Added contract coverage for malformed capability bundle entries.
  * Added coverage for debug-only bundled stale slot pin behavior and exact template sync validation.

* **Chores**
  * Updated template sync manifest to enforce exact syncing for the LLM registry tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->