### PR TITLE
fix: harden synced model registry slots

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -133,7 +133,6 @@ def load_model_registry() -> list[ModelRegistryEntry]:
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
                 lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
-                quality={},
             )
         )
     return entries
@@ -370,7 +369,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 )
                 continue
             logger.debug(
-                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection before fallback is %s",
                 provider,
                 explicit_model,
                 profile,
@@ -435,7 +434,12 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
+    if (
+        not slots
+        and not os.environ.get(ENV_SLOT_CONFIG)
+        and not _slot_path().exists()
+        and os.environ.get(env_model_name)
+    ):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -335,7 +335,7 @@ def test_load_model_registry_ignores_malformed_nested_values(
     entries = llm_registry.load_model_registry()
 
     assert len(entries) == 1
-    assert entries[0].quality == {}
+    assert entries[0].quality is None
 
 
 def test_load_model_registry_rejects_non_list_models(
@@ -372,7 +372,7 @@ def test_load_model_registry_ignores_v1_quality_scores(
 
     [entry] = llm_registry.load_model_registry()
 
-    assert entry.quality == {}
+    assert entry.quality is None
 
 
 def test_load_slot_config_ignores_tier_slot_when_registry_invalid(

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -68,6 +68,16 @@ def test_profile_selection_uses_explicit_decision_not_model_position(
     assert registry.select_model_for_profile(provider="openai") == "model-balanced"
 
 
+def test_loaded_registry_entries_keep_compatibility_quality_immutable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    assert registry.load_model_registry()[0].quality is None
+
+
 def test_new_catalog_model_does_not_auto_promote(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -195,6 +205,21 @@ def test_missing_explicit_slot_config_fails_closed(
     assert registry.load_slot_config() == []
     assert registry.resolve_slots() == []
     assert registry.configured_model_for_provider("openai") == ""
+
+
+def test_unusable_bundled_slot_config_does_not_bootstrap_env_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    slots_path = tmp_path / "slots.json"
+    _write_registry(registry_path)
+    slots_path.write_text(json.dumps({"slots": [{"provider": "unknown"}]}), encoding="utf-8")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.delenv(registry.ENV_SLOT_CONFIG, raising=False)
+    monkeypatch.setattr(registry, "DEFAULT_SLOT_CONFIG_PATH", slots_path)
+    monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
+
+    assert registry.resolve_slots() == []
 
 
 def test_invalid_registry_with_explicit_profile_slot_fails_closed(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -133,7 +133,6 @@ def load_model_registry() -> list[ModelRegistryEntry]:
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
                 lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
-                quality={},
             )
         )
     return entries
@@ -370,7 +369,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 )
                 continue
             logger.debug(
-                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection before fallback is %s",
                 provider,
                 explicit_model,
                 profile,
@@ -435,7 +434,12 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
+    if (
+        not slots
+        and not os.environ.get(ENV_SLOT_CONFIG)
+        and not _slot_path().exists()
+        and os.environ.get(env_model_name)
+    ):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(


### PR DESCRIPTION
Addresses the active shared review debt from the latest Maint 68 sync wave.

- keep compatibility quality unset rather than allocating mutable dictionaries
- do not bootstrap LANGCHAIN_MODEL when a bundled slot file exists but resolves to no usable slots
- clarify that the advisory-slot debug value is selected before fallback resolution
- cover both fail-closed and compatibility behavior with focused regressions

Validation: `python -m pytest tests/tools/test_llm_registry_selection.py tests/scripts/test_validate_template_sync.py -q` and `python scripts/validate_template_sync.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved compatibility model quality metadata without introducing empty values.
  - Prevented runtime model fallback when a bundled slot configuration exists but cannot be used.
  - Improved messaging when an advisory bundled model selection is skipped before fallback.

- **Tests**
  - Added coverage for compatibility metadata preservation and invalid slot configuration handling.
  - Updated parsing expectations for malformed or legacy quality data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->