### PR TITLE
fix: restore LLM slot bootstrap compatibility

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -133,6 +133,7 @@ def load_model_registry() -> list[ModelRegistryEntry]:
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
                 lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
+                quality={},
             )
         )
     return entries
@@ -434,12 +435,7 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if (
-        not slots
-        and not os.environ.get(ENV_SLOT_CONFIG)
-        and not _slot_path().exists()
-        and os.environ.get(env_model_name)
-    ):
+    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -335,7 +335,7 @@ def test_load_model_registry_ignores_malformed_nested_values(
     entries = llm_registry.load_model_registry()
 
     assert len(entries) == 1
-    assert entries[0].quality is None
+    assert entries[0].quality == {}
 
 
 def test_load_model_registry_rejects_non_list_models(
@@ -372,7 +372,7 @@ def test_load_model_registry_ignores_v1_quality_scores(
 
     [entry] = llm_registry.load_model_registry()
 
-    assert entry.quality is None
+    assert entry.quality == {}
 
 
 def test_load_slot_config_ignores_tier_slot_when_registry_invalid(

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -68,14 +68,14 @@ def test_profile_selection_uses_explicit_decision_not_model_position(
     assert registry.select_model_for_profile(provider="openai") == "model-balanced"
 
 
-def test_loaded_registry_entries_keep_compatibility_quality_immutable(
+def test_loaded_registry_entries_keep_empty_compatibility_quality(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registry_path = tmp_path / "registry.json"
     _write_registry(registry_path)
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
 
-    assert registry.load_model_registry()[0].quality is None
+    assert registry.load_model_registry()[0].quality == {}
 
 
 def test_new_catalog_model_does_not_auto_promote(
@@ -207,7 +207,7 @@ def test_missing_explicit_slot_config_fails_closed(
     assert registry.configured_model_for_provider("openai") == ""
 
 
-def test_unusable_bundled_slot_config_does_not_bootstrap_env_model(
+def test_unusable_bundled_slot_config_bootstraps_explicit_env_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     registry_path = tmp_path / "registry.json"
@@ -219,7 +219,11 @@ def test_unusable_bundled_slot_config_does_not_bootstrap_env_model(
     monkeypatch.setattr(registry, "DEFAULT_SLOT_CONFIG_PATH", slots_path)
     monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
 
-    assert registry.resolve_slots() == []
+    assert [slot.provider for slot in registry.resolve_slots()] == [
+        "openai",
+        "anthropic",
+        "github-models",
+    ]
 
 
 def test_invalid_registry_with_explicit_profile_slot_fails_closed(

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -133,6 +133,7 @@ def load_model_registry() -> list[ModelRegistryEntry]:
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
                 lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
+                quality={},
             )
         )
     return entries
@@ -434,12 +435,7 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if (
-        not slots
-        and not os.environ.get(ENV_SLOT_CONFIG)
-        and not _slot_path().exists()
-        and os.environ.get(env_model_name)
-    ):
+    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(


### PR DESCRIPTION
Restores the documented emergency LANGCHAIN_MODEL bootstrap when bundled slots yield no usable entries, while retaining fail-closed behavior for explicit LANGCHAIN_SLOT_CONFIG. Loaded registry entries again expose an empty compatibility quality mapping.\n\nValidation:\n- python -m pytest tests/tools/test_langchain_client.py tests/tools/test_llm_registry_selection.py -q\n- python scripts/validate_template_sync.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model registry compatibility by consistently representing unsupported quality metadata as an empty value.
  * Improved fallback model setup when no slot configuration is available, including environments with an existing but unusable configuration file.
  * Explicitly configured environment models now resolve across supported providers in this fallback scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->