### PR TITLE
docs: clarify LLM slot bootstrap condition

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -431,9 +431,9 @@ def resolve_slots(
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
     slots = load_slot_config(github_default_model=github_default_model)
-    # Preserve an explicit runtime override only when no default slot allowlist
-    # is available. A present slot config that resolves to no usable slots fails
-    # closed rather than broadening execution to the environment model.
+    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
+    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
+    # default slot file is available. Otherwise empty resolved slots fail closed.
     if (
         not slots
         and not os.environ.get(ENV_SLOT_CONFIG)

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -431,9 +431,9 @@ def resolve_slots(
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
     slots = load_slot_config(github_default_model=github_default_model)
-    # Preserve an explicit runtime override only when no default slot allowlist
-    # is available. A present slot config that resolves to no usable slots fails
-    # closed rather than broadening execution to the environment model.
+    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
+    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
+    # default slot file is available. Otherwise empty resolved slots fail closed.
     if (
         not slots
         and not os.environ.get(ENV_SLOT_CONFIG)


### PR DESCRIPTION
Clarifies the fail-closed bootstrap condition in the canonical registry and synchronized consumer template.\n\nValidation: `python -m pytest tests/tools/test_langchain_client.py tests/tools/test_llm_registry_selection.py -q` (82 passed); `python scripts/validate_template_sync.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the conditions under which a runtime model override is retained during emergency bootstrap.
  * Documented that, when an explicit slot allowlist or the bundled default slot file is available, the system returns an empty, fail-closed slot set.
  * No user-facing behavior or functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->