### PR TITLE
fix: fail closed on empty LLM config overrides

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -70,19 +70,26 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _registry_path() -> Path:
-    if ENV_MODEL_REGISTRY_CONFIG in os.environ:
-        return Path(os.environ[ENV_MODEL_REGISTRY_CONFIG])
-    return DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+def _configured_path(env_name: str, default: Path) -> Path | None:
+    configured = os.environ.get(env_name)
+    if configured is None:
+        return default
+    configured = configured.strip()
+    return Path(configured) if configured else None
 
 
-def _slot_path() -> Path:
-    if ENV_SLOT_CONFIG in os.environ:
-        return Path(os.environ[ENV_SLOT_CONFIG])
-    return DEFAULT_SLOT_CONFIG_PATH
+def _registry_path() -> Path | None:
+    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
 
 
-def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
+def _slot_path() -> Path | None:
+    return _configured_path(ENV_SLOT_CONFIG, DEFAULT_SLOT_CONFIG_PATH)
+
+
+def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
+    if path is None:
+        logger.warning("Cannot load %s: explicit configuration is empty", label)
+        return None
     if not path.is_file():
         return None
     try:

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -71,13 +71,15 @@ def normalize_provider(value: str | None) -> str | None:
 
 
 def _registry_path() -> Path:
-    configured = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
-    return Path(configured) if configured else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if ENV_MODEL_REGISTRY_CONFIG in os.environ:
+        return Path(os.environ[ENV_MODEL_REGISTRY_CONFIG])
+    return DEFAULT_MODEL_REGISTRY_CONFIG_PATH
 
 
 def _slot_path() -> Path:
-    configured = os.environ.get(ENV_SLOT_CONFIG)
-    return Path(configured) if configured else DEFAULT_SLOT_CONFIG_PATH
+    if ENV_SLOT_CONFIG in os.environ:
+        return Path(os.environ[ENV_SLOT_CONFIG])
+    return DEFAULT_SLOT_CONFIG_PATH
 
 
 def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
@@ -272,7 +274,7 @@ def configured_model_for_provider(
     # An explicit slot config is an execution allowlist, including when its
     # path is missing or malformed. Never broaden execution because a
     # configured allowlist cannot be read or does not contain this provider.
-    if os.environ.get(ENV_SLOT_CONFIG):
+    if ENV_SLOT_CONFIG in os.environ:
         configured_slots = load_slot_config()
         if not configured_slots:
             return ""
@@ -313,7 +315,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     if payload is None:
         # An unreadable or missing explicitly configured slot file must fail
         # closed. Only an unconfigured default path permits default slots.
-        if os.environ.get(ENV_SLOT_CONFIG):
+        if ENV_SLOT_CONFIG in os.environ:
             return []
         return fallback_slots
 
@@ -327,7 +329,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
+        return [] if ENV_SLOT_CONFIG in os.environ else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
@@ -359,7 +361,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             # A caller-supplied slot file is an allowlist and must fail closed.
             # The repository's bundled legacy file is advisory: ignore a stale
             # pin and retain the reviewed registry selection for that provider.
-            if os.environ.get(ENV_SLOT_CONFIG):
+            if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                     provider,
@@ -431,21 +433,6 @@ def resolve_slots(
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
     slots = load_slot_config(github_default_model=github_default_model)
-    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
-    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
-    # default slot file is available. Otherwise empty resolved slots fail closed.
-    if (
-        not slots
-        and not os.environ.get(ENV_SLOT_CONFIG)
-        and not _slot_path().exists()
-        and os.environ.get(env_model_name)
-    ):
-        slots = [
-            SlotDefinition(name=f"slot{index}", provider=provider, model="")
-            for index, provider in enumerate(
-                (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_GITHUB), start=1
-            )
-        ]
     return apply_slot_env_overrides(
         slots,
         env_model_name=env_model_name,

--- a/tests/scripts/test_consumer_sync_shadow_handoff.py
+++ b/tests/scripts/test_consumer_sync_shadow_handoff.py
@@ -134,7 +134,7 @@ def test_workflow_has_no_write_or_apply_surface() -> None:
     assert "gh pr" not in workflow
     assert "write_authority" not in workflow.lower() or "Write authority: false" in workflow
     assert "persist-credentials: false" in workflow
-    assert "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" in workflow
+    assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
     assert "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1" in workflow
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
     assert "pyyaml==6.0.2" in workflow

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -207,6 +207,29 @@ def test_missing_explicit_slot_config_fails_closed(
     assert registry.configured_model_for_provider("openai") == ""
 
 
+def test_empty_explicit_slot_config_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, "")
+    monkeypatch.setenv("LANGCHAIN_MODEL", "emergency-model")
+
+    assert registry.load_slot_config() == []
+    assert registry.resolve_slots() == []
+    assert registry.configured_model_for_provider("openai") == ""
+
+
+def test_empty_explicit_registry_config_does_not_use_default_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, "")
+
+    assert registry.load_model_registry() == []
+    assert registry.select_model_for_profile(provider="openai") is None
+
+
 def test_unusable_bundled_slot_config_fails_closed_despite_env_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -230,6 +230,16 @@ def test_empty_explicit_registry_config_does_not_use_default_registry(
     assert registry.select_model_for_profile(provider="openai") is None
 
 
+def test_whitespace_explicit_config_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(registry.ENV_SLOT_CONFIG, "  \t")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, "  \t")
+
+    assert registry.load_slot_config() == []
+    assert registry.load_model_registry() == []
+
+
 def test_unusable_bundled_slot_config_fails_closed_despite_env_model(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -217,7 +217,7 @@ def test_artifact_names_normalized() -> None:
 
     langsmith_helper_step = _step("Checkout Workflows LangSmith fleet helper")
     assert (
-        langsmith_helper_step["uses"] == "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        langsmith_helper_step["uses"] == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
     )
     assert langsmith_helper_step["with"]["persist-credentials"] is False
     assert _normalize_expr(langsmith_helper_step["if"]) == (

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -70,19 +70,26 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _registry_path() -> Path:
-    if ENV_MODEL_REGISTRY_CONFIG in os.environ:
-        return Path(os.environ[ENV_MODEL_REGISTRY_CONFIG])
-    return DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+def _configured_path(env_name: str, default: Path) -> Path | None:
+    configured = os.environ.get(env_name)
+    if configured is None:
+        return default
+    configured = configured.strip()
+    return Path(configured) if configured else None
 
 
-def _slot_path() -> Path:
-    if ENV_SLOT_CONFIG in os.environ:
-        return Path(os.environ[ENV_SLOT_CONFIG])
-    return DEFAULT_SLOT_CONFIG_PATH
+def _registry_path() -> Path | None:
+    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
 
 
-def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
+def _slot_path() -> Path | None:
+    return _configured_path(ENV_SLOT_CONFIG, DEFAULT_SLOT_CONFIG_PATH)
+
+
+def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
+    if path is None:
+        logger.warning("Cannot load %s: explicit configuration is empty", label)
+        return None
     if not path.is_file():
         return None
     try:

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -71,13 +71,15 @@ def normalize_provider(value: str | None) -> str | None:
 
 
 def _registry_path() -> Path:
-    configured = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
-    return Path(configured) if configured else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if ENV_MODEL_REGISTRY_CONFIG in os.environ:
+        return Path(os.environ[ENV_MODEL_REGISTRY_CONFIG])
+    return DEFAULT_MODEL_REGISTRY_CONFIG_PATH
 
 
 def _slot_path() -> Path:
-    configured = os.environ.get(ENV_SLOT_CONFIG)
-    return Path(configured) if configured else DEFAULT_SLOT_CONFIG_PATH
+    if ENV_SLOT_CONFIG in os.environ:
+        return Path(os.environ[ENV_SLOT_CONFIG])
+    return DEFAULT_SLOT_CONFIG_PATH
 
 
 def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
@@ -272,7 +274,7 @@ def configured_model_for_provider(
     # An explicit slot config is an execution allowlist, including when its
     # path is missing or malformed. Never broaden execution because a
     # configured allowlist cannot be read or does not contain this provider.
-    if os.environ.get(ENV_SLOT_CONFIG):
+    if ENV_SLOT_CONFIG in os.environ:
         configured_slots = load_slot_config()
         if not configured_slots:
             return ""
@@ -313,7 +315,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     if payload is None:
         # An unreadable or missing explicitly configured slot file must fail
         # closed. Only an unconfigured default path permits default slots.
-        if os.environ.get(ENV_SLOT_CONFIG):
+        if ENV_SLOT_CONFIG in os.environ:
             return []
         return fallback_slots
 
@@ -327,7 +329,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
+        return [] if ENV_SLOT_CONFIG in os.environ else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
@@ -359,7 +361,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             # A caller-supplied slot file is an allowlist and must fail closed.
             # The repository's bundled legacy file is advisory: ignore a stale
             # pin and retain the reviewed registry selection for that provider.
-            if os.environ.get(ENV_SLOT_CONFIG):
+            if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                     provider,
@@ -431,21 +433,6 @@ def resolve_slots(
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
     slots = load_slot_config(github_default_model=github_default_model)
-    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
-    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
-    # default slot file is available. Otherwise empty resolved slots fail closed.
-    if (
-        not slots
-        and not os.environ.get(ENV_SLOT_CONFIG)
-        and not _slot_path().exists()
-        and os.environ.get(env_model_name)
-    ):
-        slots = [
-            SlotDefinition(name=f"slot{index}", provider=provider, model="")
-            for index, provider in enumerate(
-                (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_GITHUB), start=1
-            )
-        ]
     return apply_slot_env_overrides(
         slots,
         env_model_name=env_model_name,


### PR DESCRIPTION
Fixes the shared LLM registry behavior exposed by the latest sync-wave review threads. Empty-but-present LANGCHAIN_SLOT_CONFIG and LANGCHAIN_MODEL_REGISTRY_CONFIG values are now treated as explicit invalid overrides rather than silently falling back to bundled defaults. Removes the unreachable emergency bootstrap branch and syncs the consumer template.\n\nValidation: pytest -q tests/tools/test_llm_registry_selection.py tests/tools/test_langchain_client.py (84 passed); python scripts/validate_template_sync.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only explicit model-registry and slot-config inputs now fail closed (no fallback to bundled defaults).
  * Slot configuration presence is now determined by whether the config variable is set, ensuring consistent “fail closed” behavior for unreadable/malformed payloads and unresolved pins.
  * Slot auto-bootstrapping from standalone model environment settings has been removed.
* **Tests**
  * Added coverage for empty explicit registry/slot inputs to confirm fail-closed results.
  * Updated workflow test assertions for refreshed pinned `actions/checkout` commit SHAs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->