### PR TITLE
fix: clarify slot validation and config diagnostics

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -91,6 +91,7 @@ def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
         logger.warning("Cannot load %s: explicit configuration is empty", label)
         return None
     if not path.is_file():
+        logger.warning("Cannot load %s: %s is not a file", label, path)
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -327,6 +328,8 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    # payload is non-null here, so the configured path is also non-null.
+    assert path is not None
     slot_entries = _slot_entries(payload, path)
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -174,6 +174,18 @@ def test_unknown_legacy_pin_is_advisory():
     assert "unknown_pin" not in _kinds(findings)
 
 
+def test_legacy_pin_requires_default_selection():
+    registry = _registry()
+    registry["selections"] = []
+    findings = gate.evaluate(
+        registry,
+        {"slots": [{"name": "slot1", "provider": "openai", "model": "absent"}]},
+        today=TODAY,
+        policy=_policy(),
+    )
+    assert "missing_selection" in _kinds(findings)
+
+
 def test_current_unblocked_legacy_pin_is_compatible_with_default_selection():
     registry = _registry()
     registry["models"].append(

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -150,7 +150,7 @@ def test_explicit_old_pin_is_flagged_against_reviewed_selection():
     assert "selection_override" in _kinds(findings)
 
 
-def test_explicit_pin_without_profile_is_flagged_against_default_selection():
+def test_explicit_pin_without_profile_is_advisory():
     registry = _registry()
     registry["models"].append(
         {"model_id": "model-old", "provider": "openai", "lifecycle": "compatibility"}
@@ -161,7 +161,17 @@ def test_explicit_pin_without_profile_is_flagged_against_default_selection():
         today=TODAY,
         policy=_policy(),
     )
-    assert "selection_override" in _kinds(findings)
+    assert "selection_override" not in _kinds(findings)
+
+
+def test_unknown_legacy_pin_is_advisory():
+    findings = gate.evaluate(
+        _registry(),
+        {"slots": [{"name": "slot1", "provider": "openai", "model": "absent"}]},
+        today=TODAY,
+        policy=_policy(),
+    )
+    assert "unknown_pin" not in _kinds(findings)
 
 
 def test_current_unblocked_legacy_pin_is_compatible_with_default_selection():

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -183,7 +183,7 @@ def test_legacy_pin_requires_default_selection():
         today=TODAY,
         policy=_policy(),
     )
-    assert "missing_selection" in _kinds(findings)
+    assert _kinds(findings) == ["missing_selection"]
 
 
 def test_current_unblocked_legacy_pin_is_compatible_with_default_selection():

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -320,16 +320,26 @@ def evaluate(
         if explicit_model:
             model = model_by_key.get((provider, explicit_model))
             # A legacy pin without a profile is advisory: runtime resolves a
-            # reviewed selection and ignores stale bundled model pins. Only a
-            # profile-bearing slot asserts selection intent and needs a
-            # freshness finding when it diverges from the reviewed decision.
-            selected = selection_by_key.get((profile, provider)) if profile else None
+            # reviewed default selection and ignores stale bundled model pins.
+            # It still needs that fallback selection to be usable.
+            effective_profile = profile or "verifier-balanced"
+            selected = selection_by_key.get((effective_profile, provider))
+            if not selected:
+                findings.append(
+                    _finding(
+                        "missing_selection",
+                        f"slot {name!r} has no selection for {effective_profile}/{provider}.",
+                    )
+                )
+                continue
             if selected and selected.get("model_id") != explicit_model:
+                if not profile:
+                    continue
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')} for {profile}.",
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
             if profile and model is None:

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -319,37 +319,27 @@ def evaluate(
             continue
         if explicit_model:
             model = model_by_key.get((provider, explicit_model))
-            # Explicit-profile pins must match their reviewed decision.  A
-            # legacy pin without a profile is also valid at runtime when the
-            # pin is a current, unblocked catalog model.
-            effective_profile = profile or "verifier-balanced"
-            selected = selection_by_key.get((effective_profile, provider))
-            legacy_pin_is_current = bool(
-                not profile
-                and model is not None
-                and not model.get("blocked")
-                and str(model.get("lifecycle", "")).strip().lower() == "current"
-            )
-            if (
-                selected
-                and selected.get("model_id") != explicit_model
-                and not legacy_pin_is_current
-            ):
+            # A legacy pin without a profile is advisory: runtime resolves a
+            # reviewed selection and ignores stale bundled model pins. Only a
+            # profile-bearing slot asserts selection intent and needs a
+            # freshness finding when it diverges from the reviewed decision.
+            selected = selection_by_key.get((profile, provider)) if profile else None
+            if selected and selected.get("model_id") != explicit_model:
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')} for {effective_profile}.",
+                        f"selection {selected.get('model_id')} for {profile}.",
                     )
                 )
-            if model is None:
+            if profile and model is None:
                 findings.append(
                     _finding(
                         "unknown_pin",
                         f"slot {name!r} pins absent model {provider}/{explicit_model}.",
                     )
                 )
-            elif model.get("blocked"):
+            elif profile and model.get("blocked"):
                 findings.append(
                     _finding(
                         "blocked_pin",

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -91,6 +91,7 @@ def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
         logger.warning("Cannot load %s: explicit configuration is empty", label)
         return None
     if not path.is_file():
+        logger.warning("Cannot load %s: %s is not a file", label, path)
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -327,6 +328,8 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    # payload is non-null here, so the configured path is also non-null.
+    assert path is not None
     slot_entries = _slot_entries(payload, path)
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()


### PR DESCRIPTION
Fixes three active consumer-sync review findings at their Workflows source: legacy profile-less pins remain advisory, explicit non-file configuration paths now log a diagnostic, and slot-path type narrowing is explicit.\n\nValidation: `python -m pytest -q tests/test_check_model_registry_freshness.py tests/tools/test_llm_registry_selection.py tests/tools/test_langchain_client.py` (107 passed); `python scripts/validate_template_sync.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy model pins without a profile are now treated as advisory, suppressing override-mismatch reporting.
  - Legacy pin validation now avoids incorrect unknown findings and reports missing selection when no compatible default selection exists.
  - Blocked, missing, or unknown pinned catalog models are only flagged when a profile is provided.
  - Configuration warnings now include the specific path that isn’t a file.
- **Tests**
  - Updated and expanded freshness-gate expectations for legacy-pin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->