### PR TITLE
fix: harden synced registry contracts

### DIFF
--- a/.github/scripts/__tests__/capability-bundle-contract.test.js
+++ b/.github/scripts/__tests__/capability-bundle-contract.test.js
@@ -125,6 +125,10 @@ test('unsafe command-style nested fields and blank gates are rejected', () => {
     /at least one gate ref/,
   );
   assert.throws(
+    () => validateCapabilityBundle(validBundle({ gates: [] })),
+    /at least one gate ref/,
+  );
+  assert.throws(
     () => validateCapabilityBundle(validBundle({ playbooks: ['docs/runbook.md', 1] })),
     /playbooks must be non-empty strings/,
   );

--- a/.github/scripts/__tests__/capability-bundle-contract.test.js
+++ b/.github/scripts/__tests__/capability-bundle-contract.test.js
@@ -120,6 +120,14 @@ test('unsafe command-style nested fields and blank gates are rejected', () => {
     () => validateCapabilityBundle(validBundle({ gates: ['frontend_verify@1', ''] })),
     /at least one gate ref/,
   );
+  assert.throws(
+    () => validateCapabilityBundle(validBundle({ gates: ['frontend_verify@1', { version: '1' }] })),
+    /at least one gate ref/,
+  );
+  assert.throws(
+    () => validateCapabilityBundle(validBundle({ playbooks: ['docs/runbook.md', 1] })),
+    /playbooks must be non-empty strings/,
+  );
 });
 
 test('standalone bundle document loads without bundles wrapper', () => {

--- a/.github/scripts/capability_bundle.js
+++ b/.github/scripts/capability_bundle.js
@@ -130,8 +130,11 @@ function validateCapabilityBundle(bundle, options = {}) {
   if (!normalise(bundle.fragments.task) && !normalise(bundle.fragments.acceptance)) {
     throw new Error('capability bundle must include a task or acceptance fragment');
   }
-  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => !normalise(gate))) {
+  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => typeof gate !== 'string' || !normalise(gate))) {
     throw new Error('capability bundle must include at least one gate ref');
+  }
+  if (bundle.playbooks !== undefined && (!Array.isArray(bundle.playbooks) || bundle.playbooks.some((playbook) => typeof playbook !== 'string' || !normalise(playbook)))) {
+    throw new Error('capability bundle playbooks must be non-empty strings');
   }
   const forbidden = walkForbiddenKeys(bundle);
   if (forbidden.length > 0) {

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T21:24:31.100466Z",
+  "emitted_at": "2026-07-22T16:47:09.624156Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2789",
+  "pr_number": "2806",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/templates/consumer-repo/.github/scripts/capability_bundle.js
+++ b/templates/consumer-repo/.github/scripts/capability_bundle.js
@@ -130,8 +130,11 @@ function validateCapabilityBundle(bundle, options = {}) {
   if (!normalise(bundle.fragments.task) && !normalise(bundle.fragments.acceptance)) {
     throw new Error('capability bundle must include a task or acceptance fragment');
   }
-  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => !normalise(gate))) {
+  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => typeof gate !== 'string' || !normalise(gate))) {
     throw new Error('capability bundle must include at least one gate ref');
+  }
+  if (bundle.playbooks !== undefined && (!Array.isArray(bundle.playbooks) || bundle.playbooks.some((playbook) => typeof playbook !== 'string' || !normalise(playbook)))) {
+    throw new Error('capability bundle playbooks must be non-empty strings');
   }
   const forbidden = walkForbiddenKeys(bundle);
   if (forbidden.length > 0) {

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -34,7 +34,7 @@ class ModelRegistryEntry:
     model: str
     blocked: bool
     lifecycle: str = "unknown"
-    # Retained as empty compatibility attributes for callers migrating from v1.
+    # Retained as optional compatibility attributes for callers migrating from v1.
     # They are deliberately not inputs to model selection.
     quality: dict[str, float] | None = None
     cost_score: float | None = None
@@ -224,17 +224,18 @@ def select_model_for_profile(
     entries = registry if registry is not None else load_model_registry()
     selections = decisions if decisions is not None else load_selection_decisions()
     normalized_provider = normalize_provider(provider)
+    normalized_profile = profile.strip() or DEFAULT_SELECTION_PROFILE
     matches = [
         decision
         for decision in selections
-        if decision.provider == normalized_provider and decision.profile == profile
+        if decision.provider == normalized_provider and decision.profile == normalized_profile
     ]
     if len(matches) != 1:
         if matches:
             logger.warning(
                 "Ambiguous model selections for %s/%s; expected exactly one",
                 normalized_provider,
-                profile,
+                normalized_profile,
             )
         return None
     decision = matches[0]
@@ -242,7 +243,7 @@ def select_model_for_profile(
         logger.warning(
             "Model selection %s/%s has no evidence; refusing to use it",
             normalized_provider,
-            profile,
+            normalized_profile,
         )
         return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
@@ -328,8 +329,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
-    # payload is non-null here, so the configured path is also non-null.
-    assert path is not None
+    # Keep the type and fail-closed contract explicit even though a non-null
+    # payload normally implies a configured path.
+    if path is None:
+        logger.warning("Cannot load slot config: configured path is unavailable")
+        return []
     slot_entries = _slot_entries(payload, path)
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()
@@ -369,8 +373,8 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
             # A caller-supplied slot file is an allowlist and must fail closed.
-            # The repository's bundled legacy file is advisory: ignore a stale
-            # pin and retain the reviewed registry selection for that provider.
+            # The repository's bundled legacy file is advisory: retain a
+            # current, unblocked pin; otherwise use the reviewed selection.
             if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -164,14 +166,24 @@ def test_explicit_pin_without_profile_is_advisory():
     assert "selection_override" not in _kinds(findings)
 
 
-def test_unknown_legacy_pin_is_advisory():
+def test_unknown_legacy_pin_is_rejected():
     findings = gate.evaluate(
         _registry(),
         {"slots": [{"name": "slot1", "provider": "openai", "model": "absent"}]},
         today=TODAY,
         policy=_policy(),
     )
-    assert "unknown_pin" not in _kinds(findings)
+    assert "unknown_pin" in _kinds(findings)
+
+
+def test_blocked_legacy_pin_is_rejected():
+    findings = gate.evaluate(
+        _registry(),
+        {"slots": [{"name": "slot1", "provider": "openai", "model": "model-blocked"}]},
+        today=TODAY,
+        policy=_policy(),
+    )
+    assert "blocked_pin" in _kinds(findings)
 
 
 def test_legacy_pin_requires_default_selection():
@@ -293,3 +305,15 @@ def test_main_exit_codes(tmp_path: Path):
     registry_path.write_text(json.dumps(_registry(review_by="2026-07-01")), encoding="utf-8")
     assert gate.main(common) == 1
     assert gate.main([*common[:-1], "not-a-date"]) == 2
+
+
+def test_direct_script_execution_uses_shared_default_profile():
+    root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "tools/check_model_registry_freshness.py", "--json"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -75,7 +75,10 @@ def test_profile_selection_normalizes_whitespace(
     _write_registry(registry_path)
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
 
-    assert registry.select_model_for_profile(provider="openai", profile=" verifier-balanced ") == "model-balanced"
+    assert (
+        registry.select_model_for_profile(provider="openai", profile=" verifier-balanced ")
+        == "model-balanced"
+    )
 
 
 def test_loaded_registry_entries_leave_compatibility_quality_unset(

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -68,6 +68,16 @@ def test_profile_selection_uses_explicit_decision_not_model_position(
     assert registry.select_model_for_profile(provider="openai") == "model-balanced"
 
 
+def test_profile_selection_normalizes_whitespace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    assert registry.select_model_for_profile(provider="openai", profile=" verifier-balanced ") == "model-balanced"
+
+
 def test_loaded_registry_entries_leave_compatibility_quality_unset(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -15,6 +15,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+try:
+    # Package import for tests and callers that import this checker.
+    from tools.llm_registry import DEFAULT_SELECTION_PROFILE
+except ModuleNotFoundError:  # pragma: no cover - exercised by the CI script entrypoint.
+    # Direct execution (`python tools/check_model_registry_freshness.py`) puts
+    # tools/, rather than the repository root, on sys.path.
+    from llm_registry import DEFAULT_SELECTION_PROFILE
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
@@ -319,10 +327,10 @@ def evaluate(
             continue
         if explicit_model:
             model = model_by_key.get((provider, explicit_model))
-            # A legacy pin without a profile is advisory: runtime resolves a
-            # reviewed default selection and ignores stale bundled model pins.
-            # It still needs that fallback selection to be usable.
-            effective_profile = profile or "verifier-balanced"
+            # A legacy pin without a profile may be honored only while it
+            # points at a current, unblocked model. Otherwise runtime falls
+            # back to the reviewed default selection.
+            effective_profile = profile or DEFAULT_SELECTION_PROFILE
             selected = selection_by_key.get((effective_profile, provider))
             if not selected:
                 findings.append(
@@ -332,7 +340,21 @@ def evaluate(
                     )
                 )
                 continue
-            if selected and selected.get("model_id") != explicit_model:
+            if model is None:
+                findings.append(
+                    _finding(
+                        "unknown_pin",
+                        f"slot {name!r} pins absent model {provider}/{explicit_model}.",
+                    )
+                )
+            elif model.get("blocked"):
+                findings.append(
+                    _finding(
+                        "blocked_pin",
+                        f"slot {name!r} pins blocked model {provider}/{explicit_model}.",
+                    )
+                )
+            if selected.get("model_id") != explicit_model:
                 if not profile:
                     continue
                 findings.append(

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -508,6 +508,7 @@ def build_chat_clients(
         slot_model = model_overrides[idx] if idx < len(model_overrides) else None
         slot_model = slot_model or slot.model
         if not slot_model:
+            logger.warning("Skipping LLM slot without a resolved model: %s", slot.name)
             continue
         if _is_model_blocked(slot.provider, slot_model, registry=registry):
             logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -34,7 +34,7 @@ class ModelRegistryEntry:
     model: str
     blocked: bool
     lifecycle: str = "unknown"
-    # Retained as empty compatibility attributes for callers migrating from v1.
+    # Retained as optional compatibility attributes for callers migrating from v1.
     # They are deliberately not inputs to model selection.
     quality: dict[str, float] | None = None
     cost_score: float | None = None
@@ -224,17 +224,18 @@ def select_model_for_profile(
     entries = registry if registry is not None else load_model_registry()
     selections = decisions if decisions is not None else load_selection_decisions()
     normalized_provider = normalize_provider(provider)
+    normalized_profile = profile.strip() or DEFAULT_SELECTION_PROFILE
     matches = [
         decision
         for decision in selections
-        if decision.provider == normalized_provider and decision.profile == profile
+        if decision.provider == normalized_provider and decision.profile == normalized_profile
     ]
     if len(matches) != 1:
         if matches:
             logger.warning(
                 "Ambiguous model selections for %s/%s; expected exactly one",
                 normalized_provider,
-                profile,
+                normalized_profile,
             )
         return None
     decision = matches[0]
@@ -242,7 +243,7 @@ def select_model_for_profile(
         logger.warning(
             "Model selection %s/%s has no evidence; refusing to use it",
             normalized_provider,
-            profile,
+            normalized_profile,
         )
         return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
@@ -328,8 +329,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
-    # payload is non-null here, so the configured path is also non-null.
-    assert path is not None
+    # Keep the type and fail-closed contract explicit even though a non-null
+    # payload normally implies a configured path.
+    if path is None:
+        logger.warning("Cannot load slot config: configured path is unavailable")
+        return []
     slot_entries = _slot_entries(payload, path)
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()
@@ -369,8 +373,8 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
             # A caller-supplied slot file is an allowlist and must fail closed.
-            # The repository's bundled legacy file is advisory: ignore a stale
-            # pin and retain the reviewed registry selection for that provider.
+            # The repository's bundled legacy file is advisory: retain a
+            # current, unblocked pin; otherwise use the reviewed selection.
             if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",


### PR DESCRIPTION
## Summary
- validate legacy slot pins before advisory fallback and normalize profile selection
- improve registry/client diagnostics and capability-bundle string validation
- synchronize affected consumer templates

## Validation
- `python -m pytest tests/test_check_model_registry_freshness.py tests/tools/test_llm_registry_selection.py tests/tools/test_langchain_client.py -q`
- `node --test .github/scripts/__tests__/capability-bundle-contract.test.js`
- `python scripts/validate_template_sync.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capability bundle validation now strictly rejects invalid `gates` entries and malformed/empty `playbooks`.
  * Model profile selection now trims whitespace and consistently defaults when a profile is empty.
  * Slot configuration loading now fails closed (logs a warning) and skips affected slots when unavailable.
  * Model freshness checks now reject unknown and blocked pinned models.
  * When a slot’s resolved model is missing, a warning is emitted instead of silently skipping.
* **Tests**
  * Expanded negative validation, added whitespace normalization coverage, updated legacy pin handling expectations, and added a freshness-script execution test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->