### PR TITLE
fix: restore legacy registry sync compatibility

### DIFF
--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -112,7 +112,7 @@ they MUST NOT infer capability identity or effects from free-form agent prose.
 
 | Output | Type | Description | Example |
 |--------|------|-------------|---------|
-| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `capability-id` | string | Existing `capability:<lowercase-kebab-id>` identifier | `capability:consumer-sync` |
 | `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
 | `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
 | `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |

--- a/templates/consumer-repo/docs/contracts/agent-runner-output.md
+++ b/templates/consumer-repo/docs/contracts/agent-runner-output.md
@@ -112,7 +112,7 @@ they MUST NOT infer capability identity or effects from free-form agent prose.
 
 | Output | Type | Description | Example |
 |--------|------|-------------|---------|
-| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `capability-id` | string | Existing `capability:<lowercase-kebab-id>` identifier | `capability:consumer-sync` |
 | `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
 | `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
 | `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |

--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -70,16 +70,24 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _configured_path(env_name: str, default: Path) -> Path | None:
+def _configured_path(
+    env_name: str, default: Path, *, empty_uses_default: bool = False
+) -> Path | None:
     configured = os.environ.get(env_name)
     if configured is None:
         return default
     configured = configured.strip()
-    return Path(configured) if configured else None
+    if configured:
+        return Path(configured)
+    return default if empty_uses_default else None
 
 
 def _registry_path() -> Path | None:
-    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
+    return _configured_path(
+        ENV_MODEL_REGISTRY_CONFIG,
+        DEFAULT_MODEL_REGISTRY_CONFIG_PATH,
+        empty_uses_default=True,
+    )
 
 
 def _slot_path() -> Path | None:
@@ -175,7 +183,9 @@ def load_selection_decisions() -> list[SelectionDecision]:
                 model=model,
                 status=str(raw.get("status", "")).strip().lower(),
                 review_by=str(raw.get("review_by", "")).strip(),
-                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
+                evidence_ids=tuple(
+                    item.strip() for item in evidence if isinstance(item, str) and item.strip()
+                ),
             )
         )
     return decisions

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -166,24 +166,24 @@ def test_explicit_pin_without_profile_is_advisory():
     assert "selection_override" not in _kinds(findings)
 
 
-def test_unknown_legacy_pin_is_rejected():
+def test_unknown_legacy_pin_is_advisory():
     findings = gate.evaluate(
         _registry(),
         {"slots": [{"name": "slot1", "provider": "openai", "model": "absent"}]},
         today=TODAY,
         policy=_policy(),
     )
-    assert "unknown_pin" in _kinds(findings)
+    assert "unknown_pin" not in _kinds(findings)
 
 
-def test_blocked_legacy_pin_is_rejected():
+def test_blocked_legacy_pin_is_advisory():
     findings = gate.evaluate(
         _registry(),
         {"slots": [{"name": "slot1", "provider": "openai", "model": "model-blocked"}]},
         today=TODAY,
         policy=_policy(),
     )
-    assert "blocked_pin" in _kinds(findings)
+    assert "blocked_pin" not in _kinds(findings)
 
 
 def test_legacy_pin_requires_default_selection():

--- a/tests/test_check_model_registry_freshness.py
+++ b/tests/test_check_model_registry_freshness.py
@@ -173,7 +173,7 @@ def test_unknown_legacy_pin_is_advisory():
         today=TODAY,
         policy=_policy(),
     )
-    assert "unknown_pin" not in _kinds(findings)
+    assert not {"unknown_pin", "selection_override"} & set(_kinds(findings))
 
 
 def test_blocked_legacy_pin_is_advisory():
@@ -183,7 +183,24 @@ def test_blocked_legacy_pin_is_advisory():
         today=TODAY,
         policy=_policy(),
     )
-    assert "blocked_pin" not in _kinds(findings)
+    assert not {"blocked_pin", "selection_override"} & set(_kinds(findings))
+
+
+def test_non_string_selection_evidence_ids_are_rejected():
+    registry = _registry()
+    registry["evidence"].append(
+        {
+            "evidence_id": "7",
+            "kind": "provider-catalog-review",
+            "status": "catalog-only",
+            "source_ids": ["models-1"],
+        }
+    )
+    registry["selections"][0]["evidence_ids"] = [7]
+
+    findings = gate.evaluate(registry, _slots(), today=TODAY, policy=_policy())
+
+    assert "missing_evidence" in _kinds(findings)
 
 
 def test_legacy_pin_requires_default_selection():

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -234,23 +234,23 @@ def test_empty_explicit_slot_config_fails_closed(
     assert registry.configured_model_for_provider("openai") == ""
 
 
-def test_empty_explicit_registry_config_does_not_use_default_registry(
+def test_empty_explicit_registry_config_uses_default_registry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, "")
 
-    assert registry.load_model_registry() == []
-    assert registry.select_model_for_profile(provider="openai") is None
+    assert registry.load_model_registry()
+    assert registry.select_model_for_profile(provider="openai")
 
 
-def test_whitespace_explicit_config_fails_closed(
+def test_whitespace_slot_config_fails_closed_but_registry_uses_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(registry.ENV_SLOT_CONFIG, "  \t")
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, "  \t")
 
     assert registry.load_slot_config() == []
-    assert registry.load_model_registry() == []
+    assert registry.load_model_registry()
 
 
 def test_unusable_bundled_slot_config_fails_closed_despite_env_model(
@@ -383,6 +383,20 @@ def test_selection_evidence_ids_are_normalized(
     _write_registry(registry_path)
     payload = json.loads(registry_path.read_text(encoding="utf-8"))
     payload["selections"][0]["evidence_ids"] = ["  benchmark-1  "]
+    registry_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    [decision] = registry.load_selection_decisions()
+    assert decision.evidence_ids == ("benchmark-1",)
+
+
+def test_selection_evidence_ids_ignore_non_strings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    payload["selections"][0]["evidence_ids"] = [" benchmark-1 ", 7, {"id": "bad"}, ""]
     registry_path.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
 

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -247,8 +247,13 @@ def evaluate(
                 )
             )
 
-        evidence_ids = raw.get("evidence_ids")
-        if not isinstance(evidence_ids, list) or not evidence_ids:
+        raw_evidence_ids = raw.get("evidence_ids")
+        evidence_ids = (
+            [item.strip() for item in raw_evidence_ids if isinstance(item, str) and item.strip()]
+            if isinstance(raw_evidence_ids, list)
+            else []
+        )
+        if not evidence_ids:
             findings.append(
                 _finding(
                     "missing_evidence",
@@ -327,9 +332,6 @@ def evaluate(
             continue
         if explicit_model:
             model = model_by_key.get((provider, explicit_model))
-            # A legacy pin without a profile may be honored only while it
-            # points at a current, unblocked model. Otherwise runtime falls
-            # back to the reviewed default selection.
             effective_profile = profile or DEFAULT_SELECTION_PROFILE
             selected = selection_by_key.get((effective_profile, provider))
             if not selected:
@@ -340,9 +342,9 @@ def evaluate(
                     )
                 )
                 continue
-            # Unprofiled pins predate the reviewed-selection contract. Runtime
-            # falls back to the default selection when one is stale or blocked,
-            # so they remain advisory while consumers migrate to profiles.
+            # Unprofiled pins predate the reviewed-selection contract. They are
+            # advisory while consumers migrate to profiles, so runtime uses the
+            # reviewed default selection regardless of the legacy pin value.
             if not profile:
                 continue
             if model is None:

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -340,6 +340,11 @@ def evaluate(
                     )
                 )
                 continue
+            # Unprofiled pins predate the reviewed-selection contract. Runtime
+            # falls back to the default selection when one is stale or blocked,
+            # so they remain advisory while consumers migrate to profiles.
+            if not profile:
+                continue
             if model is None:
                 findings.append(
                     _finding(
@@ -355,27 +360,11 @@ def evaluate(
                     )
                 )
             if selected.get("model_id") != explicit_model:
-                if not profile:
-                    continue
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
                         f"selection {selected.get('model_id')} for {effective_profile}.",
-                    )
-                )
-            if profile and model is None:
-                findings.append(
-                    _finding(
-                        "unknown_pin",
-                        f"slot {name!r} pins absent model {provider}/{explicit_model}.",
-                    )
-                )
-            elif profile and model.get("blocked"):
-                findings.append(
-                    _finding(
-                        "blocked_pin",
-                        f"slot {name!r} pins blocked model {provider}/{explicit_model}.",
                     )
                 )
             continue

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -70,16 +70,24 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _configured_path(env_name: str, default: Path) -> Path | None:
+def _configured_path(
+    env_name: str, default: Path, *, empty_uses_default: bool = False
+) -> Path | None:
     configured = os.environ.get(env_name)
     if configured is None:
         return default
     configured = configured.strip()
-    return Path(configured) if configured else None
+    if configured:
+        return Path(configured)
+    return default if empty_uses_default else None
 
 
 def _registry_path() -> Path | None:
-    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
+    return _configured_path(
+        ENV_MODEL_REGISTRY_CONFIG,
+        DEFAULT_MODEL_REGISTRY_CONFIG_PATH,
+        empty_uses_default=True,
+    )
 
 
 def _slot_path() -> Path | None:
@@ -175,7 +183,9 @@ def load_selection_decisions() -> list[SelectionDecision]:
                 model=model,
                 status=str(raw.get("status", "")).strip().lower(),
                 review_by=str(raw.get("review_by", "")).strip(),
-                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
+                evidence_ids=tuple(
+                    item.strip() for item in evidence if isinstance(item, str) and item.strip()
+                ),
             )
         )
     return decisions


### PR DESCRIPTION
## Summary
- keep empty registry-path environment values on the safe bundled registry default while explicit empty slot paths still fail closed
- restore advisory handling for unprofiled legacy pins so synced consumers fall back to their reviewed selection
- avoid duplicate profile-pin findings, ignore non-string evidence identifiers, and clarify the capability-id contract

## Validation
- python -m pytest tests/test_check_model_registry_freshness.py tests/tools/test_llm_registry_selection.py tests/tools/test_llm_provider.py -q
- python scripts/validate_template_sync.py
- python tools/check_model_registry_freshness.py --today 2026-07-22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty model registry configuration values now correctly fall back to the default registry.
  * Invalid, non-string evidence IDs are ignored during selection processing.
  * If no valid evidence IDs are present, registry freshness checks now report missing evidence consistently.
  * Legacy model pin issues are now reported as advisory findings instead of blocking validation, and override/unknown/blocked handling is more consistent.
* **Documentation**
  * Clarified the required format for capability effect evidence identifiers: `capability:<lowercase-kebab-id>`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->