### PR TITLE
fix: preserve model registry checker package import

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-22T16:47:09.624156Z",
+  "emitted_at": "2026-07-23T06:39:54.884918Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2806",
+  "pr_number": "2809",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-23T06:39:54.884918Z",
+  "emitted_at": "2026-07-23T06:54:19.970022Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -22,7 +22,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from tools.llm_registry import DEFAULT_SELECTION_PROFILE
+from tools.llm_registry import DEFAULT_SELECTION_PROFILE  # noqa: E402
 
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -15,15 +15,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-try:
-    # Package import for tests and callers that import this checker.
-    from tools.llm_registry import DEFAULT_SELECTION_PROFILE
-except ModuleNotFoundError:  # pragma: no cover - exercised by the CI script entrypoint.
-    # Direct execution (`python tools/check_model_registry_freshness.py`) puts
-    # tools/, rather than the repository root, on sys.path.
-    from llm_registry import DEFAULT_SELECTION_PROFILE
-
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Direct execution puts tools/, rather than the repository root, on sys.path.
+# Always import through the package so type checking sees one symbol definition.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.llm_registry import DEFAULT_SELECTION_PROFILE
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
 DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -23,6 +23,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from tools.llm_registry import DEFAULT_SELECTION_PROFILE
+
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
 DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"


### PR DESCRIPTION
Fixes the synced checker\u0027s direct-execution import path without defining `DEFAULT_SELECTION_PROFILE` twice for mypy.\n\nValidation: `python -m pytest tests/test_check_model_registry_freshness.py -q`; `python -m mypy tools/check_model_registry_freshness.py`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability when running the model registry freshness check directly by ensuring repository tooling is discoverable before loading required components.
  * Streamlined the check’s imports to rely on the tooling-local registry entry, removing the prior fallback behavior.
  * Updated recorded run metadata for the fleet worker attempt (timestamp and pull request reference).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->