### PR TITLE
fix: retain legacy tier parameter without lint debt

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -288,6 +288,8 @@ def configured_model_for_provider(
     tier: str | None = None,
     registry: list[ModelRegistryEntry] | None = None,
 ) -> str:
+    # Retain the legacy keyword for consumers while selection is profile-based.
+    del tier
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     # An explicit slot config is an execution allowlist, including when its

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -81,6 +81,17 @@ def test_profile_selection_normalizes_whitespace(
     )
 
 
+def test_legacy_tier_keyword_does_not_change_profile_selection(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    assert registry.configured_model_for_provider("openai", tier="fast") == "model-balanced"
+    assert registry.configured_model_for_provider("openai", tier="thorough") == "model-balanced"
+
+
 def test_loaded_registry_entries_leave_compatibility_quality_unset(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -288,6 +288,8 @@ def configured_model_for_provider(
     tier: str | None = None,
     registry: list[ModelRegistryEntry] | None = None,
 ) -> str:
+    # Retain the legacy keyword for consumers while selection is profile-based.
+    del tier
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     # An explicit slot config is an execution allowlist, including when its


### PR DESCRIPTION
<!-- meta:issue:2863 -->
> **Source:** Issue #2863

Closes #2863

## Summary
Preserves consumer compatibility for the legacy `tier=` keyword while keeping profile-driven model selection and lint behavior stable.

## Pipeline status
Adopted into the agent pipeline; current review and conflict recovery remain tracked by the source issue.