### PR TITLE
chore(deps): sync ruff 0.16.0 pins

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1088,9 +1088,10 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          # Use extend-exclude to add to ruff's defaults (which include .venv)
-          # Exclude .workflows-lib since it's synced from source repo with different ruff config
-          ruff check --output-format github --extend-exclude .workflows-lib .
+          # Keep the pre-0.16 default rule family stable for consumers that do
+          # not declare their own Ruff selection. Exclude .workflows-lib since
+          # it is synced from the source repo with different Ruff configuration.
+          ruff check --select E4,E7,E9,F --output-format github --extend-exclude .workflows-lib .
 
       - name: Finalize lint
         id: finalize

--- a/docs/ci/TOOL_VERSION_MANAGEMENT.md
+++ b/docs/ci/TOOL_VERSION_MANAGEMENT.md
@@ -32,6 +32,8 @@ COVERAGE_VERSION=7.12.0
 - Sources `autofix-versions.env` before installing tools
 - Runs `black --check`, `ruff check`, `mypy`, and `pytest`
 - Falls back to latest versions if version file is missing
+- Pins the shared Ruff default rule family to `E4,E7,E9,F` so a Ruff upgrade
+  does not silently broaden lint requirements for consumer repositories.
 
 ### 2. PR Autofix (`reusable-18-autofix.yml`)
 - Reads version file to install Black and Ruff

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-23T06:54:19.970022Z",
+  "emitted_at": "2026-07-27T00:38:38.825132Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2809",
+  "pr_number": "2812",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ app = []
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.15.22",
+    "ruff==0.16.0",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -298,7 +298,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.22
+ruff==0.16.0
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/tests/workflows/test_autofix_full_pipeline.py
+++ b/tests/workflows/test_autofix_full_pipeline.py
@@ -39,7 +39,7 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     src_dir.mkdir()
     tests_dir.mkdir()
     (tmp_path / "pyproject.toml").write_text(
-        "[tool.ruff.lint]\nselect = [\"E4\", \"E7\", \"E9\", \"F\"]\n",
+        '[tool.ruff.lint]\nselect = ["E4", "E7", "E9", "F"]\n',
         encoding="utf-8",
     )
 

--- a/tests/workflows/test_autofix_full_pipeline.py
+++ b/tests/workflows/test_autofix_full_pipeline.py
@@ -38,6 +38,10 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     tests_dir = tmp_path / "tests"
     src_dir.mkdir()
     tests_dir.mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.ruff.lint]\nselect = [\"E4\", \"E7\", \"E9\", \"F\"]\n",
+        encoding="utf-8",
+    )
 
     sample = src_dir / "autofix_target.py"
     sample.write_text(
@@ -138,6 +142,9 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     )
     exit_code = mypy_autofix.main(["--paths", str(sample)])
     assert exit_code == 0
+
+    # The type-hygiene pass can add imports after the initial formatter pass.
+    _run([sys.executable, "-m", "black", str(sample)], cwd=tmp_path)
 
     for cmd in (
         [sys.executable, "-m", "isort", str(sample)],

--- a/tests/workflows/test_autofix_pipeline_diverse.py
+++ b/tests/workflows/test_autofix_pipeline_diverse.py
@@ -51,7 +51,7 @@ def test_autofix_pipeline_handles_diverse_errors(
     trend_pkg.mkdir(parents=True)
     tests_dir.mkdir()
     (repo_root / "pyproject.toml").write_text(
-        "[tool.ruff.lint]\nselect = [\"E4\", \"E7\", \"E9\", \"F\"]\n",
+        '[tool.ruff.lint]\nselect = ["E4", "E7", "E9", "F"]\n',
         encoding="utf-8",
     )
     (sample_pkg / "__init__.py").write_text("", encoding="utf-8")

--- a/tests/workflows/test_autofix_pipeline_diverse.py
+++ b/tests/workflows/test_autofix_pipeline_diverse.py
@@ -50,6 +50,10 @@ def test_autofix_pipeline_handles_diverse_errors(
     sample_pkg.mkdir(parents=True)
     trend_pkg.mkdir(parents=True)
     tests_dir.mkdir()
+    (repo_root / "pyproject.toml").write_text(
+        "[tool.ruff.lint]\nselect = [\"E4\", \"E7\", \"E9\", \"F\"]\n",
+        encoding="utf-8",
+    )
     (sample_pkg / "__init__.py").write_text("", encoding="utf-8")
     (tests_dir / "__init__.py").write_text("", encoding="utf-8")
 

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -127,6 +127,14 @@ def test_workflow_inputs_include_python_version_defaults() -> None:
     assert "pytest_args" not in dispatch_inputs
 
 
+def test_ruff_lint_keeps_the_legacy_default_rule_family() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["lint-ruff"]["steps"]
+    ruff_step = next(step for step in steps if step.get("name") == "Ruff (lint)")
+
+    assert "ruff check --select E4,E7,E9,F" in ruff_step["run"]
+
+
 def test_default_input_contract_fixture_matches_artifacts() -> None:
     fixture = _contract_fixture("default_inputs.json")
     inputs = _merged_inputs(fixture)


### PR DESCRIPTION
Updates the canonical Ruff pin together with Workflows development metadata, lockfile, and consumer/integration template environments. This replaces partial consumer-only Ruff updates.\n\nValidation:\n- `python scripts/sync_tool_versions.py --check`\n- `python scripts/validate_version_pins.py`\n- `pytest -q tests/scripts/test_sync_tool_versions.py tests/scripts/test_validate_version_pins.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Ruff development tool pin to **0.16.0** across tooling and templates.
* **CI**
  * Adjusted the Python CI Ruff lint step to run only the legacy rule families (**E4, E7, E9, F**) to avoid unintended lint expansion.
* **Documentation**
  * Added a note clarifying the shared Ruff default rule-family pin (**E4,E7,E9,F**) for downstream validation.
* **Tests**
  * Strengthened workflow coverage to ensure the legacy Ruff rule-family selector is consistently applied during CI and autofix pipeline runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->