### PR TITLE
chore(model-eval): refresh verifier pilot candidates to current catalog (add claude-opus-4-8)

### DIFF
--- a/config/model_eval_candidates.json
+++ b/config/model_eval_candidates.json
@@ -4,7 +4,8 @@
     {"provider":"openai","model_id":"gpt-5.6-terra","role":"candidate"},
     {"provider":"openai","model_id":"gpt-5.6-sol","role":"candidate"},
     {"provider":"anthropic","model_id":"claude-opus-4-6","role":"incumbent"},
-    {"provider":"anthropic","model_id":"claude-sonnet-4-6","role":"candidate"},
+    {"provider":"anthropic","model_id":"claude-opus-4-8","role":"candidate"},
+    {"provider":"anthropic","model_id":"claude-sonnet-5","role":"candidate"},
     {"provider":"github-models","model_id":"codex-mini-latest","role":"incumbent"}
   ]
 }


### PR DESCRIPTION
## What
Refresh the verifier-pilot candidate set (`config/model_eval_candidates.json`) to match the current catalog.

It had drifted: it listed `claude-sonnet-4-6` (no longer in the model catalog) and **omitted `claude-opus-4-8`** — the current high-capability Anthropic model that supersedes the `claude-opus-4-6` incumbent verifier. So a `maint-78` pilot could not test the model that actually supersedes the incumbent, and risked a preflight abort on the defunct `sonnet-4-6`.

- **anthropic:** + `claude-opus-4-8` (candidate), `claude-sonnet-4-6` → `claude-sonnet-5` (candidate); `claude-opus-4-6` stays incumbent.
- **openai:** unchanged (already lists `gpt-5.6-terra`, `gpt-5.6-sol` candidates vs `gpt-5.4` incumbent).
- Candidates only gate what gets **benchmarked**, not what's selected — selection still requires the paired-corpus gates + human approval per `MODEL_SELECTION_POLICY.md`.

## Why now
Surfaced while validating that the `verifier-balanced` selections (still on the superseded `opus-4-6`/`gpt-5.4` incumbents) can actually be re-evaluated against current models. The candidate-file drift is a concrete instance of the broader "catalog-only evidence can never promote; the manual eval never runs" gap — tracked separately as a design issue.

## Verification
Valid JSON; `maint-78` dispatched against this branch to run the paired 30-case narrowing pilot with `claude-opus-4-8` + `gpt-5.6-terra`/`sol` as candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
