### PR TITLE
fix(llm): omit temperature for Anthropic models that reject it (unblocks verifier eval of Opus 4.8 / Claude 5)

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-23T06:54:19.970022Z",
+  "emitted_at": "2026-07-24T21:53:26.737479Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2809",
+  "pr_number": "2822",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/tests/tools/test_langchain_client.py
+++ b/tests/tools/test_langchain_client.py
@@ -799,3 +799,42 @@ def test_build_openai_client_normal_model_has_temperature(
     assert resolved is not None
     assert isinstance(resolved.client, FakeChatOpenAI)
     assert resolved.client.kwargs["temperature"] == 0.1
+
+
+class _CaptureChatAnthropic:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _build_anthropic(model: str):
+    return langchain_client._build_anthropic_client(
+        _CaptureChatAnthropic, model=model, token="t", timeout=30, max_retries=2
+    )
+
+
+def test_anthropic_rejects_temperature_matches_newer_generation():
+    # Confirmed-rejecting (maint-78 pilot 2026-07-24) + Claude 5 family.
+    assert langchain_client._anthropic_rejects_temperature("claude-opus-4-8")
+    assert langchain_client._anthropic_rejects_temperature("claude-sonnet-5")
+    assert langchain_client._anthropic_rejects_temperature("claude-fable-5")
+    assert langchain_client._anthropic_rejects_temperature("claude-opus-5")
+
+
+def test_anthropic_incumbent_and_minor5_still_accept_temperature():
+    # Incumbent opus-4-6 and minor-version -5 suffixes must NOT be treated as rejecting.
+    assert not langchain_client._anthropic_rejects_temperature("claude-opus-4-6")
+    assert not langchain_client._anthropic_rejects_temperature("claude-haiku-4-5-20251001")
+    assert not langchain_client._anthropic_rejects_temperature("claude-sonnet-4-6")
+
+
+def test_build_anthropic_omits_temperature_for_newer_models():
+    # These previously 400'd on `temperature`; now the param must be omitted.
+    for model in ("claude-opus-4-8", "claude-sonnet-5"):
+        client = _build_anthropic(model)
+        assert "temperature" not in client.kwargs, model
+        assert client.kwargs["model"] == model
+
+
+def test_build_anthropic_keeps_temperature_for_incumbent():
+    client = _build_anthropic("claude-opus-4-6")
+    assert client.kwargs["temperature"] == 0.1

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -167,16 +167,37 @@ def _build_openai_client(
     return chat_openai(**kwargs)
 
 
+def _anthropic_rejects_temperature(model: str) -> bool:
+    """Return True for Anthropic models that reject an explicit ``temperature``.
+
+    The newer "thinking" generation returns HTTP 400 ``invalid_request_error`` when a
+    custom ``temperature`` is set. Confirmed via the maint-78 verifier pilot
+    (2026-07-24): ``claude-opus-4-8`` and ``claude-sonnet-5`` (while ``claude-opus-4-6``
+    still accepts ``temperature=0.1``). Matches Opus 4.8 explicitly plus the Claude 5
+    family (``claude-<name>-5...``); minor-version ``-5`` suffixes like
+    ``claude-haiku-4-5`` are NOT matched. Interim, evidence-based guard; the durable
+    capability-aware handling (e.g. retry-on-400) is tracked in stranske/Workflows#2819.
+    """
+    name = model.lower().strip()
+    if name == "claude-opus-4-8":
+        return True
+    return any(
+        name.startswith(f"claude-{family}-5") for family in ("opus", "sonnet", "haiku", "fable")
+    )
+
+
 def _build_anthropic_client(
     chat_anthropic: type, *, model: str, token: str, timeout: int, max_retries: int
 ) -> object:
-    return chat_anthropic(
-        model=model,
-        anthropic_api_key=token,
-        temperature=0.1,
-        timeout=timeout,
-        max_retries=max_retries,
-    )
+    kwargs: dict = {
+        "model": model,
+        "anthropic_api_key": token,
+        "timeout": timeout,
+        "max_retries": max_retries,
+    }
+    if not _anthropic_rejects_temperature(model):
+        kwargs["temperature"] = 0.1
+    return chat_anthropic(**kwargs)
 
 
 def _build_github_client(


### PR DESCRIPTION
## What
The frozen verifier client passed `temperature=0.1` **unconditionally** to Anthropic (`_build_anthropic_client`), but the newer "thinking" generation returns **HTTP 400 `invalid_request_error`** on a custom temperature. This broke the maint-78 verifier pilot: run `30112277194` (2026-07-24) failed preflight because `claude-opus-4-8` and `claude-sonnet-5` 400'd on `temperature` — and preflight is all-or-nothing, so the whole pilot aborted (even though the OpenAI candidates passed).

## Fix
Mirror the existing OpenAI reasoning-model handling (`_is_reasoning_model` → omit temperature) for Anthropic:
- Add `_anthropic_rejects_temperature(model)` — matches `claude-opus-4-8` + the Claude 5 family (`claude-<name>-5…`); minor-version `-5` suffixes like `claude-haiku-4-5` are **not** matched.
- `_build_anthropic_client` omits `temperature` for those, and **preserves `temperature=0.1` for the incumbent `claude-opus-4-6`** (which still accepts it) — so the production verifier's behavior is unchanged.

## Scope / honesty
- Interim, evidence-based guard. The durable, no-maintenance approach (capability-aware / retry-on-400, plus per-candidate preflight tolerance) is tracked in #2819.
- **This does not fix the other pilot failure:** `github-models/codex-mini-latest` returned `404` (endpoint/path issue) — separate from temperature. With all-or-nothing preflight, a re-run still needs that handled (or the github incumbent excluded).

## Verification
`ruff==0.15.20` ✅ · `black==26.5.1 -l100` ✅ · `mypy==2.1.0` ✅ (CI-pinned). `pytest tests/tools/test_langchain_client.py` → **63 passed**, incl. 4 new: helper matches opus-4-8/sonnet-5/fable-5/opus-5; incumbent opus-4-6 + minor `-5` still accept; builder omits temperature for new models, keeps it for opus-4-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Claude models by not sending an unsupported `temperature` setting for models that reject it.
  * Kept the existing `temperature` behavior for Claude models that still support it.
* **Tests**
  * Added assertions to verify correct temperature handling across supported Anthropic/Claude model versions.
* **Chores**
  * Updated worker runtime metadata (timestamp and PR number).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->