### PR TITLE
fix: harden auto-pilot stall handoffs

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -3291,7 +3291,10 @@ jobs:
               // still stalled, so we escalate. Any error falls through to needs-human.
               let handedOff = false;
               try {
-                const { eligibleAgents } = require('./.github/scripts/agent_stall_rotation.js');
+                const {
+                  eligibleAgents,
+                  currentAgentFromLabels,
+                } = require('./.github/scripts/agent_stall_rotation.js');
                 const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
                 const { data: rotIssue } = await withRetry((client) => client.rest.issues.get({
                   owner: context.repo.owner,
@@ -3302,19 +3305,48 @@ jobs:
                   .map((l) => (typeof l === 'string' ? l : l && l.name))
                   .filter(Boolean);
                 const hasAuto = rotLabels.some((l) => String(l).trim().toLowerCase() === 'agent:auto');
-                const availableSecrets = {
-                  CODEX_AUTH_JSON: process.env.HAS_CODEX_AUTH_JSON === 'true',
-                  CLAUDE_CODE_OAUTH_TOKEN: process.env.HAS_CLAUDE_CODE_OAUTH_TOKEN === 'true',
-                  CLAUDE_AUTH_JSON: process.env.HAS_CLAUDE_AUTH_JSON === 'true',
-                  CURSOR_API_KEY: process.env.HAS_CURSOR_API_KEY === 'true',
-                  GEMINI_API_KEY: process.env.HAS_GEMINI_API_KEY === 'true',
-                };
+                const rotationRegistry = loadAgentRegistry();
+                // Derive the credential surface from the registry. The Actions API
+                // exposes secret names (not values), so newly registered keepalive
+                // agents are considered without another provider-specific edit here.
+                const requiredSecretNames = [...new Set(
+                  Object.values(rotationRegistry.agents || {})
+                    .filter((config) => config?.capabilities?.pr_keepalive === true)
+                    .flatMap((config) => config.required_secrets || [])
+                )];
+                const availableSecrets = Object.fromEntries(
+                  requiredSecretNames.map((name) => [name, process.env[`HAS_${name}`] === 'true'])
+                );
+                try {
+                  const { data: secretData } = await withRetry((client) =>
+                    client.rest.actions.listRepoSecrets({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      per_page: 100,
+                    })
+                  );
+                  for (const secret of secretData.secrets || []) {
+                    if (Object.hasOwn(availableSecrets, secret.name)) {
+                      availableSecrets[secret.name] = true;
+                    }
+                  }
+                } catch (secretLookupError) {
+                  core.warning(
+                    `Could not list repository secret names; using exported availability flags: ` +
+                    `${secretLookupError?.message || secretLookupError}`
+                  );
+                }
                 const keepaliveAgents = eligibleAgents({
-                  registry: loadAgentRegistry(),
+                  registry: rotationRegistry,
                   capability: 'pr_keepalive',
                   secrets: availableSecrets,
                 });
-                if (!hasAuto && keepaliveAgents.length > 1) {
+                const currentAgent = currentAgentFromLabels(
+                  rotLabels,
+                  Object.keys(rotationRegistry.agents || {})
+                ) || rotationRegistry.default_agent || '';
+                const hasAlternative = keepaliveAgents.some((agent) => agent !== currentAgent);
+                if (!hasAuto && hasAlternative) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
                   // policy picks an alternative agent on its next round.
                   await withRetry((client) => client.rest.issues.addLabels({
@@ -3339,16 +3371,37 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                   }));
-                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'agents-81-gate-followups.yml',
-                    ref: repoInfo.default_branch || 'main',
-                    inputs: {
-                      pr_number: String(prNumber),
-                      force_retry: 'true',
-                    },
-                  }));
+                  let dispatchedWorkflow = '';
+                  const dispatchFailures = [];
+                  for (const workflowId of [
+                    'agents-81-gate-followups.yml',
+                    'agents-keepalive-loop.yml',
+                  ]) {
+                    try {
+                      await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: workflowId,
+                        ref: repoInfo.default_branch || 'main',
+                        inputs: {
+                          pr_number: String(prNumber),
+                          force_retry: 'true',
+                        },
+                      }));
+                      dispatchedWorkflow = workflowId;
+                      break;
+                    } catch (dispatchError) {
+                      dispatchFailures.push(
+                        `${workflowId}: ${dispatchError?.message || dispatchError}`
+                      );
+                      if (dispatchError?.status !== 404) break;
+                    }
+                  }
+                  if (!dispatchedWorkflow) {
+                    throw new Error(
+                      `No keepalive handoff workflow could be dispatched: ${dispatchFailures.join('; ')}`
+                    );
+                  }
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.
                   await withRetry((client) => client.rest.issues.createComment({
@@ -3361,7 +3414,9 @@ jobs:
                       `(eligible: ${keepaliveAgents.join(', ')}).\n\n` +
                       `\`needs-human\` is withheld until delegation has also been exhausted.`,
                   }));
-                  core.info(`Monitor-pr stall handed off to delegation policy (agent:auto added)`);
+                  core.info(
+                    `Monitor-pr stall handed off via ${dispatchedWorkflow} (agent:auto added)`
+                  );
                   handedOff = true;
                 }
               } catch (rotationErr) {

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -3318,14 +3318,14 @@ jobs:
                   requiredSecretNames.map((name) => [name, process.env[`HAS_${name}`] === 'true'])
                 );
                 try {
-                  const { data: secretData } = await withRetry((client) =>
-                    client.rest.actions.listRepoSecrets({
+                  const repoSecrets = await withRetry((client) =>
+                    client.paginate(client.rest.actions.listRepoSecrets, {
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       per_page: 100,
                     })
                   );
-                  for (const secret of secretData.secrets || []) {
+                  for (const secret of repoSecrets) {
                     if (Object.hasOwn(availableSecrets, secret.name)) {
                       availableSecrets[secret.name] = true;
                     }
@@ -3349,24 +3349,6 @@ jobs:
                 if (!hasAuto && hasAlternative) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
                   // policy picks an alternative agent on its next round.
-                  await withRetry((client) => client.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    labels: ['agent:auto'],
-                  }));
-                  if (prNumber) {
-                    try {
-                      await withRetry((client) => client.rest.issues.addLabels({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: parseInt(prNumber, 10),
-                        labels: ['agent:auto'],
-                      }));
-                    } catch (prLabelErr) {
-                      core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
-                    }
-                  }
                   const { data: repoInfo } = await withRetry((client) => client.rest.repos.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -3401,6 +3383,26 @@ jobs:
                     throw new Error(
                       `No keepalive handoff workflow could be dispatched: ${dispatchFailures.join('; ')}`
                     );
+                  }
+                  // Switch routing only after a dispatch succeeds, so a transient
+                  // dispatch failure leaves the existing concrete route retryable.
+                  await withRetry((client) => client.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['agent:auto'],
+                  }));
+                  if (prNumber) {
+                    try {
+                      await withRetry((client) => client.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: parseInt(prNumber, 10),
+                        labels: ['agent:auto'],
+                      }));
+                    } catch (prLabelErr) {
+                      core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
+                    }
                   }
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -2576,6 +2576,37 @@ jobs:
                     core.info(`(agent:${decision.currentAgent} label not present: ${labelErr?.message})`);
                   }
                 }
+                // A stalled belt item may still carry agent:auto from an earlier
+                // keepalive handoff. Auto and explicit routing labels are mutually
+                // exclusive, so remove the former before assigning the next agent.
+                try {
+                  await withRetry((client) => client.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: 'agent:auto',
+                  }));
+                } catch (labelErr) {
+                  core.info(`(agent:auto label not present: ${labelErr?.message})`);
+                }
+                if (decision.triedMarker) {
+                  try {
+                    await withRetry((client) => client.rest.issues.getLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: decision.triedMarker,
+                    }));
+                  } catch (labelErr) {
+                    if (labelErr?.status !== 404) throw labelErr;
+                    await withRetry((client) => client.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: decision.triedMarker,
+                      color: '1d76db',
+                      description: 'Records an agent already tried during bounded stall rotation',
+                    }));
+                  }
+                }
                 await withRetry((client) => client.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -3195,6 +3226,11 @@ jobs:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           STEP_COUNT: ${{ steps.cycles.outputs.count }}
           MAX_STALL_RETRIES: '5'
+          HAS_CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          HAS_CLAUDE_AUTH_JSON: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
+          HAS_CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY != '' }}
+          HAS_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY != '' }}
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -3266,9 +3302,17 @@ jobs:
                   .map((l) => (typeof l === 'string' ? l : l && l.name))
                   .filter(Boolean);
                 const hasAuto = rotLabels.some((l) => String(l).trim().toLowerCase() === 'agent:auto');
+                const availableSecrets = {
+                  CODEX_AUTH_JSON: process.env.HAS_CODEX_AUTH_JSON === 'true',
+                  CLAUDE_CODE_OAUTH_TOKEN: process.env.HAS_CLAUDE_CODE_OAUTH_TOKEN === 'true',
+                  CLAUDE_AUTH_JSON: process.env.HAS_CLAUDE_AUTH_JSON === 'true',
+                  CURSOR_API_KEY: process.env.HAS_CURSOR_API_KEY === 'true',
+                  GEMINI_API_KEY: process.env.HAS_GEMINI_API_KEY === 'true',
+                };
                 const keepaliveAgents = eligibleAgents({
                   registry: loadAgentRegistry(),
                   capability: 'pr_keepalive',
+                  secrets: availableSecrets,
                 });
                 if (!hasAuto && keepaliveAgents.length > 1) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
@@ -3291,6 +3335,20 @@ jobs:
                       core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
                     }
                   }
+                  const { data: repoInfo } = await withRetry((client) => client.rest.repos.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  }));
+                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'agents-81-gate-followups.yml',
+                    ref: repoInfo.default_branch || 'main',
+                    inputs: {
+                      pr_number: String(prNumber),
+                      force_retry: 'true',
+                    },
+                  }));
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.
                   await withRetry((client) => client.rest.issues.createComment({

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -3291,7 +3291,10 @@ jobs:
               // still stalled, so we escalate. Any error falls through to needs-human.
               let handedOff = false;
               try {
-                const { eligibleAgents } = require('./.github/scripts/agent_stall_rotation.js');
+                const {
+                  eligibleAgents,
+                  currentAgentFromLabels,
+                } = require('./.github/scripts/agent_stall_rotation.js');
                 const { loadAgentRegistry } = require('./.github/scripts/agent_registry.js');
                 const { data: rotIssue } = await withRetry((client) => client.rest.issues.get({
                   owner: context.repo.owner,
@@ -3302,19 +3305,48 @@ jobs:
                   .map((l) => (typeof l === 'string' ? l : l && l.name))
                   .filter(Boolean);
                 const hasAuto = rotLabels.some((l) => String(l).trim().toLowerCase() === 'agent:auto');
-                const availableSecrets = {
-                  CODEX_AUTH_JSON: process.env.HAS_CODEX_AUTH_JSON === 'true',
-                  CLAUDE_CODE_OAUTH_TOKEN: process.env.HAS_CLAUDE_CODE_OAUTH_TOKEN === 'true',
-                  CLAUDE_AUTH_JSON: process.env.HAS_CLAUDE_AUTH_JSON === 'true',
-                  CURSOR_API_KEY: process.env.HAS_CURSOR_API_KEY === 'true',
-                  GEMINI_API_KEY: process.env.HAS_GEMINI_API_KEY === 'true',
-                };
+                const rotationRegistry = loadAgentRegistry();
+                // Derive the credential surface from the registry. The Actions API
+                // exposes secret names (not values), so newly registered keepalive
+                // agents are considered without another provider-specific edit here.
+                const requiredSecretNames = [...new Set(
+                  Object.values(rotationRegistry.agents || {})
+                    .filter((config) => config?.capabilities?.pr_keepalive === true)
+                    .flatMap((config) => config.required_secrets || [])
+                )];
+                const availableSecrets = Object.fromEntries(
+                  requiredSecretNames.map((name) => [name, process.env[`HAS_${name}`] === 'true'])
+                );
+                try {
+                  const { data: secretData } = await withRetry((client) =>
+                    client.rest.actions.listRepoSecrets({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      per_page: 100,
+                    })
+                  );
+                  for (const secret of secretData.secrets || []) {
+                    if (Object.hasOwn(availableSecrets, secret.name)) {
+                      availableSecrets[secret.name] = true;
+                    }
+                  }
+                } catch (secretLookupError) {
+                  core.warning(
+                    `Could not list repository secret names; using exported availability flags: ` +
+                    `${secretLookupError?.message || secretLookupError}`
+                  );
+                }
                 const keepaliveAgents = eligibleAgents({
-                  registry: loadAgentRegistry(),
+                  registry: rotationRegistry,
                   capability: 'pr_keepalive',
                   secrets: availableSecrets,
                 });
-                if (!hasAuto && keepaliveAgents.length > 1) {
+                const currentAgent = currentAgentFromLabels(
+                  rotLabels,
+                  Object.keys(rotationRegistry.agents || {})
+                ) || rotationRegistry.default_agent || '';
+                const hasAlternative = keepaliveAgents.some((agent) => agent !== currentAgent);
+                if (!hasAuto && hasAlternative) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
                   // policy picks an alternative agent on its next round.
                   await withRetry((client) => client.rest.issues.addLabels({
@@ -3339,16 +3371,37 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                   }));
-                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'agents-81-gate-followups.yml',
-                    ref: repoInfo.default_branch || 'main',
-                    inputs: {
-                      pr_number: String(prNumber),
-                      force_retry: 'true',
-                    },
-                  }));
+                  let dispatchedWorkflow = '';
+                  const dispatchFailures = [];
+                  for (const workflowId of [
+                    'agents-81-gate-followups.yml',
+                    'agents-keepalive-loop.yml',
+                  ]) {
+                    try {
+                      await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: workflowId,
+                        ref: repoInfo.default_branch || 'main',
+                        inputs: {
+                          pr_number: String(prNumber),
+                          force_retry: 'true',
+                        },
+                      }));
+                      dispatchedWorkflow = workflowId;
+                      break;
+                    } catch (dispatchError) {
+                      dispatchFailures.push(
+                        `${workflowId}: ${dispatchError?.message || dispatchError}`
+                      );
+                      if (dispatchError?.status !== 404) break;
+                    }
+                  }
+                  if (!dispatchedWorkflow) {
+                    throw new Error(
+                      `No keepalive handoff workflow could be dispatched: ${dispatchFailures.join('; ')}`
+                    );
+                  }
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.
                   await withRetry((client) => client.rest.issues.createComment({
@@ -3361,7 +3414,9 @@ jobs:
                       `(eligible: ${keepaliveAgents.join(', ')}).\n\n` +
                       `\`needs-human\` is withheld until delegation has also been exhausted.`,
                   }));
-                  core.info(`Monitor-pr stall handed off to delegation policy (agent:auto added)`);
+                  core.info(
+                    `Monitor-pr stall handed off via ${dispatchedWorkflow} (agent:auto added)`
+                  );
                   handedOff = true;
                 }
               } catch (rotationErr) {

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -3318,14 +3318,14 @@ jobs:
                   requiredSecretNames.map((name) => [name, process.env[`HAS_${name}`] === 'true'])
                 );
                 try {
-                  const { data: secretData } = await withRetry((client) =>
-                    client.rest.actions.listRepoSecrets({
+                  const repoSecrets = await withRetry((client) =>
+                    client.paginate(client.rest.actions.listRepoSecrets, {
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       per_page: 100,
                     })
                   );
-                  for (const secret of secretData.secrets || []) {
+                  for (const secret of repoSecrets) {
                     if (Object.hasOwn(availableSecrets, secret.name)) {
                       availableSecrets[secret.name] = true;
                     }
@@ -3349,24 +3349,6 @@ jobs:
                 if (!hasAuto && hasAlternative) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
                   // policy picks an alternative agent on its next round.
-                  await withRetry((client) => client.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    labels: ['agent:auto'],
-                  }));
-                  if (prNumber) {
-                    try {
-                      await withRetry((client) => client.rest.issues.addLabels({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: parseInt(prNumber, 10),
-                        labels: ['agent:auto'],
-                      }));
-                    } catch (prLabelErr) {
-                      core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
-                    }
-                  }
                   const { data: repoInfo } = await withRetry((client) => client.rest.repos.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -3401,6 +3383,26 @@ jobs:
                     throw new Error(
                       `No keepalive handoff workflow could be dispatched: ${dispatchFailures.join('; ')}`
                     );
+                  }
+                  // Switch routing only after a dispatch succeeds, so a transient
+                  // dispatch failure leaves the existing concrete route retryable.
+                  await withRetry((client) => client.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['agent:auto'],
+                  }));
+                  if (prNumber) {
+                    try {
+                      await withRetry((client) => client.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: parseInt(prNumber, 10),
+                        labels: ['agent:auto'],
+                      }));
+                    } catch (prLabelErr) {
+                      core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
+                    }
                   }
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -2576,6 +2576,37 @@ jobs:
                     core.info(`(agent:${decision.currentAgent} label not present: ${labelErr?.message})`);
                   }
                 }
+                // A stalled belt item may still carry agent:auto from an earlier
+                // keepalive handoff. Auto and explicit routing labels are mutually
+                // exclusive, so remove the former before assigning the next agent.
+                try {
+                  await withRetry((client) => client.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: 'agent:auto',
+                  }));
+                } catch (labelErr) {
+                  core.info(`(agent:auto label not present: ${labelErr?.message})`);
+                }
+                if (decision.triedMarker) {
+                  try {
+                    await withRetry((client) => client.rest.issues.getLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: decision.triedMarker,
+                    }));
+                  } catch (labelErr) {
+                    if (labelErr?.status !== 404) throw labelErr;
+                    await withRetry((client) => client.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: decision.triedMarker,
+                      color: '1d76db',
+                      description: 'Records an agent already tried during bounded stall rotation',
+                    }));
+                  }
+                }
                 await withRetry((client) => client.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -3195,6 +3226,11 @@ jobs:
           ISSUE_NUMBER: ${{ steps.context.outputs.issue_number }}
           STEP_COUNT: ${{ steps.cycles.outputs.count }}
           MAX_STALL_RETRIES: '5'
+          HAS_CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          HAS_CLAUDE_AUTH_JSON: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
+          HAS_CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY != '' }}
+          HAS_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY != '' }}
         with:
           script: |
             const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
@@ -3266,9 +3302,17 @@ jobs:
                   .map((l) => (typeof l === 'string' ? l : l && l.name))
                   .filter(Boolean);
                 const hasAuto = rotLabels.some((l) => String(l).trim().toLowerCase() === 'agent:auto');
+                const availableSecrets = {
+                  CODEX_AUTH_JSON: process.env.HAS_CODEX_AUTH_JSON === 'true',
+                  CLAUDE_CODE_OAUTH_TOKEN: process.env.HAS_CLAUDE_CODE_OAUTH_TOKEN === 'true',
+                  CLAUDE_AUTH_JSON: process.env.HAS_CLAUDE_AUTH_JSON === 'true',
+                  CURSOR_API_KEY: process.env.HAS_CURSOR_API_KEY === 'true',
+                  GEMINI_API_KEY: process.env.HAS_GEMINI_API_KEY === 'true',
+                };
                 const keepaliveAgents = eligibleAgents({
                   registry: loadAgentRegistry(),
                   capability: 'pr_keepalive',
+                  secrets: availableSecrets,
                 });
                 if (!hasAuto && keepaliveAgents.length > 1) {
                   // Add agent:auto to the issue AND the PR so the keepalive delegation
@@ -3291,6 +3335,20 @@ jobs:
                       core.info(`(could not label PR #${prNumber} with agent:auto: ${prLabelErr?.message})`);
                     }
                   }
+                  const { data: repoInfo } = await withRetry((client) => client.rest.repos.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  }));
+                  await withRetry((client) => client.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'agents-81-gate-followups.yml',
+                    ref: repoInfo.default_branch || 'main',
+                    inputs: {
+                      pr_number: String(prNumber),
+                      force_retry: 'true',
+                    },
+                  }));
                   // Leading "🤖 **Auto-pilot step**" marker resets countConsecutiveWaits()
                   // (see belt-rotation note above) so a later monitor round starts fresh.
                   await withRetry((client) => client.rest.issues.createComment({


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2864 -->
> **Source:** Issue #2864

Closes #2864

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Stalled PR recovery must route to a viable registered agent, dispatch an available handoff workflow, and avoid permanently setting `agent:auto` when dispatch fails.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2826](https://github.com/stranske/Workflows/issues/2826)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Use registry-derived required-secret availability.
- [ ] Allow a single viable alternate agent.
- [ ] Use the available root or consumer handoff workflow safely.
- [ ] Apply routing changes only after a successful dispatch and keep the template aligned.
- [ ] Resolve all current review feedback.

#### Acceptance criteria
- [ ] Workflows and consumer templates follow the same safe handoff semantics.
- [ ] Failed dispatch leaves retryable routing state.
- [ ] Focused tests and workflow validation pass.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stalled work rotation by preserving trial history and preventing conflicting routing labels.
  * Improved detection of available credentials and eligible fallback agents.
  * Added reliable fallback handling when handing off stalled pull request monitoring.
  * Clear errors are now reported when no handoff workflow can be started.
* **Chores**
  * Updated internal attempt tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->