### PR TITLE
fix(scripts): drop dead run_tests.sh recommendation from check_test_dependencies.sh

### DIFF
--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,11 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    if [ -x ./scripts/run_tests.sh ]; then
-        echo "  ./scripts/run_tests.sh"
-    else
-        echo "  python -m pytest"
-    fi
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"


### PR DESCRIPTION
## What
`scripts/check_test_dependencies.sh` recommended `./scripts/run_tests.sh`, which exists in **no** repo in the fleet. Consumers that sync this file and run the dependency-setup validator (e.g. Manager-Database's `check_dependency_script_recommendations`) fail because the recommended script path does not exist.

Recommend `python -m pytest` unconditionally.

## Why
Source-of-truth fix so the re-synced copies in Manager-Database / Inv-Man-Intake stay in sync. No behavior change beyond the recommendation text; Workflows' own validator does not check this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)