### PR TITLE
fix: retain ignored llm registry tier parameter

### DIFF
--- a/templates/consumer-repo/tools/llm_registry.py
+++ b/templates/consumer-repo/tools/llm_registry.py
@@ -288,6 +288,8 @@ def configured_model_for_provider(
     tier: str | None = None,
     registry: list[ModelRegistryEntry] | None = None,
 ) -> str:
+    # Preserve the compatibility keyword while selection remains profile-based.
+    del tier
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     # An explicit slot config is an execution allowlist, including when its

--- a/tests/tools/test_llm_registry_selection.py
+++ b/tests/tools/test_llm_registry_selection.py
@@ -81,6 +81,27 @@ def test_profile_selection_normalizes_whitespace(
     )
 
 
+def test_configured_model_ignores_legacy_tier_when_profile_is_explicit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    _write_registry(registry_path)
+    monkeypatch.setenv(registry.ENV_MODEL_REGISTRY_CONFIG, str(registry_path))
+
+    assert (
+        registry.configured_model_for_provider(
+            "openai", profile="verifier-balanced", tier="legacy-low"
+        )
+        == "model-balanced"
+    )
+    assert (
+        registry.configured_model_for_provider(
+            "openai", profile="verifier-balanced", tier="legacy-high"
+        )
+        == "model-balanced"
+    )
+
+
 def test_loaded_registry_entries_leave_compatibility_quality_unset(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -288,6 +288,8 @@ def configured_model_for_provider(
     tier: str | None = None,
     registry: list[ModelRegistryEntry] | None = None,
 ) -> str:
+    # Preserve the compatibility keyword while selection remains profile-based.
+    del tier
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
     # An explicit slot config is an execution allowlist, including when its


### PR DESCRIPTION
Fixes the Ruff ARG001 failure propagated by consumer sync PRs. The public `tier` keyword remains accepted for compatibility while model selection is profile-based.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection compatibility while preserving existing profile-based model resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->