### PR TITLE
fix: retain upgraded LLM provider pins

### DIFF
--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -9,7 +9,7 @@
 #   release resolve a mutually compatible core version.
 langchain==1.3.14
 langchain-community==0.4.2
-langchain-openai==1.3.5
-langchain-anthropic==1.4.8
+langchain-openai==1.4.1
+langchain-anthropic==1.5.2
 pydantic==2.13.4
 requests==2.34.2

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -9,7 +9,7 @@
 #   release resolve a mutually compatible core version.
 langchain==1.3.14
 langchain-community==0.4.2
-langchain-openai==1.3.5
-langchain-anthropic==1.4.8
+langchain-openai==1.4.1
+langchain-anthropic==1.5.2
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
Retains the newer langchain-openai and langchain-anthropic pins already present in the affected consumer rather than downgrading them during template sync. Updates the canonical source and its exact-sync template together.\n\nValidation: `scripts/sync_templates.sh`, `python3.12 scripts/validate_template_completeness.py`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the LLM workflow components to newer versions.
  * Applied the same updates across the relevant project templates and tooling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->