### PR TITLE
fix: preserve consumer Ruff selections with 0.16

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1123,22 +1123,30 @@ jobs:
                           return True
               return False
 
-          for name in ("pyproject.toml", "ruff.toml", ".ruff.toml"):
-              path = Path(name)
-              if not path.is_file():
-                  continue
-              if tomllib is None:
-                  if text_has_selection(
-                      path.read_text(encoding="utf-8"),
-                      pyproject=(name == "pyproject.toml"),
-                  ):
-                      sys.exit(0)
-                  continue
-              with path.open("rb") as handle:
-                  data = tomllib.load(handle)
-              config = data.get("tool", {}).get("ruff", {}) if name == "pyproject.toml" else data
-              if has_explicit_selection(config):
-                  sys.exit(0)
+          def pyproject_has_ruff_config(text):
+              return bool(re.search(r"(?m)^\[tool\.ruff(?:\.|\])", text))
+
+          # Ruff discovers the nearest configuration from the directory of the
+          # files being linted. Stop at the first usable config so a parent
+          # selection is not incorrectly inherited through a child config.
+          for directory in (Path.cwd(), *Path.cwd().parents):
+              for name in (".ruff.toml", "ruff.toml", "pyproject.toml"):
+                  path = directory / name
+                  if not path.is_file():
+                      continue
+                  text = path.read_text(encoding="utf-8")
+                  if name == "pyproject.toml" and not pyproject_has_ruff_config(text):
+                      continue
+                  if tomllib is None:
+                      sys.exit(
+                          0
+                          if text_has_selection(text, pyproject=(name == "pyproject.toml"))
+                          else 1
+                      )
+                  with path.open("rb") as handle:
+                      data = tomllib.load(handle)
+                  config = data.get("tool", {}).get("ruff", {}) if name == "pyproject.toml" else data
+                  sys.exit(0 if has_explicit_selection(config) else 1)
           sys.exit(1)
           PY
           then

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1094,18 +1094,50 @@ jobs:
           # is synced from the source repo with different Ruff configuration.
           if python - <<'PY'
           from pathlib import Path
+          import re
           import sys
-          import tomllib
+
+          try:
+              import tomllib
+          except ModuleNotFoundError:  # Python < 3.11
+              try:
+                  import tomli as tomllib
+              except ModuleNotFoundError:
+                  tomllib = None
+
+          SELECT_KEYS = ("select", "extend-select")
+          SELECT_LINE = re.compile(r"(?m)^\s*(?:extend-)?select\s*=")
+
+          def has_explicit_selection(config):
+              lint = config.get("lint", {}) if isinstance(config, dict) else {}
+              return any(key in lint or key in config for key in SELECT_KEYS)
+
+          def text_has_selection(text, *, pyproject):
+              if not pyproject:
+                  return bool(SELECT_LINE.search(text))
+              for part in re.split(r"(?m)^\[", text):
+                  header, _, body = part.partition("]")
+                  header = header.strip()
+                  if header == "tool.ruff" or header.startswith("tool.ruff."):
+                      if SELECT_LINE.search(body):
+                          return True
+              return False
 
           for name in ("pyproject.toml", "ruff.toml", ".ruff.toml"):
               path = Path(name)
               if not path.is_file():
                   continue
+              if tomllib is None:
+                  if text_has_selection(
+                      path.read_text(encoding="utf-8"),
+                      pyproject=(name == "pyproject.toml"),
+                  ):
+                      sys.exit(0)
+                  continue
               with path.open("rb") as handle:
                   data = tomllib.load(handle)
               config = data.get("tool", {}).get("ruff", {}) if name == "pyproject.toml" else data
-              lint = config.get("lint", {})
-              if "select" in lint or "select" in config:
+              if has_explicit_selection(config):
                   sys.exit(0)
           sys.exit(1)
           PY

--- a/.github/workflows/reusable-10-ci-python.yml
+++ b/.github/workflows/reusable-10-ci-python.yml
@@ -1088,9 +1088,32 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          # Use extend-exclude to add to ruff's defaults (which include .venv)
-          # Exclude .workflows-lib since it's synced from source repo with different ruff config
-          ruff check --output-format github --extend-exclude .workflows-lib .
+          # Keep the pre-0.16 default rule family stable for consumers that do
+          # not declare their own Ruff selection. A consumer's explicit
+          # selection remains authoritative. Exclude .workflows-lib since it
+          # is synced from the source repo with different Ruff configuration.
+          if python - <<'PY'
+          from pathlib import Path
+          import sys
+          import tomllib
+
+          for name in ("pyproject.toml", "ruff.toml", ".ruff.toml"):
+              path = Path(name)
+              if not path.is_file():
+                  continue
+              with path.open("rb") as handle:
+                  data = tomllib.load(handle)
+              config = data.get("tool", {}).get("ruff", {}) if name == "pyproject.toml" else data
+              lint = config.get("lint", {})
+              if "select" in lint or "select" in config:
+                  sys.exit(0)
+          sys.exit(1)
+          PY
+          then
+            ruff check --output-format github --extend-exclude .workflows-lib .
+          else
+            ruff check --select E4,E7,E9,F --output-format github --extend-exclude .workflows-lib .
+          fi
 
       - name: Finalize lint
         id: finalize

--- a/docs/ci/TOOL_VERSION_MANAGEMENT.md
+++ b/docs/ci/TOOL_VERSION_MANAGEMENT.md
@@ -32,6 +32,9 @@ COVERAGE_VERSION=7.12.0
 - Sources `autofix-versions.env` before installing tools
 - Runs `black --check`, `ruff check`, `mypy`, and `pytest`
 - Falls back to latest versions if version file is missing
+- Uses the shared Ruff `E4,E7,E9,F` default family only when a consumer does
+  not declare its own Ruff selection, so a tool upgrade cannot silently
+  broaden consumer lint requirements.
 
 ### 2. PR Autofix (`reusable-18-autofix.yml`)
 - Reads version file to install Black and Ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ app = []
 dev = [
     "pre-commit==4.6.0",
     "black==26.5.1",
-    "ruff==0.15.22",
+    "ruff==0.16.0",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -298,7 +298,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.22
+ruff==0.16.0
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.0
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.0
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/tests/workflows/test_autofix_full_pipeline.py
+++ b/tests/workflows/test_autofix_full_pipeline.py
@@ -38,6 +38,10 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     tests_dir = tmp_path / "tests"
     src_dir.mkdir()
     tests_dir.mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff.lint]\nselect = ["E4", "E7", "E9", "F"]\n',
+        encoding="utf-8",
+    )
 
     sample = src_dir / "autofix_target.py"
     sample.write_text(
@@ -138,6 +142,9 @@ def test_autofix_pipeline_resolves_lint_and_typing(
     )
     exit_code = mypy_autofix.main(["--paths", str(sample)])
     assert exit_code == 0
+
+    # The type-hygiene pass can add imports after the initial formatter pass.
+    _run([sys.executable, "-m", "black", str(sample)], cwd=tmp_path)
 
     for cmd in (
         [sys.executable, "-m", "isort", str(sample)],

--- a/tests/workflows/test_autofix_pipeline_diverse.py
+++ b/tests/workflows/test_autofix_pipeline_diverse.py
@@ -50,6 +50,10 @@ def test_autofix_pipeline_handles_diverse_errors(
     sample_pkg.mkdir(parents=True)
     trend_pkg.mkdir(parents=True)
     tests_dir.mkdir()
+    (repo_root / "pyproject.toml").write_text(
+        '[tool.ruff.lint]\nselect = ["E4", "E7", "E9", "F"]\n',
+        encoding="utf-8",
+    )
     (sample_pkg / "__init__.py").write_text("", encoding="utf-8")
     (tests_dir / "__init__.py").write_text("", encoding="utf-8")
 

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -127,6 +127,28 @@ def test_workflow_inputs_include_python_version_defaults() -> None:
     assert "pytest_args" not in dispatch_inputs
 
 
+def test_ruff_lint_preserves_consumer_rule_selection() -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["lint-ruff"]["steps"]
+    ruff_step = next(step for step in steps if step.get("name") == "Ruff (lint)")
+
+    commands = [
+        line.strip()
+        for line in ruff_step["run"].splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert "if python - <<'PY'" in commands
+    assert 'if "select" in lint or "select" in config:' in commands
+    assert (
+        "ruff check --select E4,E7,E9,F --output-format github "
+        "--extend-exclude .workflows-lib ." in commands
+    )
+    assert (
+        "ruff check --output-format github --extend-exclude .workflows-lib ."
+        in commands
+    )
+
+
 def test_default_input_contract_fixture_matches_artifacts() -> None:
     fixture = _contract_fixture("default_inputs.json")
     inputs = _merged_inputs(fixture)

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -143,10 +143,7 @@ def test_ruff_lint_preserves_consumer_rule_selection() -> None:
         "ruff check --select E4,E7,E9,F --output-format github "
         "--extend-exclude .workflows-lib ." in commands
     )
-    assert (
-        "ruff check --output-format github --extend-exclude .workflows-lib ."
-        in commands
-    )
+    assert "ruff check --output-format github --extend-exclude .workflows-lib ." in commands
 
 
 def test_default_input_contract_fixture_matches_artifacts() -> None:

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -157,9 +157,7 @@ def test_ruff_selection_probe_uses_nearest_config_and_parent_discovery(
 
     explicit = tmp_path / "explicit"
     explicit.mkdir()
-    (explicit / "ruff.toml").write_text(
-        "[lint]\nextend-select = [\"I\"]\n", encoding="utf-8"
-    )
+    (explicit / "ruff.toml").write_text('[lint]\nextend-select = ["I"]\n', encoding="utf-8")
     assert subprocess.run([sys.executable, "-c", probe], cwd=explicit).returncode == 0
 
     no_selection = tmp_path / "no-selection"
@@ -173,7 +171,7 @@ def test_ruff_selection_probe_uses_nearest_config_and_parent_discovery(
     nested = inherited / "src" / "package"
     nested.mkdir(parents=True)
     (inherited / "pyproject.toml").write_text(
-        "[tool.ruff.lint]\nselect = [\"E4\"]\n", encoding="utf-8"
+        '[tool.ruff.lint]\nselect = ["E4"]\n', encoding="utf-8"
     )
     assert subprocess.run([sys.executable, "-c", probe], cwd=nested).returncode == 0
 

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -137,11 +139,43 @@ def test_ruff_lint_preserves_consumer_rule_selection() -> None:
     assert 'SELECT_KEYS = ("select", "extend-select")' in script
     assert "import tomli as tomllib" in script
     assert "text_has_selection(" in script
+    assert "Path.cwd().parents" in script
     assert (
         "ruff check --select E4,E7,E9,F --output-format github "
         "--extend-exclude .workflows-lib ." in script
     )
     assert "ruff check --output-format github --extend-exclude .workflows-lib ." in script
+
+
+def test_ruff_selection_probe_uses_nearest_config_and_parent_discovery(
+    tmp_path: Path,
+) -> None:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["lint-ruff"]["steps"]
+    script = next(step for step in steps if step.get("name") == "Ruff (lint)")["run"]
+    probe = script.split("if python - <<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    (explicit / "ruff.toml").write_text(
+        "[lint]\nextend-select = [\"I\"]\n", encoding="utf-8"
+    )
+    assert subprocess.run([sys.executable, "-c", probe], cwd=explicit).returncode == 0
+
+    no_selection = tmp_path / "no-selection"
+    no_selection.mkdir()
+    (no_selection / "pyproject.toml").write_text(
+        "[tool.ruff]\nline-length = 88\n", encoding="utf-8"
+    )
+    assert subprocess.run([sys.executable, "-c", probe], cwd=no_selection).returncode == 1
+
+    inherited = tmp_path / "inherited"
+    nested = inherited / "src" / "package"
+    nested.mkdir(parents=True)
+    (inherited / "pyproject.toml").write_text(
+        "[tool.ruff.lint]\nselect = [\"E4\"]\n", encoding="utf-8"
+    )
+    assert subprocess.run([sys.executable, "-c", probe], cwd=nested).returncode == 0
 
 
 def test_default_input_contract_fixture_matches_artifacts() -> None:

--- a/tests/workflows/test_reusable_ci_workflow.py
+++ b/tests/workflows/test_reusable_ci_workflow.py
@@ -131,19 +131,17 @@ def test_ruff_lint_preserves_consumer_rule_selection() -> None:
     workflow = _load_workflow()
     steps = workflow["jobs"]["lint-ruff"]["steps"]
     ruff_step = next(step for step in steps if step.get("name") == "Ruff (lint)")
+    script = ruff_step["run"]
 
-    commands = [
-        line.strip()
-        for line in ruff_step["run"].splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    ]
-    assert "if python - <<'PY'" in commands
-    assert 'if "select" in lint or "select" in config:' in commands
+    assert "if python - <<'PY'" in script
+    assert 'SELECT_KEYS = ("select", "extend-select")' in script
+    assert "import tomli as tomllib" in script
+    assert "text_has_selection(" in script
     assert (
         "ruff check --select E4,E7,E9,F --output-format github "
-        "--extend-exclude .workflows-lib ." in commands
+        "--extend-exclude .workflows-lib ." in script
     )
-    assert "ruff check --output-format github --extend-exclude .workflows-lib ." in commands
+    assert "ruff check --output-format github --extend-exclude .workflows-lib ." in script
 
 
 def test_default_input_contract_fixture_matches_artifacts() -> None:


### PR DESCRIPTION
Replaces the conflicted #2812 Ruff pin proposal. Moves the full shared pin surface together and retains consumer-defined Ruff selections while using the pre-0.16 default family only when no selection is configured.

Validation: ..........                                                               [100%]
10 passed in 0.61s; ✅ All consumer workflows are properly templated and manifested; 🔄 Syncing scripts to template directory...
✅ All files already in sync; .

Supersedes #2812.

<!-- workflow-source:review_followup -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Ruff to version 0.16.0 across development and workflow templates.

* **Bug Fixes**
  * Preserved custom Ruff rule selections in reusable CI workflows.
  * Maintained legacy default lint rules when no custom selection is configured.

* **Documentation**
  * Clarified Ruff rule-selection behavior for CI validation.

* **Tests**
  * Expanded workflow and autofix pipeline coverage for Ruff configuration and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->