### PR TITLE
chore(deps): sync ruff 0.16.1 pins

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.0
+RUFF_VERSION=0.16.1
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ app = []
 dev = [
     "pre-commit==4.6.1",
     "black==26.5.1",
-    "ruff==0.16.0",
+    "ruff==0.16.1",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -298,7 +298,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.0
+ruff==0.16.1
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.22
+RUFF_VERSION=0.16.1
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.0
+RUFF_VERSION=0.16.1
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0


### PR DESCRIPTION
Align the Workflows-owned ruff pin across the canonical env file, source pyproject, direct lockfile, and both consumer/integration env templates.

This replaces the partial consumer-only Renovate update in stranske/Workflows-Integration-Tests#50, whose CI cannot resolve ruff 0.16.1 against the still-synced 0.16.0 env pin.

Validation:
- pytest -q tests/scripts/test_sync_tool_versions.py tests/scripts/test_sync_dev_dependencies.py
- python scripts/sync_tool_versions.py
- python scripts/validate_version_pins.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s code-quality tooling to the latest Ruff patch release.
  * Aligned Ruff versions across the main project and repository templates.
  * Maintains consistent automated formatting and linting behavior across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->