### PR TITLE
fix(verifier): vendor the LLM model registry into .workflows-lib

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -79,6 +79,7 @@ jobs:
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
+            config
             scripts/langchain
             tools
           sparse-checkout-cone-mode: false

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -78,6 +78,7 @@ jobs:
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
+            config
             scripts/langchain
             tools
           sparse-checkout-cone-mode: false

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -125,6 +125,7 @@ jobs:
             .github/agents/registry.yml
             .github/scripts
             .github/codex/prompts
+            config
             scripts
             tools
           sparse-checkout-cone-mode: false

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -78,6 +78,7 @@ jobs:
             .github/scripts/github-api-with-retry.js
             .github/scripts/terminal_disposition.js
             .github/scripts/token_load_balancer.js
+            config
             scripts/langchain
             tools
           sparse-checkout-cone-mode: false

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -15,6 +15,7 @@ WORKFLOWS_DIR = Path(".github/workflows")
 AUTO_PILOT = WORKFLOWS_DIR / "agents-auto-pilot.yml"
 ISSUE_OPTIMIZER = WORKFLOWS_DIR / "agents-issue-optimizer.yml"
 VERIFIER = WORKFLOWS_DIR / "reusable-agents-verifier.yml"
+VERIFY_TO_ISSUE = WORKFLOWS_DIR / "agents-verify-to-issue-v2.yml"
 REUSABLE_CODEX_RUN = WORKFLOWS_DIR / "reusable-codex-run.yml"
 REUSABLE_CLAUDE_RUN = WORKFLOWS_DIR / "reusable-claude-run.yml"
 NEEDS_HUMAN_COMMENT = Path("agents/codex-1447.md")
@@ -26,6 +27,8 @@ MIN_CODEX_CLI_BY_RUN_MODEL = {
     "gpt-5.4": (0, 125, 0),
 }
 ACTIONS_CACHE_V6_REF = "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+LLM_REGISTRY_MODULE = "tools/llm_registry.py"
+LLM_CONFIG_PATHS = (Path("config/llm_slots.json"), Path("config/model_registry.json"))
 
 
 def _load_text(path: Path) -> str:
@@ -87,6 +90,20 @@ def _iter_steps(workflow: dict) -> list[dict]:
         job_steps = job.get("steps") or []
         if isinstance(job_steps, list):
             steps.extend(step for step in job_steps if isinstance(step, dict))
+    return steps
+
+
+def _sparse_checkout_paths(step: dict) -> list[str]:
+    raw = str((step.get("with") or {}).get("sparse-checkout", ""))
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _workflows_library_checkout_steps(workflow: dict) -> list[dict]:
+    steps = []
+    for step in _iter_steps(workflow):
+        with_block = step.get("with") or {}
+        if with_block.get("repository") == "stranske/Workflows" and "sparse-checkout" in with_block:
+            steps.append(step)
     return steps
 
 
@@ -239,6 +256,42 @@ def test_reusable_agents_verifier_pip_cache_is_configured() -> None:
         pytest.skip("needs-human: workflow updates require agent-high-privilege")
     workflow = _load_workflow(VERIFIER)
     _assert_pip_cache(workflow, ".workflows-lib/tools/requirements-llm.txt", VERIFIER.name)
+
+
+@pytest.mark.parametrize("workflow_path", [VERIFIER, VERIFY_TO_ISSUE])
+def test_llm_workflows_vendor_the_model_registry_config(workflow_path: Path) -> None:
+    workflow = _load_workflow(workflow_path)
+    checkouts = _workflows_library_checkout_steps(workflow)
+    assert checkouts, f"{workflow_path.name} must sparse-checkout stranske/Workflows"
+
+    vendors_tools = False
+    for step in checkouts:
+        paths = _sparse_checkout_paths(step)
+        if "tools" not in paths:
+            continue
+        vendors_tools = True
+        missing = [entry for entry in ("config",) if entry not in paths]
+        assert not missing, (
+            f"{workflow_path.name} vendors `tools` but not {missing}; "
+            f"{LLM_REGISTRY_MODULE} resolves {', '.join(str(p) for p in LLM_CONFIG_PATHS)} "
+            "relative to the vendored tree, so every judge slot resolves to no model and "
+            'compare mode reports "available families: none".'
+        )
+
+    assert vendors_tools, f"{workflow_path.name} must vendor `tools` for the LLM client"
+
+
+def test_bundled_llm_config_resolves_two_cross_family_judges() -> None:
+    for config_path in LLM_CONFIG_PATHS:
+        assert config_path.is_file(), f"Vendored LLM config {config_path} must exist"
+
+    from tools.llm_registry import load_slot_config
+
+    families = {slot.provider for slot in load_slot_config() if slot.model}
+    assert len(families) >= 2, (
+        "Compare mode needs two cross-family judges; the bundled config resolved "
+        f"models for {sorted(families) or 'no provider'}."
+    )
 
 
 def test_reusable_codex_run_persists_refreshed_auth_bundle_with_app_token() -> None:

--- a/tests/workflows/test_workflow_llm_installs.py
+++ b/tests/workflows/test_workflow_llm_installs.py
@@ -29,6 +29,9 @@ MIN_CODEX_CLI_BY_RUN_MODEL = {
 ACTIONS_CACHE_V6_REF = "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 LLM_REGISTRY_MODULE = "tools/llm_registry.py"
 LLM_CONFIG_PATHS = (Path("config/llm_slots.json"), Path("config/model_registry.json"))
+LANGCHAIN_ENTRYPOINT_DIR = "scripts/langchain"
+VERIFY_TO_NEW_PR = WORKFLOWS_DIR / "agents-verify-to-new-pr.yml"
+KNOWN_LLM_CLIENT_WORKFLOWS = (VERIFIER, VERIFY_TO_ISSUE, VERIFY_TO_NEW_PR)
 
 
 def _load_text(path: Path) -> str:
@@ -105,6 +108,28 @@ def _workflows_library_checkout_steps(workflow: dict) -> list[dict]:
         if with_block.get("repository") == "stranske/Workflows" and "sparse-checkout" in with_block:
             steps.append(step)
     return steps
+
+
+def _discover_llm_client_workflows() -> list[Path]:
+    """Workflows that vendor `tools` and then run the LangChain client from it.
+
+    Discovery rather than an explicit list: any future workflow that vendors the
+    client inherits the config-vendoring requirement automatically.
+    """
+    matches = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        if LANGCHAIN_ENTRYPOINT_DIR not in text:
+            continue
+        workflow = yaml.safe_load(text)
+        if not isinstance(workflow, dict):
+            continue
+        if any(
+            "tools" in _sparse_checkout_paths(step)
+            for step in _workflows_library_checkout_steps(workflow)
+        ):
+            matches.append(path)
+    return matches
 
 
 def _find_step_by_name(workflow: dict, step_name: str) -> dict:
@@ -258,7 +283,18 @@ def test_reusable_agents_verifier_pip_cache_is_configured() -> None:
     _assert_pip_cache(workflow, ".workflows-lib/tools/requirements-llm.txt", VERIFIER.name)
 
 
-@pytest.mark.parametrize("workflow_path", [VERIFIER, VERIFY_TO_ISSUE])
+def test_llm_client_workflow_discovery_covers_the_known_verifier_surfaces() -> None:
+    discovered = set(_discover_llm_client_workflows())
+    missing = [path.name for path in KNOWN_LLM_CLIENT_WORKFLOWS if path not in discovered]
+    assert not missing, (
+        f"Discovery no longer sees {missing}; the config-vendoring guard below would "
+        "silently stop covering them."
+    )
+
+
+@pytest.mark.parametrize(
+    "workflow_path", _discover_llm_client_workflows(), ids=lambda path: path.name
+)
 def test_llm_workflows_vendor_the_model_registry_config(workflow_path: Path) -> None:
     workflow = _load_workflow(workflow_path)
     checkouts = _workflows_library_checkout_steps(workflow)
@@ -281,11 +317,21 @@ def test_llm_workflows_vendor_the_model_registry_config(workflow_path: Path) -> 
     assert vendors_tools, f"{workflow_path.name} must vendor `tools` for the LLM client"
 
 
-def test_bundled_llm_config_resolves_two_cross_family_judges() -> None:
+def test_bundled_llm_config_resolves_two_cross_family_judges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slots_path, registry_path = LLM_CONFIG_PATHS
     for config_path in LLM_CONFIG_PATHS:
         assert config_path.is_file(), f"Vendored LLM config {config_path} must exist"
 
+    from tools import llm_registry
     from tools.llm_registry import load_slot_config
+
+    # Pin resolution to the bundled files so an ambient override cannot make this pass.
+    monkeypatch.delenv(llm_registry.ENV_SLOT_CONFIG, raising=False)
+    monkeypatch.delenv(llm_registry.ENV_MODEL_REGISTRY_CONFIG, raising=False)
+    monkeypatch.setattr(llm_registry, "DEFAULT_SLOT_CONFIG_PATH", slots_path.resolve())
+    monkeypatch.setattr(llm_registry, "DEFAULT_MODEL_REGISTRY_CONFIG_PATH", registry_path.resolve())
 
     families = {slot.provider for slot in load_slot_config() if slot.model}
     assert len(families) >= 2, (


### PR DESCRIPTION
## Root cause

Every `verify:compare` run across the fleet has been returning `CONCERNS` with:

> **Error:** `unverified: compare mode requires two cross-family verifier judges; available families: none.`
> Concerns: `LLM evaluation could not run.`

This has been attributed to missing/unconfigured verifier judges and escalated to the owner on at least ten sources. It is not a credentials problem. `Manager-Database` (and the other affected repos) already have both `OPENAI_API_KEY` and `CLAUDE_API_STRANSKE` configured, and the workflow does pass them into the compare step.

The real cause is in the vendored library. `reusable-agents-verifier.yml` sparse-checks-out `stranske/Workflows` into `.workflows-lib` with `scripts` and `tools`, but **not** `config`. `tools/llm_registry.py` resolves its configuration relative to that vendored tree:

```python
DEFAULT_SLOT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "llm_slots.json"
```

So the run log for the manual compare dispatch on merged `Manager-Database#1474` ([run 30160098574](https://github.com/stranske/Manager-Database/actions/runs/30160098574)) shows:

```
Cannot load model registry: .../.workflows-lib/config/model_registry.json is not a file
Cannot load slot config: .../.workflows-lib/config/llm_slots.json is not a file
Skipping LLM slot without a resolved model: slot1
Skipping LLM slot without a resolved model: slot2
```

With no registry, every slot resolves to an empty model, `build_chat_clients` returns no clients, and `pr_verifier.py` short-circuits to the `available families: none` fallback before any judge is invoked.

## Fix

Add `config` to the sparse-checkout of both workflows that vendor `tools` for the LangChain client:

- `reusable-agents-verifier.yml` — evaluate/compare judges.
- `agents-verify-to-issue-v2.yml` — `followup_issue_generator.py`, which builds the same client and had the identical omission.

With `config` vendored, the bundled configuration resolves two cross-family judges whose keys are already present as secrets:

```
SlotDefinition(name='slot1', provider='openai',    model='gpt-5.4')
SlotDefinition(name='slot2', provider='anthropic', model='claude-opus-4-6')
```

## Test gate

`tests/workflows/test_workflow_llm_installs.py`:

- `test_llm_workflows_vendor_the_model_registry_config` — any workflow vendoring `tools` from `stranske/Workflows` must also vendor `config`.
- `test_bundled_llm_config_resolves_two_cross_family_judges` — the shipped config resolves models for at least two provider families.

Deliberate-break demonstration: reverting only the two workflow edits fails the gate with

```
AssertionError: agents-verify-to-issue-v2.yml vendors `tools` but not ['config']; tools/llm_registry.py
resolves config/llm_slots.json, config/model_registry.json relative to the vendored tree, so every judge
slot resolves to no model and compare mode reports "available families: none".
```

Restoring the edits passes. Full local run: `717 passed, 6 skipped` in `tests/workflows`; `ruff` and `black` clean.

## Impact

This is the shared root cause behind the verifier blockers currently parked for owner decision on `Manager-Database#1463`/`#1262`/`#1267`/`#1489`, `Pension-Data#637`, `trip-planner#1493`/`#1495`/`#1496`, `learning-management-system#392`, `Workflows#2654`, and `Inv-Man-Intake#851`. Those were all reported as "configure two cross-family judges" decisions; they should be re-dispatchable once this merges, since re-dispatch will then run against a changed configuration rather than reproducing the same missing-registry fingerprint.

## Non-goals

No change to model selection policy, judge model choices, or the separate GitHub Models access gate tracked in `#2768`/`#2819`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated workflow checkouts to include required configuration files, improving reliability for verification and issue-processing workflows.
  * Improved consistency across automated checks that rely on shared tools and model settings.

* **Tests**
  * Added coverage to confirm workflows include all required tools and configuration.
  * Added validation that bundled language-model settings resolve providers across multiple model families.
  * Expanded checks for known verification workflows and configuration discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->