### PR TITLE
fix: port auto-label campaign guards to consumers

### DIFF
--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -161,9 +161,20 @@ jobs:
           # Get issue content
           issue_title = os.environ.get('ISSUE_TITLE', '')
           issue_body = os.environ.get('ISSUE_BODY', '')
-          query_max_chars = int(os.environ.get('AUTO_LABEL_QUERY_MAX_CHARS', '6000'))
+          query_max_chars_raw = os.environ.get('AUTO_LABEL_QUERY_MAX_CHARS', '6000')
+          try:
+              query_max_chars = int(query_max_chars_raw)
+          except ValueError:
+              query_max_chars = 6000
+              print(
+                  "Invalid AUTO_LABEL_QUERY_MAX_CHARS value "
+                  f"{query_max_chars_raw!r}; using 6000"
+              )
+          if query_max_chars <= 0:
+              query_max_chars = 6000
+              print("AUTO_LABEL_QUERY_MAX_CHARS must be positive; using 6000")
           query = f"{issue_title}\n\n{issue_body}"
-          if query_max_chars > 0 and len(query) > query_max_chars:
+          if len(query) > query_max_chars:
               query = query[:query_max_chars]
               print(f"Truncated issue query to {query_max_chars} characters")
 

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -66,9 +66,9 @@ reason = Existing reviewed baseline drift re-baselined 2026-06-19: runtime AC me
 [pair.5]
 main = .github/workflows/agents-auto-label.yml
 template = templates/consumer-repo/.github/workflows/agents-auto-label.yml
-main_sha256 = 6f88039b65073cac04b163def45f33b41e3981fd8ad08e87becc6524e7087887
-template_sha256 = 2e9ed1cf287520e196f5c9379203cc058c7e259d13f787574d466481136e97cf
-reason = Intentional divergence updated 2026-07-31: consumer template now shares the campaign-label guard, bounded semantic-label query, and per-issue concurrency from root while retaining consumer SHA pins and auth plumbing. Do not align wholesale: that would strip the consumer security contract.
+main_sha256 = 6276b24994010fab62c79085cc41d67ca2d0031580df2f5892c5ed2c7d1e7eba
+template_sha256 = c351fecad5ee3bc4231fc33d7e0c3edbcf539f57105d649601bfbf435561b1f3
+reason = Intentional divergence updated 2026-07-31: root and consumer queries now reject non-positive or invalid bounds and share executable guard tests while retaining consumer SHA pins and auth plumbing. Do not align wholesale: that would strip the consumer security contract.
 
 [pair.6]
 main = .github/workflows/agents-autofix-dispatcher.yml

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -67,8 +67,8 @@ reason = Existing reviewed baseline drift re-baselined 2026-06-19: runtime AC me
 main = .github/workflows/agents-auto-label.yml
 template = templates/consumer-repo/.github/workflows/agents-auto-label.yml
 main_sha256 = 6f88039b65073cac04b163def45f33b41e3981fd8ad08e87becc6524e7087887
-template_sha256 = 272c57c6a717b98ecff85d92a1415d883738bb6e840b5b93645499c7e26f58d3
-reason = Intentional divergence (re-baselined 2026-06-14): consumer template SHA-pins third-party actions per the fleet action-pin contract (docs/HISTORY.md, PR #1925) and sets LangSmith tracing env; root uses floating major tags with repo-internal concurrency + sparse-checkout (docs/fixes/sparse-checkout-audit-2026-02-03.csv). Fingerprints refreshed after #2391/#2394 bumps. Do not align: would strip consumer action pins.
+template_sha256 = 2e9ed1cf287520e196f5c9379203cc058c7e259d13f787574d466481136e97cf
+reason = Intentional divergence updated 2026-07-31: consumer template now shares the campaign-label guard, bounded semantic-label query, and per-issue concurrency from root while retaining consumer SHA pins and auth plumbing. Do not align wholesale: that would strip the consumer security contract.
 
 [pair.6]
 main = .github/workflows/agents-autofix-dispatcher.yml

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-25T23:08:09.089511Z",
+  "emitted_at": "2026-07-31T15:28:28.994570Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "2832",
+  "pr_number": "2851",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-31T15:35:49.282999Z",
+  "emitted_at": "2026-07-31T15:40:08.987901Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-31T15:32:11.949296Z",
+  "emitted_at": "2026-07-31T15:35:49.282999Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-31T15:28:28.994570Z",
+  "emitted_at": "2026-07-31T15:32:11.949296Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-31T15:40:08.987901Z",
+  "emitted_at": "2026-07-31T15:42:00.588004Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -17,11 +17,18 @@ env:
   AUTO_APPLY_THRESHOLD: "0.90"
   # Threshold for suggesting labels (lower, for comments)
   SUGGEST_THRESHOLD: "0.75"
+  # Keep embedding queries bounded for large issue bodies.
+  AUTO_LABEL_QUERY_MAX_CHARS: "6000"
+
+concurrency:
+  group: >-
+    agents-auto-label-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   auto-label:
     runs-on: ubuntu-latest
-    # Skip if issue already has agent-related labels
+    # Skip issues already routed by agents or machine-managed campaign issues.
     if: |
       !contains(github.event.issue.labels.*.name, 'agents:auto-pilot') &&
       !contains(github.event.issue.labels.*.name, 'agents:formatted') &&
@@ -29,6 +36,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'agent:codex') &&
       !contains(github.event.issue.labels.*.name, 'agent:claude') &&
       !contains(github.event.issue.labels.*.name, 'agent:auto') &&
+      !contains(join(github.event.issue.labels.*.name, ','), 'campaign:') &&
       !contains(github.event.issue.labels.*.name, 'automated')
 
     steps:
@@ -136,7 +144,11 @@ jobs:
           # Get issue content
           issue_title = os.environ.get('ISSUE_TITLE', '')
           issue_body = os.environ.get('ISSUE_BODY', '')
+          query_max_chars = int(os.environ.get('AUTO_LABEL_QUERY_MAX_CHARS', '6000'))
           query = f"{issue_title}\n\n{issue_body}"
+          if query_max_chars > 0 and len(query) > query_max_chars:
+              query = query[:query_max_chars]
+              print(f"Truncated issue query to {query_max_chars} characters")
 
           # Get thresholds
           auto_threshold = float(os.environ.get('AUTO_APPLY_THRESHOLD', '0.90'))

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -144,9 +144,20 @@ jobs:
           # Get issue content
           issue_title = os.environ.get('ISSUE_TITLE', '')
           issue_body = os.environ.get('ISSUE_BODY', '')
-          query_max_chars = int(os.environ.get('AUTO_LABEL_QUERY_MAX_CHARS', '6000'))
+          query_max_chars_raw = os.environ.get('AUTO_LABEL_QUERY_MAX_CHARS', '6000')
+          try:
+              query_max_chars = int(query_max_chars_raw)
+          except ValueError:
+              query_max_chars = 6000
+              print(
+                  "Invalid AUTO_LABEL_QUERY_MAX_CHARS value "
+                  f"{query_max_chars_raw!r}; using 6000"
+              )
+          if query_max_chars <= 0:
+              query_max_chars = 6000
+              print("AUTO_LABEL_QUERY_MAX_CHARS must be positive; using 6000")
           query = f"{issue_title}\n\n{issue_body}"
-          if query_max_chars > 0 and len(query) > query_max_chars:
+          if len(query) > query_max_chars:
               query = query[:query_max_chars]
               print(f"Truncated issue query to {query_max_chars} characters")
 

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -385,17 +385,27 @@ def test_consumer_auto_label_preserves_campaign_guards_and_query_bound():
     text = Path("templates/consumer-repo/.github/workflows/agents-auto-label.yml").read_text(
         encoding="utf-8"
     )
+    query_slice = "query = query[:query_max_chars]"
+    match_call = "matches = find_similar_labels(store, query"
     assert (
         "agents-auto-label-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}"
         in text
     ), "Consumer auto-label should serialize work per issue"
     assert (
+        "concurrency:" in text and "cancel-in-progress: false" in text
+    ), "Consumer auto-label should keep queued work instead of cancelling an active issue run"
+    assert (
         "!contains(join(github.event.issue.labels.*.name, ','), 'campaign:')" in text
     ), "Consumer auto-label must skip machine-managed campaign issues"
     assert (
-        "AUTO_LABEL_QUERY_MAX_CHARS" in text
+        'AUTO_LABEL_QUERY_MAX_CHARS: "6000"' in text
+        and "query_max_chars = 6000" in text
+        and query_slice in text
         and "Truncated issue query to {query_max_chars} characters" in text
     ), "Consumer auto-label must bound issue text sent to semantic label matching"
+    assert text.index(query_slice) < text.index(
+        match_call
+    ), "Consumer auto-label must truncate the query before semantic matching"
 
 
 def test_consumer_sync_diff_keeps_functional_lines_in_comparison():

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -382,9 +382,9 @@ def test_auto_label_uses_retry_paginate_with_github_client_first():
 
 
 def test_consumer_auto_label_preserves_campaign_guards_and_query_bound():
-    text = Path(
-        "templates/consumer-repo/.github/workflows/agents-auto-label.yml"
-    ).read_text(encoding="utf-8")
+    text = Path("templates/consumer-repo/.github/workflows/agents-auto-label.yml").read_text(
+        encoding="utf-8"
+    )
     assert (
         "agents-auto-label-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}"
         in text

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -381,6 +381,23 @@ def test_auto_label_uses_retry_paginate_with_github_client_first():
     ), "Auto-label should use the create-github-app-token v3 client-id input"
 
 
+def test_consumer_auto_label_preserves_campaign_guards_and_query_bound():
+    text = Path(
+        "templates/consumer-repo/.github/workflows/agents-auto-label.yml"
+    ).read_text(encoding="utf-8")
+    assert (
+        "agents-auto-label-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}"
+        in text
+    ), "Consumer auto-label should serialize work per issue"
+    assert (
+        "!contains(join(github.event.issue.labels.*.name, ','), 'campaign:')" in text
+    ), "Consumer auto-label must skip machine-managed campaign issues"
+    assert (
+        "AUTO_LABEL_QUERY_MAX_CHARS" in text
+        and "Truncated issue query to {query_max_chars} characters" in text
+    ), "Consumer auto-label must bound issue text sent to semantic label matching"
+
+
 def test_consumer_sync_diff_keeps_functional_lines_in_comparison():
     text = (WORKFLOWS_DIR / "maint-68-sync-consumer-repos.yml").read_text(encoding="utf-8")
     assert (


### PR DESCRIPTION
<!-- workflow-source:sync_campaign -->

Salvages the consumer-safe portion of the local alignment work found on #2795 without carrying over its Workflows-internal authentication, broad secret access, floating action refs, or unrelated workflow rewrites.

What changed:
- skip semantic auto-labeling for machine-managed `campaign:*` issues
- cap issue text sent to embedding matching at 6,000 characters
- serialize auto-label work per repository and issue
- preserve the consumer template's SHA-pinned actions and existing token plumbing
- add regression coverage and refresh the reviewed template-drift fingerprint

This ports behavior originally reviewed for the Workflows root in #1841. It is intentionally separate from the clean `actions/setup-python` v7 replacement for #2795.

Validation:
- `python scripts/check_template_drift.py`
- `python scripts/validate_template_completeness.py`
- `python scripts/validate_template_sync.py`
- `python -m pytest -q tests/workflows/test_workflow_agents_consolidation.py -k auto_label`
- `python -m pytest -q tests/scripts/test_check_workflow_action_pins.py`
- `actionlint -color=false templates/consumer-repo/.github/workflows/agents-auto-label.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic issue labeling with validated, bounded query sizes.
  * Added per-repository and per-issue processing controls without canceling active runs.
  * Campaign-labeled issues are now skipped to protect existing campaign labels.

* **Bug Fixes**
  * Prevented oversized issue content from affecting label-matching queries.
  * Added safe fallback behavior for invalid query-limit settings.
  * Improved messaging for campaign-label exclusions.

* **Tests**
  * Added coverage for query limits, campaign safeguards, and concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->