### PR TITLE
test(actions): make setup-python contract upgrade-safe

### DIFF
--- a/.github/workflows/health-69-consumer-sync-shadow-evidence.yml
+++ b/.github/workflows/health-69-consumer-sync-shadow-evidence.yml
@@ -2,11 +2,19 @@ name: Health 69 Consumer Sync Shadow Evidence
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/health-69-consumer-sync-shadow-evidence.yml'
+      - '.github/sync-manifest.yml'
+      - 'scripts/sync_manifest_compiler.py'
+      - 'scripts/build_consumer_sync_shadow_handoff.py'
+      - 'templates/consumer-repo/**'
   schedule:
     - cron: '17 8 * * 1'
   push:
     branches: [main]
     paths:
+      - '.github/workflows/health-69-consumer-sync-shadow-evidence.yml'
       - '.github/sync-manifest.yml'
       - 'scripts/sync_manifest_compiler.py'
       - 'scripts/build_consumer_sync_shadow_handoff.py'

--- a/tests/scripts/test_consumer_sync_shadow_handoff.py
+++ b/tests/scripts/test_consumer_sync_shadow_handoff.py
@@ -124,9 +124,7 @@ def test_cli_reports_invalid_plan_without_writing_handoff(tmp_path: Path) -> Non
 
 def test_workflow_has_no_write_or_apply_surface() -> None:
     root = Path(__file__).parents[2]
-    workflow_path = (
-        root / ".github" / "workflows" / "health-69-consumer-sync-shadow-evidence.yml"
-    )
+    workflow_path = root / ".github" / "workflows" / "health-69-consumer-sync-shadow-evidence.yml"
     workflow = workflow_path.read_text(encoding="utf-8")
 
     assert "contents: read" in workflow

--- a/tests/scripts/test_consumer_sync_shadow_handoff.py
+++ b/tests/scripts/test_consumer_sync_shadow_handoff.py
@@ -124,9 +124,10 @@ def test_cli_reports_invalid_plan_without_writing_handoff(tmp_path: Path) -> Non
 
 def test_workflow_has_no_write_or_apply_surface() -> None:
     root = Path(__file__).parents[2]
-    workflow = (
+    workflow_path = (
         root / ".github" / "workflows" / "health-69-consumer-sync-shadow-evidence.yml"
-    ).read_text(encoding="utf-8")
+    )
+    workflow = workflow_path.read_text(encoding="utf-8")
 
     assert "contents: read" in workflow
     assert "contents: write" not in workflow
@@ -136,10 +137,13 @@ def test_workflow_has_no_write_or_apply_surface() -> None:
     assert "write_authority" not in workflow.lower() or "Write authority: false" in workflow
     assert "persist-credentials: false" in workflow
     assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
-    assert re.search(
+    setup_python_refs = re.findall(
         r"uses:\s+actions/setup-python@[0-9a-f]{40}\s+# v\d+\b",
         workflow,
     )
+    assert len(setup_python_refs) == 1
+    assert "pull_request:" in workflow
+    assert f"- '{workflow_path.relative_to(root).as_posix()}'" in workflow
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
     assert "pyyaml==6.0.2" in workflow
     assert (

--- a/tests/scripts/test_consumer_sync_shadow_handoff.py
+++ b/tests/scripts/test_consumer_sync_shadow_handoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -135,7 +136,10 @@ def test_workflow_has_no_write_or_apply_surface() -> None:
     assert "write_authority" not in workflow.lower() or "Write authority: false" in workflow
     assert "persist-credentials: false" in workflow
     assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
-    assert "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1" in workflow
+    assert re.search(
+        r"uses:\s+actions/setup-python@[0-9a-f]{40}\s+# v\d+\b",
+        workflow,
+    )
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
     assert "pyyaml==6.0.2" in workflow
     assert (

--- a/tests/workflows/test_template_drift_workflow.py
+++ b/tests/workflows/test_template_drift_workflow.py
@@ -19,5 +19,8 @@ def test_template_drift_workflow_installs_pyyaml_before_checker() -> None:
     )
     prior_steps = steps[:checker_index]
 
-    assert any(step.get("uses") == "actions/setup-python@v6" for step in prior_steps)
+    assert any(
+        str(step.get("uses", "")).startswith("actions/setup-python@")
+        for step in prior_steps
+    )
     assert any("pip install pyyaml" in step.get("run", "").lower() for step in prior_steps)

--- a/tests/workflows/test_template_drift_workflow.py
+++ b/tests/workflows/test_template_drift_workflow.py
@@ -20,6 +20,13 @@ def test_template_drift_workflow_installs_pyyaml_before_checker() -> None:
     )
     prior_steps = steps[:checker_index]
 
+    setup_python_steps = [
+        step
+        for step in prior_steps
+        if re.fullmatch(r"actions/setup-python@v\d+", str(step.get("uses", "")))
+    ]
+
+    assert len(setup_python_steps) == 1
     assert any(
         re.fullmatch(r"actions/setup-python@v\d+", str(step.get("uses", "")))
         for step in prior_steps

--- a/tests/workflows/test_template_drift_workflow.py
+++ b/tests/workflows/test_template_drift_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -20,7 +21,7 @@ def test_template_drift_workflow_installs_pyyaml_before_checker() -> None:
     prior_steps = steps[:checker_index]
 
     assert any(
-        str(step.get("uses", "")).startswith("actions/setup-python@")
+        re.fullmatch(r"actions/setup-python@v\d+", str(step.get("uses", "")))
         for step in prior_steps
     )
     assert any("pip install pyyaml" in step.get("run", "").lower() for step in prior_steps)


### PR DESCRIPTION
## Summary
- verify template-drift setup uses setup-python before the checker without hard-coding a major version
- preserve the consumer shadow workflow security contract by requiring an official setup-python action pinned to a 40-character digest with a major-version comment
- remove duplicated exact-version assertions that make trusted Renovate major upgrades require manual test edits

## Relationship
- #2849 has merged, so this branch is now rebased directly on the canonical Ruff 0.16.1 pin set
- companion repair for #2795; it intentionally does not modify the Renovate branch
- after this PR merges, Renovate can rebase #2795 and normal CI can evaluate the bot-only v7 delta

## Validation
- `python -m pytest tests/workflows/test_template_drift_workflow.py tests/scripts/test_consumer_sync_shadow_handoff.py -q` (9 passed)
- broader version-sync test set reached 38 passes before a live PyPI SSL read stalled; the merged #2849 CI separately validated the canonical pin set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated health checks to run when relevant workflow and synchronization files change, while preserving scheduled and main-branch checks.
  - Added pull request coverage for improved validation before changes are merged.

- **Tests**
  - Strengthened workflow validation to confirm required triggers, paths, and version-pinned tooling.
  - Improved checks that detect configuration drift and ensure automated verification runs consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->