### PR TITLE
feat(model-promotion): teach model_family a github-models publisher rule

### DIFF
--- a/tests/tools/test_prepare_model_promotion.py
+++ b/tests/tools/test_prepare_model_promotion.py
@@ -59,8 +59,23 @@ def test_model_family_rules():
     assert pmp.model_family("anthropic", "claude-sonnet-5") == "claude-sonnet"
     assert pmp.model_family("openai", "gpt-5.6-terra") == "gpt-5"
     assert pmp.model_family("openai", "gpt-5.4") == "gpt-5"
-    # Unknown provider -> exact id, so nothing is ever "same family" by accident.
+    # github-models ids are publisher-namespaced: keep the publisher and apply the
+    # OpenAI-style rule to the remainder, so a future openai/gpt-5.x is a
+    # same-family successor to the reviewed openai/gpt-5 selection.
+    assert pmp.model_family("github-models", "openai/gpt-5") == "openai/gpt-5"
+    assert pmp.model_family("github-models", "openai/gpt-5-mini") == "openai/gpt-5"
+    assert pmp.model_family("github-models", "openai/gpt-5.1") == "openai/gpt-5"
+    # A different major line stays a different family.
+    assert pmp.model_family("github-models", "openai/gpt-4.1") == "openai/gpt-4"
+    # A bare (unpublished) github-models id keeps its exact id, so the superseded
+    # codex-mini-latest is never "same family" as openai/gpt-5 by accident.
     assert pmp.model_family("github-models", "codex-mini-latest") == "codex-mini-latest"
+    assert pmp.model_family("github-models", "codex-mini-latest") != pmp.model_family(
+        "github-models", "openai/gpt-5"
+    )
+    # Unknown provider -> exact id, so nothing is ever "same family" by accident.
+    # (azure-openai is NOT unknown: it normalizes to openai and uses that rule.)
+    assert pmp.model_family("mistral", "some-model-7") == "some-model-7"
 
 
 def test_same_family_cheaper_pass_is_prepared():

--- a/tools/prepare_model_promotion.py
+++ b/tools/prepare_model_promotion.py
@@ -51,13 +51,27 @@ def _normalize_provider(provider: str) -> str:
     return normalized
 
 
+def _openai_style_family(model_id: str) -> str:
+    """Collapse an OpenAI-style id to ``<head>-<major>`` (``gpt-5.6-terra`` -> ``gpt-5``)."""
+    parts = model_id.split("-")
+    head = parts[0] if parts else model_id  # "gpt", then version token in parts[1]
+    if len(parts) >= 2:
+        major = parts[1].split(".")[0]
+        return f"{head}-{major}"
+    return model_id
+
+
 def model_family(provider: str, model_id: str) -> str:
     """Return a conservative model-family key used to gate same-family promotions.
 
     anthropic ``claude-opus-4-8`` -> ``claude-opus``; openai ``gpt-5.6-terra`` ->
-    ``gpt-5``. For any other provider the family is the exact model id, so an
-    unrecognised provider never yields a same-family candidate (auto-preparation
-    stays off until a human teaches it the family rule).
+    ``gpt-5``. github-models ids are publisher-namespaced, so the publisher is
+    preserved and the OpenAI-style rule is applied to the remainder:
+    ``openai/gpt-5-mini`` -> ``openai/gpt-5``. A bare github-models id with no
+    publisher (e.g. ``codex-mini-latest``) keeps its exact id, and for any other
+    provider the family is the exact model id, so an unrecognised provider never
+    yields a same-family candidate (auto-preparation stays off until a human
+    teaches it the family rule).
     """
     provider = _normalize_provider(provider)
     model_id = (model_id or "").strip()
@@ -65,11 +79,13 @@ def model_family(provider: str, model_id: str) -> str:
         parts = model_id.split("-")
         return "-".join(parts[:2]) if len(parts) >= 2 else model_id
     if provider == "openai":
-        parts = model_id.split("-")
-        head = parts[0] if parts else model_id  # "gpt", then version token in parts[1]
-        if len(parts) >= 2:
-            major = parts[1].split(".")[0]
-            return f"{head}-{major}"
+        return _openai_style_family(model_id)
+    if provider == "github-models" and "/" in model_id:
+        publisher, _, remainder = model_id.partition("/")
+        publisher = publisher.strip()
+        remainder = remainder.strip()
+        if publisher and remainder:
+            return f"{publisher}/{_openai_style_family(remainder)}"
         return model_id
     return model_id
 


### PR DESCRIPTION
## Why

`model_family()` returned the **exact model id** for github-models, so no github-models candidate could ever be same-family as the incumbent, and `tools/prepare_model_promotion.py:137` (`if model_family(candidate) != model_family(incumbent): continue`) could never auto-prepare a promotion for that provider. Every github-models model change would require a human indefinitely — surfaced while advancing the selections in #2852.

## What changed

github-models ids are publisher-namespaced, so preserve the publisher and apply the existing OpenAI-style `<head>-<major>` rule to the remainder:

| input | family | note |
|---|---|---|
| `openai/gpt-5` | `openai/gpt-5` | the reviewed selection after #2852 |
| `openai/gpt-5-mini` | `openai/gpt-5` | tier variants share a family (same as the openai rule) |
| `openai/gpt-5.1` | `openai/gpt-5` | **a future same-family successor is now auto-preparable** |
| `openai/gpt-4.1` | `openai/gpt-4` | a different major stays a different family |
| `codex-mini-latest` | `codex-mini-latest` | bare/unpublished id keeps its exact id |

Conservative by construction:
- A bare id with no publisher keeps its exact id, so the superseded `codex-mini-latest` is **never** same-family as `openai/gpt-5` by accident (that swap was the human-initiated one in #2852, and remains human-only).
- Unknown providers still return the exact id, so auto-preparation stays off until someone teaches the rule.
- Same-family is only *one* of the promotion conditions — a passing benchmark, paired non-inferiority, and cost ≤ incumbent are all still required.

Extracted the shared logic into `_openai_style_family()` so the openai and github-models rules cannot drift apart.

## Test gate

`tests/tools/test_prepare_model_promotion.py::test_model_family_rules` extended with the five github-models cases above, an explicit `codex-mini-latest != openai/gpt-5` assertion, and an unknown-provider case.

**Deliberate break → revert:** disabling the `github-models` branch (`if False and "/" in model_id`) makes `test_model_family_rules` FAIL; restoring it returns 12/12 green.

Note: the unknown-provider assertion uses `mistral`, not `azure-openai` — `azure-openai` normalizes to `openai` and correctly uses the OpenAI rule (verified; my first draft asserted this wrongly and the test caught it).

## Verification

```
pytest tests/tools/test_prepare_model_promotion.py -> 12 passed
pytest + test_langchain_client + test_llm_registry_selection -> 108 passed
ruff check / format --check -> clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)