### PR TITLE
fix(deps): route promotion PR source context

### DIFF
--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -206,6 +206,27 @@ test('malformed dependency repair promotion marker does not authorize source con
   assert.equal(context.isValid, false);
 });
 
+test('promotion marker casing must match the dependency repair contract', () => {
+  const context = resolvePrSourceContext({
+    body: [
+      '<!-- Dependency-Repair-Promotion:v1 ',
+      JSON.stringify({
+        schema: 'dependency-repair-promotion/v1',
+        source_repo: 'stranske/Workflows',
+        source_pr: 2795,
+        source_head_sha: 'a'.repeat(40),
+        promotion_base_sha: 'b'.repeat(40),
+        classification: 'coupled-repair',
+      }),
+      ' -->',
+    ].join(''),
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.UNKNOWN);
+  assert.equal(context.isExplicit, false);
+  assert.equal(context.isValid, false);
+});
+
 test('sourceTypeFromCheckedTemplate reads direct GitHub PR source choice', () => {
   const body = `
 ## Workflow Source

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -7,6 +7,7 @@ const {
   SOURCE_TYPES,
   extractIssueNumberFromPull,
   normalizeSourceType,
+  parseDependencyRepairPromotionSource,
   parseWorkflowSourceBlock,
   hasNoAutomationWorkflowContext,
   resolvePrSourceContext,
@@ -166,6 +167,43 @@ automation: verifier_required
     lifecycle: 'substantive_delivery',
     automation: 'verifier_required',
   });
+});
+
+test('dependency repair promotion marker supplies explicit dependency source context', () => {
+  const marker = [
+    '<!-- dependency-repair-promotion:v1 ',
+    JSON.stringify({
+      source_pr: 2795,
+      source_base_sha: 'a'.repeat(40),
+      source_head_sha: 'b'.repeat(40),
+      promotion_base_sha: 'c'.repeat(40),
+    }),
+    ' -->',
+  ].join('');
+  const context = resolvePrSourceContext({
+    body: marker,
+    head: { ref: 'agent/deps-repair-2795' },
+    title: 'fix(deps): repair setup-python v7 compatibility',
+  });
+
+  assert.equal(parseDependencyRepairPromotionSource(marker).source_pr, 2795);
+  assert.equal(context.sourceType, SOURCE_TYPES.DEPENDABOT);
+  assert.equal(context.sourceRef, 'dependency-pr:#2795');
+  assert.equal(context.isExplicit, true);
+  assert.equal(context.isValid, true);
+  assert.equal(context.requiresIssue, false);
+});
+
+test('malformed dependency repair promotion marker does not authorize source context', () => {
+  const context = resolvePrSourceContext({
+    body: '<!-- dependency-repair-promotion:v1 {"source_pr":2795} -->',
+    head: { ref: 'agent/deps-repair-2795' },
+    title: 'fix(deps): repair setup-python v7 compatibility',
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.UNKNOWN);
+  assert.equal(context.isExplicit, false);
+  assert.equal(context.isValid, false);
 });
 
 test('sourceTypeFromCheckedTemplate reads direct GitHub PR source choice', () => {

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -50,6 +50,8 @@ const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
 ]);
 
 const NO_AUTOMATION_CHECKBOX_PATTERN = /\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i;
+const DEPENDENCY_REPAIR_PROMOTION_PATTERN =
+  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/i;
 
 function cleanString(value) {
   return String(value || '').trim();
@@ -281,6 +283,29 @@ function parseWorkflowSourceBlock(body) {
   return result;
 }
 
+function parseDependencyRepairPromotionSource(body) {
+  const match = String(body || '').match(DEPENDENCY_REPAIR_PROMOTION_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    const metadata = JSON.parse(match[1]);
+    const sourcePr = Number(metadata?.source_pr);
+    const validShas = [
+      metadata?.source_base_sha,
+      metadata?.source_head_sha,
+      metadata?.promotion_base_sha,
+    ].every((value) => /^[0-9a-f]{40}$/i.test(String(value || '')));
+    if (!Number.isInteger(sourcePr) || sourcePr <= 0 || !validShas) {
+      return null;
+    }
+    return { ...metadata, source_pr: sourcePr };
+  } catch {
+    return null;
+  }
+}
+
 function sourceTypeFromCheckedTemplate(body) {
   const sectionLines = workflowSourceSectionLines(body);
   if (!sectionLines.length) {
@@ -355,6 +380,7 @@ function inferredSourceType(pull = {}) {
 function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
+  const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
   const issueNumber = extractIssueNumberFromPull(pull);
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
@@ -363,7 +389,9 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const detectedSourceType = issueNumber
+  const detectedSourceType = dependencyRepairPromotion
+    ? SOURCE_TYPES.DEPENDABOT
+    : issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
     : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
       || SOURCE_TYPES.UNKNOWN;
@@ -372,6 +400,9 @@ function resolvePrSourceContext(pull = {}) {
     : detectedSourceType;
 
   const sourceRef =
+    (dependencyRepairPromotion
+      ? `dependency-pr:#${dependencyRepairPromotion.source_pr}`
+      : '') ||
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
     cleanString(block.source_ref || block.ref || block.reference) ||
     (issueNumber ? `#${issueNumber}` : '');
@@ -392,6 +423,7 @@ function resolvePrSourceContext(pull = {}) {
     isValid: VALID_SOURCE_TYPES.has(sourceType),
     isExplicit: Boolean(
       issueNumber ||
+        dependencyRepairPromotion ||
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||
@@ -433,6 +465,7 @@ module.exports = {
   extractIssueNumbersFromText,
   extractIssueNumberFromPull,
   parseWorkflowSourceBlock,
+  parseDependencyRepairPromotionSource,
   sourceTypeFromCheckedTemplate,
   sourceTypeFromLabels,
   hasNoAutomationWorkflowContext,

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -51,7 +51,7 @@ const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
 
 const NO_AUTOMATION_CHECKBOX_PATTERN = /\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i;
 const DEPENDENCY_REPAIR_PROMOTION_PATTERN =
-  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/i;
+  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/;
 
 function cleanString(value) {
   return String(value || '').trim();

--- a/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
+++ b/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
@@ -65,6 +65,11 @@ branch. The PR remains attributable to dependency automation through
 `workflow:source-dependabot` and identifiable through
 `dependency:repair-promotion`.
 
+A structurally valid promotion marker is itself explicit dependency source
+context, so keepalive can dispatch the coding agent without a linked issue or a
+manually applied source label. PR 46 still validates the referenced bot PR,
+commit ancestry, and patch identity before the promotion can merge.
+
 ## Machine-enforced contract
 
 `PR 46 Dependency Repair Contract` runs only for dependency-bot PRs and marked

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -50,6 +50,8 @@ const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
 ]);
 
 const NO_AUTOMATION_CHECKBOX_PATTERN = /\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i;
+const DEPENDENCY_REPAIR_PROMOTION_PATTERN =
+  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/i;
 
 function cleanString(value) {
   return String(value || '').trim();
@@ -281,6 +283,29 @@ function parseWorkflowSourceBlock(body) {
   return result;
 }
 
+function parseDependencyRepairPromotionSource(body) {
+  const match = String(body || '').match(DEPENDENCY_REPAIR_PROMOTION_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    const metadata = JSON.parse(match[1]);
+    const sourcePr = Number(metadata?.source_pr);
+    const validShas = [
+      metadata?.source_base_sha,
+      metadata?.source_head_sha,
+      metadata?.promotion_base_sha,
+    ].every((value) => /^[0-9a-f]{40}$/i.test(String(value || '')));
+    if (!Number.isInteger(sourcePr) || sourcePr <= 0 || !validShas) {
+      return null;
+    }
+    return { ...metadata, source_pr: sourcePr };
+  } catch {
+    return null;
+  }
+}
+
 function sourceTypeFromCheckedTemplate(body) {
   const sectionLines = workflowSourceSectionLines(body);
   if (!sectionLines.length) {
@@ -355,6 +380,7 @@ function inferredSourceType(pull = {}) {
 function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
+  const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
   const issueNumber = extractIssueNumberFromPull(pull);
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
@@ -363,7 +389,9 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const detectedSourceType = issueNumber
+  const detectedSourceType = dependencyRepairPromotion
+    ? SOURCE_TYPES.DEPENDABOT
+    : issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
     : [markerType, blockType, checkboxType, labelType, inferredType].find((type) => type !== SOURCE_TYPES.UNKNOWN)
       || SOURCE_TYPES.UNKNOWN;
@@ -372,6 +400,9 @@ function resolvePrSourceContext(pull = {}) {
     : detectedSourceType;
 
   const sourceRef =
+    (dependencyRepairPromotion
+      ? `dependency-pr:#${dependencyRepairPromotion.source_pr}`
+      : '') ||
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
     cleanString(block.source_ref || block.ref || block.reference) ||
     (issueNumber ? `#${issueNumber}` : '');
@@ -392,6 +423,7 @@ function resolvePrSourceContext(pull = {}) {
     isValid: VALID_SOURCE_TYPES.has(sourceType),
     isExplicit: Boolean(
       issueNumber ||
+        dependencyRepairPromotion ||
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||
@@ -433,6 +465,7 @@ module.exports = {
   extractIssueNumbersFromText,
   extractIssueNumberFromPull,
   parseWorkflowSourceBlock,
+  parseDependencyRepairPromotionSource,
   sourceTypeFromCheckedTemplate,
   sourceTypeFromLabels,
   hasNoAutomationWorkflowContext,

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -51,7 +51,7 @@ const CHECKBOX_SOURCE_PATTERNS = Object.freeze([
 
 const NO_AUTOMATION_CHECKBOX_PATTERN = /\bdo\s+not\s+automate\b|\bhuman[- ]only\b/i;
 const DEPENDENCY_REPAIR_PROMOTION_PATTERN =
-  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/i;
+  /<!--\s*dependency-repair-promotion:v1\s+(\{[^\n]*\})\s*-->/;
 
 function cleanString(value) {
   return String(value || '').trim();


### PR DESCRIPTION
## Summary
- classify structurally valid dependency-repair promotion markers as explicit dependency automation source context
- provide a stable dependency PR source reference so issue-less promotion PRs can enter keepalive
- reject malformed or incomplete markers instead of granting source context
- document that PR 46 remains the merge-time provenance gate

## Review follow-up
Addresses the P1 source-context gap identified after #2853 merged. Without this fix, a marked `agent/deps-repair-*` PR could still stop at `missing-source-context` unless someone manually added `workflow:source-dependabot`.

## Validation
- `node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/agents-pr-meta-keepalive.test.js` (56 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency-repair promotion markers now automatically identify the originating Dependabot pull request.
  * Valid promotion metadata provides explicit source context, enabling automated coding-agent dispatch without a linked issue or manually applied source label.

* **Bug Fixes**
  * Invalid or malformed promotion metadata is safely ignored to prevent incorrect source attribution.

* **Documentation**
  * Updated operational guidance for dependency-repair promotions and source validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->