### PR TITLE
fix: preserve CRLF for Windows command files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@ ci/autofix/history.json merge=ours linguist-generated
 # Agent ledger files are metadata, not reviewable code
 # Mark as generated to exclude from Copilot/Codex code reviews
 .agents/*.yml linguist-generated
+
+# Windows command launchers must retain native line endings after checkout.
+*.cmd text eol=crlf

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           sparse-checkout: |
             templates/consumer-repo
+            .gitattributes
             .github/sync-manifest.yml
             .github/templates
             .github/actions

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -203,3 +203,6 @@ def test_prepare_checkout_includes_manifest_owned_github_roots() -> None:
     # copy also exists. Without this root, the manifest compiler silently reads
     # the stale template copy during a sync run.
     assert ".github/agents" in sparse_checkout
+    assert ".gitattributes" in {
+        line.strip() for line in sparse_checkout.splitlines() if line.strip()
+    }


### PR DESCRIPTION
<!-- workflow-source:local_request -->

## What changed

- Declare `*.cmd` files as text with CRLF worktree line endings in the synced `.gitattributes` source.

## Why

The consumer sync overwrote Counter_Risk’s repo-local launcher rule, converting its Windows launcher to LF and failing `tests/test_windows_gui_launcher.py` on Linux. A generic source rule keeps Windows command files usable and prevents future consumer syncs from reintroducing the failure.

## Validation

- `pytest tests/workflows/test_sync_manifest_delivery.py -q` (7 passed)
- Counter_Risk focused launcher test passes after applying the synced rule (1 passed)