### PR TITLE
test(actions): close setup-python v7 review gaps

### DIFF
--- a/tests/scripts/test_consumer_sync_shadow_handoff.py
+++ b/tests/scripts/test_consumer_sync_shadow_handoff.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 from scripts.build_consumer_sync_shadow_handoff import (
     CAPABILITY_ID,
     HANDOFF_SCHEMA,
@@ -125,26 +126,45 @@ def test_cli_reports_invalid_plan_without_writing_handoff(tmp_path: Path) -> Non
 def test_workflow_has_no_write_or_apply_surface() -> None:
     root = Path(__file__).parents[2]
     workflow_path = root / ".github" / "workflows" / "health-69-consumer-sync-shadow-evidence.yml"
-    workflow = workflow_path.read_text(encoding="utf-8")
+    workflow_source = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_source)
+    steps = workflow["jobs"]["produce"]["steps"]
+    action_refs = [
+        str(step["uses"])
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("uses"), str)
+    ]
+    third_party_action_refs = [ref for ref in action_refs if not ref.startswith("./")]
+    setup_python_refs = [ref for ref in action_refs if ref.startswith("actions/setup-python@")]
+    events = workflow.get("on", workflow.get(True))
 
-    assert "contents: read" in workflow
-    assert "contents: write" not in workflow
-    assert "pull-requests: write" not in workflow
-    assert "git push" not in workflow
-    assert "gh pr" not in workflow
-    assert "write_authority" not in workflow.lower() or "Write authority: false" in workflow
-    assert "persist-credentials: false" in workflow
-    assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
-    setup_python_refs = re.findall(
-        r"uses:\s+actions/setup-python@[0-9a-f]{40}\s+# v\d+\b",
-        workflow,
-    )
-    assert len(setup_python_refs) == 1
-    assert "pull_request:" in workflow
-    assert f"- '{workflow_path.relative_to(root).as_posix()}'" in workflow
-    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
-    assert "pyyaml==6.0.2" in workflow
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "contents: write" not in workflow_source
+    assert "pull-requests: write" not in workflow_source
+    assert "git push" not in workflow_source
+    assert "gh pr" not in workflow_source
     assert (
-        "consumer-sync-shadow-evidence-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
+        "write_authority" not in workflow_source.lower()
+        or "Write authority: false" in workflow_source
     )
-    assert "github.run_id }}:${{ github.run_attempt" in workflow
+    assert steps[0]["with"]["persist-credentials"] is False
+    assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in action_refs
+    assert len(setup_python_refs) == 1
+    assert re.fullmatch(r"actions/setup-python@[0-9a-f]{40}", setup_python_refs[0])
+    assert len(third_party_action_refs) == 3
+    for action_ref in third_party_action_refs:
+        assert re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action_ref)
+        assert re.search(
+            rf"^\s*uses:\s*{re.escape(action_ref)}\s+# v\d+(?:[.\w-]+)?\s*$",
+            workflow_source,
+            re.MULTILINE,
+        )
+    assert "pull_request" in events
+    assert workflow_path.relative_to(root).as_posix() in events["pull_request"]["paths"]
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in action_refs
+    assert "pyyaml==6.0.2" in workflow_source
+    assert (
+        "consumer-sync-shadow-evidence-${{ github.run_id }}-${{ github.run_attempt }}"
+        in workflow_source
+    )
+    assert "github.run_id }}:${{ github.run_attempt" in workflow_source

--- a/tests/workflows/test_template_drift_workflow.py
+++ b/tests/workflows/test_template_drift_workflow.py
@@ -18,17 +18,17 @@ def test_template_drift_workflow_installs_pyyaml_before_checker() -> None:
         for index, step in enumerate(steps)
         if "scripts/check_template_drift.py" in step.get("run", "")
     )
-    prior_steps = steps[:checker_index]
-
-    setup_python_steps = [
-        step
-        for step in prior_steps
+    setup_python_indexes = [
+        index
+        for index, step in enumerate(steps)
         if re.fullmatch(r"actions/setup-python@v\d+", str(step.get("uses", "")))
     ]
+    pyyaml_install_indexes = [
+        index
+        for index, step in enumerate(steps)
+        if "pip install pyyaml" in step.get("run", "").lower()
+    ]
 
-    assert len(setup_python_steps) == 1
-    assert any(
-        re.fullmatch(r"actions/setup-python@v\d+", str(step.get("uses", "")))
-        for step in prior_steps
-    )
-    assert any("pip install pyyaml" in step.get("run", "").lower() for step in prior_steps)
+    assert len(setup_python_indexes) == 1
+    assert len(pyyaml_install_indexes) == 1
+    assert setup_python_indexes[0] < pyyaml_install_indexes[0] < checker_index


### PR DESCRIPTION
## Summary

Follow-up to #2854, which auto-merged while two late review threads were still active.

- parse the Health 69 workflow and inspect actual action steps
- require exactly one setup-python step and SHA-pin every third-party action
- validate version annotations and pull-request path registration
- enforce setup-python → PyYAML installation → checker ordering

## Verification

- `black --check --line-length 100 tests/scripts/test_consumer_sync_shadow_handoff.py tests/workflows/test_template_drift_workflow.py`
- `python -m pytest -q tests/scripts/test_consumer_sync_shadow_handoff.py tests/workflows/test_template_drift_workflow.py` (9 passed)
- `python scripts/check_gate_diff_quality.py --base refs/remotes/origin/main --head HEAD`

## Source

Review follow-up for #2854 discussions r3691924163 and r3691924171.