### PR TITLE
fix(meta): suppress issue links for dependency promotions

### DIFF
--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -184,6 +184,10 @@ test('dependency repair promotion marker supplies explicit dependency source con
     body: marker,
     head: { ref: 'agent/deps-repair-2795' },
     title: 'fix(deps): repair setup-python v7 compatibility',
+    labels: [
+      { name: 'dependency:repair-promotion' },
+      { name: 'workflow:source-dependabot' },
+    ],
   });
 
   assert.equal(parseDependencyRepairPromotionSource(marker).source_pr, 2795);
@@ -208,12 +212,37 @@ test('dependency repair promotion marker suppresses incidental issue references'
   const context = resolvePrSourceContext({
     body: `${marker}\nFixes #99`,
     head: { ref: 'agent/deps-repair-2795' },
+    labels: [
+      { name: 'dependency:repair-promotion' },
+      { name: 'workflow:source-dependabot' },
+    ],
   });
 
   assert.equal(context.sourceType, SOURCE_TYPES.DEPENDABOT);
   assert.equal(context.issueNumber, null);
   assert.equal(context.sourceRef, 'dependency-pr:#2795');
   assert.equal(context.requiresIssue, false);
+});
+
+test('untrusted dependency repair promotion marker preserves issue routing', () => {
+  const marker = [
+    '<!-- dependency-repair-promotion:v1 ',
+    JSON.stringify({
+      source_pr: 2795,
+      source_base_sha: 'a'.repeat(40),
+      source_head_sha: 'b'.repeat(40),
+      promotion_base_sha: 'c'.repeat(40),
+    }),
+    ' -->',
+  ].join('');
+  const context = resolvePrSourceContext({
+    body: `${marker}\nFixes #99`,
+    head: { ref: 'feature/forged-promotion-marker' },
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.GITHUB_ISSUE);
+  assert.equal(context.issueNumber, 99);
+  assert.equal(context.requiresIssue, true);
 });
 
 test('malformed dependency repair promotion marker does not authorize source context', () => {

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -242,6 +242,7 @@ test('untrusted dependency repair promotion marker preserves issue routing', () 
 
   assert.equal(context.sourceType, SOURCE_TYPES.GITHUB_ISSUE);
   assert.equal(context.issueNumber, 99);
+  assert.equal(context.sourceRef, '#99');
   assert.equal(context.requiresIssue, true);
 });
 

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -194,6 +194,28 @@ test('dependency repair promotion marker supplies explicit dependency source con
   assert.equal(context.requiresIssue, false);
 });
 
+test('dependency repair promotion marker suppresses incidental issue references', () => {
+  const marker = [
+    '<!-- dependency-repair-promotion:v1 ',
+    JSON.stringify({
+      source_pr: 2795,
+      source_base_sha: 'a'.repeat(40),
+      source_head_sha: 'b'.repeat(40),
+      promotion_base_sha: 'c'.repeat(40),
+    }),
+    ' -->',
+  ].join('');
+  const context = resolvePrSourceContext({
+    body: `${marker}\nFixes #99`,
+    head: { ref: 'agent/deps-repair-2795' },
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.DEPENDABOT);
+  assert.equal(context.issueNumber, null);
+  assert.equal(context.sourceRef, 'dependency-pr:#2795');
+  assert.equal(context.requiresIssue, false);
+});
+
 test('malformed dependency repair promotion marker does not authorize source context', () => {
   const context = resolvePrSourceContext({
     body: '<!-- dependency-repair-promotion:v1 {"source_pr":2795} -->',

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -381,7 +381,10 @@ function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
   const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
-  const issueNumber = extractIssueNumberFromPull(pull);
+  const extractedIssueNumber = extractIssueNumberFromPull(pull);
+  // Promotion provenance is authoritative: a coincidental issue reference must
+  // not route the PR through issue-body synchronization.
+  const issueNumber = dependencyRepairPromotion ? null : extractedIssueNumber;
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
   const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -381,10 +381,18 @@ function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
   const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
+  const labels = labelNames(pull).map((label) => label.toLowerCase());
+  // The marker is supplied in untrusted PR text. Promotion labels are applied
+  // by the controlled promotion workflow after it has established provenance.
+  const trustedDependencyRepairPromotion = Boolean(
+    dependencyRepairPromotion &&
+      labels.includes('dependency:repair-promotion') &&
+      labels.includes('workflow:source-dependabot'),
+  );
   const extractedIssueNumber = extractIssueNumberFromPull(pull);
   // Promotion provenance is authoritative: a coincidental issue reference must
   // not route the PR through issue-body synchronization.
-  const issueNumber = dependencyRepairPromotion ? null : extractedIssueNumber;
+  const issueNumber = trustedDependencyRepairPromotion ? null : extractedIssueNumber;
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
   const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));
@@ -392,7 +400,7 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const detectedSourceType = dependencyRepairPromotion
+  const detectedSourceType = trustedDependencyRepairPromotion
     ? SOURCE_TYPES.DEPENDABOT
     : issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
@@ -403,7 +411,7 @@ function resolvePrSourceContext(pull = {}) {
     : detectedSourceType;
 
   const sourceRef =
-    (dependencyRepairPromotion
+    (trustedDependencyRepairPromotion
       ? `dependency-pr:#${dependencyRepairPromotion.source_pr}`
       : '') ||
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
@@ -426,7 +434,7 @@ function resolvePrSourceContext(pull = {}) {
     isValid: VALID_SOURCE_TYPES.has(sourceType),
     isExplicit: Boolean(
       issueNumber ||
-        dependencyRepairPromotion ||
+        trustedDependencyRepairPromotion ||
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||

--- a/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
+++ b/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
@@ -65,10 +65,12 @@ branch. The PR remains attributable to dependency automation through
 `workflow:source-dependabot` and identifiable through
 `dependency:repair-promotion`.
 
-A structurally valid promotion marker is itself explicit dependency source
-context, so keepalive can dispatch the coding agent without a linked issue or a
-manually applied source label. PR 46 still validates the referenced bot PR,
-commit ancestry, and patch identity before the promotion can merge.
+The marker becomes explicit dependency source context only alongside both
+promotion labels. The controlled promotion workflow applies
+`workflow:source-dependabot` and `dependency:repair-promotion` after it has
+established provenance; an untrusted marker alone cannot bypass issue routing.
+PR 46 still validates the referenced bot PR, commit ancestry, and patch
+identity before the promotion can merge.
 
 ## Machine-enforced contract
 

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -381,7 +381,10 @@ function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
   const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
-  const issueNumber = extractIssueNumberFromPull(pull);
+  const extractedIssueNumber = extractIssueNumberFromPull(pull);
+  // Promotion provenance is authoritative: a coincidental issue reference must
+  // not route the PR through issue-body synchronization.
+  const issueNumber = dependencyRepairPromotion ? null : extractedIssueNumber;
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
   const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -381,10 +381,18 @@ function resolvePrSourceContext(pull = {}) {
   const body = String(pull?.body || '');
   const block = parseWorkflowSourceBlock(body);
   const dependencyRepairPromotion = parseDependencyRepairPromotionSource(body);
+  const labels = labelNames(pull).map((label) => label.toLowerCase());
+  // The marker is supplied in untrusted PR text. Promotion labels are applied
+  // by the controlled promotion workflow after it has established provenance.
+  const trustedDependencyRepairPromotion = Boolean(
+    dependencyRepairPromotion &&
+      labels.includes('dependency:repair-promotion') &&
+      labels.includes('workflow:source-dependabot'),
+  );
   const extractedIssueNumber = extractIssueNumberFromPull(pull);
   // Promotion provenance is authoritative: a coincidental issue reference must
   // not route the PR through issue-body synchronization.
-  const issueNumber = dependencyRepairPromotion ? null : extractedIssueNumber;
+  const issueNumber = trustedDependencyRepairPromotion ? null : extractedIssueNumber;
   const noAutomation = hasNoAutomationWorkflowContext(pull);
 
   const markerType = normalizeSourceType(parseHtmlMarker(body, 'workflow-source'));
@@ -392,7 +400,7 @@ function resolvePrSourceContext(pull = {}) {
   const checkboxType = sourceTypeFromCheckedTemplate(body);
   const labelType = sourceTypeFromLabels(pull);
   const inferredType = inferredSourceType(pull);
-  const detectedSourceType = dependencyRepairPromotion
+  const detectedSourceType = trustedDependencyRepairPromotion
     ? SOURCE_TYPES.DEPENDABOT
     : issueNumber
     ? SOURCE_TYPES.GITHUB_ISSUE
@@ -403,7 +411,7 @@ function resolvePrSourceContext(pull = {}) {
     : detectedSourceType;
 
   const sourceRef =
-    (dependencyRepairPromotion
+    (trustedDependencyRepairPromotion
       ? `dependency-pr:#${dependencyRepairPromotion.source_pr}`
       : '') ||
     cleanString(parseHtmlMarker(body, 'workflow-source-ref')) ||
@@ -426,7 +434,7 @@ function resolvePrSourceContext(pull = {}) {
     isValid: VALID_SOURCE_TYPES.has(sourceType),
     isExplicit: Boolean(
       issueNumber ||
-        dependencyRepairPromotion ||
+        trustedDependencyRepairPromotion ||
         markerType !== SOURCE_TYPES.UNKNOWN ||
         blockType !== SOURCE_TYPES.UNKNOWN ||
         checkboxType !== SOURCE_TYPES.UNKNOWN ||


### PR DESCRIPTION
<!-- meta:issue:2865 -->
> **Source:** Issue #2865

Closes #2865

## Summary
Authenticates dependency-repair promotion provenance before source routing can suppress incidental issue links.

## Pipeline status
Adopted into the agent pipeline; consumer-template parity and review recovery remain tracked by the source issue.