### PR TITLE
fix: harden dependency repair promotion trust

### DIFF
--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -181,6 +181,7 @@ test('dependency repair promotion marker supplies explicit dependency source con
       source_base_sha: 'a'.repeat(40),
       source_head_sha: 'b'.repeat(40),
       promotion_base_sha: 'c'.repeat(40),
+      ignored_untrusted_field: '__proto__',
     }),
     ' -->',
   ].join('');
@@ -194,12 +195,36 @@ test('dependency repair promotion marker supplies explicit dependency source con
     ],
   });
 
-  assert.equal(parseDependencyRepairPromotionSource(marker).source_pr, 2795);
+  assert.deepEqual(parseDependencyRepairPromotionSource(marker), {
+    source_pr: 2795,
+    source_base_sha: 'a'.repeat(40),
+    source_head_sha: 'b'.repeat(40),
+    promotion_base_sha: 'c'.repeat(40),
+  });
   assert.equal(context.sourceType, SOURCE_TYPES.DEPENDABOT);
   assert.equal(context.sourceRef, 'dependency-pr:#2795');
   assert.equal(context.isExplicit, true);
   assert.equal(context.isValid, true);
   assert.equal(context.requiresIssue, false);
+});
+
+test('underscore dependency source label authorizes a valid promotion marker', () => {
+  const marker = `<!-- dependency-repair-promotion:v1 ${JSON.stringify({
+    source_pr: 2795,
+    source_base_sha: 'a'.repeat(40),
+    source_head_sha: 'b'.repeat(40),
+    promotion_base_sha: 'c'.repeat(40),
+  })} -->`;
+  const context = resolvePrSourceContext({
+    body: `${marker}\nFixes #99`,
+    labels: [
+      { name: 'dependency:repair-promotion' },
+      { name: 'workflow_source_dependabot' },
+    ],
+  });
+
+  assert.equal(context.sourceType, SOURCE_TYPES.DEPENDABOT);
+  assert.equal(context.issueNumber, null);
 });
 
 test('dependency repair promotion marker suppresses incidental issue references', () => {

--- a/.github/scripts/agents_pr_meta_keepalive.js
+++ b/.github/scripts/agents_pr_meta_keepalive.js
@@ -570,11 +570,11 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     return finalise();
   }
 
-  const issueNumber = extractIssueNumberFromPull(pull);
+  const sourceContext = resolvePrSourceContext(pull);
+  const issueNumber = sourceContext.issueNumber;
   if (issueNumber) {
     outputs.issue = String(issueNumber);
   }
-  const sourceContext = resolvePrSourceContext(pull);
   if (sourceContext.isKnown) {
     outputs.source_type = sourceContext.sourceType;
   }

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -300,7 +300,12 @@ function parseDependencyRepairPromotionSource(body) {
     if (!Number.isInteger(sourcePr) || sourcePr <= 0 || !validShas) {
       return null;
     }
-    return { ...metadata, source_pr: sourcePr };
+    return {
+      source_pr: sourcePr,
+      source_base_sha: metadata.source_base_sha,
+      source_head_sha: metadata.source_head_sha,
+      promotion_base_sha: metadata.promotion_base_sha,
+    };
   } catch {
     return null;
   }
@@ -387,7 +392,8 @@ function resolvePrSourceContext(pull = {}) {
   const trustedDependencyRepairPromotion = Boolean(
     dependencyRepairPromotion &&
       labels.includes('dependency:repair-promotion') &&
-      labels.includes('workflow:source-dependabot'),
+      (labels.includes('workflow:source-dependabot') ||
+        labels.includes('workflow_source_dependabot')),
   );
   const extractedIssueNumber = extractIssueNumberFromPull(pull);
   // Promotion provenance is authoritative: a coincidental issue reference must

--- a/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -19,7 +19,11 @@ jobs:
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' ||
       github.event.pull_request.user.login == 'dependabot[bot]' ||
-      startsWith(github.event.pull_request.head.ref, 'renovate/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/') ||
-      contains(github.event.pull_request.body || '', 'dependency-repair-promotion:v1')
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       (startsWith(github.event.pull_request.head.ref, 'renovate/') ||
+        startsWith(github.event.pull_request.head.ref, 'dependabot/'))) ||
+      (contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+       contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
+       (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
+        contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
     uses: stranske/Workflows/.github/workflows/reusable-19-dependency-repair-contract.yml@main

--- a/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -4,7 +4,11 @@ on:
   # zizmor: ignore[dangerous-triggers] trusted reusable workflow reads only
   # PR metadata and git objects
   pull_request_target:
-    types: [opened, reopened, synchronize, edited]
+    # `labeled`/`unlabeled` are required: the controlled promotion workflow
+    # applies the two trust labels after the PR is opened, so without them the
+    # `opened` run skips the contract and the required check stays satisfied
+    # while provenance is never validated.
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -22,7 +26,8 @@ jobs:
       (github.event.pull_request.head.repo.full_name == github.repository &&
        (startsWith(github.event.pull_request.head.ref, 'renovate/') ||
         startsWith(github.event.pull_request.head.ref, 'dependabot/'))) ||
-      (contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
        contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))

--- a/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -32,3 +32,28 @@ jobs:
        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
     uses: stranske/Workflows/.github/workflows/reusable-19-dependency-repair-contract.yml@main
+
+  # `contract` is gated on the two trust labels, and a skipped job reports
+  # success. Without this guard a same-repository promotion marker whose labels
+  # were never applied — or were removed again — would merge with no provenance
+  # validation at all. Fail closed instead.
+  unauthorized-promotion-marker:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+      !(contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
+        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
+         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Reject an unauthorized promotion marker
+        run: |
+          echo "::error::This pull request carries a dependency-repair-promotion marker" \
+            "without both controlled promotion labels (dependency:repair-promotion and" \
+            "workflow:source-dependabot). The provenance contract therefore cannot run." \
+            "Remove the marker, or let the controlled promotion workflow apply the trust" \
+            "labels so PR 46 can validate the source PR, ancestry, and patch identity."
+          exit 1

--- a/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
+++ b/docs/ops/DEPENDENCY_REPAIR_PROMOTION.md
@@ -98,3 +98,29 @@ For promotion PRs, it verifies:
 Later commits are deliberately allowed: those commits are where local coding
 agents provide the repair. Normal CI, active review-thread checks, shared
 template ownership, and dependency security review still apply.
+
+### Why authorization lives in the caller workflow
+
+`reusable-19-dependency-repair-contract.yml` cannot decline its own invocation:
+a `workflow_call` workflow runs whenever the caller's job runs. The decision of
+*whether* a PR is entitled to the contract therefore has to be a job-level `if:`
+in the caller, `pr-46-dependency-repair-contract.yml`, where the consumer's own
+`pull_request_target` payload (author, head repository, body marker, labels) is
+available. This is not a consumer-template exception: the root copy and
+`templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml`
+are byte-identical and kept that way by `.github/sync-manifest.yml`, so every
+consumer evaluates the same authorization rule against its own PRs.
+
+Two properties of that caller-side condition are load-bearing:
+
+- **It must re-evaluate on label changes.** The promotion labels are applied
+  after the PR is opened, so the caller subscribes to `labeled` and `unlabeled`
+  in addition to `opened`/`reopened`/`synchronize`/`edited`. Without them the
+  `opened` run would skip the job while the marker was still unlabeled, the
+  required check would stay satisfied, and none of the verification above would
+  ever run.
+- **It must require a same-repository head.** Marker text and labels are both
+  reachable from a fork PR, but the contract checks out the head SHA from the
+  base repository, so the marker path is gated on
+  `head.repo.full_name == github.repository` exactly like the branch-prefix
+  path.

--- a/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
+++ b/templates/consumer-repo/.github/scripts/agents_pr_meta_keepalive.js
@@ -570,11 +570,11 @@ async function detectKeepalive({ core, github, context, env = process.env }) {
     return finalise();
   }
 
-  const issueNumber = extractIssueNumberFromPull(pull);
+  const sourceContext = resolvePrSourceContext(pull);
+  const issueNumber = sourceContext.issueNumber;
   if (issueNumber) {
     outputs.issue = String(issueNumber);
   }
-  const sourceContext = resolvePrSourceContext(pull);
   if (sourceContext.isKnown) {
     outputs.source_type = sourceContext.sourceType;
   }

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -300,7 +300,12 @@ function parseDependencyRepairPromotionSource(body) {
     if (!Number.isInteger(sourcePr) || sourcePr <= 0 || !validShas) {
       return null;
     }
-    return { ...metadata, source_pr: sourcePr };
+    return {
+      source_pr: sourcePr,
+      source_base_sha: metadata.source_base_sha,
+      source_head_sha: metadata.source_head_sha,
+      promotion_base_sha: metadata.promotion_base_sha,
+    };
   } catch {
     return null;
   }
@@ -387,7 +392,8 @@ function resolvePrSourceContext(pull = {}) {
   const trustedDependencyRepairPromotion = Boolean(
     dependencyRepairPromotion &&
       labels.includes('dependency:repair-promotion') &&
-      labels.includes('workflow:source-dependabot'),
+      (labels.includes('workflow:source-dependabot') ||
+        labels.includes('workflow_source_dependabot')),
   );
   const extractedIssueNumber = extractIssueNumberFromPull(pull);
   // Promotion provenance is authoritative: a coincidental issue reference must

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -324,6 +324,7 @@ jobs:
             tools
             .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         if: steps.check-merged.outputs.merged == 'true'

--- a/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -19,7 +19,11 @@ jobs:
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' ||
       github.event.pull_request.user.login == 'dependabot[bot]' ||
-      startsWith(github.event.pull_request.head.ref, 'renovate/') ||
-      startsWith(github.event.pull_request.head.ref, 'dependabot/') ||
-      contains(github.event.pull_request.body || '', 'dependency-repair-promotion:v1')
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       (startsWith(github.event.pull_request.head.ref, 'renovate/') ||
+        startsWith(github.event.pull_request.head.ref, 'dependabot/'))) ||
+      (contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+       contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
+       (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
+        contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
     uses: stranske/Workflows/.github/workflows/reusable-19-dependency-repair-contract.yml@main

--- a/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -4,7 +4,11 @@ on:
   # zizmor: ignore[dangerous-triggers] trusted reusable workflow reads only
   # PR metadata and git objects
   pull_request_target:
-    types: [opened, reopened, synchronize, edited]
+    # `labeled`/`unlabeled` are required: the controlled promotion workflow
+    # applies the two trust labels after the PR is opened, so without them the
+    # `opened` run skips the contract and the required check stays satisfied
+    # while provenance is never validated.
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -22,7 +26,8 @@ jobs:
       (github.event.pull_request.head.repo.full_name == github.repository &&
        (startsWith(github.event.pull_request.head.ref, 'renovate/') ||
         startsWith(github.event.pull_request.head.ref, 'dependabot/'))) ||
-      (contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
        contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))

--- a/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
+++ b/templates/consumer-repo/.github/workflows/pr-46-dependency-repair-contract.yml
@@ -32,3 +32,28 @@ jobs:
        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
     uses: stranske/Workflows/.github/workflows/reusable-19-dependency-repair-contract.yml@main
+
+  # `contract` is gated on the two trust labels, and a skipped job reports
+  # success. Without this guard a same-repository promotion marker whose labels
+  # were never applied — or were removed again — would merge with no provenance
+  # validation at all. Fail closed instead.
+  unauthorized-promotion-marker:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.body || '', '<!-- dependency-repair-promotion:v1') &&
+      !(contains(github.event.pull_request.labels.*.name, 'dependency:repair-promotion') &&
+        (contains(github.event.pull_request.labels.*.name, 'workflow:source-dependabot') ||
+         contains(github.event.pull_request.labels.*.name, 'workflow_source_dependabot')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Reject an unauthorized promotion marker
+        run: |
+          echo "::error::This pull request carries a dependency-repair-promotion marker" \
+            "without both controlled promotion labels (dependency:repair-promotion and" \
+            "workflow:source-dependabot). The provenance contract therefore cannot run." \
+            "Remove the marker, or let the controlled promotion workflow apply the trust" \
+            "labels so PR 46 can validate the source PR, ancestry, and patch identity."
+          exit 1


### PR DESCRIPTION
Fixes shared consumer-sync review debt: gates the dependency repair contract on controlled promotion labels, preserves only validated provenance fields, honors the documented underscore source-label alias, propagates resolved issue suppression to keepalive, and sets non-cone sparse checkout for the consumer PR event hub.

Validation:
- node --test .github/scripts/__tests__/source-context.test.js .github/scripts/__tests__/agents-pr-meta-keepalive.test.js
- python scripts/validate_template_completeness.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency-repair promotion validation by recognizing supported Dependabot label formats and requiring valid repository, branch, and promotion markers.
  * Workflows now recheck pull requests when labels are added or removed.
  * Prevented untrusted metadata from appearing in promotion results.
  * Improved issue-number tracking for pull request automation.
  * Fixed verification workflow checkout behavior.

* **Tests**
  * Expanded coverage for authorization and untrusted payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->