### PR TITLE
fix: request Actions capability for auto-pilot create-pr dispatches

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -2310,7 +2310,7 @@ jobs:
               core,
               env: process.env,
               task: 'auto-pilot-create-pr',
-              capabilities: ['issues:write', 'contents:read']
+              capabilities: ['issues:write', 'contents:read', 'actions:write']
             });
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
             const issueTitle = process.env.ISSUE_TITLE || `Issue #${issueNumber}`;

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -2310,7 +2310,7 @@ jobs:
               core,
               env: process.env,
               task: 'auto-pilot-create-pr',
-              capabilities: ['issues:write', 'contents:read']
+              capabilities: ['issues:write', 'contents:read', 'actions:write']
             });
             const issueNumber = parseInt(process.env.ISSUE_NUMBER);
             const issueTitle = process.env.ISSUE_TITLE || `Issue #${issueNumber}`;


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary

Bounded follow-up to #2869 (merged `81e5821`). That PR added `actions:write` to the `auto-pilot-monitor-pr` token client so the stall handoff could dispatch a keepalive workflow. Verifying it surfaced the same defect, still unfixed, on a busier path.

The `Execute step - Create PR` client declares `capabilities: ['issues:write', 'contents:read']` but issues **four** `createWorkflowDispatch` calls (belt-dispatcher and belt-worker-dispatch). Those capabilities normalize to `write-repo`/`comments`/`labels`/`read-repo` (`token_load_balancer.js:130-144`), all of which `GITHUB_TOKEN` advertises (`:68`), while `GITHUB_TOKEN` carries no `workflow-dispatch` capability at all (`:69-70` show only `PAT` and `APP` do). The load balancer could therefore select a token that definitively cannot dispatch, and `withRetry` does not rotate on permission errors, so the dispatch returns 403.

This adds `actions:write` to that one capability array, matching the shape already used by `auto-pilot-capability-check`, `auto-pilot-redispatch`, and now `auto-pilot-monitor-pr`.

## Why this is safe

`createTokenAwareRetry` initializes `currentGithub` to the default Actions client and replaces it only when `getOptimalToken` returns a token (`github-api-with-retry.js:572-589`). If no `workflow-dispatch`-capable token is configured — the typical consumer-repo case — selection returns `null` and the step keeps the default client, which is exactly the pre-change behavior. The change can only narrow selection toward tokens that can actually dispatch; it cannot strand a repo.

## Not addressed here, deliberately

Choosing `ACTIONS_BOT_PAT` over `SERVICE_BOT_PAT` *within* the workflow-dispatch-capable set is a separate, repo-wide `token_load_balancer.js` design property: `TOKEN_CAPABILITIES.PAT` blanket-advertises `workflow-dispatch` for every PAT (`:69`), and none of the four dispatching auto-pilot tasks appear in any `TOKEN_SPECIALIZATIONS[*].primaryTasks` (`:95-128`), so `taskBonus` stays `0` (`:805-808`) and selection falls back to remaining quota. Fixing that means either routing dispatch calls through a `workflow-dispatch` specialization or recording real per-PAT scopes — both larger than this change. See the discussion on #2869.

## Validation

Both files are byte-identical after the edit (they produced the same git blob `b8ffd84`), so template drift stays clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated pull request workflows with permission to manage workflow actions.
  - Applied the same configuration to the consumer repository template for consistent automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->