### PR TITLE
docs(ops): retarget durable-tracker table at the live tracker issues

### DIFF
--- a/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
+++ b/.github/workflows/maint-80-langsmith-metrics-dashboard.yml
@@ -444,14 +444,15 @@ jobs:
               --title "$ISSUE_TITLE" \
               --body-file .metrics-tmp/issue-body.md \
               --add-label "metrics" \
-              --add-label "automated"
+              --add-label "automated" \
+              --add-label "tracker:durable"
             echo "LANGSMITH_DASHBOARD_ISSUE=$DASHBOARD_ISSUE" >> "$GITHUB_ENV"
             echo "Updated LangSmith dashboard issue #$DASHBOARD_ISSUE"
           else
             DASHBOARD_URL=$(gh issue create \
               --title "$ISSUE_TITLE" \
               --body-file .metrics-tmp/issue-body.md \
-              --label "metrics,automated")
+              --label "metrics,automated,tracker:durable")
             echo "LANGSMITH_DASHBOARD_ISSUE_URL=$DASHBOARD_URL" >> "$GITHUB_ENV"
             echo "Created LangSmith dashboard issue $DASHBOARD_URL"
           fi
@@ -544,7 +545,7 @@ jobs:
             echo "  - Dashboard file: docs/dashboards/langsmith-metrics.md"
             if [ "${{ github.event_name }}" == "schedule" ] || \
                [ "${{ inputs.create_issue }}" == "true" ]; then
-              echo "  - Issue: Upserted with labels 'metrics,automated'"
+              echo "  - Issue: Upserted with labels 'metrics,automated,tracker:durable'"
             fi
           else
             echo "⚠️ No metrics data available for the specified period"

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -92,7 +92,7 @@ For bugs affecting multiple repos, create a tracking issue with:
 - [ ] Verification steps
 
 > Not to be confused with the **durable tracker** for consumer-sync drift
-> ([#1868](https://github.com/stranske/Workflows/issues/1868)), which the
+> ([#2210](https://github.com/stranske/Workflows/issues/2210)), which the
 > `Health 68 Consumer Sync Drift` workflow re-uses across cycles and resolves
 > automatically when drift clears. See
 > [`DURABLE_TRACKING_ISSUES.md`](DURABLE_TRACKING_ISSUES.md).

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -93,8 +93,8 @@ For bugs affecting multiple repos, create a tracking issue with:
 
 > Not to be confused with the **durable tracker** for consumer-sync drift
 > ([#2210](https://github.com/stranske/Workflows/issues/2210)), which the
-> `Health 68 Consumer Sync Drift` workflow re-uses across cycles and resolves
-> automatically when drift clears. See
+> `Health 68 Consumer Sync Drift` workflow re-uses across cycles and refreshes
+> when drift is detected. A clean run does not close the tracker. See
 > [`DURABLE_TRACKING_ISSUES.md`](DURABLE_TRACKING_ISSUES.md).
 
 ---

--- a/docs/ops/DURABLE_TRACKING_ISSUES.md
+++ b/docs/ops/DURABLE_TRACKING_ISSUES.md
@@ -21,10 +21,13 @@ metrics summary). Without a tracker convention each run would either:
 
 The trackers below solve this by reusing one issue per controller. The bot
 either appends a comment per cycle (`#2211`) or rewrites the body in place
-(`#1836`, `#2210`, `#2470`). Either way, **the issue itself is the dashboard**:
-do not close it during routine triage. Each controller has its own lifecycle;
-for example, closing the active `#1836` campaign queue stops that controller's
-work, while `#2470` is recreated only through its failure-notification path.
+(`#1836`, `#2210`, `#2415`); `#2470` is a hybrid that stamps a marker into the
+body and appends a recovery comment. Check the `Update style` column before
+assuming append-versus-rewrite handling. Either way, **the issue itself is the
+dashboard**: do not close it during routine triage. Each controller has its own
+lifecycle; for example, closing the active `#1836` campaign queue stops that
+controller's work, while `#2470` is recreated only through its
+failure-notification path.
 
 ---
 

--- a/docs/ops/DURABLE_TRACKING_ISSUES.md
+++ b/docs/ops/DURABLE_TRACKING_ISSUES.md
@@ -21,9 +21,9 @@ metrics summary). Without a tracker convention each run would either:
 
 The trackers below solve this by reusing one issue per controller. The bot
 either appends a comment per cycle (`#2211`) or rewrites the body in place
-(`#1836`, `#1868`). Either way, **the issue itself is the dashboard** — closing
-it does not advance any work; the controller will simply re-create one on the
-next cycle.
+(`#1836`, `#2210`, `#2470`). Either way, **the issue itself is the dashboard** —
+closing it does not advance any work; the controller will simply re-create one
+on the next cycle.
 
 ---
 
@@ -32,14 +32,29 @@ next cycle.
 | Issue | Title | Source workflow | Cadence | Update style |
 |-------|-------|-----------------|---------|--------------|
 | [#2211](https://github.com/stranske/Workflows/issues/2211) | Agent metrics weekly summary | [`agents-weekly-metrics.yml`](../../.github/workflows/agents-weekly-metrics.yml) | Mondays 06:00 UTC | New comment per run |
-| [#1836](https://github.com/stranske/Workflows/issues/1836) | Sync/Dependency campaign queue | [`maint-82-sync-dependency-campaign.yml`](../../.github/workflows/maint-82-sync-dependency-campaign.yml) + [`.github/scripts/sync_dependency_campaign.js`](../../.github/scripts/sync_dependency_campaign.js) | Every 6h + Mondays 10:30 UTC | Body rewritten in place |
-| [#1868](https://github.com/stranske/Workflows/issues/1868) | 🔄 Consumer repo drift detected | [`health-68-consumer-sync-drift.yml`](../../.github/workflows/health-68-consumer-sync-drift.yml) | Daily 05:10 UTC | Body rewritten in place |
+| [#1836](https://github.com/stranske/Workflows/issues/1836) | Sync/Dependabot campaign queue | [`maint-82-sync-dependency-campaign.yml`](../../.github/workflows/maint-82-sync-dependency-campaign.yml) + [`.github/scripts/sync_dependency_campaign.js`](../../.github/scripts/sync_dependency_campaign.js) | Every 6h + Mondays 10:30 UTC | Body rewritten in place |
+| [#2210](https://github.com/stranske/Workflows/issues/2210) | 🔄 Consumer repo drift detected | [`health-68-consumer-sync-drift.yml`](../../.github/workflows/health-68-consumer-sync-drift.yml) | Daily 05:10 UTC | Body rewritten in place |
+| [#2470](https://github.com/stranske/Workflows/issues/2470) | 🚨 Integration-Tests Sync Failed - Action Required | [`maint-69-sync-integration-repo.yml`](../../.github/workflows/maint-69-sync-integration-repo.yml) | On push to `templates/integration-repo/**` | Stuck-window marker in body + recovery comment |
 
 The signal flow each tracker carries:
 
 - **#2211** — health check on the weekly metrics pipeline. Healthy state is `Parse errors: 0` and non-zero terminal disposition records. A regression here usually means a producer is emitting a malformed artifact, not that the dashboard itself is broken.
 - **#1836** — work queue for items the local Codex watcher should claim. The body holds the live queue state with a sync hash, repo counts, and per-item status. Active campaigns must not be closed; the controller treats a closed campaign as "stop work."
-- **#1868** — fan-out drift report across registered consumer repos. Auto-resolves on the next clean `Maint 68` run; the closure happens in the workflow, not by hand.
+- **#2210** — fan-out drift report across registered consumer repos. Auto-resolves on the next clean `Maint 68` run; the closure happens in the workflow, not by hand.
+- **#2470** — stuck-window marker for the integration-repo template sync. A `<!-- sync-tracker-stuck-window:v1 ... -->` marker in the body means the sync is currently failing. The next successful run strips the marker and appends a `✅ Integration sync recovered` comment, but never closes the issue, so a marker-free body carrying a recovery comment is the healthy resting state. The `Resolution Steps` list in the issue body still says "Close this issue once the next run succeeds"; that line predates the stuck-window marker and does not reflect how `maint-69` actually treats the tracker.
+
+### Superseded tracker numbers
+
+A controller re-mints its tracker if the previous one is closed, so tracker
+numbers change over time. Numbers that appear in older comments and commits:
+
+| Controller | Superseded | Current |
+|------------|-----------|---------|
+| `agents-weekly-metrics.yml` | [#1796](https://github.com/stranske/Workflows/issues/1796) — closed 2026-08-01 as a duplicate; last comment 2026-05-25 | [#2211](https://github.com/stranske/Workflows/issues/2211) |
+| `health-68-consumer-sync-drift.yml` | [#1868](https://github.com/stranske/Workflows/issues/1868) — closed 2026-05-14 | [#2210](https://github.com/stranske/Workflows/issues/2210) |
+
+When a controller's tracker is replaced, update the table above in the same
+change so this page never points at a closed issue.
 
 ---
 
@@ -66,11 +81,14 @@ same change.
 
 - **Do not close them as part of routine triage**, even if the latest comment
   looks "stale" — the controller may have nothing to report on a quiet day.
-  Close only when retiring the underlying controller.
+  Close only when retiring the underlying controller, or when the tracker is a
+  proven duplicate of a newer one for the same controller (see *Superseded
+  tracker numbers* above — the surviving tracker must stay open).
 - **Read the latest comment / body**, not the original creation body. The
   original snapshot is frozen at issue creation; current state lives further
-  down (or in the rewritten body for `#1836` / `#1868`).
-- **A red signal** (parse errors > 0 in `#2211`, drift count > 0 in `#1868`,
+  down (or in the rewritten body for `#1836` / `#2210` / `#2470`).
+- **A red signal** (parse errors > 0 in `#2211`, drift count > 0 in `#2210`,
+  a stuck-window marker present in `#2470`,
   unclaimed `needs-local-codex` items in `#1836`) means the underlying system
   needs attention — but the fix lands in code or in another repo, not by
   closing the tracker.
@@ -89,6 +107,13 @@ addressed. Examples:
   expiry window. Close after token rotation.
 - `🔴 Integration CI failed (run N)` — single-incident issue, close after the
   branch / fix lands.
+- `📊 LangSmith Trace Coverage Report - Week of <date>` — **retired format.**
+  `maint-80-langsmith-metrics-dashboard.yml` used to mint one issue per
+  schedule; it now upserts the single
+  [#2415](https://github.com/stranske/Workflows/issues/2415)
+  `📊 LangSmith Trace Coverage Dashboard` instead. The dashboard lookup matches
+  that exact title, so leftover `Report - Week of …` issues are unreachable by
+  the controller and were closed on 2026-08-01 (#2213, #2247; #2194 earlier).
 
 Rule of thumb: if the title carries a counter or a fixed timestamp ("expires
 in 39 hours", "run 235"), it is **transient**. If the title is generic and the
@@ -99,5 +124,5 @@ body is a recurring snapshot ("queue", "summary", "drift detected"), it is
 
 ## See also
 
-- [`CONSUMER_REPO_MAINTENANCE.md`](CONSUMER_REPO_MAINTENANCE.md) — context for `#1868` (consumer drift) and the `Maint 68` sync surface.
+- [`CONSUMER_REPO_MAINTENANCE.md`](CONSUMER_REPO_MAINTENANCE.md) — context for `#2210` (consumer drift) and the `Maint 68` sync surface.
 - [`REPO_REVIEW_PROCESS.md`](REPO_REVIEW_PROCESS.md) — the repo-review pipeline emits its own evidence trail; it does not currently use a durable tracker, but the same "do not triage automated review evidence as work" rule applies.

--- a/docs/ops/DURABLE_TRACKING_ISSUES.md
+++ b/docs/ops/DURABLE_TRACKING_ISSUES.md
@@ -21,9 +21,10 @@ metrics summary). Without a tracker convention each run would either:
 
 The trackers below solve this by reusing one issue per controller. The bot
 either appends a comment per cycle (`#2211`) or rewrites the body in place
-(`#1836`, `#2210`, `#2470`). Either way, **the issue itself is the dashboard** —
-closing it does not advance any work; the controller will simply re-create one
-on the next cycle.
+(`#1836`, `#2210`, `#2470`). Either way, **the issue itself is the dashboard**:
+do not close it during routine triage. Each controller has its own lifecycle;
+for example, closing the active `#1836` campaign queue stops that controller's
+work, while `#2470` is recreated only through its failure-notification path.
 
 ---
 
@@ -34,14 +35,15 @@ on the next cycle.
 | [#2211](https://github.com/stranske/Workflows/issues/2211) | Agent metrics weekly summary | [`agents-weekly-metrics.yml`](../../.github/workflows/agents-weekly-metrics.yml) | Mondays 06:00 UTC | New comment per run |
 | [#1836](https://github.com/stranske/Workflows/issues/1836) | Sync/Dependabot campaign queue | [`maint-82-sync-dependency-campaign.yml`](../../.github/workflows/maint-82-sync-dependency-campaign.yml) + [`.github/scripts/sync_dependency_campaign.js`](../../.github/scripts/sync_dependency_campaign.js) | Every 6h + Mondays 10:30 UTC | Body rewritten in place |
 | [#2210](https://github.com/stranske/Workflows/issues/2210) | 🔄 Consumer repo drift detected | [`health-68-consumer-sync-drift.yml`](../../.github/workflows/health-68-consumer-sync-drift.yml) | Daily 05:10 UTC | Body rewritten in place |
-| [#2470](https://github.com/stranske/Workflows/issues/2470) | 🚨 Integration-Tests Sync Failed - Action Required | [`maint-69-sync-integration-repo.yml`](../../.github/workflows/maint-69-sync-integration-repo.yml) | On push to `templates/integration-repo/**` | Stuck-window marker in body + recovery comment |
+| [#2470](https://github.com/stranske/Workflows/issues/2470) | 🚨 Integration-Tests Sync Failed - Action Required | [`maint-69-sync-integration-repo.yml`](../../.github/workflows/maint-69-sync-integration-repo.yml) | On qualifying template/config pushes or manual dispatch | Stuck-window marker in body + recovery comment |
+| [#2415](https://github.com/stranske/Workflows/issues/2415) | 📊 LangSmith Trace Coverage Dashboard | [`maint-80-langsmith-metrics-dashboard.yml`](../../.github/workflows/maint-80-langsmith-metrics-dashboard.yml) | Mondays 09:00 UTC + manual dispatch | Body rewritten in place |
 
 The signal flow each tracker carries:
 
 - **#2211** — health check on the weekly metrics pipeline. Healthy state is `Parse errors: 0` and non-zero terminal disposition records. A regression here usually means a producer is emitting a malformed artifact, not that the dashboard itself is broken.
 - **#1836** — work queue for items the local Codex watcher should claim. The body holds the live queue state with a sync hash, repo counts, and per-item status. Active campaigns must not be closed; the controller treats a closed campaign as "stop work."
-- **#2210** — fan-out drift report across registered consumer repos. Auto-resolves on the next clean `Maint 68` run; the closure happens in the workflow, not by hand.
-- **#2470** — stuck-window marker for the integration-repo template sync. A `<!-- sync-tracker-stuck-window:v1 ... -->` marker in the body means the sync is currently failing. The next successful run strips the marker and appends a `✅ Integration sync recovered` comment, but never closes the issue, so a marker-free body carrying a recovery comment is the healthy resting state. The `Resolution Steps` list in the issue body still says "Close this issue once the next run succeeds"; that line predates the stuck-window marker and does not reflect how `maint-69` actually treats the tracker.
+- **#2210** — fan-out drift report across registered consumer repos. `Health 68` creates or refreshes it when drift is detected; a clean run does not close it, so its latest body must be read as the last detected signal rather than an automatic current-status promise.
+- **#2470** — stuck-window marker for the integration-repo template sync. A `<!-- sync-tracker-stuck-window:v1 ... -->` marker in the body means the sync is currently failing. The next successful non-dry run with a sync token strips the marker and appends a `✅ Integration sync recovered` comment, but never closes the issue, so a marker-free body carrying a recovery comment is the healthy resting state. The `Resolution Steps` list in the issue body still says "Close this issue once the next run succeeds"; that line predates the stuck-window marker and does not reflect how `maint-69` actually treats the tracker.
 
 ### Superseded tracker numbers
 

--- a/tests/workflows/test_langsmith_metrics_dashboard.py
+++ b/tests/workflows/test_langsmith_metrics_dashboard.py
@@ -29,12 +29,13 @@ def test_fleet_registry_declares_trusted_artifact_workflows() -> None:
     ]
 
 
-def test_dashboard_issue_uses_existing_labels() -> None:
+def test_dashboard_issue_uses_durable_tracker_labels() -> None:
     source = WORKFLOW.read_text(encoding="utf-8")
 
-    assert '--label "metrics,automated"' in source
+    assert '--label "metrics,automated,tracker:durable"' in source
+    assert '--add-label "tracker:durable"' in source
     assert "metrics,langsmith,automated" not in source
-    assert "labels 'metrics,automated'" in source
+    assert "labels 'metrics,automated,tracker:durable'" in source
 
 
 def test_run_discovery_targets_workflows_with_runs() -> None:


### PR DESCRIPTION
## Summary

`docs/ops/DURABLE_TRACKING_ISSUES.md` is the page that tells automations and humans which auto-bot issues must **not** be closed in routine triage. Two of its four facts were wrong, so following it led to a closed issue.

Found while auditing every open `tracker:durable` issue in this repo during a closer sweep.

| Row | Doc said | Actual |
|---|---|---|
| Consumer drift | #1868 | **CLOSED 2026-05-14**; live tracker is #2210 (created 2026-06-01, updated 2026-07-31) |
| Campaign queue | "Sync/Dependency campaign queue" | live title is "Sync/**Dependabot** campaign queue" |
| maint-69 sync | *absent* | #2470 is a real durable tracker and its body links here |

## Changes

- Retarget the consumer-drift row and its three prose references from #1868 to #2210, including the cross-reference in `CONSUMER_REPO_MAINTENANCE.md`.
- Correct the #1836 title.
- Add the missing **#2470** row. `maint-69-sync-integration-repo.yml` stamps `> **Durable tracker** — see docs/ops/DURABLE_TRACKING_ISSUES.md` into that issue's body, but the doc never listed it, so the header pointed at a page that disclaimed it.
- Add a **Superseded tracker numbers** table so #1796 / #1868 in older comments stay traceable.
- Document the one legitimate exception to "do not close": a proven duplicate of a newer tracker for the same controller, provided the survivor stays open.
- Add the retired `LangSmith Trace Coverage Report - Week of <date>` format to the transient-alert examples.

## Why #2470 needed a nuanced note

Its `Resolution Steps` still say *"Close this issue once the next run succeeds."* That predates the stuck-window marker. `clearStuckWindow` in `.github/scripts/sync_tracker_state/index.js` only strips the marker from the body and appends a `✅ Integration sync recovered` comment — it never closes the issue, and `findTracker` is called with `createIfMissing: false`, so the issue is reused indefinitely. A marker-free body carrying a recovery comment is therefore the **healthy resting state**, not an oversight. The doc now says so.

## Evidence for the #1796 → #2211 supersession

`agents-weekly-metrics.yml` picks its tracker with `issues.find((issue) => issue.title === title)` over `listForRepo`, which defaults to `sort=created&direction=desc`. The newest matching open issue always wins, so #2211 (created 2026-06-01) permanently shadowed #1796 (last comment 2026-05-25, 45 comments, no `closed`/`reopened`/`renamed` event in its timeline). No third tracker has appeared in the nine weeks since, so the current dedup path is sound and this was a one-off historical duplicate. #1796 was closed on evidence; #2211 remains open and green (`Parse errors: 0`).

## Test plan

Docs-only; no runtime surface is touched.

- [x] `rg '#1868|#1796'` across the repo — remaining hits are the new supersession table and dated snapshots in `docs/HISTORY.md`, which are historical records and intentionally unchanged.
- [x] Every issue number in the tracker table verified OPEN via the API: #2211, #1836, #2210, #2470.
- [x] Each row's cadence and update style checked against the producing workflow (`agents-weekly-metrics.yml`, `maint-82-sync-dependency-campaign.yml`, `health-68-consumer-sync-drift.yml`, `maint-69-sync-integration-repo.yml`).
- [x] No markdownlint or link-check job exists in `.github/workflows/`, and no test asserts this doc's contents (`.github/scripts/__tests__/sync-tracker-state.test.js` covers the marker helpers, not the table).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated durable tracking guidance with current consumer and integration synchronization tracker references.
  * Documented retired and superseded trackers, recovery behavior, revised reporting guidance, and current dashboard references.
  * Updated related maintenance links and clarified tracker refresh and closure behavior.

* **Maintenance**
  * Dashboard issues now use durable-tracking labels for clearer status and follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->