### PR TITLE
fix(branch-protection): stop requiring a conditionally-posted status context

### DIFF
--- a/.github/config/required-contexts.json
+++ b/.github/config/required-contexts.json
@@ -1,6 +1,6 @@
 {
   "required_contexts": [
-    "Gate / gate",
-    "Health 45 Agents Guard / guard"
-  ]
+    "Gate / gate"
+  ],
+  "_note": "Only universally-posted contexts belong here: health-44 can pass this file to enforce_gate_branch_protection.py --apply, so any context listed becomes a REQUIRED status check. 'Health 45 Agents Guard / guard' is deliberately absent: agents-guard.yml posts that status only when the PR carries an agent label (agent:codex, agents:auto-pilot, ...), so requiring it would leave every other PR permanently un-mergeable. See issue #2858."
 }

--- a/.github/workflows/health-40-repo-selfcheck.yml
+++ b/.github/workflows/health-40-repo-selfcheck.yml
@@ -119,7 +119,6 @@ jobs:
             --apply \
             --branch "${DEFAULT_BRANCH}" \
             --context "Gate / gate" \
-            --context "Health 45 Agents Guard / guard" \
             --no-clean
 
       - name: Snapshot branch protection state
@@ -134,7 +133,6 @@ jobs:
             --require-strict \
             --branch "${DEFAULT_BRANCH}" \
             --context "Gate / gate" \
-            --context "Health 45 Agents Guard / guard" \
             --no-clean \
             --snapshot repo-health-branch-protection.json
 
@@ -403,6 +401,14 @@ jobs:
             core.setOutput('branch_fetch_error', branchFetchError || '');
 
       - name: Root allowlist guard
+        # `always()` so an earlier failure (e.g. the branch-protection snapshot)
+        # cannot silently skip this guard. That is how six unlisted root files
+        # accumulated undetected for a month — see #2858. NOTE: this only rescues
+        # THIS step; "Collect repository signals" and "Aggregate & Summarize"
+        # still skip when an earlier step fails, because the aggregate depends on
+        # the collect step's outputs. Making the whole job resilient needs a
+        # different shape than a per-step always().
+        if: always()
         # Fail when a tracked file appears at the repo root (depth 0) that is
         # not on the reviewed allowlist (config/root-allowlist.txt). Keeps
         # one-off debris (stray fixer scripts, per-run CI snapshots, *.patch)

--- a/tools/enforce_gate_branch_protection.py
+++ b/tools/enforce_gate_branch_protection.py
@@ -30,8 +30,10 @@ def resolve_api_root(explicit: str | None = None) -> str:
 
 
 DEFAULT_CONTEXTS = (
+    # Only universally-posted contexts may be required. "Health 45 Agents Guard /
+    # guard" is posted by agents-guard.yml ONLY for agent-labelled PRs, so requiring
+    # it would block every other PR forever (issue #2858).
     "Gate / gate",
-    "Health 45 Agents Guard / guard",
 )
 
 DEFAULT_CONFIG_PATH = Path(".github/config/required-contexts.json")
@@ -248,7 +250,7 @@ def _fetch_ruleset_status_checks(
 
     Example return values:
         - None: No rulesets found, or no rulesets apply to the branch, or no status checks required.
-        - StatusCheckState(strict=False, contexts=['Gate / gate', 'Health 45 Agents Guard / guard']):
+        - StatusCheckState(strict=False, contexts=['Gate / gate', 'summary']):
             Required status checks found for the branch, with strict mode disabled.
         - StatusCheckState(strict=True, contexts=['ci/test', 'lint']):
             Required status checks found for the branch, with strict mode enabled.
@@ -643,7 +645,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="append",
         help=(
             "Status check context to require. May be passed multiple times. Defaults to"
-            " 'Gate / gate' and 'Health 45 Agents Guard / guard'."
+            " 'Gate / gate'."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Closes the code-side half of #2858. The ruleset edit itself still needs an admin.

## Why

`Health 45 Agents Guard / guard` **cannot** be a required status check.

It is a commit *status* posted by `agents-guard.yml:690-701`, inside the step **"Report agents guard commit status"** (`:594`), whose condition is:

```yaml
if: always() && steps.eligibility.outputs.should-run == 'true'
```

`steps.eligibility` (`:46`) requires one of `agent:auto, agent:codex, agent:claude, agent:copilot, agents:auto-pilot, agents:keepalive` on the PR. **On a PR without an agent label the status is never posted**, and a required check that never reports leaves the PR permanently un-mergeable.

Verified: on the head of #2856 the statuses API returns only `Gate / gate [success]` and `CodeRabbit [success]`. The guard status is absent there and on all 12 most recent PRs (#2850-#2862).

**This was not theoretical.** `health-44-gate-branch-protection.yml:220-225` passes this same config to `enforce_gate_branch_protection.py --apply` whenever `github.event_name != 'pull_request'` and an enforcement token is present. Dispatching health-44 today would have added the context and **frozen every non-agent PR in the repo** — including the ones fixing it.

## What changed

- `.github/config/required-contexts.json` — drop the context, leaving `Gate / gate`, and record the reason inline so it is not re-added. (Not in the sync manifest, so consumers are unaffected.)
- `tools/enforce_gate_branch_protection.py` — `DEFAULT_CONTEXTS` reduced to `Gate / gate` with the rationale as a comment; docstring example and `--context` help text updated to match.
- `health-40-repo-selfcheck.yml` — remove `--context "Health 45 Agents Guard / guard"` from both invocations.
- `health-40-repo-selfcheck.yml` — give **"Root allowlist guard"** `if: always()`. Steps run sequentially, so the failing snapshot step was skipping it; that is how six unlisted repo-root files accumulated unseen for a month. The comment is explicit that this rescues *only* that step — `Collect repository signals` and `Aggregate & Summarize` still skip, because the aggregate consumes the collect step's outputs and making the whole job resilient needs a different shape.

`agents-guard.yml` is unchanged: it still posts its status, now purely informational. Requiring it would need it to post on *every* PR (e.g. `success` / "not applicable" when ineligible) — noted as the alternative on #2858, deliberately not done here since it edits a security-sensitive guard with a `pull_request_target` path.

`Gate / gate` remains required-worthy: posted on every PR by `pr-00-gate.yml`, **pass** on all 12 most recent PRs.

## Verification

```
pytest tests/test_enforce_gate_branch_protection.py tests/tools/test_enforce_gate_branch_protection.py \
       tests/test_post_ci_summary.py                      -> 32 passed
yaml.safe_load(health-40-repo-selfcheck.yml)               -> OK
ruff check / format --check                                -> clean

enforce_gate_branch_protection.py --check --require-strict --config .github/config/required-contexts.json
  Current contexts: summary
  Target contexts:  Gate / gate, summary
  Would add contexts: Gate / gate
  exit 1   <- correct; goes to 0 once the ruleset adds `Gate / gate` + strict
```

The existing tests that pass `Health 45 Agents Guard / guard` explicitly via `--context` or as payload fixtures are left alone — they exercise arbitrary-context handling and do not depend on the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated branch protection checks to rely on the Gate status check.
  * Ensured repository validation continues running even when an earlier check fails.
  * Aligned enforcement guidance and command-line help with the updated required-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->