### PR TITLE
fix(llm-config): propagate the advanced selections to the consumer template

### DIFF
--- a/docs/MODEL_SELECTION_POLICY.md
+++ b/docs/MODEL_SELECTION_POLICY.md
@@ -4,7 +4,7 @@
 > `config/llm_slots.json`
 > **Policy version:** `auxiliary-verifier-model-selection-v1`
 > **Reviewed:** 2026-07-10
-> **Next decision review:** 2026-07-24
+> **Next decision review:** 2026-08-30
 
 ## Decision Principle
 

--- a/templates/consumer-repo/config/model_registry.json
+++ b/templates/consumer-repo/config/model_registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2.0.0",
   "as_of": "2026-07-10",
-  "review_by": "2026-07-24",
+  "review_by": "2026-08-30",
   "purpose": "Auditable model facts and auxiliary judge/evaluator selections. Coding-worker execution profiles remain in .github/agents/registry.yml::execution_profiles.",
   "selection_policy": "config/model_selection_policy.json",
   "catalog_baselines": {
@@ -238,12 +238,47 @@
     {
       "profile": "verifier-balanced",
       "provider": "openai",
+      "model_id": "gpt-5.6-terra",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional selection advanced to the current catalog generation; positioning 'balanced' matches the verifier-balanced profile. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or for the superseded incumbent, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    },
+    {
+      "profile": "verifier-balanced",
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-5",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional selection advanced to the current catalog generation; positioning 'balanced' matches the verifier-balanced profile. Cross-family relative to the superseded claude-opus incumbent, so it was human-initiated rather than auto-prepared. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or the incumbent, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    },
+    {
+      "profile": "verifier-balanced",
+      "provider": "github-models",
+      "model_id": "openai/gpt-5",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional catalog fallback advanced to a model confirmed present in the 2026-07-10 GitHub Models catalog baseline. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or the superseded codex-mini-latest, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    }
+  ],
+  "selection_history": [
+    {
+      "profile": "verifier-balanced",
+      "provider": "openai",
       "model_id": "gpt-5.4",
       "status": "provisional",
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "gpt-5.6-terra",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     },
     {
       "profile": "verifier-balanced",
@@ -253,7 +288,10 @@
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "claude-sonnet-5",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     },
     {
       "profile": "verifier-balanced",
@@ -263,7 +301,10 @@
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent fallback retained until catalog availability and paired repository evidence approve a replacement."
+      "rationale": "Incumbent fallback retained until catalog availability and paired repository evidence approve a replacement.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "openai/gpt-5",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     }
   ],
   "evidence": [


### PR DESCRIPTION
## Why — #2852 did not actually reach consumers

I reported that `config/model_registry.json` "syncs and overwrites", so consumers would pick up the advanced selections automatically. **That was wrong**, and the evidence is that after three successful `maint-68` runs today (05:58 schedule + two dispatches) both consumers still resolve the *old* trio:

```
Manager-Database  -> gpt-5.4 / claude-opus-4-6 / codex-mini-latest
Inv-Man-Intake    -> gpt-5.4 / claude-opus-4-6 / codex-mini-latest
```

The manifest places `config/model_registry.json` in the **`llm_config`** section, and `scripts/sync_manifest_compiler.py:35-36` treats `llm_config` as **template-sourced** (`TEMPLATE_SOURCE_SECTIONS = COPY_SYNCED_SECTIONS - ROOT_SOURCE_SECTIONS`). The compiled entry is:

```json
{ "source":          "config/model_registry.json",
  "resolved_source": "templates/consumer-repo/config/model_registry.json",
  "sync_mode":       null,
  "section":         "llm_config",
  "target":          "config/model_registry.json" }
```

So the repo-root file governs **Workflows' own runtime only**. Consumers receive `templates/consumer-repo/config/model_registry.json` — which still held the pre-#2852 selections and the lapsed `review_by: 2026-07-24`. And because the mode is `null` (overwrite, not `create_only`), maint-68 was **actively re-asserting the old selections** onto consumers on every run.

## What changed

- `templates/consumer-repo/config/model_registry.json` ← copied from the repo-root registry.
- `docs/MODEL_SELECTION_POLICY.md` — refresh the stale `> **Next decision review:** 2026-07-24` header.

**Safety of the copy:** I diffed the two files first. The entire difference was exactly #2852's change — `review_by`, the three `selections`, and the new `selection_history`. `models`, `sources`, `evidence`, and `catalog_baselines` were byte-identical, so nothing consumer-specific is clobbered.

`config/llm_slots.json` needs no change: it is `create_only`, and the template copy is already profile-driven (`profile: verifier-balanced`, no model pins), which is what stranske/Manager-Database#1501 and stranske/Inv-Man-Intake#870 aligned the consumers to. Slot resolution therefore follows the reviewed selection.

## Verification

```
freshness gate against the TEMPLATE trio (registry + slots + policy)
  -> "Model registry is fresh: decisions, evidence, and slots are consistent."

pytest tests/scripts/test_validate_template_sync.py \
       tests/workflows/test_sync_manifest_delivery.py tests/docs/   -> 50 passed
```

After this merges, the next `maint-68` run propagates `gpt-5.6-terra` / `claude-sonnet-5` / `openai/gpt-5` to the consumer fleet.

## Follow-up

`config/model_selection_policy.json` is in the same `llm_config` section and has the same root-vs-template split, so the `minimum_cases_per_category_overrides` added in #2873 will need the same template copy once that lands. Tracked there rather than pre-empted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)