### PR TITLE
docs(contracts): stop synced contract docs linking to unsynced siblings

### DIFF
--- a/docs/contracts/identity-map-conventions.md
+++ b/docs/contracts/identity-map-conventions.md
@@ -7,7 +7,7 @@ lets the orchestrator **join entities across tools**.
 
 > **Status: P0 landing (under human review).** Part of the `run-contract/v1`
 > contract set. See [`run-contract-v1.md`](./run-contract-v1.md) for the
-> envelope spec and [`research-backplane-contract.md`](./research-backplane-contract.md)
+> envelope spec and [`research-backplane-contract.md`](https://github.com/stranske/Workflows/blob/main/docs/contracts/research-backplane-contract.md)
 > for ownership. These are *conventions*, not central code: resolution stays in
 > the authoritative repos.
 

--- a/docs/contracts/run-contract-v1.md
+++ b/docs/contracts/run-contract-v1.md
@@ -8,8 +8,10 @@ rollup.
 
 > **Status: P0 landing (under human review).** This is the wire-format spec.
 > Schema: [`run-contract-v1.schema.json`](./schemas/run-contract-v1.schema.json).
-> Program/ownership doc: [`research-backplane-contract.md`](./research-backplane-contract.md).
-> Sibling observability contract: [`langsmith-fleet-v1.md`](./langsmith-fleet-v1.md).
+> Program/ownership doc: [`research-backplane-contract.md`](https://github.com/stranske/Workflows/blob/main/docs/contracts/research-backplane-contract.md)
+> (Workflows-only; not synced to participants).
+> Sibling observability contract: [`langsmith-fleet-v1.md`](https://github.com/stranske/Workflows/blob/main/docs/contracts/langsmith-fleet-v1.md)
+> (Workflows-only; not synced to participants).
 > The contract is **opt-in**: a repo participates only via an entry in
 > `config/backplane_participants.json`. No participant emits an envelope yet
 > (that is P1+); nothing here is wired into any repo's CI.


### PR DESCRIPTION
## Why

`docs/contracts/run-contract-v1.md` and `docs/contracts/identity-map-conventions.md` **are** synced to consumer repos, but they carried relative links to `research-backplane-contract.md` and `langsmith-fleet-v1.md`, which are deliberately **not** synced — `.github/sync-manifest.yml:803-806`:

> The registry (`config/backplane_participants.json`) and the program doc (`docs/contracts/research-backplane-contract.md`) are intentionally NOT synced (Workflows-only single source of truth)

So in every consumer those links dangle. It went unnoticed until the first sync PR delivered these docs to a repo that actually tests links: **stranske/Collab-Admin#961** failed `tests/test_docs_links.py::test_docs_links_are_resolvable` on exactly those three links —

```
- docs/contracts/identity-map-conventions.md -> ./research-backplane-contract.md
- docs/contracts/run-contract-v1.md          -> ./research-backplane-contract.md
- docs/contracts/run-contract-v1.md          -> ./langsmith-fleet-v1.md
```

— blocking an otherwise config-only sync PR (all four of those docs are absent from Collab-Admin today, so this sync was their first delivery).

## What changed

The three links now point at canonical `github.com/stranske/Workflows/blob/main/...` URLs, with an inline note that those docs are Workflows-only. This keeps the deliberate no-sync decision fully intact while making the synced docs self-contained.

Untouched: `research-backplane-contract.md` and `langsmith-observability-contract.md` keep their relative links, because they are not synced and their siblings are local to this repo. The bare `` `research-backplane-contract.md` `` code reference at `run-contract-v1.md:203` is not a link and needed no change.

## Verification

Rather than fix only the three reported links, I scanned every synced doc against the compiled manifest:

```
for each synced *.md: every ](./*.md) target must also be synced
  -> OK: every relative .md link in a synced doc points at another synced doc
```

`pytest tests/docs/` → 34 passed.

## Follow-up

Once this merges, Collab-Admin's sync PR needs the refreshed docs to go green — a `maint-68` run will update its sync branch.

A guard for this class of defect (assert no synced doc relative-links to an unsynced target, using the same compiled-manifest scan) would stop it recurring; not added here to keep the fix reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)