### PR TITLE
fix(verifier): normalize structured provider content

### DIFF
--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -686,7 +686,10 @@ def _coerce_response_content(content: object) -> str:
             if isinstance(block, dict) and isinstance(block.get("text"), str)
         ]
         if text_blocks:
-            return "\n".join(text_blocks)
+            # Concatenate without a separator: a provider may split one JSON
+            # document across blocks, and an inserted newline inside a string
+            # literal would make the reassembled payload invalid JSON.
+            return "".join(text_blocks)
     return json.dumps(content, default=str)
 
 
@@ -741,11 +744,14 @@ def _build_verifier_repair_callback(client: object) -> Callable[[str, str, str],
     repair = build_repair_callback(client)
 
     def _repair(schema_json: str, validation_errors: str, raw_response: str) -> str | None:
-        return repair(
+        repaired = repair(
             schema_json,
             validation_errors,
             _cap_prompt_text(raw_response, EVAL_SCHEMA_REPAIR_BUDGET_TOKENS),
         )
+        if not repaired:
+            return None
+        return _coerce_response_content(repaired)
 
     return _repair
 

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -675,12 +675,28 @@ def _fallback_evaluation(
     )
 
 
+def _coerce_response_content(content: object) -> str:
+    """Return text from provider response blocks without losing a safe fallback."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_blocks = [
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        ]
+        if text_blocks:
+            return "\n".join(text_blocks)
+    return json.dumps(content, default=str)
+
+
 def _parse_llm_response(
-    content: str, provider: str, *, client: object | None = None
+    content: object, provider: str, *, client: object | None = None
 ) -> EvaluationResult:
+    content_text = _coerce_response_content(content)
     repair = _build_verifier_repair_callback(client) if client is not None else None
     parsed = parse_structured_output(
-        content,
+        content_text,
         EvaluationPayload,
         repair=repair,
         max_repair_attempts=SCHEMA_REPAIR_POLICY.max_attempts,
@@ -704,7 +720,7 @@ def _parse_llm_response(
             summary=None,
             provider_used=provider,
             used_llm=True,
-            raw_content=content,
+            raw_content=content_text,
             error=error,
         )
 
@@ -717,7 +733,7 @@ def _parse_llm_response(
         summary=payload.summary,
         provider_used=provider,
         used_llm=True,
-        raw_content=parsed.raw_content or content,
+        raw_content=parsed.raw_content or content_text,
     )
 
 

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -83,6 +83,30 @@ def test_comparison_runner_repairs_malformed_output() -> None:
     assert mock_client.invoke.call_count == 2
 
 
+def test_comparison_runner_handles_structured_response_content() -> None:
+    payload = json.dumps(_valid_payload())
+    response = _response_with(
+        [
+            {"type": "thinking", "thinking": "reviewing", "signature": "opaque"},
+            {"type": "text", "text": payload},
+        ]
+    )
+    mock_client = mock.MagicMock()
+    mock_client.invoke.return_value = response
+
+    runner = pr_verifier.ComparisonRunner(
+        context="context",
+        diff=None,
+        prompt="prompt",
+        clients=[(mock_client, "anthropic", "claude-sonnet")],
+    )
+
+    result = runner.run_single(mock_client, "anthropic", "claude-sonnet")
+
+    assert result.verdict == "PASS"
+    assert result.raw_content == payload
+
+
 def test_evaluate_pr_valid_output_no_repair(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = _valid_payload()
     good = json.dumps(payload)

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -107,6 +107,65 @@ def test_comparison_runner_handles_structured_response_content() -> None:
     assert result.raw_content == payload
 
 
+def test_comparison_runner_concatenates_split_text_blocks() -> None:
+    payload = json.dumps(_valid_payload())
+    # Split inside the summary string literal, where an inserted newline would
+    # be an unescaped control character and invalidate the JSON.
+    split = payload.index("Looks good.") + 5
+    response = _response_with(
+        [
+            {"type": "text", "text": payload[:split]},
+            {"type": "text", "text": payload[split:]},
+        ]
+    )
+    mock_client = mock.MagicMock()
+    mock_client.invoke.return_value = response
+
+    runner = pr_verifier.ComparisonRunner(
+        context="context",
+        diff=None,
+        prompt="prompt",
+        clients=[(mock_client, "anthropic", "claude-sonnet")],
+    )
+
+    result = runner.run_single(mock_client, "anthropic", "claude-sonnet")
+
+    assert result.verdict == "PASS"
+    assert result.raw_content == payload
+    assert mock_client.invoke.call_count == 1
+
+
+def test_comparison_runner_normalizes_structured_repair_response() -> None:
+    payload = json.dumps(_valid_payload())
+    malformed = _response_with(
+        [
+            {"type": "thinking", "thinking": "reviewing", "signature": "opaque"},
+            {"type": "text", "text": "```json\n" + payload + "\n```"},
+        ]
+    )
+    repaired = _response_with(
+        [
+            {"type": "thinking", "thinking": "repairing", "signature": "opaque"},
+            {"type": "text", "text": payload},
+        ]
+    )
+    mock_client = mock.MagicMock()
+    mock_client.invoke.side_effect = [malformed, repaired]
+
+    runner = pr_verifier.ComparisonRunner(
+        context="context",
+        diff=None,
+        prompt="prompt",
+        clients=[(mock_client, "anthropic", "claude-sonnet")],
+    )
+
+    result = runner.run_single(mock_client, "anthropic", "claude-sonnet")
+
+    assert result.verdict == "PASS"
+    assert result.raw_content == payload
+    assert mock_client.invoke.call_count == 2
+
+
 def test_evaluate_pr_valid_output_no_repair(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = _valid_payload()
     good = json.dumps(payload)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2878 -->
> **Source:** Issue #2878

Closes #2878

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/check_consumer_sync_drift.py:420-456` already records `pending_sync_prs`, but `build_report()` still sets top-level status to `drift`; `main()` then returns 1 for every non-converged state (`scripts/check_consumer_sync_drift.py:841-860`). The workflow runs on source pushes and at 05:10 UTC (`.github/workflows/health-68-consumer-sync-drift.yml:6-17`), before the 05:30 janitor, and comments on the durable issue for every failure (`health-68-consumer-sync-drift.yml:81-201`). Live evidence showed 249 runs with zero successes in 49 days and 223 comments on #2210. This is a **current observability break**: expected, covered propagation is reported as failure.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2210](https://github.com/stranske/Workflows/issues/2210)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Extend `scripts/check_consumer_sync_drift.py:358-495` to parse current sync provenance and classify repo-level remediation states.
- [ ] Add desired plan/hash input from `scripts/sync_manifest_compiler.py` and require an open PR marker/branch to match it before state becomes `covered`.
- [ ] Change `scripts/check_consumer_sync_drift.py:841-860` so `converged` and fully `covered` reports exit zero; `blocked`, `untracked_drift`, lookup errors, and expired coverage exit non-zero.
- [ ] Update `.github/workflows/health-68-consumer-sync-drift.yml` to run after Maint 71 and invoke issue mutation only for actionable failure states.
- [ ] Update `.github/scripts/consumer_sync_drift_issue_body.js` so body/marker/comment output renders the five states and does not append an unchanged covered-state comment.
- [ ] Extend `tests/scripts/test_check_consumer_sync_drift.py` with current, superseded, blocked, expired, and lookup-error fixtures.
- [ ] Extend `.github/scripts/__tests__/consumer-sync-drift-issue-body.test.js` with comment-suppression and actionable-state cases.
- [ ] Update `docs/ops/CONSUMER_REPO_MAINTENANCE.md` and `docs/ops/DURABLE_TRACKING_ISSUES.md` with the state and SLO contract.

#### Acceptance criteria
- [ ] `python -m pytest tests/scripts/test_check_consumer_sync_drift.py -q` and `node --test .github/scripts/__tests__/consumer-sync-drift-issue-body.test.js` pass.
- [ ] Drift in every affected repo with a current, unexpired generated PR produces top-level status `covered` and process exit 0.
- [ ] Drift with no current PR, a superseded hash, a deterministic failed check, or an expired lease produces a non-zero exit and exact actionable repo list.
- [ ] Repeated covered-state runs do not add comments to #2210; a changed actionable fingerprint updates the durable tracker once.
- [ ] **Deliberate-break gate:** temporarily make the PR hash differ from the compiler plan in the `covered` fixture; `tests/scripts/test_check_consumer_sync_drift.py::test_current_sync_pr_covers_drift` must fail or change the report to `untracked_drift`. Restore the fixture before review.

<!-- auto-status-summary:end -->