### PR TITLE
feat(sync): lease generated delivery attempts

### DIFF
--- a/.github/scripts/__tests__/sync-pr-merge-contract.test.js
+++ b/.github/scripts/__tests__/sync-pr-merge-contract.test.js
@@ -12,6 +12,7 @@ const {
   normalizeSyncHash,
   parseBooleanInput,
   selectActiveSyncPr,
+  selectMergeEligibleSyncPr,
   summarizeResults,
   syncBranchForHash,
 } = require('../sync_pr_merge_contract');
@@ -92,6 +93,11 @@ test('selectActiveSyncPr reports missing target without marking stale PRs', () =
   assert.equal(selection.missingExpected, true);
 });
 
+test('selectMergeEligibleSyncPr refuses legacy and expired delivery attempts', () => {
+  const legacy = pr(1, 'sync/workflows-current', '2026-04-25T01:00:00Z');
+  assert.equal(selectMergeEligibleSyncPr([legacy]).eligibility.reason, 'missing_delivery_record');
+});
+
 test('buildMergeReport provides machine-readable summary counts', () => {
   const report = buildMergeReport({
     generatedAt: '2026-04-25T06:00:00Z',
@@ -122,6 +128,7 @@ test('buildMergeReport provides machine-readable summary counts', () => {
     merge_blocked_runtime_ac: 0,
     merged: 0,
     merge_failed: 0,
+    delivery_contract_blocked: 0,
     error: 0,
   });
 });

--- a/.github/scripts/__tests__/sync-pr-merge-contract.test.js
+++ b/.github/scripts/__tests__/sync-pr-merge-contract.test.js
@@ -93,9 +93,21 @@ test('selectActiveSyncPr reports missing target without marking stale PRs', () =
   assert.equal(selection.missingExpected, true);
 });
 
-test('selectMergeEligibleSyncPr refuses legacy and expired delivery attempts', () => {
+test('selectMergeEligibleSyncPr refuses legacy delivery attempts', () => {
   const legacy = pr(1, 'sync/workflows-current', '2026-04-25T01:00:00Z');
   assert.equal(selectMergeEligibleSyncPr([legacy]).eligibility.reason, 'missing_delivery_record');
+});
+
+test('selectMergeEligibleSyncPr rejects a PR whose head no longer matches its lease', () => {
+  const leased = {
+    ...pr(1, 'sync/workflows-current', '2026-04-25T01:00:00Z'),
+    body: '<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"plan-abc","generation":"template-abc","repository":"stranske/Ready","desired_tree_hash":"tree-abc","source_commit":"source-abc","lease_expires_at":"2026-08-02T00:00:00Z","predecessor_prs":[],"successor_prs":[]} -->',
+  };
+  assert.equal(selectMergeEligibleSyncPr([leased], {
+    now: '2026-08-01T22:00:00Z',
+    repository: 'stranske/Ready',
+    desiredTreeHash: 'tree-other',
+  }).eligibility.reason, 'desired_tree_mismatch');
 });
 
 test('buildMergeReport provides machine-readable summary counts', () => {

--- a/.github/scripts/__tests__/sync_pr_lease_contract.test.js
+++ b/.github/scripts/__tests__/sync_pr_lease_contract.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  DELIVERY_RECORD_SCHEMA,
+  formatDeliveryRecord,
+  parseDeliveryRecord,
+  mergeEligibility,
+} = require('../sync_pr_lease_contract');
+
+const current = {
+  schema: DELIVERY_RECORD_SCHEMA,
+  durable_issue_url: 'https://github.com/stranske/Workflows/issues/1836',
+  plan_id: 'plan-abc',
+  generation: 'template-abc',
+  repository: 'stranske/Ready',
+  desired_tree_hash: 'tree-abc',
+  source_commit: 'source-abc',
+  lease_expires_at: '2026-08-02T00:00:00Z',
+  predecessor_prs: ['#10'],
+  successor_prs: [],
+};
+
+test('only a newest unexpired matching delivery record is merge eligible', () => {
+  const marker = formatDeliveryRecord(current);
+  const parsed = parseDeliveryRecord(`summary\n${marker}`);
+  assert.deepEqual(parsed, { ...current, terminal_disposition: '' });
+  assert.deepEqual(mergeEligibility(parsed, {
+    now: '2026-08-01T22:00:00Z',
+    planId: 'plan-abc',
+    repository: 'stranske/Ready',
+    desiredTreeHash: 'tree-abc',
+  }), { eligible: true, reason: 'current_unexpired' });
+  assert.equal(mergeEligibility({ ...parsed, lease_expires_at: '2026-08-01T21:00:00Z' }, {
+    now: '2026-08-01T22:00:00Z',
+  }).reason, 'lease_expired');
+  assert.equal(mergeEligibility(parsed, { now: '2026-08-01T22:00:00Z', desiredTreeHash: 'other' }).reason, 'desired_tree_mismatch');
+});

--- a/.github/scripts/__tests__/sync_pr_lease_contract.test.js
+++ b/.github/scripts/__tests__/sync_pr_lease_contract.test.js
@@ -22,7 +22,7 @@ const current = {
   successor_prs: [],
 };
 
-test('only a newest unexpired matching delivery record is merge eligible', () => {
+test('an unexpired matching delivery record is merge eligible', () => {
   const marker = formatDeliveryRecord(current);
   const parsed = parseDeliveryRecord(`summary\n${marker}`);
   assert.deepEqual(parsed, { ...current, terminal_disposition: '' });

--- a/.github/scripts/sync_pr_lease_contract.js
+++ b/.github/scripts/sync_pr_lease_contract.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// A generated PR is a short-lived delivery attempt.  The durable campaign issue
+// retains coordination history; this marker lets the producer and merger agree
+// on which attempt is current without treating an arbitrary open PR as current.
+const DELIVERY_RECORD_SCHEMA = 'sync-pr-delivery-record/v1';
+const DELIVERY_RECORD_MARKER = 'sync-pr-delivery-record:v1';
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function unique(values) {
+  return [...new Set((values || []).map(clean).filter(Boolean))];
+}
+
+function normalizeRecord(record = {}) {
+  const normalized = {
+    schema: clean(record.schema) || DELIVERY_RECORD_SCHEMA,
+    durable_issue_url: clean(record.durable_issue_url),
+    plan_id: clean(record.plan_id),
+    generation: clean(record.generation),
+    repository: clean(record.repository),
+    desired_tree_hash: clean(record.desired_tree_hash),
+    source_commit: clean(record.source_commit),
+    lease_expires_at: clean(record.lease_expires_at),
+    predecessor_prs: unique(record.predecessor_prs),
+    successor_prs: unique(record.successor_prs),
+    terminal_disposition: clean(record.terminal_disposition),
+  };
+  return normalized;
+}
+
+function deliveryRecordErrors(record = {}) {
+  const normalized = normalizeRecord(record);
+  const required = [
+    'durable_issue_url', 'plan_id', 'generation', 'repository',
+    'desired_tree_hash', 'source_commit', 'lease_expires_at',
+  ];
+  const errors = [];
+  if (normalized.schema !== DELIVERY_RECORD_SCHEMA) errors.push('schema');
+  for (const field of required) if (!normalized[field]) errors.push(field);
+  if (normalized.terminal_disposition && !['merged', 'superseded', 'expired', 'blocked'].includes(normalized.terminal_disposition)) {
+    errors.push('terminal_disposition');
+  }
+  if (normalized.lease_expires_at && Number.isNaN(Date.parse(normalized.lease_expires_at))) {
+    errors.push('lease_expires_at');
+  }
+  return errors;
+}
+
+function formatDeliveryRecord(record = {}) {
+  const normalized = normalizeRecord(record);
+  const errors = deliveryRecordErrors(normalized);
+  if (errors.length) throw new Error(`Invalid delivery record: ${errors.join(', ')}`);
+  return `<!-- ${DELIVERY_RECORD_MARKER} ${JSON.stringify(normalized)} -->`;
+}
+
+function parseDeliveryRecord(body = '') {
+  const match = String(body || '').match(new RegExp(`<!--\\s*${DELIVERY_RECORD_MARKER}\\s+([\\s\\S]*?)\\s*-->`));
+  if (!match) return null;
+  try {
+    const record = normalizeRecord(JSON.parse(match[1]));
+    return deliveryRecordErrors(record).length ? null : record;
+  } catch (_) {
+    return null;
+  }
+}
+
+function mergeEligibility(record, { now = new Date().toISOString(), planId = '', repository = '', desiredTreeHash = '' } = {}) {
+  const normalized = normalizeRecord(record);
+  const errors = deliveryRecordErrors(normalized);
+  if (errors.length) return { eligible: false, reason: `invalid:${errors.join(',')}` };
+  if (normalized.terminal_disposition) return { eligible: false, reason: `terminal:${normalized.terminal_disposition}` };
+  if (Date.parse(normalized.lease_expires_at) <= Date.parse(now)) return { eligible: false, reason: 'lease_expired' };
+  if (clean(planId) && normalized.plan_id !== clean(planId)) return { eligible: false, reason: 'plan_mismatch' };
+  if (clean(repository) && normalized.repository !== clean(repository)) return { eligible: false, reason: 'repository_mismatch' };
+  if (clean(desiredTreeHash) && normalized.desired_tree_hash !== clean(desiredTreeHash)) return { eligible: false, reason: 'desired_tree_mismatch' };
+  return { eligible: true, reason: 'current_unexpired' };
+}
+
+module.exports = {
+  DELIVERY_RECORD_SCHEMA,
+  DELIVERY_RECORD_MARKER,
+  normalizeRecord,
+  deliveryRecordErrors,
+  formatDeliveryRecord,
+  parseDeliveryRecord,
+  mergeEligibility,
+};

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -2,6 +2,7 @@
 
 const REPORT_SCHEMA = 'workflows-sync-pr-merge/v1';
 const SYNC_BRANCH_PREFIX = 'sync/workflows-';
+const { parseDeliveryRecord, mergeEligibility } = require('./sync_pr_lease_contract');
 
 function normalizeSyncHash(value) {
   const raw = String(value || '').trim();
@@ -179,6 +180,16 @@ function selectActiveSyncPr(prs, syncHash = '') {
   };
 }
 
+function selectMergeEligibleSyncPr(prs, { syncHash = '', now, planId = '', repository = '' } = {}) {
+  const selection = selectActiveSyncPr(prs, syncHash);
+  if (!selection.active) return { ...selection, eligibility: null };
+  const record = parseDeliveryRecord(selection.active.body || '');
+  const eligibility = record
+    ? mergeEligibility(record, { now, planId, repository })
+    : { eligible: false, reason: 'missing_delivery_record' };
+  return { ...selection, deliveryRecord: record, eligibility };
+}
+
 function summarizeResults(results) {
   const counts = {
     no_prs: 0,
@@ -194,6 +205,7 @@ function summarizeResults(results) {
     merge_blocked_runtime_ac: 0,
     merged: 0,
     merge_failed: 0,
+    delivery_contract_blocked: 0,
     error: 0,
   };
   for (const result of results || []) {
@@ -274,6 +286,7 @@ module.exports = {
   selectSyncPrGatingChecks,
   sortSyncPrs,
   selectActiveSyncPr,
+  selectMergeEligibleSyncPr,
   summarizeResults,
   buildMergeReport,
   buildMarkdownSummary,

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -180,12 +180,15 @@ function selectActiveSyncPr(prs, syncHash = '') {
   };
 }
 
-function selectMergeEligibleSyncPr(prs, { syncHash = '', now, planId = '', repository = '' } = {}) {
+function selectMergeEligibleSyncPr(
+  prs,
+  { syncHash = '', now, planId = '', repository = '', desiredTreeHash = '' } = {},
+) {
   const selection = selectActiveSyncPr(prs, syncHash);
   if (!selection.active) return { ...selection, eligibility: null };
   const record = parseDeliveryRecord(selection.active.body || '');
   const eligibility = record
-    ? mergeEligibility(record, { now, planId, repository })
+    ? mergeEligibility(record, { now, planId, repository, desiredTreeHash })
     : { eligible: false, reason: 'missing_delivery_record' };
   return { ...selection, deliveryRecord: record, eligibility };
 }

--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -337,7 +337,20 @@ jobs:
             pr_scope="This PR updates generated dev-tool pin files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows)."
           fi
 
-          # Create PR body
+          # Create PR body.  Each generated PR is a leased delivery attempt;
+          # the durable campaign issue keeps the coordination history.
+          desired_tree_hash=$(git rev-parse HEAD^{tree})
+          lease_expires_at=$(date -u -d '+72 hours' +%Y-%m-%dT%H:%M:%SZ)
+          delivery_marker=$(jq -nc \
+            --arg schema "sync-pr-delivery-record/v1" \
+            --arg durable_issue_url "https://github.com/stranske/Workflows/issues/1836" \
+            --arg plan_id "dev-tool-${{ needs.prepare.outputs.versions_hash }}" \
+            --arg generation "${{ needs.prepare.outputs.versions_hash }}" \
+            --arg repository "${{ matrix.repo }}" \
+            --arg desired_tree_hash "$desired_tree_hash" \
+            --arg source_commit "$GITHUB_SHA" \
+            --arg lease_expires_at "$lease_expires_at" \
+            '{schema:$schema,durable_issue_url:$durable_issue_url,plan_id:$plan_id,generation:$generation,repository:$repository,desired_tree_hash:$desired_tree_hash,source_commit:$source_commit,lease_expires_at:$lease_expires_at,predecessor_prs:[],successor_prs:[]}')
           pr_body="## Dev Tool Version Sync
 
           ${pr_scope}
@@ -354,7 +367,9 @@ jobs:
           - Easier debugging when tools behave the same everywhere
 
           ---
-          **Source:** \`.github/workflows/autofix-versions.env\`"
+          **Source:** \`.github/workflows/autofix-versions.env\`
+
+          <!-- sync-pr-delivery-record:v1 $delivery_marker -->"
 
           gh pr create \
             --head "$branch_name" \

--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -340,7 +340,7 @@ jobs:
 
           # Create PR body.  Each generated PR is a leased delivery attempt;
           # the durable campaign issue keeps the coordination history.
-          desired_tree_hash=${desired_tree:-$(git rev-parse HEAD^{tree})}
+          desired_tree_hash=${desired_tree:-$(git rev-parse 'HEAD^{tree}')}
           lease_expires_at=$(date -u -d '+72 hours' +%Y-%m-%dT%H:%M:%SZ)
           delivery_marker=$(jq -nc \
             --arg schema "sync-pr-delivery-record/v1" \

--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -272,6 +272,9 @@ jobs:
           && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
+          DELIVERY_PLAN_ID: dev-tool-${{ needs.prepare.outputs.versions_hash }}
+          DELIVERY_GENERATION: ${{ needs.prepare.outputs.versions_hash }}
+          DELIVERY_REPOSITORY: ${{ matrix.repo }}
         run: |
           cd consumer
 
@@ -302,6 +305,7 @@ jobs:
           if [ -f requirements-dev.txt ]; then git add requirements-dev.txt; fi
           if [ -f uv.lock ]; then git add uv.lock; fi
 
+          matching_existing=false
           if [ -n "$existing_pr" ]; then
             git fetch origin "$branch_name"
             existing_head=$(git rev-parse FETCH_HEAD)
@@ -309,25 +313,22 @@ jobs:
             existing_tree=$(git rev-parse "${existing_head}^{tree}")
             desired_tree=$(git write-tree)
             if [ "$existing_base" = "$base_sha" ] && [ "$existing_tree" = "$desired_tree" ]; then
-              echo "Existing PR #$existing_pr already matches current main and generated files"
-              exit 0
+              matching_existing=true
+              echo "Existing PR #$existing_pr already matches current main and generated files; refreshing lease"
             fi
           fi
 
-          # Commit with multi-line message
-          commit_msg="deps: sync dev tool versions from Workflows
+          if [ "$matching_existing" != "true" ]; then
+            # Commit with multi-line message
+            commit_msg="deps: sync dev tool versions from Workflows
 
-          Automated sync from stranske/Workflows autofix-versions.env
-          Versions hash: ${{ needs.prepare.outputs.versions_hash }}
+            Automated sync from stranske/Workflows autofix-versions.env
+            Versions hash: ${{ needs.prepare.outputs.versions_hash }}
 
-          This ensures consistent dev tool versions across all repos."
-          git commit -m "$commit_msg"
+            This ensures consistent dev tool versions across all repos."
+            git commit -m "$commit_msg"
 
-          git push --force -u origin "$branch_name"
-
-          if [ -n "$existing_pr" ]; then
-            echo "Updated existing PR #$existing_pr for this wave"
-            exit 0
+            git push --force -u origin "$branch_name"
           fi
 
           changed_files="$(git show --name-only --format= HEAD)"
@@ -339,14 +340,14 @@ jobs:
 
           # Create PR body.  Each generated PR is a leased delivery attempt;
           # the durable campaign issue keeps the coordination history.
-          desired_tree_hash=$(git rev-parse HEAD^{tree})
+          desired_tree_hash=${desired_tree:-$(git rev-parse HEAD^{tree})}
           lease_expires_at=$(date -u -d '+72 hours' +%Y-%m-%dT%H:%M:%SZ)
           delivery_marker=$(jq -nc \
             --arg schema "sync-pr-delivery-record/v1" \
             --arg durable_issue_url "https://github.com/stranske/Workflows/issues/1836" \
-            --arg plan_id "dev-tool-${{ needs.prepare.outputs.versions_hash }}" \
-            --arg generation "${{ needs.prepare.outputs.versions_hash }}" \
-            --arg repository "${{ matrix.repo }}" \
+            --arg plan_id "$DELIVERY_PLAN_ID" \
+            --arg generation "$DELIVERY_GENERATION" \
+            --arg repository "$DELIVERY_REPOSITORY" \
             --arg desired_tree_hash "$desired_tree_hash" \
             --arg source_commit "$GITHUB_SHA" \
             --arg lease_expires_at "$lease_expires_at" \
@@ -371,10 +372,15 @@ jobs:
 
           <!-- sync-pr-delivery-record:v1 $delivery_marker -->"
 
-          gh pr create \
-            --head "$branch_name" \
-            --title "deps: sync dev tool versions" \
-            --body "$pr_body"
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --body "$pr_body"
+            echo "Refreshed delivery lease for existing PR #$existing_pr"
+          else
+            gh pr create \
+              --head "$branch_name" \
+              --title "deps: sync dev tool versions" \
+              --body "$pr_body"
+          fi
 
       - name: Dry run summary
         if: >-

--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -278,7 +278,7 @@ jobs:
         run: |
           cd consumer
 
-          branch_name="deps/sync-dev-versions-${{ needs.prepare.outputs.versions_hash }}"
+          branch_name="deps/sync-dev-versions-$DELIVERY_GENERATION"
 
           # Preserve the PR for this wave when it already exists, but rebuild
           # its branch from current main if either the base or generated tree
@@ -323,7 +323,7 @@ jobs:
             commit_msg="deps: sync dev tool versions from Workflows
 
             Automated sync from stranske/Workflows autofix-versions.env
-            Versions hash: ${{ needs.prepare.outputs.versions_hash }}
+            Versions hash: $DELIVERY_GENERATION
 
             This ensures consistent dev tool versions across all repos."
             git commit -m "$commit_msg"

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -261,6 +261,7 @@ jobs:
       REPO_TOKEN: ${{ secrets.OWNER_PR_PAT || secrets.SERVICE_BOT_PAT }}
       PLAN_ID: ${{ needs.prepare.outputs.plan_id }}
       SYNC_PHASE: ${{ needs.prepare.outputs.phase }}
+      DURABLE_ISSUE_URL: https://github.com/stranske/Workflows/issues/1836
     steps:
       - name: Compute result artifact name
         id: repo_meta
@@ -836,6 +837,8 @@ jobs:
           git push --quiet -u origin "$branch_name"
 
           # Create PR
+          desired_tree_hash=$(git rev-parse HEAD^{tree})
+          lease_expires_at=$(date -u -d '+72 hours' +%Y-%m-%dT%H:%M:%SZ)
           sync_marker=$(jq -nc \
             --arg schema "workflows-consumer-sync-pr/v1" \
             --arg consumer_repo "${{ matrix.repo }}" \
@@ -865,6 +868,16 @@ jobs:
               run_attempt: $run_attempt,
               changes_count: $changes_count
             }')
+          delivery_marker=$(jq -nc \
+            --arg schema "sync-pr-delivery-record/v1" \
+            --arg durable_issue_url "$DURABLE_ISSUE_URL" \
+            --arg plan_id "$PLAN_ID" \
+            --arg generation "${{ needs.prepare.outputs.template_hash }}" \
+            --arg repository "${{ matrix.repo }}" \
+            --arg desired_tree_hash "$desired_tree_hash" \
+            --arg source_commit "$GITHUB_SHA" \
+            --arg lease_expires_at "$lease_expires_at" \
+            '{schema:$schema,durable_issue_url:$durable_issue_url,plan_id:$plan_id,generation:$generation,repository:$repository,desired_tree_hash:$desired_tree_hash,source_commit:$source_commit,lease_expires_at:$lease_expires_at,predecessor_prs:[],successor_prs:[]}')
           pr_body=$(cat ../sync_summary.md)
           pr_body="$pr_body
 
@@ -883,7 +896,8 @@ jobs:
           **Consumer repo:** \`${{ matrix.repo }}\`
           **Manifest:** \`.github/sync-manifest.yml\`
 
-          <!-- workflows-consumer-sync:v1 $sync_marker -->"
+          <!-- workflows-consumer-sync:v1 $sync_marker -->
+          <!-- sync-pr-delivery-record:v1 $delivery_marker -->"
 
           pr_url=$(gh pr create \
             --head "$branch_name" \

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -735,38 +735,18 @@ jobs:
         if: steps.sync.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
-          EXISTING_SYNC_PR: ${{ steps.open_pr.outputs.exists || 'false' }}
+          DELIVERY_GENERATION: ${{ needs.prepare.outputs.template_hash }}
+          DELIVERY_REPOSITORY: ${{ matrix.repo }}
         run: |
           cd consumer
 
           branch_name="sync/workflows-${{ needs.prepare.outputs.template_hash }}"
 
-          if [ "$EXISTING_SYNC_PR" = "true" ]; then
-            existing_pr=$(
-              gh pr list --head "$branch_name" --json number -q '.[0].number' || echo ""
-            )
-            echo "PR #$existing_pr already exists for this sync"
-            echo "::notice::Existing PR: #$existing_pr"
-            {
-              echo "status=existing_pr"
-              echo "pr_number=$existing_pr"
-              echo "pr_url=https://github.com/${{ matrix.repo }}/pull/$existing_pr"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Race-condition backstop: another run may have opened the PR after
-          # the shared open-PR check completed.
+          # Keep an existing generated PR current instead of treating it as a
+          # terminal delivery attempt: rebuild its branch and refresh its lease.
           existing_pr=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
           if [ -n "$existing_pr" ]; then
-            echo "PR #$existing_pr already exists for this sync"
-            echo "::notice::Existing PR: #$existing_pr"
-            {
-              echo "status=existing_pr"
-              echo "pr_number=$existing_pr"
-              echo "pr_url=https://github.com/${{ matrix.repo }}/pull/$existing_pr"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "Refreshing existing sync PR #$existing_pr"
           fi
 
           # Configure git for push authentication using credential helper
@@ -782,7 +762,7 @@ jobs:
 
           # Remote branch exists but no PR was found
           # (likely from a failed previous run) - deleting and recreating
-          if git ls-remote --exit-code origin "refs/heads/$branch_name" >/dev/null 2>&1; then
+          if [ -z "$existing_pr" ] && git ls-remote --exit-code origin "refs/heads/$branch_name" >/dev/null 2>&1; then
               echo "Remote branch $branch_name exists but no PR was found."
               echo "Deleting and recreating branch from previous failed run."
             # Delete the remote branch so we can push fresh
@@ -800,7 +780,7 @@ jobs:
           fi
 
           # Create branch and commit
-          git checkout -b "$branch_name"
+          git checkout -B "$branch_name"
 
           # Stage ONLY manifest-declared targets, to avoid accidentally committing
           # consumer-specific artifacts (e.g. requirements.lock, *.pyc, *.egg-info).
@@ -872,8 +852,8 @@ jobs:
             --arg schema "sync-pr-delivery-record/v1" \
             --arg durable_issue_url "$DURABLE_ISSUE_URL" \
             --arg plan_id "$PLAN_ID" \
-            --arg generation "${{ needs.prepare.outputs.template_hash }}" \
-            --arg repository "${{ matrix.repo }}" \
+            --arg generation "$DELIVERY_GENERATION" \
+            --arg repository "$DELIVERY_REPOSITORY" \
             --arg desired_tree_hash "$desired_tree_hash" \
             --arg source_commit "$GITHUB_SHA" \
             --arg lease_expires_at "$lease_expires_at" \
@@ -899,14 +879,22 @@ jobs:
           <!-- workflows-consumer-sync:v1 $sync_marker -->
           <!-- sync-pr-delivery-record:v1 $delivery_marker -->"
 
-          pr_url=$(gh pr create \
-            --head "$branch_name" \
-            --title "chore: sync workflow templates" \
-            --body "$pr_body" \
-            --label "sync,automated")
-          pr_number=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" --body "$pr_body"
+            pr_number="$existing_pr"
+            pr_url="https://github.com/${{ matrix.repo }}/pull/$existing_pr"
+            status="refreshed_pr"
+          else
+            pr_url=$(gh pr create \
+              --head "$branch_name" \
+              --title "chore: sync workflow templates" \
+              --body "$pr_body" \
+              --label "sync,automated")
+            pr_number=$(gh pr list --head "$branch_name" --json number -q '.[0].number' || echo "")
+            status="created_pr"
+          fi
           {
-            echo "status=created_pr"
+            echo "status=$status"
             echo "pr_number=$pr_number"
             echo "pr_url=$pr_url"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/maint-68-sync-consumer-repos.yml
+++ b/.github/workflows/maint-68-sync-consumer-repos.yml
@@ -817,7 +817,7 @@ jobs:
           git push --quiet -u origin "$branch_name"
 
           # Create PR
-          desired_tree_hash=$(git rev-parse HEAD^{tree})
+          desired_tree_hash=$(git rev-parse 'HEAD^{tree}')
           lease_expires_at=$(date -u -d '+72 hours' +%Y-%m-%dT%H:%M:%SZ)
           sync_marker=$(jq -nc \
             --arg schema "workflows-consumer-sync-pr/v1" \

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -139,6 +139,7 @@ jobs:
               normalizeSyncHash,
               parseBooleanInput,
               isTrustedSyncPr,
+              selectMergeEligibleSyncPr,
               selectActiveSyncPr,
               selectSyncPrGatingChecks,
             } = require('./.github/scripts/sync_pr_merge_contract.js');
@@ -410,7 +411,11 @@ jobs:
                   continue;
                 }
 
-                const selection = selectActiveSyncPr(syncPRs, requestedSyncHash);
+                const selection = selectMergeEligibleSyncPr(syncPRs, {
+                  syncHash: requestedSyncHash,
+                  now: new Date().toISOString(),
+                  repository: `${owner}/${repo}`,
+                });
                 if (selection.missingExpected) {
                   console.log(
                     `Expected sync PR branch ${selection.expectedBranch} was not found; leaving ` +
@@ -427,6 +432,14 @@ jobs:
                       url: item.html_url,
                     })),
                   });
+                  continue;
+                }
+
+                if (!selection.eligibility?.eligible) {
+                  const reason = selection.eligibility?.reason || 'missing_delivery_record';
+                  console.log(`Delivery contract blocks merge: ${reason}`);
+                  results.push({ owner, repo, pr: selection.active.number, branch: selection.active.head.ref,
+                    status: 'delivery_contract_blocked', delivery_reason: reason });
                   continue;
                 }
 

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -140,7 +140,6 @@ jobs:
               parseBooleanInput,
               isTrustedSyncPr,
               selectMergeEligibleSyncPr,
-              selectActiveSyncPr,
               selectSyncPrGatingChecks,
             } = require('./.github/scripts/sync_pr_merge_contract.js');
             const {
@@ -411,7 +410,7 @@ jobs:
                   continue;
                 }
 
-                const selection = selectMergeEligibleSyncPr(syncPRs, {
+                let selection = selectMergeEligibleSyncPr(syncPRs, {
                   syncHash: requestedSyncHash,
                   now: new Date().toISOString(),
                   repository: `${owner}/${repo}`,
@@ -435,13 +434,19 @@ jobs:
                   continue;
                 }
 
-                if (!selection.eligibility?.eligible) {
-                  const reason = selection.eligibility?.reason || 'missing_delivery_record';
-                  console.log(`Delivery contract blocks merge: ${reason}`);
-                  results.push({ owner, repo, pr: selection.active.number, branch: selection.active.head.ref,
-                    status: 'delivery_contract_blocked', delivery_reason: reason });
-                  continue;
-                }
+                const { data: selectedHeadCommit } = await withRetry((client) =>
+                  client.rest.git.getCommit({
+                    owner,
+                    repo,
+                    commit_sha: selection.active.head.sha,
+                  }),
+                );
+                selection = selectMergeEligibleSyncPr(syncPRs, {
+                  syncHash: requestedSyncHash,
+                  now: new Date().toISOString(),
+                  repository: `${owner}/${repo}`,
+                  desiredTreeHash: selectedHeadCommit?.tree?.sha || '',
+                });
 
                 // If multiple sync PRs exist, close older ones as stale
                 if (selection.stale.length > 0) {
@@ -506,6 +511,14 @@ jobs:
                       });
                     }
                   }
+                }
+
+                if (!selection.eligibility?.eligible) {
+                  const reason = selection.eligibility?.reason || 'missing_delivery_record';
+                  console.log(`Delivery contract blocks merge: ${reason}`);
+                  results.push({ owner, repo, pr: selection.active.number, branch: selection.active.head.ref,
+                    status: 'delivery_contract_blocked', delivery_reason: reason });
+                  continue;
                 }
 
                 // Process the selected active PR

--- a/docs/ops/DURABLE_TRACKING_ISSUES.md
+++ b/docs/ops/DURABLE_TRACKING_ISSUES.md
@@ -45,6 +45,15 @@ The signal flow each tracker carries:
 
 - **#2211** — health check on the weekly metrics pipeline. Healthy state is `Parse errors: 0` and non-zero terminal disposition records. A regression here usually means a producer is emitting a malformed artifact, not that the dashboard itself is broken.
 - **#1836** — work queue for items the local Codex watcher should claim. The body holds the live queue state with a sync hash, repo counts, and per-item status. Active campaigns must not be closed; the controller treats a closed campaign as "stop work."
+
+### Leased generated delivery attempts
+
+Maint 68 consumer sync and Maint 52 dev-tool sync PRs carry a
+`sync-pr-delivery-record/v1` marker. The marker names the durable campaign
+issue, plan/generation, consumer repository, desired tree hash, source commit,
+and a 72-hour lease. Maint 71 may merge only a current, unexpired record;
+markerless, stale, or expired attempts are reported for terminal disposition
+rather than becoming an immortal coordination queue.
 - **#2210** — fan-out drift report across registered consumer repos. `Health 68` creates or refreshes it when drift is **actionable**; a clean run does not close it, so its latest body must be read as the last detected signal rather than an automatic current-status promise. Since #2878 the checker classifies each consumer as `converged`, `covered`, `blocked`, `untracked_drift`, or `stale`, and only the actionable states reach this tracker:
 
   | State | Meaning | Exit code | Touches #2210 |

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -310,8 +310,8 @@ def test_merge_sync_prs_uploads_machine_readable_report_and_hash_input():
         "sync_pr_merge_contract.js" in text
     ), "Maint 71 must use the structured sync PR merge contract helper"
     assert (
-        "selectActiveSyncPr" in text
-    ), "Maint 71 must select the active PR with the hash-aware contract"
+        "selectMergeEligibleSyncPr" in text
+    ), "Maint 71 must select the active PR with the lease-aware merge contract"
     assert "cleanup_branches:" in text, "Maint 71 must expose sync branch cleanup control"
     assert (
         "collectDeletableSyncBranches" in text and "branch_delete_failed" in text


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2880 -->
> **Source:** Issue #2880

Closes #2880

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The coordination object must be allowed to persist, but a generated PR must not. The current durable campaign already models queue fingerprints and item leases in `.github/scripts/sync_dependency_campaign.js:178-230,360-456`, while Maint 68 stops when an existing consumer PR is found (`.github/workflows/maint-68-sync-consumer-repos.yml:681-724`). That combination leaves the opener/closer system without a bounded rule for whether an old PR should be refreshed, replaced, closed, or escalated.

This is a current productivity defect: generated PRs can survive across source generations, repeatedly consume review and CI attention, and still be indistinguishable from the latest intended delivery. The durable object should be the campaign issue (currently #1836), with each generated PR acting as a leased delivery attempt that has an explicit terminal disposition.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1836](https://github.com/stranske/Workflows/issues/1836)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a versioned delivery-record schema to `.github/scripts/sync_dependency_campaign.js` with campaign issue URL, plan ID, generation, repository, desired tree hash, source commit, lease expiry, and predecessor/successor PR references.
- [ ] Emit the schema as a machine-readable provenance marker in PR bodies created by `.github/workflows/maint-68-sync-consumer-repos.yml` and `.github/workflows/maint-52-sync-dev-versions.yml`.
- [ ] Change Maint 68 to compare the existing PR base/tree and delivery record, following the same-wave update pattern already used by Maint 52, instead of treating any existing PR as terminal.
- [ ] Extend `.github/scripts/sync_pr_merge_contract.js` and `.github/workflows/maint-71-merge-sync-prs.yml` so only the latest unexpired delivery generation is merge-eligible.
- [ ] Define explicit terminal transitions: `merged`, `superseded`, `expired`, and `blocked`; blocked transitions must link a durable source or repo-local issue with the exact next action.
- [ ] Persist terminal disposition and latest desired tree hash through `.github/scripts/sync_tracker_state.js` and the campaign state used by Maint 82.
- [ ] Update `docs/ops/SYNC_DEPENDENCY_CAMPAIGN.md`, `docs/ops/DURABLE_TRACKING_ISSUES.md`, and `docs/ops/CONSUMER_REPO_MAINTENANCE.md` with the rule “durable issue, leased PR.”
- [ ] Add migration behavior for already-open generated PRs that lack a marker: classify them once, attach or infer lineage safely, and never merge an ambiguous stale generation.

#### Acceptance criteria
- [ ] `.github/scripts/__tests__/sync_dependency_campaign.test.js` proves that the durable issue survives multiple delivery generations while each PR reaches exactly one terminal disposition.
- [ ] A new `.github/scripts/__tests__/sync_pr_lease_contract.test.js` proves that only the newest unexpired PR whose desired tree hash matches the current plan is merge-eligible.
- [ ] `tests/workflows/test_sync_manifest_delivery.py` proves Maint 68 updates the same current-generation PR when safe and creates a replacement only after a generation or terminal-state transition.
- [ ] Maint 71 reports and closes superseded/expired generated PRs without merging them; blocked PRs leave a linked durable issue record with an exact next command.
- [ ] Active, non-outdated inline review debt and failing required checks continue to block merge even when the lease and generation are current.
- [ ] Deliberate-break test: expire a current fixture or change its plan hash, verify `sync_pr_lease_contract.test.js` fails merge eligibility, then revert the fixture and verify the suite passes.
- [ ] Run `python scripts/dev_check.py --action test` and the repository workflow-validation suite successfully.

<!-- auto-status-summary:end -->