### PR TITLE
fix(sync): persist Maint 71 delivery handoffs

### DIFF
--- a/.github/scripts/__tests__/sync-pr-merge-contract.test.js
+++ b/.github/scripts/__tests__/sync-pr-merge-contract.test.js
@@ -172,12 +172,32 @@ test('buildDeliveryHandoff preserves the restart fields for a generated PR', () 
     owner: 'stranske', repo: 'Ready', pr: 11, branch: 'deps/sync-dev-versions-20260801',
     head_sha: 'abc', delivery_generation: 'g2', delivery_disposition: 'review-blocked',
     blocker_owner: 'closer', next_command: 'resolve-active-review-threads',
+    status: 'review_blocked', active_review_thread_count: 2,
   }), {
     schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
     branch: 'deps/sync-dev-versions-20260801', head_sha: 'abc', delivery_generation: 'g2',
     lane: 'dev-tool-sync', disposition: 'review-blocked', blocker_owner: 'closer',
     next_command: 'resolve-active-review-threads',
+    check_state: 'ready', review_state: 'blocked',
   });
+});
+
+test('buildDeliveryHandoff rewrites terminal merge outcomes', () => {
+  assert.deepEqual(buildDeliveryHandoff({
+    owner: 'stranske', repo: 'Ready', pr: 11, branch: 'sync/workflows-abc',
+    head_sha: 'abc', delivery_generation: 'g2', delivery_disposition: 'current',
+    blocker_owner: 'maint-71', next_command: 'merge-current-delivery',
+    status: 'merged',
+  }), {
+    schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
+    branch: 'sync/workflows-abc', head_sha: 'abc', delivery_generation: 'g2',
+    lane: 'sync', disposition: 'merged', blocker_owner: 'none', next_command: 'none',
+    check_state: 'ready', review_state: 'clear',
+  });
+  assert.equal(buildDeliveryHandoff({
+    owner: 'stranske', repo: 'Ready', pr: 11, branch: 'sync/workflows-abc',
+    head_sha: 'abc', delivery_generation: 'g2', status: 'branch_deleted',
+  }), null);
 });
 
 test('buildDeliveryHandoff rejects results that lack required restart fields', () => {

--- a/.github/scripts/__tests__/sync_dependency_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependency_campaign.test.js
@@ -16,6 +16,7 @@ const {
   isSyncPullRequest,
   mergeCampaignState,
   mergeDeliveryHandoffs,
+  normalizeDeliveryHandoff,
   paginateWithRetry,
   parseCampaignMarker,
   replaceCampaignMarker,
@@ -27,14 +28,24 @@ test('mergeDeliveryHandoffs retains one current record per generated PR', () => 
   const stale = {
     schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
     head_sha: 'old', delivery_generation: 'g1', disposition: 'awaiting-checks',
+    blocker_owner: 'ci', next_command: 'await-required-checks',
+    check_state: 'checks_pending', review_state: 'clear',
   };
   const current = {
     ...stale, head_sha: 'new', delivery_generation: 'g2', disposition: 'review-blocked',
-    next_command: 'resolve-active-review-threads',
+    blocker_owner: 'closer', next_command: 'resolve-active-review-threads',
+    check_state: 'ready', review_state: 'blocked',
   };
   assert.deepEqual(mergeDeliveryHandoffs([stale], [current], '2026-08-02T00:00:00Z'), [{
-    ...current, branch: '', lane: '', blocker_owner: '', observed_at: '2026-08-02T00:00:00Z',
+    ...current, branch: '', lane: '', observed_at: '2026-08-02T00:00:00Z',
   }]);
+});
+
+test('normalizeDeliveryHandoff rejects incomplete restart fields', () => {
+  assert.equal(normalizeDeliveryHandoff({
+    schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
+    head_sha: 'abc', delivery_generation: 'g1', disposition: 'current',
+  }), null);
 });
 
 test('mergeCampaignState persists Maint 71 handoffs in the durable marker state', () => {
@@ -42,11 +53,33 @@ test('mergeCampaignState persists Maint 71 handoffs in the durable marker state'
     deliveryHandoffRecords: [{
       schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
       head_sha: 'abc', delivery_generation: 'g1', disposition: 'current',
+      blocker_owner: 'maint-71', next_command: 'merge-current-delivery',
+      check_state: 'ready', review_state: 'clear',
     }],
   });
   assert.equal(state.stats.delivery_handoffs_observed, 1);
-  assert.equal(state.delivery_handoffs[0].next_command, '');
+  assert.equal(state.delivery_handoffs[0].next_command, 'merge-current-delivery');
   assert.equal(parseCampaignMarker(formatCampaignMarker(state)).delivery_handoffs[0].pr, 11);
+});
+
+test('mergeCampaignState counts observed handoffs from the current payload only', () => {
+  const previous = {
+    delivery_handoffs: [{
+      schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 10,
+      head_sha: 'prev', delivery_generation: 'g0', disposition: 'merged',
+      blocker_owner: 'none', next_command: 'none', check_state: 'ready', review_state: 'clear',
+    }],
+  };
+  const state = mergeCampaignState(previous, [], '2026-08-02T00:00:00Z', {
+    deliveryHandoffRecords: [{
+      schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
+      head_sha: 'abc', delivery_generation: 'g1', disposition: 'current',
+      blocker_owner: 'maint-71', next_command: 'merge-current-delivery',
+      check_state: 'ready', review_state: 'clear',
+    }],
+  });
+  assert.equal(state.stats.delivery_handoffs_observed, 1);
+  assert.equal(state.delivery_handoffs.length, 2);
 });
 
 test('formats and parses campaign marker', () => {

--- a/.github/scripts/__tests__/sync_dependency_campaign.test.js
+++ b/.github/scripts/__tests__/sync_dependency_campaign.test.js
@@ -15,12 +15,39 @@ const {
   isDependabotPullRequest,
   isSyncPullRequest,
   mergeCampaignState,
+  mergeDeliveryHandoffs,
   paginateWithRetry,
   parseCampaignMarker,
   replaceCampaignMarker,
   verboseDryRunLoggingEnabled,
   validateCampaignState,
 } = require('../sync_dependency_campaign.js');
+
+test('mergeDeliveryHandoffs retains one current record per generated PR', () => {
+  const stale = {
+    schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
+    head_sha: 'old', delivery_generation: 'g1', disposition: 'awaiting-checks',
+  };
+  const current = {
+    ...stale, head_sha: 'new', delivery_generation: 'g2', disposition: 'review-blocked',
+    next_command: 'resolve-active-review-threads',
+  };
+  assert.deepEqual(mergeDeliveryHandoffs([stale], [current], '2026-08-02T00:00:00Z'), [{
+    ...current, branch: '', lane: '', blocker_owner: '', observed_at: '2026-08-02T00:00:00Z',
+  }]);
+});
+
+test('mergeCampaignState persists Maint 71 handoffs in the durable marker state', () => {
+  const state = mergeCampaignState({}, [], '2026-08-02T00:00:00Z', {
+    deliveryHandoffRecords: [{
+      schema: 'workflows-generated-delivery-handoff/v1', repository: 'stranske/Ready', pr: 11,
+      head_sha: 'abc', delivery_generation: 'g1', disposition: 'current',
+    }],
+  });
+  assert.equal(state.stats.delivery_handoffs_observed, 1);
+  assert.equal(state.delivery_handoffs[0].next_command, '');
+  assert.equal(parseCampaignMarker(formatCampaignMarker(state)).delivery_handoffs[0].pr, 11);
+});
 
 test('formats and parses campaign marker', () => {
   const state = {

--- a/.github/scripts/sync_dependency_campaign.js
+++ b/.github/scripts/sync_dependency_campaign.js
@@ -355,7 +355,14 @@ function normalizeDeliveryHandoff(record = {}, observedAt = '') {
   const pr = cleanInteger(record.pr);
   const headSha = cleanString(record.head_sha);
   const generation = cleanString(record.delivery_generation);
+  const disposition = cleanString(record.disposition);
+  const blockerOwner = cleanString(record.blocker_owner);
+  const nextCommand = cleanString(record.next_command);
+  const checkState = cleanString(record.check_state);
+  const reviewState = cleanString(record.review_state);
   if (!repository || !pr || !headSha || !generation) return null;
+  // Require the full restart/routing contract so durable records can classify exceptions.
+  if (!disposition || !blockerOwner || !nextCommand || !checkState || !reviewState) return null;
   return {
     schema: DELIVERY_HANDOFF_SCHEMA,
     repository,
@@ -364,9 +371,11 @@ function normalizeDeliveryHandoff(record = {}, observedAt = '') {
     head_sha: headSha,
     delivery_generation: generation,
     lane: cleanString(record.lane),
-    disposition: cleanString(record.disposition),
-    blocker_owner: cleanString(record.blocker_owner),
-    next_command: cleanString(record.next_command),
+    disposition,
+    blocker_owner: blockerOwner,
+    next_command: nextCommand,
+    check_state: checkState,
+    review_state: reviewState,
     observed_at: cleanString(observedAt || record.observed_at),
   };
 }
@@ -485,9 +494,12 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
 
   const items = pruneItems(nextItems, options.maxRetainedItems || DEFAULT_MAX_RETAINED_ITEMS)
     .map(annotateLocalCodexQueueState);
+  const observedIncomingHandoffs = cleanArray(options.deliveryHandoffRecords)
+    .map((record) => normalizeDeliveryHandoff(record, now))
+    .filter(Boolean);
   const deliveryHandoffs = mergeDeliveryHandoffs(
     previousState.delivery_handoffs,
-    options.deliveryHandoffRecords,
+    observedIncomingHandoffs,
     now,
     options.maxDeliveryHandoffs,
   );
@@ -499,7 +511,8 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
     current_sync_hash: normalizeSyncHash(options.currentSyncHash || previousState.current_sync_hash),
     stats: {
       ...buildStats(items, discoveredItems, options),
-      delivery_handoffs_observed: deliveryHandoffs.length,
+      // Count only this run's payload observations, not the retained durable total.
+      delivery_handoffs_observed: observedIncomingHandoffs.length,
     },
     source_review_history: sourceReviewHistory,
     delivery_handoffs: deliveryHandoffs,

--- a/.github/scripts/sync_dependency_campaign.js
+++ b/.github/scripts/sync_dependency_campaign.js
@@ -18,6 +18,8 @@ const DEV_TOOL_SYNC_BRANCH_PREFIX = 'deps/sync-dev-versions-';
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_MAX_RETAINED_ITEMS = 120;
 const DEFAULT_MAX_SOURCE_REVIEW_HISTORY = 80;
+const DELIVERY_HANDOFF_SCHEMA = 'workflows-generated-delivery-handoff/v1';
+const DEFAULT_MAX_DELIVERY_HANDOFFS = 80;
 const MAX_ISSUE_BODY_LENGTH = 60000;
 const MAX_MARKER_ITEMS = 80;
 const MAX_QUEUE_ROWS = 15;
@@ -347,6 +349,43 @@ function isLeaseExpired(item = {}, now = new Date()) {
   return new Date(expiresAt).getTime() <= now.getTime();
 }
 
+function normalizeDeliveryHandoff(record = {}, observedAt = '') {
+  if (cleanString(record.schema) !== DELIVERY_HANDOFF_SCHEMA) return null;
+  const repository = cleanString(record.repository);
+  const pr = cleanInteger(record.pr);
+  const headSha = cleanString(record.head_sha);
+  const generation = cleanString(record.delivery_generation);
+  if (!repository || !pr || !headSha || !generation) return null;
+  return {
+    schema: DELIVERY_HANDOFF_SCHEMA,
+    repository,
+    pr,
+    branch: cleanString(record.branch),
+    head_sha: headSha,
+    delivery_generation: generation,
+    lane: cleanString(record.lane),
+    disposition: cleanString(record.disposition),
+    blocker_owner: cleanString(record.blocker_owner),
+    next_command: cleanString(record.next_command),
+    observed_at: cleanString(observedAt || record.observed_at),
+  };
+}
+
+function mergeDeliveryHandoffs(previous = [], incoming = [], observedAt = '', limit = DEFAULT_MAX_DELIVERY_HANDOFFS) {
+  const byKey = new Map();
+  for (const record of cleanArray(previous)) {
+    const normalized = normalizeDeliveryHandoff(record);
+    if (normalized) byKey.set(`${normalized.repository}#${normalized.pr}`, normalized);
+  }
+  for (const record of cleanArray(incoming)) {
+    const normalized = normalizeDeliveryHandoff(record, observedAt);
+    if (normalized) byKey.set(`${normalized.repository}#${normalized.pr}`, normalized);
+  }
+  return [...byKey.values()]
+    .sort((a, b) => cleanString(b.observed_at).localeCompare(cleanString(a.observed_at)))
+    .slice(0, limit);
+}
+
 function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, options = {}) {
   const now = cleanString(nowValue) || new Date().toISOString();
   const nowDate = new Date(now);
@@ -446,14 +485,24 @@ function mergeCampaignState(previousState = {}, discoveredItems = [], nowValue, 
 
   const items = pruneItems(nextItems, options.maxRetainedItems || DEFAULT_MAX_RETAINED_ITEMS)
     .map(annotateLocalCodexQueueState);
+  const deliveryHandoffs = mergeDeliveryHandoffs(
+    previousState.delivery_handoffs,
+    options.deliveryHandoffRecords,
+    now,
+    options.maxDeliveryHandoffs,
+  );
   return {
     schema: CAMPAIGN_SCHEMA,
     updated_at: now,
     run_id: cleanString(options.runId || previousState.run_id),
     controller: 'maint-82-sync-dependabot-campaign',
     current_sync_hash: normalizeSyncHash(options.currentSyncHash || previousState.current_sync_hash),
-    stats: buildStats(items, discoveredItems, options),
+    stats: {
+      ...buildStats(items, discoveredItems, options),
+      delivery_handoffs_observed: deliveryHandoffs.length,
+    },
     source_review_history: sourceReviewHistory,
+    delivery_handoffs: deliveryHandoffs,
     items,
   };
 }
@@ -793,6 +842,7 @@ function compactStateForMarker(state = {}) {
     source_review_history: cleanArray(state.source_review_history)
       .map(compactSourceReviewHistoryEntry)
       .filter(Boolean),
+    delivery_handoffs: cleanArray(state.delivery_handoffs).slice(0, DEFAULT_MAX_DELIVERY_HANDOFFS),
     marker_item_filter: 'actionable-claimed-blocked-unpublished',
     items: markerItems.map(compactQueueItemForMarker),
   };
@@ -1524,6 +1574,7 @@ async function runCampaign({
   botAuthors = DEFAULT_BOT_AUTHORS,
   ignoredPaths = DEFAULT_IGNORED_PATHS,
   currentSyncHash = '',
+  deliveryHandoffRecords = [],
   now = new Date().toISOString(),
 } = {}) {
   if (!github || !context?.repo) {
@@ -1579,6 +1630,7 @@ async function runCampaign({
     syncPrsOpen,
     dependabotPrsOpen,
     failedRepos: errors.map((error) => error.repo),
+    deliveryHandoffRecords,
   });
   if (errors.length) {
     state.errors = errors.slice(0, 20);
@@ -1646,6 +1698,7 @@ module.exports = {
   CAMPAIGN_SCHEMA,
   CAMPAIGN_MARKER,
   CAMPAIGN_TITLE,
+  DELIVERY_HANDOFF_SCHEMA,
   LABEL_CAMPAIGN,
   LABEL_ACTIVE,
   LABEL_NEEDS_LOCAL_CODEX,
@@ -1662,6 +1715,8 @@ module.exports = {
   isDependabotPullRequest,
   isSyncPullRequest,
   mergeCampaignState,
+  mergeDeliveryHandoffs,
+  normalizeDeliveryHandoff,
   paginateWithRetry,
   parseCampaignMarker,
   replaceCampaignMarker,

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -54,7 +54,13 @@ function isTrustedGeneratedDeliveryPr(pr, trustedActors = []) {
 function classifyGeneratedPr({ pr = {}, checkState = {}, activeReviewThreadCount = 0, now } = {}) {
   const record = parseDeliveryRecord(pr.body || '');
   const lane = generatedDeliveryLane(pr?.head?.ref || pr?.headRefName);
-  if (!lane) return { disposition: 'owner-decision', blocker_owner: 'source', next_command: '' };
+  if (!lane) {
+    return {
+      disposition: 'owner-decision',
+      blocker_owner: 'source',
+      next_command: 'owner-decision-required',
+    };
+  }
   if (!record) return {
     disposition: 'owner-decision',
     blocker_owner: 'source',
@@ -270,11 +276,78 @@ function summarizeResults(results) {
   return counts;
 }
 
+function deriveHandoffCheckState(result = {}) {
+  const explicit = String(result.check_state || '').trim();
+  if (explicit) return explicit;
+  const status = String(result.status || '');
+  if (status === 'checks_pending') return 'checks_pending';
+  if (status === 'checks_failed') return 'checks_failed';
+  if (
+    status === 'ready'
+    || status === 'dry_run_merge'
+    || status === 'merged'
+    || status === 'review_blocked'
+    || status === 'merge_blocked_runtime_ac'
+  ) {
+    return 'ready';
+  }
+  if (status === 'stale_closed' || status === 'delivery_contract_blocked') {
+    return 'not-applicable';
+  }
+  return status || 'unknown';
+}
+
+function deriveHandoffReviewState(result = {}) {
+  const explicit = String(result.review_state || '').trim();
+  if (explicit) return explicit;
+  const status = String(result.status || '');
+  const threadCount = Number(result.active_review_thread_count);
+  if (status === 'review_blocked' || (Number.isFinite(threadCount) && threadCount > 0)) {
+    return 'blocked';
+  }
+  if (status === 'stale_closed' || status === 'delivery_contract_blocked') {
+    return 'not-applicable';
+  }
+  return 'clear';
+}
+
 function buildDeliveryHandoff(result = {}) {
   if (!result.pr) return null;
+  const status = String(result.status || '');
+  // Branch-delete rows are companions to the merged row; emit one terminal handoff only.
+  if (status === 'branch_deleted' || status === 'branch_delete_failed') {
+    return null;
+  }
   const headSha = String(result.head_sha || '');
   const deliveryGeneration = String(result.delivery_generation || '');
   if (!headSha || !deliveryGeneration) return null;
+
+  let disposition = String(result.delivery_disposition || status || '');
+  let blockerOwner = String(result.blocker_owner || '');
+  let nextCommand = String(result.next_command || '');
+  let checkState = deriveHandoffCheckState(result);
+  let reviewState = deriveHandoffReviewState(result);
+
+  // After a successful merge/close, rewrite pre-merge restart fields so consumers
+  // do not keep seeing merge-current-delivery for an already-terminal PR.
+  if (status === 'merged') {
+    disposition = 'merged';
+    blockerOwner = 'none';
+    nextCommand = 'none';
+    checkState = checkState === 'unknown' ? 'ready' : checkState;
+    reviewState = reviewState === 'not-applicable' ? 'clear' : reviewState;
+  } else if (status === 'stale_closed') {
+    if (!disposition || disposition === 'stale_closed') {
+      disposition = 'closed';
+    }
+    blockerOwner = 'none';
+    nextCommand = 'none';
+  }
+
+  if (!disposition || !blockerOwner || !nextCommand || !checkState || !reviewState) {
+    return null;
+  }
+
   return {
     schema: 'workflows-generated-delivery-handoff/v1',
     repository: `${result.owner || ''}/${result.repo || ''}`.replace(/^\//, ''),
@@ -283,9 +356,11 @@ function buildDeliveryHandoff(result = {}) {
     head_sha: headSha,
     delivery_generation: deliveryGeneration,
     lane: generatedDeliveryLane(result.branch),
-    disposition: String(result.delivery_disposition || result.status || ''),
-    blocker_owner: String(result.blocker_owner || ''),
-    next_command: String(result.next_command || ''),
+    disposition,
+    blocker_owner: blockerOwner,
+    next_command: nextCommand,
+    check_state: checkState,
+    review_state: reviewState,
   };
 }
 

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -827,6 +827,17 @@ jobs:
               'utf8',
             );
             await core.summary.addRaw(buildMarkdownSummary(report)).write();
+            if (!dryRun && report.handoff_records.length > 0) {
+              await withRetry((client) => client.rest.repos.createDispatchEvent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                event_type: 'sync-dependabot-campaign',
+                client_payload: {
+                  repos: targetRepos.join(','),
+                  delivery_handoff_records: report.handoff_records,
+                },
+              }));
+            }
 
             const merged = report.summary.merged;
             const stale = report.summary.stale_closed;

--- a/.github/workflows/maint-71-merge-sync-prs.yml
+++ b/.github/workflows/maint-71-merge-sync-prs.yml
@@ -828,15 +828,24 @@ jobs:
             );
             await core.summary.addRaw(buildMarkdownSummary(report)).write();
             if (!dryRun && report.handoff_records.length > 0) {
-              await withRetry((client) => client.rest.repos.createDispatchEvent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                event_type: 'sync-dependabot-campaign',
-                client_payload: {
-                  repos: targetRepos.join(','),
-                  delivery_handoff_records: report.handoff_records,
-                },
-              }));
+              // Fleet-wide refresh: a targeted Maint 71 repos filter must not cause
+              // Maint 82 to stale unscanned repos. Dispatch is best-effort so a
+              // permissions/transient failure does not fail the reconciler run.
+              try {
+                await withRetry((client) => client.rest.repos.createDispatchEvent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  event_type: 'sync-dependabot-campaign',
+                  client_payload: {
+                    repos: registeredRepos.join(','),
+                    delivery_handoff_records: report.handoff_records,
+                  },
+                }));
+              } catch (dispatchError) {
+                core.notice(
+                  `Maint 71 handoff dispatch failed (non-blocking): ${dispatchError.message}`,
+                );
+              }
             }
 
             const merged = report.summary.merged;

--- a/.github/workflows/maint-82-sync-dependency-campaign.yml
+++ b/.github/workflows/maint-82-sync-dependency-campaign.yml
@@ -113,6 +113,8 @@ jobs:
             const dryRun = '${{ steps.inputs.outputs.dry_run }}' === 'true';
             const maxRepos = Number('${{ steps.inputs.outputs.max_repos }}') || 0;
             const currentSyncHash = '${{ steps.hash.outputs.hash }}';
+            const deliveryHandoffRecords =
+              context.payload.client_payload?.delivery_handoff_records || [];
 
             const result = await runCampaign({
               github,
@@ -122,6 +124,7 @@ jobs:
               dryRun,
               maxRepos,
               currentSyncHash,
+              deliveryHandoffRecords,
             });
 
             const stats = result.state.stats || {};
@@ -153,6 +156,7 @@ jobs:
                 `Source-fixed candidates: ${stats.items_source_fixed_candidates || 0}`,
                 `Superseded sync candidates: ${stats.items_superseded_sync_candidates || 0}`,
                 `Source sync states: ${sourceSyncStates}`,
+                `Maint 71 handoffs observed: ${stats.delivery_handoffs_observed || 0}`,
                 `Finished local results without published source changes: ${unpublishedResults}`,
                 `Campaign issue: ${result.issue?.html_url || '(dry run)'}`,
               ])

--- a/tests/workflows/test_maint82_sync_campaign_contract.py
+++ b/tests/workflows/test_maint82_sync_campaign_contract.py
@@ -43,6 +43,9 @@ def test_maint71_dispatches_machine_readable_handoffs_to_campaign():
 
     assert "event_type: 'sync-dependabot-campaign'" in workflow
     assert "delivery_handoff_records: report.handoff_records" in workflow
+    # Targeted Maint 71 runs must still refresh the full registered fleet.
+    assert "repos: registeredRepos.join(',')" in workflow
+    assert "Maint 71 handoff dispatch failed (non-blocking)" in workflow
 
 
 def test_campaign_workflow_bot_agnostic_identity():

--- a/tests/workflows/test_maint82_sync_campaign_contract.py
+++ b/tests/workflows/test_maint82_sync_campaign_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 WORKFLOW = Path(".github/workflows/maint-82-sync-dependency-campaign.yml")
+MERGE_WORKFLOW = Path(".github/workflows/maint-71-merge-sync-prs.yml")
 CAMPAIGN_SCRIPT = Path(".github/scripts/sync_dependency_campaign.js")
 
 
@@ -27,6 +28,21 @@ def test_campaign_refresh_passes_current_sync_hash_to_runner():
 
     assert "const currentSyncHash = '${{ steps.hash.outputs.hash }}';" in script
     assert "currentSyncHash," in script
+
+
+def test_campaign_refresh_consumes_maint71_delivery_handoffs():
+    script = _refresh_script()
+
+    assert "context.payload.client_payload?.delivery_handoff_records || []" in script
+    assert "deliveryHandoffRecords," in script
+    assert "Maint 71 handoffs observed:" in script
+
+
+def test_maint71_dispatches_machine_readable_handoffs_to_campaign():
+    workflow = MERGE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "event_type: 'sync-dependabot-campaign'" in workflow
+    assert "delivery_handoff_records: report.handoff_records" in workflow
 
 
 def test_campaign_workflow_bot_agnostic_identity():


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2881 -->
> **Source:** Issue #2881

Closes #2881

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Generated PR ownership is split across overlapping controllers. Maint 71 filters only `sync/workflows-` heads today (`.github/workflows/maint-71-merge-sync-prs.yml:284`), while Maint 82 and `.github/scripts/sync_dependency_campaign.js:493-530` separately decide which exceptions are claimable by Codex. Dev-tool-sync PRs therefore follow a different merge path, and unchanged exception state can continue to produce automation work.

This is a current efficiency defect: repeated observation of the same blocker consumes agent runs without changing repository state. One repository-owned reconciliation contract should decide merge/close disposition, and agent handoff should occur only when the exception fingerprint changes.

#### Tasks
- [ ] Extend `.github/workflows/maint-71-merge-sync-prs.yml` to reconcile both `sync/workflows-` and `deps/sync-dev-versions-` PRs through the same contract.
- [ ] Centralize classification in `.github/scripts/sync_pr_merge_contract.js`: current, awaiting-checks, review-blocked, repo-local-failure, shared-source-failure, superseded, expired, and owner-decision.
- [ ] Have Maint 71 emit a normalized result record containing PR identity, head SHA, delivery generation, check/review state, disposition, blocker owner, and exact next command.
- [ ] Make `.github/workflows/maint-82-sync-dependency-auto-pilot.yml` consume those records and own durable campaign state rather than recomputing merge disposition independently.
- [ ] Extend the existing fingerprint in `.github/scripts/sync_dependency_campaign.js` to include only state that should trigger new work; preserve `updated_at`, claim generation, and lease history.
- [ ] Apply `campaign:needs-local-codex` only for new or materially changed actionable exception fingerprints, and remove it after terminal disposition or successful claim completion.
- [ ] Document the remote handoff schema and local-consumer migration in `docs/ops/SYNC_DEPENDENCY_CAMPAIGN.md`; mark local watcher changes as an operator follow-up, not repository implementation.
- [ ] Add observability showing new, unchanged, resolved, and re-opened exception counts per run.

#### Acceptance criteria
- [ ] `.github/scripts/__tests__/sync_dependency_campaign.test.js` proves the same exception observed on three consecutive runs creates one claim generation and one agent handoff.
- [ ] `.github/scripts/__tests__/sync_pr_merge_contract.test.js` applies identical merge/review/check rules to sync and dev-tool-sync fixtures.
- [ ] Workflow tests prove Maint 71 is the only path that merges or closes generated PRs and Maint 82 only persists state and requests bounded exception work.
- [ ] A changed head SHA, review-thread set, check-failure cluster, or delivery generation creates a new fingerprint; a timestamp-only change does not.
- [ ] Durable state records the exact blocker owner and next command, allowing an opener/closer run to resume without rediscovery.
- [ ] Deliberate-break test: remove fingerprint persistence or vary only `updated_at`, verify the campaign test detects duplicate handoffs, then revert and verify it passes.
- [ ] Run `python scripts/dev_check.py --action test` and workflow validation successfully.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delivery handoff tracking across dependency campaign workflows.
  * Handoffs are validated, deduplicated, ordered, and limited to the most recent records.
  * Campaign reports and serialized markers now include retained handoff details and counts.
  * Merge workflows can automatically forward handoff records to campaign processing.

* **Tests**
  * Added coverage for handoff persistence, deduplication, workflow events, and payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->