### PR TITLE
fix(maint): close #2882 verifier CONCERNS gaps

### DIFF
--- a/.github/workflows/maint-auto-update-pypi-versions.yml
+++ b/.github/workflows/maint-auto-update-pypi-versions.yml
@@ -215,34 +215,58 @@ jobs:
           set -euo pipefail
           # Close open Dependabot/Renovate PRs that touch the Workflows-owned
           # pin surfaces only after the canonical source proposal exists.
-          managed_paths=(
-            ".github/workflows/autofix-versions.env"
-            "pyproject.toml"
-            "requirements.lock"
-            "templates/consumer-repo/.github/workflows/autofix-versions.env"
-            "templates/integration-repo/.github/workflows/autofix-versions.env"
-          )
+          source_patches=$(mktemp)
+          bot_patches=$(mktemp)
+          trap 'rm -f "$source_patches" "$bot_patches"' EXIT
+          gh pr diff "$SOURCE_PR" > "$source_patches"
           mapfile -t bot_prs < <(
             gh pr list --state open --limit 100 \
-              --json number,author,headRefName,files \
+              --json number,author \
               --jq '.[] | select(
-                  (.author.login | test("dependabot|renovate"; "i"))
-                  or (.headRefName | test("^(dependabot|renovate)/"))
+                  .author.login == "dependabot[bot]"
+                  or .author.login == "renovate[bot]"
                 ) | .number'
           )
           for pr in "${bot_prs[@]:-}"; do
             [ -n "$pr" ] || continue
-            files=$(gh pr view "$pr" --json files --jq '[.files[].path] | join("\n")')
-            overlap=false
-            for path in "${managed_paths[@]}"; do
-              if printf '%s\n' "$files" | grep -Fxq "$path"; then
-                overlap=true
-                break
-              fi
-            done
-            if [ "$overlap" = true ]; then
+            gh pr diff "$pr" > "$bot_patches"
+            if python - "$source_patches" "$bot_patches" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          MANAGED_PATHS = {
+              ".github/workflows/autofix-versions.env",
+              "pyproject.toml",
+              "requirements.lock",
+              "templates/consumer-repo/.github/workflows/autofix-versions.env",
+              "templates/integration-repo/.github/workflows/autofix-versions.env",
+          }
+
+
+          def changed_pin_keys(path: str) -> set[str]:
+              keys: set[str] = set()
+              current_path = None
+              for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+                  if raw_line.startswith("diff --git a/"):
+                      current_path = raw_line.split(" b/", 1)[-1]
+                      continue
+                  if current_path not in MANAGED_PATHS:
+                      continue
+                  if not raw_line.startswith(("+", "-")) or raw_line.startswith(("+++", "---")):
+                      continue
+                  line = raw_line[1:].strip()
+                  match = re.match(r"([A-Za-z0-9_.-]+)(?:\[[^]]+\])?\s*(?:==|!=|~=|>=|<=|>|<|=)", line)
+                  if match:
+                      keys.add(match.group(1).lower().replace("_", "-"))
+              return keys
+
+
+          sys.exit(not bool(changed_pin_keys(sys.argv[1]) & changed_pin_keys(sys.argv[2])))
+          PY
+            then
               gh pr close "$pr" --comment "Superseded by canonical dev-tool source proposal #$SOURCE_PR. Workflows-owned pin updates land only through maint-auto-update-pypi-versions.yml."
-              echo "Closed overlapping dependency-bot PR #$pr"
+              echo "Closed dependency-bot PR #$pr with an overlapping canonical pin update"
             fi
           done
 

--- a/.github/workflows/maint-auto-update-pypi-versions.yml
+++ b/.github/workflows/maint-auto-update-pypi-versions.yml
@@ -100,7 +100,20 @@ jobs:
           python scripts/sync_tool_versions.py --apply
           python scripts/sync_dev_dependencies.py --apply --lockfile
 
+      # security_override may bypass the weekly window, but never this gate.
+      - name: Validate synchronized pins before proposal
+        if: >-
+          steps.check.outputs.has_updates == 'true'
+          && steps.policy.outputs.should_propose == 'true'
+          && inputs.dry_run != true
+        run: |
+          set -euo pipefail
+          echo "🧪 Validating synchronized pin surfaces before opening a source PR..."
+          python scripts/sync_tool_versions.py --check
+          python scripts/sync_dev_dependencies.py --check --lockfile
+
       - name: Create PR
+        id: create_pr
         if: >-
           steps.check.outputs.has_updates == 'true'
           && steps.policy.outputs.should_propose == 'true'
@@ -178,13 +191,60 @@ jobs:
 
           if [ -n "$existing_pr" ]; then
             gh pr edit "$existing_pr" --title "chore: update dev tool versions from PyPI" --body "$pr_body"
+            echo "source_pr=$existing_pr" >> "$GITHUB_OUTPUT"
           else
-            gh pr create \
+            new_pr=$(gh pr create \
               --title "chore: update dev tool versions from PyPI" \
               --body "$pr_body" \
               --label "dependencies" \
-              --label "automation"
+              --label "automation")
+            # gh pr create prints the URL; extract the trailing number.
+            echo "source_pr=${new_pr##*/}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Supersede overlapping dependency-bot PRs
+        if: >-
+          steps.check.outputs.has_updates == 'true'
+          && steps.policy.outputs.should_propose == 'true'
+          && inputs.dry_run != true
+          && steps.create_pr.outputs.source_pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_PR: ${{ steps.create_pr.outputs.source_pr }}
+        run: |
+          set -euo pipefail
+          # Close open Dependabot/Renovate PRs that touch the Workflows-owned
+          # pin surfaces only after the canonical source proposal exists.
+          managed_paths=(
+            ".github/workflows/autofix-versions.env"
+            "pyproject.toml"
+            "requirements.lock"
+            "templates/consumer-repo/.github/workflows/autofix-versions.env"
+            "templates/integration-repo/.github/workflows/autofix-versions.env"
+          )
+          mapfile -t bot_prs < <(
+            gh pr list --state open --limit 100 \
+              --json number,author,headRefName,files \
+              --jq '.[] | select(
+                  (.author.login | test("dependabot|renovate"; "i"))
+                  or (.headRefName | test("^(dependabot|renovate)/"))
+                ) | .number'
+          )
+          for pr in "${bot_prs[@]:-}"; do
+            [ -n "$pr" ] || continue
+            files=$(gh pr view "$pr" --json files --jq '[.files[].path] | join("\n")')
+            overlap=false
+            for path in "${managed_paths[@]}"; do
+              if printf '%s\n' "$files" | grep -Fxq "$path"; then
+                overlap=true
+                break
+              fi
+            done
+            if [ "$overlap" = true ]; then
+              gh pr close "$pr" --comment "Superseded by canonical dev-tool source proposal #$SOURCE_PR. Workflows-owned pin updates land only through maint-auto-update-pypi-versions.yml."
+              echo "Closed overlapping dependency-bot PR #$pr"
+            fi
+          done
 
       - name: Dry run summary
         if: inputs.dry_run == true

--- a/docs/ci/TOOL_VERSION_MANAGEMENT.md
+++ b/docs/ci/TOOL_VERSION_MANAGEMENT.md
@@ -76,6 +76,13 @@ COVERAGE_VERSION=7.12.0
 - Uses one mutable `auto/weekly-dev-tool-update-YYYY-Www` PR per weekly window
 - An operator may use the explicit `security_override` dispatch input for an
   urgent security update outside that window
+- Always runs `sync_tool_versions.py --check` and
+  `sync_dev_dependencies.py --check --lockfile` after applying pin updates and
+  before opening or refreshing the source PR (`security_override` cannot skip
+  this gate)
+- After the canonical source PR exists, closes open Dependabot/Renovate PRs that
+  touch the same Workflows-owned pin surfaces so overlapping bot proposals are
+  superseded rather than raced
 
 ## Update Process
 

--- a/tests/scripts/test_sync_dev_dependencies.py
+++ b/tests/scripts/test_sync_dev_dependencies.py
@@ -211,6 +211,7 @@ def test_main_apply_updates_all_present_requirements_lockfiles(
 def test_main_check_reports_lockfile_mismatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """Deliberate-break AC: mismatched managed pin fails with exact path:tool."""
     env_path = tmp_path / "pins.env"
     pyproject_path = tmp_path / "pyproject.toml"
     lockfile = tmp_path / "requirements.lock"
@@ -236,6 +237,7 @@ def test_main_check_reports_lockfile_mismatch(
 
     assert exit_code == 1
     assert "requirements.lock:ruff" in captured.out
+    assert "0.9.0 -> ==1.0.0" in captured.out
 
 
 def test_main_check_auto_syncs_lockfile_when_present(

--- a/tests/workflows/test_dev_tool_source_lane.py
+++ b/tests/workflows/test_dev_tool_source_lane.py
@@ -17,6 +17,20 @@ def test_auto_updater_is_the_single_weekly_source_proposal_lane():
     assert 'gh pr edit "$existing_pr"' in text
 
 
+def test_source_lane_validates_pins_before_create_pr_even_for_security_override():
+    text = AUTO_UPDATE.read_text(encoding="utf-8")
+    validate_at = text.index("Validate synchronized pins before proposal")
+    create_at = text.index("Create PR", validate_at)
+    supersede_at = text.index("Supersede overlapping dependency-bot PRs", create_at)
+
+    assert validate_at < create_at < supersede_at
+    assert "python scripts/sync_tool_versions.py --check" in text[validate_at:create_at]
+    assert "python scripts/sync_dev_dependencies.py --check --lockfile" in text[validate_at:create_at]
+    assert "security_override" in text
+    assert "gh pr close" in text[supersede_at:]
+    assert "dependabot|renovate" in text[supersede_at:]
+
+
 def test_maint50_reports_freshness_without_creating_competing_work():
     text = MAINT50.read_text(encoding="utf-8")
 
@@ -32,3 +46,5 @@ def test_maint52_records_the_settled_canonical_source_commit():
     assert "canonical_source_sha" in text
     assert "git rev-parse HEAD" in text
     assert "needs.prepare.outputs.canonical_source_sha" in text
+    assert "**Settled source commit:**" in text
+    assert "update_versions_from_pypi.py --apply" not in text

--- a/tests/workflows/test_dev_tool_source_lane.py
+++ b/tests/workflows/test_dev_tool_source_lane.py
@@ -30,7 +30,14 @@ def test_source_lane_validates_pins_before_create_pr_even_for_security_override(
     )
     assert "security_override" in text
     assert "gh pr close" in text[supersede_at:]
-    assert "dependabot|renovate" in text[supersede_at:]
+    assert 'echo "source_pr=$existing_pr" >> "$GITHUB_OUTPUT"' in text[create_at:supersede_at]
+    assert 'echo "source_pr=${new_pr##*/}" >> "$GITHUB_OUTPUT"' in text[create_at:supersede_at]
+    assert "steps.create_pr.outputs.source_pr != ''" in text[supersede_at:]
+    assert '.author.login == "dependabot[bot]"' in text[supersede_at:]
+    assert '.author.login == "renovate[bot]"' in text[supersede_at:]
+    assert "headRefName" not in text[supersede_at:]
+    assert "changed_pin_keys" in text[supersede_at:]
+    assert "gh api" not in text[supersede_at:]
 
 
 def test_maint50_reports_freshness_without_creating_competing_work():

--- a/tests/workflows/test_dev_tool_source_lane.py
+++ b/tests/workflows/test_dev_tool_source_lane.py
@@ -25,7 +25,9 @@ def test_source_lane_validates_pins_before_create_pr_even_for_security_override(
 
     assert validate_at < create_at < supersede_at
     assert "python scripts/sync_tool_versions.py --check" in text[validate_at:create_at]
-    assert "python scripts/sync_dev_dependencies.py --check --lockfile" in text[validate_at:create_at]
+    assert (
+        "python scripts/sync_dev_dependencies.py --check --lockfile" in text[validate_at:create_at]
+    )
     assert "security_override" in text
     assert "gh pr close" in text[supersede_at:]
     assert "dependabot|renovate" in text[supersede_at:]

--- a/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
+++ b/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
@@ -37,3 +37,14 @@ def test_dev_version_sync_fails_fast_and_checks_uv_lockfiles():
     assert text.count("set -euo pipefail") >= 2
     assert "if ! uv lock --check; then" in text
     assert "uv_lock_stale=true" in text
+
+
+def test_maint52_pr_body_reports_canonical_source_commit_and_never_proposes_upstream():
+    """AC: Maint 52 reports the settled source commit and never opens an upstream bump."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "CANONICAL_SOURCE_SHA" in text
+    assert "**Settled source commit:** \\`$CANONICAL_SOURCE_SHA\\`" in text
+    assert "source_commit:$source_commit" in text or "source_commit:$CANONICAL_SOURCE_SHA" in text or '"source_commit"' in text
+    assert "update_versions_from_pypi.py --apply" not in text
+    assert "python scripts/update_versions_from_pypi.py --check" in text

--- a/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
+++ b/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
@@ -45,10 +45,7 @@ def test_maint52_pr_body_reports_canonical_source_commit_and_never_proposes_upst
 
     assert "CANONICAL_SOURCE_SHA" in text
     assert "**Settled source commit:** \\`$CANONICAL_SOURCE_SHA\\`" in text
-    assert (
-        "source_commit:$source_commit" in text
-        or "source_commit:$CANONICAL_SOURCE_SHA" in text
-        or '"source_commit"' in text
-    )
+    assert '--arg source_commit "$CANONICAL_SOURCE_SHA"' in text
+    assert "source_commit:$source_commit" in text
     assert "update_versions_from_pypi.py --apply" not in text
     assert "python scripts/update_versions_from_pypi.py --check" in text

--- a/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
+++ b/tests/workflows/test_maint52_sync_dev_versions_pr_body.py
@@ -45,6 +45,10 @@ def test_maint52_pr_body_reports_canonical_source_commit_and_never_proposes_upst
 
     assert "CANONICAL_SOURCE_SHA" in text
     assert "**Settled source commit:** \\`$CANONICAL_SOURCE_SHA\\`" in text
-    assert "source_commit:$source_commit" in text or "source_commit:$CANONICAL_SOURCE_SHA" in text or '"source_commit"' in text
+    assert (
+        "source_commit:$source_commit" in text
+        or "source_commit:$CANONICAL_SOURCE_SHA" in text
+        or '"source_commit"' in text
+    )
     assert "update_versions_from_pypi.py --apply" not in text
     assert "python scripts/update_versions_from_pypi.py --check" in text


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2882 -->
> **Source:** Issue #2882

Closes #2882

<!-- pr-preamble:end -->

## Summary
Bounded closer follow-up after merged #2902 received durable `verify:compare` **CONCERNS** (Provider Comparison Report 2026-08-02T19:30:48Z). Audited current main and landed the residual acceptance gaps:

- Source lane now runs `sync_tool_versions.py --check` and `sync_dev_dependencies.py --check --lockfile` after applying pin updates and **before** Create PR; `security_override` cannot skip this gate.
- After the canonical source PR exists, overlapping open Dependabot/Renovate PRs that touch Workflows-owned pin surfaces are closed as superseded.
- Strengthened `test_maint52_sync_dev_versions_pr_body.py` to prove Maint 52 reports the settled source commit and never runs `update_versions_from_pypi.py --apply`.
- Structure test proves validation → Create PR → supersession ordering.
- Made the deliberate lockfile mismatch AC assertion explicit (`requirements.lock:ruff` + version delta).
- Documented the validation gate and supersession rule in `docs/ci/TOOL_VERSION_MANAGEMENT.md`.

Already-satisfied claims left alone: Maint 50 exclusivity, weekly/security policy helper tests, existing template mismatch coverage in `test_sync_tool_versions.py`.

## Test plan
- [x] `python -m pytest tests/workflows/test_dev_tool_source_lane.py tests/workflows/test_maint52_sync_dev_versions_pr_body.py tests/scripts/test_dev_tool_update_policy.py tests/scripts/test_sync_dev_dependencies.py::test_main_check_reports_lockfile_mismatch -q` (16 passed)
- [ ] Fresh Gate / summary green on this head

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Shared developer-tool pins are currently checked and propagated by several scheduled surfaces: `.github/workflows/maint-auto-update-pypi-versions.yml:11-15,45-141`, `.github/workflows/maint-50-tool-version-check.yml:6-9,43-149`, Maint 52, and `maint-sync-env-from-pyproject.yml`. The repository documentation in `docs/ci/TOOL_VERSION_MANAGEMENT.md` still describes a partly manual Maint 50 flow even though a daily updater can open source PRs.

This is a current churn source: the same upstream version movement can be detected, commented on, proposed, and propagated by different workflows before the canonical source state settles. That creates extra source PRs, consumer waves, and agent decisions.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2876](https://github.com/stranske/Workflows/issues/2876)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Define the canonical pin set and owner across `.github/workflows/autofix-versions.env`, `pyproject.toml`, consumer/integration template env files, and `requirements.lock`.
- [ ] Refactor `.github/workflows/maint-auto-update-pypi-versions.yml` into the sole source proposal lane with a weekly batch window and a documented security override.
- [ ] Remove duplicate upstream-version proposal/comment behavior from `.github/workflows/maint-50-tool-version-check.yml`; retain only a bounded policy/freshness audit if it adds unique evidence.
- [ ] Make `.github/workflows/maint-52-sync-dev-versions.yml` propagation-only: it must consume a settled canonical source commit and must not independently decide newer versions.
- [ ] Keep `.github/workflows/maint-sync-env-from-pyproject.yml` as a deterministic source-consistency check or replace it with a named equivalent; prevent it from racing the source proposal lane.
- [ ] Group routine ruff, black, mypy, pytest, pytest-cov, pytest-xdist, coverage, isort, and docformatter changes into one bounded source PR per window.
- [ ] Update `docs/ci/TOOL_VERSION_MANAGEMENT.md`, `docs/ops/CONSUMER_REPO_MAINTENANCE.md`, and contributor guidance with ownership, cadence, emergency handling, and supersession rules.
- [ ] Close or explicitly supersede overlapping dependency-bot PRs only after the canonical source proposal or merged source commit exists.

#### Acceptance criteria
- [ ] `tests/workflows/test_maint52_sync_dev_versions_pr_body.py` proves Maint 52 reports the canonical source commit and never proposes an upstream version independently.
- [ ] `tests/workflows/test_sync_dev_dependencies.py` proves env, pyproject, template, and lockfile pins move together for every managed tool.
- [ ] A new policy test proves one weekly source proposal can contain multiple routine tool updates and that a security fixture bypasses the window without bypassing tests.
- [ ] Maint 50 and the source updater cannot open or comment competing proposals for the same canonical delta.
- [ ] Consumer propagation starts only after canonical source validation succeeds and creates at most one current wave per repo.
- [ ] Deliberate-break test: introduce one mismatched managed-tool pin in a template or lockfile, verify the named consistency test fails with the exact path/tool, then revert and verify it passes.
- [ ] Run `python scripts/dev_check.py --action test` and the workflow-validation suite successfully.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated version update workflows by validating synchronized pins before creating pull requests.
  * Prevented direct package registry version updates when a canonical source update is available.
  * Automatically closes overlapping automated update pull requests after the canonical source proposal is created.
  * Added clearer source commit and version details to generated pull requests.

* **Documentation**
  * Updated tool-version management documentation to describe validation and duplicate pull request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->