### PR TITLE
corpus: harvest realized-outcome verifier cases

### DIFF
--- a/config/model_eval_corpus_staging.json
+++ b/config/model_eval_corpus_staging.json
@@ -37,6 +37,105 @@
       "category": "clean-pass",
       "provenance": "harvested",
       "harvested_at": "2026-07-27"
+    },
+    {
+      "case_id": "workflows-2727",
+      "repo": "stranske/Workflows",
+      "pr": 2727,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "manager-database-1386",
+      "repo": "stranske/Manager-Database",
+      "pr": 1386,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "manager-database-1384",
+      "repo": "stranske/Manager-Database",
+      "pr": 1384,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "inv-man-intake-735",
+      "repo": "stranske/Inv-Man-Intake",
+      "pr": 735,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "inv-man-intake-734",
+      "repo": "stranske/Inv-Man-Intake",
+      "pr": 734,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "pension-data-687",
+      "repo": "stranske/Pension-Data",
+      "pr": 687,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "pension-data-685",
+      "repo": "stranske/Pension-Data",
+      "pr": 685,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "pension-data-684",
+      "repo": "stranske/Pension-Data",
+      "pr": 684,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "trip-planner-1513",
+      "repo": "stranske/trip-planner",
+      "pr": 1513,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "fine-art-archive-239",
+      "repo": "stranske/Fine-Art-Archive",
+      "pr": 239,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "fine-art-archive-238",
+      "repo": "stranske/Fine-Art-Archive",
+      "pr": 238,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-03"
     }
   ]
 }


### PR DESCRIPTION
Automated corpus growth (stranske/Workflows#2819 move 2).

High-confidence cases derived from realized PR outcomes — see the run
summary for the promoted case list. Ambiguous cases were routed to the
auto-expiring staging file, not here.

Expected verdicts here come from what the world already adjudicated by
merging or reverting each PR. The semantic NON_PASS categories
(stale-verifier-claim, review-thread-debt, missing-acceptance-criterion)
remain owner-sourced and are never machine-added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the staging evaluation corpus with 11 additional passing cases.
  * Added coverage across Workflows, Manager-Database, Inv-Man-Intake, Pension-Data, trip-planner, and Fine-Art-Archive pull requests.
  * Recorded consistent provenance and harvest metadata for the new cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->