### PR TITLE
fix(sync): preserve CRLF for consumer command launchers

### DIFF
--- a/templates/consumer-repo/.gitattributes
+++ b/templates/consumer-repo/.gitattributes
@@ -12,3 +12,6 @@ ci/autofix/history.json merge=ours linguist-generated
 # Agent ledger files are metadata, not reviewable code
 # Mark as generated to exclude from Copilot/Codex code reviews
 .agents/*.yml linguist-generated
+
+# Windows command launchers must retain native line endings after checkout.
+*.cmd text eol=crlf

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -209,6 +209,15 @@ def test_prepare_checkout_includes_manifest_owned_github_roots() -> None:
     }
 
 
+def test_consumer_gitattributes_preserves_windows_launcher_crlf() -> None:
+    """The template-owned git config must retain native Windows line endings."""
+    consumer_gitattributes = (
+        REPO_ROOT / "templates" / "consumer-repo" / ".gitattributes"
+    ).read_text(encoding="utf-8")
+
+    assert "*.cmd text eol=crlf" in consumer_gitattributes.splitlines()
+
+
 def test_sync_fanout_is_canary_gated_and_promotion_is_plan_bound() -> None:
     workflow = yaml.safe_load(SYNC_WORKFLOW_PATH.read_text(encoding="utf-8"))
     dispatch_inputs = workflow.get("on", workflow.get(True))["workflow_dispatch"]["inputs"]


### PR DESCRIPTION
## Summary
- add the Windows command-launcher CRLF rule to the authoritative consumer `.gitattributes` template
- add a regression test for the template-owned sync source

## Why
Maint-68 resolves `git_config` entries from `templates/consumer-repo`. The CRLF rule existed only in the Workflows root copy, so sync PRs could remove it from consumers and break Windows launcher tests.

## Validation
- `uv run pytest -q tests/workflows/test_sync_manifest_delivery.py tests/scripts/test_sync_manifest_compiler.py` (41 passed)
- `uv run ruff check tests/workflows/test_sync_manifest_delivery.py`
- `git diff --check`