### PR TITLE
fix(sync): clarify generated validation contracts

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -33,8 +33,8 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
-PYTEST_RUNTIME_VERSION = "6.0.3"
-PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYTEST_RUNTIME_VERSION}",)
+PYYAML_VERSION = "6.0.3"
+PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 
 
 @dataclass(frozen=True)
@@ -145,7 +145,7 @@ def _ensure_pytest_runtime_deps() -> None:
         installed_version = metadata.version("PyYAML")
     except metadata.PackageNotFoundError:
         installed_version = None
-    if installed_version != PYTEST_RUNTIME_VERSION:
+    if installed_version != PYYAML_VERSION:
         subprocess.run(
             [
                 sys.executable,

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -305,7 +305,7 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
     monkeypatch.setattr(
         deliberate_break.metadata,
         "version",
-        lambda _name: deliberate_break.PYTEST_RUNTIME_VERSION,
+        lambda _name: deliberate_break.PYYAML_VERSION,
     )
     monkeypatch.setattr(
         deliberate_break.subprocess,

--- a/tests/workflows/test_sync_manifest_delivery.py
+++ b/tests/workflows/test_sync_manifest_delivery.py
@@ -210,7 +210,7 @@ def test_prepare_checkout_includes_manifest_owned_github_roots() -> None:
 
 
 def test_consumer_gitattributes_preserves_windows_launcher_crlf() -> None:
-    """The template-owned git config must retain native Windows line endings."""
+    """The template-owned attributes must retain native Windows line endings."""
     consumer_gitattributes = (
         REPO_ROOT / "templates" / "consumer-repo" / ".gitattributes"
     ).read_text(encoding="utf-8")

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -167,12 +167,12 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
         floor = raw_overrides.get(category, minimum_per_category)
         if type(floor) is not int:
             raise ValueError(
-                "minimum_cases_per_category_overrides values must be integers "
+                "approval_stage.minimum_cases_per_category_overrides values must be integers "
                 f"(got {floor!r} for {category!r})"
             )
         if floor < 1:
             raise ValueError(
-                "minimum_cases_per_category_overrides values must be >= 1 "
+                "approval_stage.minimum_cases_per_category_overrides values must be >= 1 "
                 f"(got {floor} for {category!r}); every required category must be represented"
             )
         category_floors[category] = floor


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary
- name the PyYAML runtime pin for the package it controls
- include the approval-stage config path in category-floor validation errors
- preserve the existing generated behavior while resolving the live consumer review findings

## Validation
- 67 focused tests passed
- Black check passed
- Ruff check passed
- git diff --check passed

Follow-up to the corrected consumer wave generated from #2911.