### PR TITLE
fix(sync): repair broken PyYAML runtime installs

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -15,7 +15,7 @@ import tarfile
 import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
-from importlib import metadata
+from importlib import import_module, metadata
 from io import BytesIO
 from pathlib import Path
 
@@ -145,7 +145,15 @@ def _ensure_pytest_runtime_deps() -> None:
         installed_version = metadata.version("PyYAML")
     except metadata.PackageNotFoundError:
         installed_version = None
-    if installed_version != PYYAML_VERSION:
+    import_works = False
+    if installed_version == PYYAML_VERSION:
+        try:
+            import_module("yaml")
+        except ImportError:
+            pass
+        else:
+            import_works = True
+    if installed_version != PYYAML_VERSION or not import_works:
         subprocess.run(
             [
                 sys.executable,

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -307,6 +307,7 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
         "version",
         lambda _name: deliberate_break.PYYAML_VERSION,
     )
+    monkeypatch.setattr(deliberate_break, "import_module", lambda _name: object())
     monkeypatch.setattr(
         deliberate_break.subprocess,
         "run",
@@ -316,6 +317,30 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
     deliberate_break._ensure_pytest_runtime_deps()
 
     assert calls == []
+
+
+def test_runtime_dependency_installer_repairs_broken_pyyaml_import(monkeypatch) -> None:
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def broken_import(_name):
+        raise ImportError("broken PyYAML install")
+
+    monkeypatch.setattr(
+        deliberate_break.metadata,
+        "version",
+        lambda _name: deliberate_break.PYYAML_VERSION,
+    )
+    monkeypatch.setattr(deliberate_break, "import_module", broken_import)
+    monkeypatch.setattr(
+        deliberate_break.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    deliberate_break._ensure_pytest_runtime_deps()
+
+    assert len(calls) == 1
+    assert calls[0][0][0][-1] == f"pyyaml=={deliberate_break.PYYAML_VERSION}"
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:


### PR DESCRIPTION
## Summary
- verify both the locked PyYAML distribution version and the `yaml` import
- reinstall the locked runtime dependency when metadata exists but the import is broken
- add regression coverage for a partial/broken install

## Source disposition
Source-first resolution for the live review finding on stranske/Manager-Database#1521. The consumer canary will be regenerated after this merges.

## Validation
- `uv run pytest -q tests/scripts/test_check_deliberate_break.py` (16 passed)
- `uv run ruff check scripts/check_deliberate_break.py tests/scripts/test_check_deliberate_break.py`
- `uv run black --check scripts/check_deliberate_break.py tests/scripts/test_check_deliberate_break.py`
- `git diff --check`