### PR TITLE
fix(sync): address generated review follow-ups

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -146,31 +146,39 @@ def _ensure_pytest_runtime_deps() -> None:
         installed_version = metadata.version("PyYAML")
     except metadata.PackageNotFoundError:
         installed_version = None
-    import_works = False
+    import_error: Exception | None = None
     if installed_version == PYYAML_VERSION:
         try:
             import_module("yaml")
-        except Exception:
+        except Exception as exc:
             # Any ordinary import-time failure means the installed distribution
             # is unusable. Reinstall the locked wheel before collecting tests.
-            pass
+            import_error = exc
         else:
-            import_works = True
-    if installed_version != PYYAML_VERSION or not import_works:
+            return
+    if installed_version != PYYAML_VERSION or import_error is not None:
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+        ]
+        if import_error is not None:
+            command.append("--force-reinstall")
+        command.extend(PYTEST_RUNTIME_DEPENDENCIES)
         subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                *PYTEST_RUNTIME_DEPENDENCIES,
-            ],
+            command,
             check=True,
             text=True,
             capture_output=True,
             timeout=DEFAULT_TIMEOUT_SECONDS,
         )
+        try:
+            import_module("yaml")
+        except Exception as retry_error:
+            error = ImportError(f"PyYAML remained unimportable after reinstall: {retry_error}")
+            raise error from (import_error or retry_error)
 
 
 def _run(
@@ -321,6 +329,13 @@ def verify_spec(
             returncode=exc.returncode,
             stdout=exc.stdout,
             stderr=exc.stderr,
+        )
+    except ImportError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-import-failed",
+            detail=str(exc),
+            cause=str(exc.__cause__) if exc.__cause__ is not None else None,
         )
     except OSError as exc:
         return _json_result(

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -33,7 +33,7 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
-# Keep this bootstrap pin aligned with the canonical PyYAML pin in requirements.lock.
+# Keep this pin aligned with the PyYAML entry in requirements.lock.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 
@@ -135,7 +135,7 @@ def _pytest_command(test_id: str) -> tuple[str, ...]:
 
 
 def _ensure_pytest_runtime_deps() -> None:
-    """Install lightweight deps that Gate test-quality may not preinstall.
+    """Install lightweight dependencies that Gate test-quality may not preinstall.
 
     Gate's test-quality job installs only ``pytest``. Deliberate-break may still
     collect tests that import PyYAML (for example via ``sync_manifest_compiler``).
@@ -151,6 +151,8 @@ def _ensure_pytest_runtime_deps() -> None:
         try:
             import_module("yaml")
         except Exception:
+            # Any ordinary import-time failure means the installed distribution
+            # is unusable. Reinstall the locked wheel before collecting tests.
             pass
         else:
             import_works = True

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -682,7 +682,12 @@ def _text_from_response_content(content: object) -> str | None:
     if isinstance(content, list):
         text_blocks: list[str] = []
         for block in content:
-            text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+            if isinstance(block, str):
+                text = block
+            elif isinstance(block, dict):
+                text = block.get("text")
+            else:
+                text = getattr(block, "text", None)
             if isinstance(text, str):
                 text_blocks.append(text)
         if any(block and not block.isspace() for block in text_blocks):

--- a/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
+++ b/templates/consumer-repo/WORKFLOW_USER_GUIDE.md
@@ -1125,6 +1125,11 @@ The Workflows repository includes maintenance workflows that handle sync, update
 
 **Result:** Freshness evidence only; it never creates a competing update issue or PR
 
+**Consumer note:** Maint 50 is not synced into consumer repositories. Older
+consumer-local documentation may still describe a legacy
+`maint-50-tool-version-check.yml`; treat those references as historical unless
+that workflow actually exists in the consumer checkout.
+
 ---
 
 ### `maint-52-validate-workflows.yml` - Workflow Validation

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -319,12 +319,14 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
     assert calls == []
 
 
-@pytest.mark.parametrize("error_type", [ImportError, OSError, AttributeError, SyntaxError])
-def test_runtime_dependency_installer_repairs_broken_pyyaml_import(monkeypatch, error_type) -> None:
+@pytest.mark.parametrize("import_error", [ImportError, OSError, AttributeError, SyntaxError])
+def test_runtime_dependency_installer_repairs_broken_pyyaml_import(
+    monkeypatch, import_error
+) -> None:
     calls: list[tuple[object, dict[str, object]]] = []
 
     def broken_import(_name):
-        raise error_type("broken PyYAML install")
+        raise import_error("broken PyYAML install")
 
     monkeypatch.setattr(
         deliberate_break.metadata,
@@ -382,14 +384,14 @@ def test_dependency_install_timeout_is_broken(tmp_path, monkeypatch) -> None:
     }
 
 
-def test_dependency_install_failure_is_broken_with_diagnostics(tmp_path, monkeypatch) -> None:
+def test_dependency_install_failure_preserves_subprocess_context(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_repo(repo)
     base, spec = _sound_spec(repo)
     error = subprocess.CalledProcessError(
-        1,
-        ["python", "-m", "pip", "install", "pyyaml==6.0.3"],
+        17,
+        ["pip", "install", "pyyaml==6.0.3"],
         output="resolver output",
         stderr="pip denied",
     )
@@ -404,8 +406,8 @@ def test_dependency_install_failure_is_broken_with_diagnostics(tmp_path, monkeyp
     assert result == {
         "verdict": VERDICT_BROKEN,
         "reason": "dependency-install-failed",
-        "command": ["python", "-m", "pip", "install", "pyyaml==6.0.3"],
-        "returncode": 1,
+        "command": ["pip", "install", "pyyaml==6.0.3"],
+        "returncode": 17,
         "stdout": "resolver output",
         "stderr": "pip denied",
     }

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -273,6 +273,7 @@ def test_runtime_dependency_installer_uses_locked_pyyaml(monkeypatch, installed_
         return subprocess.CompletedProcess(args[0], 0, "", "")
 
     monkeypatch.setattr(deliberate_break.metadata, "version", package_version)
+    monkeypatch.setattr(deliberate_break, "import_module", lambda _name: object())
     monkeypatch.setattr(deliberate_break.subprocess, "run", record_install)
 
     deliberate_break._ensure_pytest_runtime_deps()
@@ -324,9 +325,14 @@ def test_runtime_dependency_installer_repairs_broken_pyyaml_import(
     monkeypatch, import_error
 ) -> None:
     calls: list[tuple[object, dict[str, object]]] = []
+    imports = 0
 
     def broken_import(_name):
-        raise import_error("broken PyYAML install")
+        nonlocal imports
+        imports += 1
+        if imports == 1:
+            raise import_error("broken PyYAML install")
+        return object()
 
     monkeypatch.setattr(
         deliberate_break.metadata,
@@ -344,6 +350,40 @@ def test_runtime_dependency_installer_repairs_broken_pyyaml_import(
 
     assert len(calls) == 1
     assert calls[0][0][0][-1] == f"pyyaml=={deliberate_break.PYYAML_VERSION}"
+    assert "--force-reinstall" in calls[0][0][0]
+    assert imports == 2
+
+
+def test_runtime_dependency_installer_preserves_initial_import_failure(
+    monkeypatch,
+) -> None:
+    initial_error = OSError("broken PyYAML install")
+    imports = 0
+
+    def broken_import(_name):
+        nonlocal imports
+        imports += 1
+        if imports == 1:
+            raise initial_error
+        raise AttributeError("still broken after reinstall")
+
+    monkeypatch.setattr(
+        deliberate_break.metadata,
+        "version",
+        lambda _name: deliberate_break.PYYAML_VERSION,
+    )
+    monkeypatch.setattr(deliberate_break, "import_module", broken_import)
+    monkeypatch.setattr(
+        deliberate_break.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "", ""),
+    )
+
+    with pytest.raises(ImportError, match="still broken after reinstall") as caught:
+        deliberate_break._ensure_pytest_runtime_deps()
+
+    assert caught.value.__cause__ is initial_error
+    assert imports == 2
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:
@@ -430,4 +470,26 @@ def test_dependency_install_unavailable_is_broken(tmp_path, monkeypatch) -> None
         "verdict": VERDICT_BROKEN,
         "reason": "dependency-install-unavailable",
         "detail": "pip unavailable",
+    }
+
+
+def test_dependency_import_failure_is_broken(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    original = OSError("original import failed")
+
+    def failed() -> None:
+        raise ImportError("retry failed") from original
+
+    monkeypatch.setattr(deliberate_break, "_ensure_pytest_runtime_deps", failed)
+
+    result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "dependency-import-failed",
+        "detail": "retry failed",
+        "cause": "original import failed",
     }

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -266,6 +266,15 @@ def test_text_from_response_content_does_not_copy_blocks_to_check_whitespace() -
     assert pr_verifier._text_from_response_content(blocks) == "large response"
 
 
+def test_text_from_response_content_accepts_strings_and_object_blocks() -> None:
+    class TextBlock:
+        text = 'ponse"}'
+
+    blocks = ['{"summary":"res', TextBlock()]
+
+    assert pr_verifier._text_from_response_content(blocks) == '{"summary":"response"}'
+
+
 def test_evaluate_pr_valid_output_no_repair(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = _valid_payload()
     good = json.dumps(payload)


### PR DESCRIPTION
## Summary
- repair any ordinary PyYAML import-time failure with the locked wheel and preserve pip failure context
- accept string and object-backed provider response blocks without lossy JSON fallback
- clarify the locked pin, dependency helper docstring, and consumer maint-50 documentation boundary

## Validation
- `python -m pytest -q tests/scripts/test_check_deliberate_break.py tests/scripts/test_pr_verifier_structured_output.py` (47 passed)
- Ruff, Black, `git diff --check`
- `python scripts/validate_template_sync.py`

Follow-up to live review findings on the corrected consumer sync wave; no source-issue lineage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency validation to detect a wider range of unusable package states.
  - Installation failures now provide clearer command, status, and output details.
  - Improved handling of structured responses containing mixed text formats.

- **Documentation**
  - Clarified that the maintenance tool-version workflow is central-only and is not synchronized to consumer repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->