### PR TITLE
fix(gate): install PyYAML only on demand

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -225,9 +225,14 @@ def _run_with_runtime_deps(
             'no module named "yaml"',
             "modulenotfounderror: yaml",
             "importerror: yaml",
-            "pyyaml",
         )
     )
+    yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
+    if yaml_traceback and not missing_pyyaml:
+        try:
+            import_module("yaml")
+        except Exception:
+            missing_pyyaml = True
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -202,6 +202,33 @@ def _run(
     )
 
 
+def _run_with_runtime_deps(
+    command: tuple[str, ...],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Retry a command after repairing PyYAML only when its output requires it."""
+    completed = _run(command, cwd)
+    if completed.returncode == 0:
+        return completed
+
+    output = f"{completed.stdout}\n{completed.stderr}".lower()
+    missing_pyyaml = any(
+        marker in output
+        for marker in (
+            "no module named 'yaml'",
+            'no module named "yaml"',
+            "modulenotfounderror: yaml",
+            "importerror: yaml",
+            "pyyaml",
+        )
+    )
+    if not missing_pyyaml:
+        return completed
+
+    _ensure_pytest_runtime_deps()
+    return _run(command, cwd)
+
+
 def _git(
     args: list[str],
     cwd: Path,
@@ -313,7 +340,7 @@ def verify_spec(
         )
 
     try:
-        _ensure_pytest_runtime_deps()
+        head_run = _run_with_runtime_deps(spec.command, repo)
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
@@ -344,16 +371,6 @@ def verify_spec(
             detail=str(exc),
         )
 
-    try:
-        head_run = _run(spec.command, repo)
-    except subprocess.TimeoutExpired as exc:
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="command-timeout",
-            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-            timeout=exc.timeout,
-        )
-
     if head_run.returncode != 0:
         return _json_result(
             VERDICT_BROKEN,
@@ -371,7 +388,7 @@ def verify_spec(
             base_test = base_dir / spec.test_file
             base_test.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(test_path, base_test)
-            base_run = _run(spec.command, base_dir)
+            base_run = _run_with_runtime_deps(spec.command, base_dir)
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
@@ -383,6 +400,28 @@ def verify_spec(
         return _json_result(
             VERDICT_BROKEN,
             reason="archive-extract-failed",
+            detail=str(exc),
+        )
+    except subprocess.CalledProcessError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-failed",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            returncode=exc.returncode,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        )
+    except ImportError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-import-failed",
+            detail=str(exc),
+            cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+        )
+    except OSError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-unavailable",
             detail=str(exc),
         )
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -33,7 +33,7 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
-# Keep this pin aligned with the PyYAML entry in requirements.lock.
+# This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -157,6 +157,12 @@ def _ensure_pytest_runtime_deps() -> None:
         else:
             return
     if installed_version != PYYAML_VERSION or import_error is not None:
+        if os.environ.get("GITHUB_ACTIONS") != "true":
+            error = ImportError(
+                f"PyYAML {PYYAML_VERSION} is required; install "
+                f"{PYTEST_RUNTIME_DEPENDENCIES[0]} in the active environment"
+            )
+            raise error from import_error
         command = [
             sys.executable,
             "-m",

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -703,7 +703,10 @@ def _coerce_response_content(content: object) -> str:
     text = _text_from_response_content(content)
     if text is not None:
         return text
-    return json.dumps(content, default=str)
+    try:
+        return json.dumps(content, default=str)
+    except (TypeError, ValueError):
+        return str(content)
 
 
 def _parse_llm_response(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -386,6 +386,59 @@ def test_runtime_dependency_installer_preserves_initial_import_failure(
     assert imports == 2
 
 
+def test_runtime_dependencies_are_not_installed_for_successful_custom_command(
+    tmp_path, monkeypatch
+) -> None:
+    completed = subprocess.CompletedProcess(["custom-check"], 0, "ok", "")
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: pytest.fail("dependency repair should not run"),
+    )
+
+    assert deliberate_break._run_with_runtime_deps(("custom-check",), tmp_path) is completed
+
+
+def test_runtime_dependencies_are_not_installed_for_unrelated_failure(
+    tmp_path, monkeypatch
+) -> None:
+    completed = subprocess.CompletedProcess(["custom-check"], 1, "", "assertion failed")
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: pytest.fail("dependency repair should not run"),
+    )
+
+    assert deliberate_break._run_with_runtime_deps(("custom-check",), tmp_path) is completed
+
+
+def test_runtime_dependencies_retry_pyyaml_import_failure(tmp_path, monkeypatch) -> None:
+    attempts = [
+        subprocess.CompletedProcess(
+            ["pytest"],
+            1,
+            "",
+            "ModuleNotFoundError: No module named 'yaml'",
+        ),
+        subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
+    ]
+    repairs: list[bool] = []
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: repairs.append(True),
+    )
+
+    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+
+    assert completed.returncode == 0
+    assert repairs == [True]
+    assert attempts == []
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")
@@ -412,7 +465,7 @@ def test_dependency_install_timeout_is_broken(tmp_path, monkeypatch) -> None:
     def timed_out() -> None:
         raise subprocess.TimeoutExpired(command, 17)
 
-    monkeypatch.setattr(deliberate_break, "_ensure_pytest_runtime_deps", timed_out)
+    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: timed_out())
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -439,7 +492,7 @@ def test_dependency_install_failure_preserves_subprocess_context(tmp_path, monke
     def failed() -> None:
         raise error
 
-    monkeypatch.setattr(deliberate_break, "_ensure_pytest_runtime_deps", failed)
+    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -462,7 +515,7 @@ def test_dependency_install_unavailable_is_broken(tmp_path, monkeypatch) -> None
     def failed() -> None:
         raise OSError("pip unavailable")
 
-    monkeypatch.setattr(deliberate_break, "_ensure_pytest_runtime_deps", failed)
+    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -483,7 +536,7 @@ def test_dependency_import_failure_is_broken(tmp_path, monkeypatch) -> None:
     def failed() -> None:
         raise ImportError("retry failed") from original
 
-    monkeypatch.setattr(deliberate_break, "_ensure_pytest_runtime_deps", failed)
+    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -262,6 +262,7 @@ def test_cli_skips_without_marker(tmp_path) -> None:
 @pytest.mark.parametrize("installed_version", [None, "6.0.2"])
 def test_runtime_dependency_installer_uses_locked_pyyaml(monkeypatch, installed_version) -> None:
     calls: list[tuple[object, dict[str, object]]] = []
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
     def package_version(_name):
         if installed_version is None:
@@ -326,6 +327,7 @@ def test_runtime_dependency_installer_repairs_broken_pyyaml_import(
 ) -> None:
     calls: list[tuple[object, dict[str, object]]] = []
     imports = 0
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
     def broken_import(_name):
         nonlocal imports
@@ -359,6 +361,7 @@ def test_runtime_dependency_installer_preserves_initial_import_failure(
 ) -> None:
     initial_error = OSError("broken PyYAML install")
     imports = 0
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
     def broken_import(_name):
         nonlocal imports
@@ -384,6 +387,23 @@ def test_runtime_dependency_installer_preserves_initial_import_failure(
 
     assert caught.value.__cause__ is initial_error
     assert imports == 2
+
+
+def test_runtime_dependency_installer_does_not_modify_local_environment(monkeypatch) -> None:
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.setattr(
+        deliberate_break.metadata,
+        "version",
+        lambda _name: (_ for _ in ()).throw(deliberate_break.metadata.PackageNotFoundError),
+    )
+    monkeypatch.setattr(
+        deliberate_break.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("local dependency install should not run"),
+    )
+
+    with pytest.raises(ImportError, match="install pyyaml=="):
+        deliberate_break._ensure_pytest_runtime_deps()
 
 
 def test_runtime_dependencies_are_not_installed_for_successful_custom_command(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -434,6 +434,22 @@ def test_runtime_dependencies_are_not_installed_for_unrelated_failure(
     assert deliberate_break._run_with_runtime_deps(("custom-check",), tmp_path) is completed
 
 
+def test_runtime_dependencies_are_not_installed_for_unrelated_pyyaml_mention(
+    tmp_path, monkeypatch
+) -> None:
+    completed = subprocess.CompletedProcess(
+        ["custom-check"], 1, "", "test_pyyaml_behavior: assertion failed"
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: pytest.fail("dependency repair should not run"),
+    )
+
+    assert deliberate_break._run_with_runtime_deps(("custom-check",), tmp_path) is completed
+
+
 def test_runtime_dependencies_retry_pyyaml_import_failure(tmp_path, monkeypatch) -> None:
     attempts = [
         subprocess.CompletedProcess(
@@ -446,6 +462,36 @@ def test_runtime_dependencies_retry_pyyaml_import_failure(tmp_path, monkeypatch)
     ]
     repairs: list[bool] = []
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: repairs.append(True),
+    )
+
+    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+
+    assert completed.returncode == 0
+    assert repairs == [True]
+    assert attempts == []
+
+
+def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatch) -> None:
+    attempts = [
+        subprocess.CompletedProcess(
+            ["pytest"],
+            1,
+            "",
+            'File "/venv/lib/site-packages/yaml/__init__.py", line 1\nSyntaxError: invalid syntax',
+        ),
+        subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
+    ]
+    repairs: list[bool] = []
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "import_module",
+        lambda _name: (_ for _ in ()).throw(SyntaxError("broken wheel")),
+    )
     monkeypatch.setattr(
         deliberate_break,
         "_ensure_pytest_runtime_deps",

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -214,6 +214,12 @@ def test_coerce_response_content_falls_back_to_json_for_unblocked_payloads() -> 
     assert pr_verifier._text_from_response_content(payload) is None
 
 
+def test_coerce_response_content_falls_back_to_string_when_json_serialization_fails() -> None:
+    payload = {(1, 2): "unsupported JSON key"}
+
+    assert pr_verifier._coerce_response_content(payload) == str(payload)
+
+
 def test_text_from_response_content_concatenates_split_text_blocks_without_separator() -> None:
     payload = _valid_payload()
     encoded = json.dumps(payload)


### PR DESCRIPTION
## Summary
- run deliberate-break commands before attempting PyYAML repair
- retry only when failure output identifies a missing or broken PyYAML import
- restrict automatic dependency repair to GitHub Actions; local runs fail with an actionable install message
- correct the consumer pin ownership comment
- make structured provider-content serialization fall back safely to `str(content)`
- preserve structured dependency failure context for head and base runs

## Validation
- `python -m pytest -q tests/scripts/test_check_deliberate_break.py tests/scripts/test_pr_verifier_structured_output.py` (57 passed)
- `python -m ruff check scripts/check_deliberate_break.py scripts/langchain/pr_verifier.py tests/scripts/test_check_deliberate_break.py tests/scripts/test_pr_verifier_structured_output.py`
- `python -m black --check scripts/check_deliberate_break.py scripts/langchain/pr_verifier.py tests/scripts/test_check_deliberate_break.py tests/scripts/test_pr_verifier_structured_output.py`
- `python scripts/validate_template_sync.py`
- `git diff --check`

## Review lineage
Addresses source-level findings raised on Portable-Alpha-Extension-Model#2186, Inv-Man-Intake#881, Ready#491, Pension-Data#800, and Template#971. Consumer sync PRs remain held until this source fix is reviewed and propagated.