### PR TITLE
fix(gate): attribute base setup failures accurately

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -46,6 +46,14 @@ class DeliberateBreakSpec:
     command: tuple[str, ...]
 
 
+class RuntimeDependencyError(Exception):
+    """Wrap failures raised specifically while repairing runtime dependencies."""
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__(str(error))
+        self.error = error
+
+
 def _json_result(verdict: str, **fields: object) -> dict[str, object]:
     return {"verdict": verdict, **fields}
 
@@ -236,7 +244,10 @@ def _run_with_runtime_deps(
     if not missing_pyyaml:
         return completed
 
-    _ensure_pytest_runtime_deps()
+    try:
+        _ensure_pytest_runtime_deps()
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, ImportError, OSError) as exc:
+        raise RuntimeDependencyError(exc) from exc
     return _run(command, cwd)
 
 
@@ -359,26 +370,41 @@ def verify_spec(
             command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
             timeout=exc.timeout,
         )
-    except subprocess.CalledProcessError as exc:
+    except RuntimeDependencyError as wrapped:
+        exc = wrapped.error
+        if isinstance(exc, subprocess.TimeoutExpired):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="command-timeout",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                timeout=exc.timeout,
+            )
+        if isinstance(exc, subprocess.CalledProcessError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-install-failed",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                returncode=exc.returncode,
+                stdout=exc.stdout,
+                stderr=exc.stderr,
+            )
+        if isinstance(exc, ImportError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-import-failed",
+                detail=str(exc),
+                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+            )
         return _json_result(
             VERDICT_BROKEN,
-            reason="dependency-install-failed",
-            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-            returncode=exc.returncode,
-            stdout=exc.stdout,
-            stderr=exc.stderr,
-        )
-    except ImportError as exc:
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-import-failed",
+            reason="dependency-install-unavailable",
             detail=str(exc),
-            cause=str(exc.__cause__) if exc.__cause__ is not None else None,
         )
     except OSError as exc:
         return _json_result(
             VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
+            reason="command-unavailable",
+            command=list(spec.command),
             detail=str(exc),
         )
 
@@ -413,26 +439,49 @@ def verify_spec(
             reason="archive-extract-failed",
             detail=str(exc),
         )
+    except RuntimeDependencyError as wrapped:
+        exc = wrapped.error
+        if isinstance(exc, subprocess.TimeoutExpired):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="command-timeout",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                timeout=exc.timeout,
+            )
+        if isinstance(exc, subprocess.CalledProcessError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-install-failed",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                returncode=exc.returncode,
+                stdout=exc.stdout,
+                stderr=exc.stderr,
+            )
+        if isinstance(exc, ImportError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-import-failed",
+                detail=str(exc),
+                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+            )
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-unavailable",
+            detail=str(exc),
+        )
     except subprocess.CalledProcessError as exc:
         return _json_result(
             VERDICT_BROKEN,
-            reason="dependency-install-failed",
+            reason="archive-command-failed",
             command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
             returncode=exc.returncode,
             stdout=exc.stdout,
             stderr=exc.stderr,
         )
-    except ImportError as exc:
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-import-failed",
-            detail=str(exc),
-            cause=str(exc.__cause__) if exc.__cause__ is not None else None,
-        )
     except OSError as exc:
         return _json_result(
             VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
+            reason="base-setup-failed",
             detail=str(exc),
         )
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -528,10 +528,13 @@ def test_dependency_install_timeout_is_broken(tmp_path, monkeypatch) -> None:
     base, spec = _sound_spec(repo)
     command = [sys.executable, "-m", "pip", "install", *PYTEST_RUNTIME_DEPENDENCIES]
 
-    def timed_out() -> None:
-        raise subprocess.TimeoutExpired(command, 17)
-
-    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: timed_out())
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run_with_runtime_deps",
+        lambda *_args: (_ for _ in ()).throw(
+            deliberate_break.RuntimeDependencyError(subprocess.TimeoutExpired(command, 17))
+        ),
+    )
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -555,10 +558,11 @@ def test_dependency_install_failure_preserves_subprocess_context(tmp_path, monke
         stderr="pip denied",
     )
 
-    def failed() -> None:
-        raise error
-
-    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run_with_runtime_deps",
+        lambda *_args: (_ for _ in ()).throw(deliberate_break.RuntimeDependencyError(error)),
+    )
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -578,10 +582,13 @@ def test_dependency_install_unavailable_is_broken(tmp_path, monkeypatch) -> None
     _init_repo(repo)
     base, spec = _sound_spec(repo)
 
-    def failed() -> None:
-        raise OSError("pip unavailable")
-
-    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run_with_runtime_deps",
+        lambda *_args: (_ for _ in ()).throw(
+            deliberate_break.RuntimeDependencyError(OSError("pip unavailable"))
+        ),
+    )
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -600,9 +607,16 @@ def test_dependency_import_failure_is_broken(tmp_path, monkeypatch) -> None:
     original = OSError("original import failed")
 
     def failed() -> None:
-        raise ImportError("retry failed") from original
+        try:
+            raise ImportError("retry failed") from original
+        except ImportError as exc:
+            raise deliberate_break.RuntimeDependencyError(exc) from exc
 
-    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", lambda *_args: failed())
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run_with_runtime_deps",
+        lambda *_args: failed(),
+    )
 
     result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
 
@@ -611,4 +625,53 @@ def test_dependency_import_failure_is_broken(tmp_path, monkeypatch) -> None:
         "reason": "dependency-import-failed",
         "detail": "retry failed",
         "cause": "original import failed",
+    }
+
+
+def test_base_archive_command_failure_is_not_dependency_failure(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    error = subprocess.CalledProcessError(
+        17,
+        ["git", "archive", base],
+        output="archive output",
+        stderr="bad ref",
+    )
+    monkeypatch.setattr(
+        deliberate_break,
+        "_archive_ref",
+        lambda *_args: (_ for _ in ()).throw(error),
+    )
+
+    result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "archive-command-failed",
+        "command": ["git", "archive", base],
+        "returncode": 17,
+        "stdout": "archive output",
+        "stderr": "bad ref",
+    }
+
+
+def test_base_setup_failure_is_not_dependency_failure(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_archive_ref",
+        lambda *_args: (_ for _ in ()).throw(OSError("disk unavailable")),
+    )
+
+    result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "base-setup-failed",
+        "detail": "disk unavailable",
     }


### PR DESCRIPTION
## Summary
- wrap only PyYAML repair exceptions as runtime-dependency failures
- preserve dependency install/import failure reporting
- report command launch failures separately
- report git-archive and base setup failures with accurate non-dependency reasons
- add regressions for archive command and filesystem/setup failures

## Validation
- `python -m pytest -q tests/scripts/test_check_deliberate_break.py tests/scripts/test_pr_verifier_structured_output.py` (59 passed)
- Ruff pass
- Black check pass
- template sync validation pass
- `git diff --check` pass

## Review lineage
Addresses source-owned findings raised on Travel-Plan-Permission#1376 and trip-planner#1623. All generated consumer PRs remain held pending corrected resync.