### PR TITLE
fix(gate): mirror error-attribution repair to consumers

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -54,6 +54,14 @@ class RuntimeDependencyError(Exception):
         self.error = error
 
 
+class CommandUnavailableError(Exception):
+    """Wrap OS failures raised while launching the deliberate-break command."""
+
+    def __init__(self, error: OSError) -> None:
+        super().__init__(str(error))
+        self.error = error
+
+
 def _json_result(verdict: str, **fields: object) -> dict[str, object]:
     return {"verdict": verdict, **fields}
 
@@ -221,7 +229,10 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
-    completed = _run(command, cwd)
+    try:
+        completed = _run(command, cwd)
+    except OSError as exc:
+        raise CommandUnavailableError(exc) from exc
     if completed.returncode == 0:
         return completed
 
@@ -248,7 +259,10 @@ def _run_with_runtime_deps(
         _ensure_pytest_runtime_deps()
     except (subprocess.TimeoutExpired, subprocess.CalledProcessError, ImportError, OSError) as exc:
         raise RuntimeDependencyError(exc) from exc
-    return _run(command, cwd)
+    try:
+        return _run(command, cwd)
+    except OSError as exc:
+        raise CommandUnavailableError(exc) from exc
 
 
 def _git(
@@ -400,12 +414,12 @@ def verify_spec(
             reason="dependency-install-unavailable",
             detail=str(exc),
         )
-    except OSError as exc:
+    except CommandUnavailableError as wrapped:
         return _json_result(
             VERDICT_BROKEN,
             reason="command-unavailable",
             command=list(spec.command),
-            detail=str(exc),
+            detail=str(wrapped.error),
         )
 
     if head_run.returncode != 0:
@@ -468,6 +482,13 @@ def verify_spec(
             VERDICT_BROKEN,
             reason="dependency-install-unavailable",
             detail=str(exc),
+        )
+    except CommandUnavailableError as wrapped:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-unavailable",
+            command=list(spec.command),
+            detail=str(wrapped.error),
         )
     except subprocess.CalledProcessError as exc:
         return _json_result(

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -385,34 +385,38 @@ def verify_spec(
             timeout=exc.timeout,
         )
     except RuntimeDependencyError as wrapped:
-        exc = wrapped.error
-        if isinstance(exc, subprocess.TimeoutExpired):
+        error = wrapped.error
+        if isinstance(error, subprocess.TimeoutExpired):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="command-timeout",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                timeout=exc.timeout,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                timeout=error.timeout,
             )
-        if isinstance(exc, subprocess.CalledProcessError):
+        if isinstance(error, subprocess.CalledProcessError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-install-failed",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                returncode=exc.returncode,
-                stdout=exc.stdout,
-                stderr=exc.stderr,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                returncode=error.returncode,
+                stdout=error.stdout,
+                stderr=error.stderr,
             )
-        if isinstance(exc, ImportError):
+        if isinstance(error, ImportError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-import-failed",
-                detail=str(exc),
-                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+                detail=str(error),
+                cause=str(error.__cause__) if error.__cause__ is not None else None,
             )
         return _json_result(
             VERDICT_BROKEN,
             reason="dependency-install-unavailable",
-            detail=str(exc),
+            detail=str(error),
         )
     except CommandUnavailableError as wrapped:
         return _json_result(
@@ -454,34 +458,38 @@ def verify_spec(
             detail=str(exc),
         )
     except RuntimeDependencyError as wrapped:
-        exc = wrapped.error
-        if isinstance(exc, subprocess.TimeoutExpired):
+        error = wrapped.error
+        if isinstance(error, subprocess.TimeoutExpired):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="command-timeout",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                timeout=exc.timeout,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                timeout=error.timeout,
             )
-        if isinstance(exc, subprocess.CalledProcessError):
+        if isinstance(error, subprocess.CalledProcessError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-install-failed",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                returncode=exc.returncode,
-                stdout=exc.stdout,
-                stderr=exc.stderr,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                returncode=error.returncode,
+                stdout=error.stdout,
+                stderr=error.stderr,
             )
-        if isinstance(exc, ImportError):
+        if isinstance(error, ImportError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-import-failed",
-                detail=str(exc),
-                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+                detail=str(error),
+                cause=str(error.__cause__) if error.__cause__ is not None else None,
             )
         return _json_result(
             VERDICT_BROKEN,
             reason="dependency-install-unavailable",
-            detail=str(exc),
+            detail=str(error),
         )
     except CommandUnavailableError as wrapped:
         return _json_result(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -385,34 +385,38 @@ def verify_spec(
             timeout=exc.timeout,
         )
     except RuntimeDependencyError as wrapped:
-        exc = wrapped.error
-        if isinstance(exc, subprocess.TimeoutExpired):
+        error = wrapped.error
+        if isinstance(error, subprocess.TimeoutExpired):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="command-timeout",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                timeout=exc.timeout,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                timeout=error.timeout,
             )
-        if isinstance(exc, subprocess.CalledProcessError):
+        if isinstance(error, subprocess.CalledProcessError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-install-failed",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                returncode=exc.returncode,
-                stdout=exc.stdout,
-                stderr=exc.stderr,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                returncode=error.returncode,
+                stdout=error.stdout,
+                stderr=error.stderr,
             )
-        if isinstance(exc, ImportError):
+        if isinstance(error, ImportError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-import-failed",
-                detail=str(exc),
-                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+                detail=str(error),
+                cause=str(error.__cause__) if error.__cause__ is not None else None,
             )
         return _json_result(
             VERDICT_BROKEN,
             reason="dependency-install-unavailable",
-            detail=str(exc),
+            detail=str(error),
         )
     except CommandUnavailableError as wrapped:
         return _json_result(
@@ -454,34 +458,38 @@ def verify_spec(
             detail=str(exc),
         )
     except RuntimeDependencyError as wrapped:
-        exc = wrapped.error
-        if isinstance(exc, subprocess.TimeoutExpired):
+        error = wrapped.error
+        if isinstance(error, subprocess.TimeoutExpired):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="command-timeout",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                timeout=exc.timeout,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                timeout=error.timeout,
             )
-        if isinstance(exc, subprocess.CalledProcessError):
+        if isinstance(error, subprocess.CalledProcessError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-install-failed",
-                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
-                returncode=exc.returncode,
-                stdout=exc.stdout,
-                stderr=exc.stderr,
+                command=(
+                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
+                ),
+                returncode=error.returncode,
+                stdout=error.stdout,
+                stderr=error.stderr,
             )
-        if isinstance(exc, ImportError):
+        if isinstance(error, ImportError):
             return _json_result(
                 VERDICT_BROKEN,
                 reason="dependency-import-failed",
-                detail=str(exc),
-                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+                detail=str(error),
+                cause=str(error.__cause__) if error.__cause__ is not None else None,
             )
         return _json_result(
             VERDICT_BROKEN,
             reason="dependency-install-unavailable",
-            detail=str(exc),
+            detail=str(error),
         )
     except CommandUnavailableError as wrapped:
         return _json_result(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -15,6 +15,7 @@ import tarfile
 import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
+from importlib import import_module, metadata
 from io import BytesIO
 from pathlib import Path
 
@@ -32,6 +33,9 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
+# This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
+PYYAML_VERSION = "6.0.3"
+PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,22 @@ class DeliberateBreakSpec:
     test_file: str
     break_file: str
     command: tuple[str, ...]
+
+
+class RuntimeDependencyError(Exception):
+    """Wrap failures raised specifically while repairing runtime dependencies."""
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__(str(error))
+        self.error = error
+
+
+class CommandUnavailableError(Exception):
+    """Wrap OS failures raised while launching the deliberate-break command."""
+
+    def __init__(self, error: OSError) -> None:
+        super().__init__(str(error))
+        self.error = error
 
 
 def _json_result(verdict: str, **fields: object) -> dict[str, object]:
@@ -130,6 +150,59 @@ def _pytest_command(test_id: str) -> tuple[str, ...]:
     return (sys.executable, "-m", "pytest", test_id, "-q")
 
 
+def _ensure_pytest_runtime_deps() -> None:
+    """Install lightweight dependencies that Gate test-quality may not preinstall.
+
+    Gate's test-quality job installs only ``pytest``. Deliberate-break may still
+    collect tests that import PyYAML (for example via ``sync_manifest_compiler``).
+    Installing here avoids editing ``pr-00-gate.yml``, which forces an
+    Actions ``action_required`` approval wait on workflow-touching PRs.
+    """
+    try:
+        installed_version = metadata.version("PyYAML")
+    except metadata.PackageNotFoundError:
+        installed_version = None
+    import_error: Exception | None = None
+    if installed_version == PYYAML_VERSION:
+        try:
+            import_module("yaml")
+        except Exception as exc:
+            # Any ordinary import-time failure means the installed distribution
+            # is unusable. Reinstall the locked wheel before collecting tests.
+            import_error = exc
+        else:
+            return
+    if installed_version != PYYAML_VERSION or import_error is not None:
+        if os.environ.get("GITHUB_ACTIONS") != "true":
+            error = ImportError(
+                f"PyYAML {PYYAML_VERSION} is required; install "
+                f"{PYTEST_RUNTIME_DEPENDENCIES[0]} in the active environment"
+            )
+            raise error from import_error
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+        ]
+        if import_error is not None:
+            command.append("--force-reinstall")
+        command.extend(PYTEST_RUNTIME_DEPENDENCIES)
+        subprocess.run(
+            command,
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        try:
+            import_module("yaml")
+        except Exception as retry_error:
+            error = ImportError(f"PyYAML remained unimportable after reinstall: {retry_error}")
+            raise error from (import_error or retry_error)
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -149,6 +222,47 @@ def _run(
         env=env,
         timeout=timeout,
     )
+
+
+def _run_with_runtime_deps(
+    command: tuple[str, ...],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Retry a command after repairing PyYAML only when its output requires it."""
+    try:
+        completed = _run(command, cwd)
+    except OSError as exc:
+        raise CommandUnavailableError(exc) from exc
+    if completed.returncode == 0:
+        return completed
+
+    output = f"{completed.stdout}\n{completed.stderr}".lower()
+    missing_pyyaml = any(
+        marker in output
+        for marker in (
+            "no module named 'yaml'",
+            'no module named "yaml"',
+            "modulenotfounderror: yaml",
+            "importerror: yaml",
+        )
+    )
+    yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
+    if yaml_traceback and not missing_pyyaml:
+        try:
+            import_module("yaml")
+        except Exception:
+            missing_pyyaml = True
+    if not missing_pyyaml:
+        return completed
+
+    try:
+        _ensure_pytest_runtime_deps()
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, ImportError, OSError) as exc:
+        raise RuntimeDependencyError(exc) from exc
+    try:
+        return _run(command, cwd)
+    except OSError as exc:
+        raise CommandUnavailableError(exc) from exc
 
 
 def _git(
@@ -244,7 +358,6 @@ def verify_spec(
                     changed_assertions=tampered,
                 )
 
-        head_run = _run(spec.command, repo)
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
@@ -260,6 +373,53 @@ def verify_spec(
             returncode=exc.returncode,
             stdout=exc.stdout,
             stderr=exc.stderr,
+        )
+
+    try:
+        head_run = _run_with_runtime_deps(spec.command, repo)
+    except subprocess.TimeoutExpired as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            timeout=exc.timeout,
+        )
+    except RuntimeDependencyError as wrapped:
+        exc = wrapped.error
+        if isinstance(exc, subprocess.TimeoutExpired):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="command-timeout",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                timeout=exc.timeout,
+            )
+        if isinstance(exc, subprocess.CalledProcessError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-install-failed",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                returncode=exc.returncode,
+                stdout=exc.stdout,
+                stderr=exc.stderr,
+            )
+        if isinstance(exc, ImportError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-import-failed",
+                detail=str(exc),
+                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+            )
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-unavailable",
+            detail=str(exc),
+        )
+    except CommandUnavailableError as wrapped:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-unavailable",
+            command=list(spec.command),
+            detail=str(wrapped.error),
         )
 
     if head_run.returncode != 0:
@@ -279,7 +439,7 @@ def verify_spec(
             base_test = base_dir / spec.test_file
             base_test.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(test_path, base_test)
-            base_run = _run(spec.command, base_dir)
+            base_run = _run_with_runtime_deps(spec.command, base_dir)
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
@@ -291,6 +451,58 @@ def verify_spec(
         return _json_result(
             VERDICT_BROKEN,
             reason="archive-extract-failed",
+            detail=str(exc),
+        )
+    except RuntimeDependencyError as wrapped:
+        exc = wrapped.error
+        if isinstance(exc, subprocess.TimeoutExpired):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="command-timeout",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                timeout=exc.timeout,
+            )
+        if isinstance(exc, subprocess.CalledProcessError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-install-failed",
+                command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+                returncode=exc.returncode,
+                stdout=exc.stdout,
+                stderr=exc.stderr,
+            )
+        if isinstance(exc, ImportError):
+            return _json_result(
+                VERDICT_BROKEN,
+                reason="dependency-import-failed",
+                detail=str(exc),
+                cause=str(exc.__cause__) if exc.__cause__ is not None else None,
+            )
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-unavailable",
+            detail=str(exc),
+        )
+    except CommandUnavailableError as wrapped:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-unavailable",
+            command=list(spec.command),
+            detail=str(wrapped.error),
+        )
+    except subprocess.CalledProcessError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="archive-command-failed",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            returncode=exc.returncode,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        )
+    except OSError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="base-setup-failed",
             detail=str(exc),
         )
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -675,3 +675,32 @@ def test_base_setup_failure_is_not_dependency_failure(tmp_path, monkeypatch) -> 
         "reason": "base-setup-failed",
         "detail": "disk unavailable",
     }
+
+
+def test_base_command_launch_failure_is_reported_as_command_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    calls = 0
+
+    def run_command(*_args):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return subprocess.CompletedProcess(spec.command, 0, "", "")
+        error = FileNotFoundError("base-only command is unavailable")
+        raise deliberate_break.CommandUnavailableError(error) from error
+
+    monkeypatch.setattr(deliberate_break, "_run_with_runtime_deps", run_command)
+
+    result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "command-unavailable",
+        "command": list(spec.command),
+        "detail": "base-only command is unavailable",
+    }


### PR DESCRIPTION
## Summary
- mirror the reviewed deliberate-break source changes into the consumer template copy
- distinguish command launch failures from archive/filesystem setup failures on both head and base
- keep dependency repair errors explicitly attributed
- add base command-unavailable regression coverage

## Validation
- focused deliberate-break and structured-output suite: 60 passed
- Ruff pass
- Black check pass
- template sync validation pass
- `git diff --check` pass

## Incident lineage
Workflows #2925 merged concurrently before the required review window and with two active review threads. This bounded replacement carries both late-review corrections. Generated consumers remain held until this PR passes the full window and is resynced.