### PR TITLE
fix(gate): harden runtime review fallbacks

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -203,6 +203,21 @@ def _ensure_pytest_runtime_deps() -> None:
             raise error from (import_error or retry_error)
 
 
+def _pyyaml_runtime_needs_repair() -> bool:
+    """Return whether the active PyYAML runtime is missing, stale, or unusable."""
+    try:
+        installed_version = metadata.version("PyYAML")
+    except metadata.PackageNotFoundError:
+        return True
+    if installed_version != PYYAML_VERSION:
+        return True
+    try:
+        import_module("yaml")
+    except Exception:
+        return True
+    return False
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -248,10 +263,7 @@ def _run_with_runtime_deps(
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     if yaml_traceback and not missing_pyyaml:
-        try:
-            import_module("yaml")
-        except Exception:
-            missing_pyyaml = True
+        missing_pyyaml = _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
 
@@ -263,6 +275,38 @@ def _run_with_runtime_deps(
         return _run(command, cwd)
     except OSError as exc:
         raise CommandUnavailableError(exc) from exc
+
+
+def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
+    """Map dependency-repair failures consistently for head and base runs."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
+            timeout=error.timeout,
+        )
+    if isinstance(error, subprocess.CalledProcessError):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-failed",
+            command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
+            returncode=error.returncode,
+            stdout=error.stdout,
+            stderr=error.stderr,
+        )
+    if isinstance(error, ImportError):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-import-failed",
+            detail=str(error),
+            cause=str(error.__cause__) if error.__cause__ is not None else None,
+        )
+    return _json_result(
+        VERDICT_BROKEN,
+        reason="dependency-install-unavailable",
+        detail=str(error),
+    )
 
 
 def _git(
@@ -385,39 +429,7 @@ def verify_spec(
             timeout=exc.timeout,
         )
     except RuntimeDependencyError as wrapped:
-        error = wrapped.error
-        if isinstance(error, subprocess.TimeoutExpired):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="command-timeout",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                timeout=error.timeout,
-            )
-        if isinstance(error, subprocess.CalledProcessError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-install-failed",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                returncode=error.returncode,
-                stdout=error.stdout,
-                stderr=error.stderr,
-            )
-        if isinstance(error, ImportError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-import-failed",
-                detail=str(error),
-                cause=str(error.__cause__) if error.__cause__ is not None else None,
-            )
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
-            detail=str(error),
-        )
+        return _runtime_dependency_error_result(wrapped.error)
     except CommandUnavailableError as wrapped:
         return _json_result(
             VERDICT_BROKEN,
@@ -458,39 +470,7 @@ def verify_spec(
             detail=str(exc),
         )
     except RuntimeDependencyError as wrapped:
-        error = wrapped.error
-        if isinstance(error, subprocess.TimeoutExpired):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="command-timeout",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                timeout=error.timeout,
-            )
-        if isinstance(error, subprocess.CalledProcessError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-install-failed",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                returncode=error.returncode,
-                stdout=error.stdout,
-                stderr=error.stderr,
-            )
-        if isinstance(error, ImportError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-import-failed",
-                detail=str(error),
-                cause=str(error.__cause__) if error.__cause__ is not None else None,
-            )
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
-            detail=str(error),
-        )
+        return _runtime_dependency_error_result(wrapped.error)
     except CommandUnavailableError as wrapped:
         return _json_result(
             VERDICT_BROKEN,

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -282,7 +282,7 @@ def _run_with_runtime_deps(
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = _pyyaml_runtime_needs_repair()
+        missing_pyyaml = True if not managed_runtime else _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -252,8 +252,8 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
-    normalize_runtime = os.environ.get("GITHUB_ACTIONS") == "true" or _uses_pytest_runtime(command)
-    if normalize_runtime and _pyyaml_runtime_needs_repair():
+    managed_runtime = _uses_pytest_runtime(command)
+    if managed_runtime and _pyyaml_runtime_needs_repair():
         try:
             _ensure_pytest_runtime_deps()
         except (
@@ -285,6 +285,14 @@ def _run_with_runtime_deps(
         missing_pyyaml = _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
+
+    if not managed_runtime:
+        error = ImportError(
+            "PyYAML failed inside a wrapped or custom deliberate-break command; "
+            "automatic repair is disabled because the wrapper may use a different "
+            "Python environment"
+        )
+        raise RuntimeDependencyError(error) from error
 
     try:
         _ensure_pytest_runtime_deps()

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -252,7 +252,8 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
-    if _uses_pytest_runtime(command) and _pyyaml_runtime_needs_repair():
+    normalize_runtime = os.environ.get("GITHUB_ACTIONS") == "true" or _uses_pytest_runtime(command)
+    if normalize_runtime and _pyyaml_runtime_needs_repair():
         try:
             _ensure_pytest_runtime_deps()
         except (

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -218,6 +218,14 @@ def _pyyaml_runtime_needs_repair() -> bool:
     return False
 
 
+def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
+    """Return whether a command runs pytest in the active Python environment."""
+    executable = Path(command[0]).name if command else ""
+    return executable in {"pytest", "py.test"} or (
+        len(command) >= 3 and command[1:3] == ("-m", "pytest")
+    )
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -244,6 +252,16 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
+    if _uses_pytest_runtime(command) and _pyyaml_runtime_needs_repair():
+        try:
+            _ensure_pytest_runtime_deps()
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.CalledProcessError,
+            ImportError,
+            OSError,
+        ) as exc:
+            raise RuntimeDependencyError(exc) from exc
     try:
         completed = _run(command, cwd)
     except OSError as exc:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -220,10 +220,10 @@ def _pyyaml_runtime_needs_repair() -> bool:
 
 def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
-    executable = Path(command[0]).name if command else ""
-    return executable in {"pytest", "py.test"} or (
-        len(command) >= 3 and command[1:3] == ("-m", "pytest")
-    )
+    if len(command) < 3 or command[1:3] != ("-m", "pytest"):
+        return False
+    executable = shutil.which(command[0]) or command[0]
+    return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
 def _run(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -705,8 +705,11 @@ def _coerce_response_content(content: object) -> str:
         return text
     try:
         return json.dumps(content, default=str)
-    except (TypeError, ValueError):
-        return str(content)
+    except Exception:
+        try:
+            return str(content)
+        except Exception:
+            return f"<unserializable {type(content).__name__}>"
 
 
 def _parse_llm_response(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -203,6 +203,21 @@ def _ensure_pytest_runtime_deps() -> None:
             raise error from (import_error or retry_error)
 
 
+def _pyyaml_runtime_needs_repair() -> bool:
+    """Return whether the active PyYAML runtime is missing, stale, or unusable."""
+    try:
+        installed_version = metadata.version("PyYAML")
+    except metadata.PackageNotFoundError:
+        return True
+    if installed_version != PYYAML_VERSION:
+        return True
+    try:
+        import_module("yaml")
+    except Exception:
+        return True
+    return False
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -248,10 +263,7 @@ def _run_with_runtime_deps(
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     if yaml_traceback and not missing_pyyaml:
-        try:
-            import_module("yaml")
-        except Exception:
-            missing_pyyaml = True
+        missing_pyyaml = _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
 
@@ -263,6 +275,38 @@ def _run_with_runtime_deps(
         return _run(command, cwd)
     except OSError as exc:
         raise CommandUnavailableError(exc) from exc
+
+
+def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
+    """Map dependency-repair failures consistently for head and base runs."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="command-timeout",
+            command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
+            timeout=error.timeout,
+        )
+    if isinstance(error, subprocess.CalledProcessError):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-install-failed",
+            command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
+            returncode=error.returncode,
+            stdout=error.stdout,
+            stderr=error.stderr,
+        )
+    if isinstance(error, ImportError):
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="dependency-import-failed",
+            detail=str(error),
+            cause=str(error.__cause__) if error.__cause__ is not None else None,
+        )
+    return _json_result(
+        VERDICT_BROKEN,
+        reason="dependency-install-unavailable",
+        detail=str(error),
+    )
 
 
 def _git(
@@ -385,39 +429,7 @@ def verify_spec(
             timeout=exc.timeout,
         )
     except RuntimeDependencyError as wrapped:
-        error = wrapped.error
-        if isinstance(error, subprocess.TimeoutExpired):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="command-timeout",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                timeout=error.timeout,
-            )
-        if isinstance(error, subprocess.CalledProcessError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-install-failed",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                returncode=error.returncode,
-                stdout=error.stdout,
-                stderr=error.stderr,
-            )
-        if isinstance(error, ImportError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-import-failed",
-                detail=str(error),
-                cause=str(error.__cause__) if error.__cause__ is not None else None,
-            )
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
-            detail=str(error),
-        )
+        return _runtime_dependency_error_result(wrapped.error)
     except CommandUnavailableError as wrapped:
         return _json_result(
             VERDICT_BROKEN,
@@ -458,39 +470,7 @@ def verify_spec(
             detail=str(exc),
         )
     except RuntimeDependencyError as wrapped:
-        error = wrapped.error
-        if isinstance(error, subprocess.TimeoutExpired):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="command-timeout",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                timeout=error.timeout,
-            )
-        if isinstance(error, subprocess.CalledProcessError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-install-failed",
-                command=(
-                    list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd)
-                ),
-                returncode=error.returncode,
-                stdout=error.stdout,
-                stderr=error.stderr,
-            )
-        if isinstance(error, ImportError):
-            return _json_result(
-                VERDICT_BROKEN,
-                reason="dependency-import-failed",
-                detail=str(error),
-                cause=str(error.__cause__) if error.__cause__ is not None else None,
-            )
-        return _json_result(
-            VERDICT_BROKEN,
-            reason="dependency-install-unavailable",
-            detail=str(error),
-        )
+        return _runtime_dependency_error_result(wrapped.error)
     except CommandUnavailableError as wrapped:
         return _json_result(
             VERDICT_BROKEN,

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -282,7 +282,7 @@ def _run_with_runtime_deps(
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = _pyyaml_runtime_needs_repair()
+        missing_pyyaml = True if not managed_runtime else _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -252,8 +252,8 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
-    normalize_runtime = os.environ.get("GITHUB_ACTIONS") == "true" or _uses_pytest_runtime(command)
-    if normalize_runtime and _pyyaml_runtime_needs_repair():
+    managed_runtime = _uses_pytest_runtime(command)
+    if managed_runtime and _pyyaml_runtime_needs_repair():
         try:
             _ensure_pytest_runtime_deps()
         except (
@@ -285,6 +285,14 @@ def _run_with_runtime_deps(
         missing_pyyaml = _pyyaml_runtime_needs_repair()
     if not missing_pyyaml:
         return completed
+
+    if not managed_runtime:
+        error = ImportError(
+            "PyYAML failed inside a wrapped or custom deliberate-break command; "
+            "automatic repair is disabled because the wrapper may use a different "
+            "Python environment"
+        )
+        raise RuntimeDependencyError(error) from error
 
     try:
         _ensure_pytest_runtime_deps()

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -252,7 +252,8 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
-    if _uses_pytest_runtime(command) and _pyyaml_runtime_needs_repair():
+    normalize_runtime = os.environ.get("GITHUB_ACTIONS") == "true" or _uses_pytest_runtime(command)
+    if normalize_runtime and _pyyaml_runtime_needs_repair():
         try:
             _ensure_pytest_runtime_deps()
         except (

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -218,6 +218,14 @@ def _pyyaml_runtime_needs_repair() -> bool:
     return False
 
 
+def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
+    """Return whether a command runs pytest in the active Python environment."""
+    executable = Path(command[0]).name if command else ""
+    return executable in {"pytest", "py.test"} or (
+        len(command) >= 3 and command[1:3] == ("-m", "pytest")
+    )
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -244,6 +252,16 @@ def _run_with_runtime_deps(
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
     """Retry a command after repairing PyYAML only when its output requires it."""
+    if _uses_pytest_runtime(command) and _pyyaml_runtime_needs_repair():
+        try:
+            _ensure_pytest_runtime_deps()
+        except (
+            subprocess.TimeoutExpired,
+            subprocess.CalledProcessError,
+            ImportError,
+            OSError,
+        ) as exc:
+            raise RuntimeDependencyError(exc) from exc
     try:
         completed = _run(command, cwd)
     except OSError as exc:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -220,10 +220,10 @@ def _pyyaml_runtime_needs_repair() -> bool:
 
 def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
-    executable = Path(command[0]).name if command else ""
-    return executable in {"pytest", "py.test"} or (
-        len(command) >= 3 and command[1:3] == ("-m", "pytest")
-    )
+    if len(command) < 3 or command[1:3] != ("-m", "pytest"):
+        return False
+    executable = shutil.which(command[0]) or command[0]
+    return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
 def _run(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -537,6 +537,29 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
     assert events == ["repair", "run"]
 
 
+def test_runtime_dependencies_normalize_before_wrapped_gate_command(tmp_path, monkeypatch) -> None:
+    events: list[str] = []
+    command = ("uv", "run", "pytest")
+    completed = subprocess.CompletedProcess(command, 0, "passed", "")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run",
+        lambda *_args: events.append("run") or completed,
+    )
+    monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "0.0.0")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: events.append("repair"),
+    )
+
+    result = deliberate_break._run_with_runtime_deps(command, tmp_path)
+
+    assert result is completed
+    assert events == ["repair", "run"]
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -544,14 +544,22 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
         ("/other/venv/bin/python", "-m", "pytest"),
     ],
 )
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "ModuleNotFoundError: No module named 'yaml'",
+        'File "/other/venv/lib/site-packages/yaml/__init__.py", line 1\n'
+        "SyntaxError: broken wheel",
+    ],
+)
 def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
-    tmp_path, monkeypatch, command
+    tmp_path, monkeypatch, command, stderr
 ) -> None:
     completed = subprocess.CompletedProcess(
         command,
         1,
         "",
-        "ModuleNotFoundError: No module named 'yaml'",
+        stderr,
     )
     monkeypatch.setattr(
         deliberate_break,

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -505,6 +505,32 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
     assert attempts == []
 
 
+def test_runtime_dependencies_retry_stale_pyyaml_traceback(tmp_path, monkeypatch) -> None:
+    attempts = [
+        subprocess.CompletedProcess(
+            ["pytest"],
+            1,
+            "",
+            'File "/venv/lib/site-packages/yaml/__init__.py", line 1\nRuntimeError: stale',
+        ),
+        subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
+    ]
+    repairs: list[bool] = []
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "6.0.2")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: repairs.append(True),
+    )
+
+    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+
+    assert completed.returncode == 0
+    assert repairs == [True]
+    assert attempts == []
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -464,6 +464,11 @@ def test_runtime_dependencies_retry_pyyaml_import_failure(tmp_path, monkeypatch)
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
     monkeypatch.setattr(
         deliberate_break,
+        "_pyyaml_runtime_needs_repair",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        deliberate_break,
         "_ensure_pytest_runtime_deps",
         lambda: repairs.append(True),
     )
@@ -486,7 +491,13 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
         subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
     ]
     repairs: list[bool] = []
+    repair_checks = iter((False, True))
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_pyyaml_runtime_needs_repair",
+        lambda: next(repair_checks),
+    )
     monkeypatch.setattr(
         deliberate_break,
         "import_module",
@@ -505,30 +516,25 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
     assert attempts == []
 
 
-def test_runtime_dependencies_retry_stale_pyyaml_traceback(tmp_path, monkeypatch) -> None:
-    attempts = [
-        subprocess.CompletedProcess(
-            ["pytest"],
-            1,
-            "",
-            'File "/venv/lib/site-packages/yaml/__init__.py", line 1\nRuntimeError: stale',
-        ),
-        subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
-    ]
-    repairs: list[bool] = []
-    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
-    monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "6.0.2")
+def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, monkeypatch) -> None:
+    events: list[str] = []
+    completed = subprocess.CompletedProcess(["pytest"], 0, "passed", "")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run",
+        lambda *_args: events.append("run") or completed,
+    )
+    monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "0.0.0")
     monkeypatch.setattr(
         deliberate_break,
         "_ensure_pytest_runtime_deps",
-        lambda: repairs.append(True),
+        lambda: events.append("repair"),
     )
 
-    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+    result = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
 
-    assert completed.returncode == 0
-    assert repairs == [True]
-    assert attempts == []
+    assert result is completed
+    assert events == ["repair", "run"]
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -473,7 +473,7 @@ def test_runtime_dependencies_retry_pyyaml_import_failure(tmp_path, monkeypatch)
         lambda: repairs.append(True),
     )
 
-    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+    completed = deliberate_break._run_with_runtime_deps((sys.executable, "-m", "pytest"), tmp_path)
 
     assert completed.returncode == 0
     assert repairs == [True]
@@ -509,7 +509,7 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
         lambda: repairs.append(True),
     )
 
-    completed = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+    completed = deliberate_break._run_with_runtime_deps((sys.executable, "-m", "pytest"), tmp_path)
 
     assert completed.returncode == 0
     assert repairs == [True]
@@ -531,16 +531,22 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
         lambda: events.append("repair"),
     )
 
-    result = deliberate_break._run_with_runtime_deps(("pytest",), tmp_path)
+    result = deliberate_break._run_with_runtime_deps((sys.executable, "-m", "pytest"), tmp_path)
 
     assert result is completed
     assert events == ["repair", "run"]
 
 
-def test_runtime_dependencies_do_not_repair_wrapped_command_environment(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("uv", "run", "pytest"),
+        ("/other/venv/bin/python", "-m", "pytest"),
+    ],
+)
+def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
+    tmp_path, monkeypatch, command
 ) -> None:
-    command = ("uv", "run", "pytest")
     completed = subprocess.CompletedProcess(
         command,
         1,

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -537,27 +537,32 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
     assert events == ["repair", "run"]
 
 
-def test_runtime_dependencies_normalize_before_wrapped_gate_command(tmp_path, monkeypatch) -> None:
-    events: list[str] = []
+def test_runtime_dependencies_do_not_repair_wrapped_command_environment(
+    tmp_path, monkeypatch
+) -> None:
     command = ("uv", "run", "pytest")
-    completed = subprocess.CompletedProcess(command, 0, "passed", "")
-    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    completed = subprocess.CompletedProcess(
+        command,
+        1,
+        "",
+        "ModuleNotFoundError: No module named 'yaml'",
+    )
     monkeypatch.setattr(
         deliberate_break,
         "_run",
-        lambda *_args: events.append("run") or completed,
+        lambda *_args: completed,
     )
-    monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "0.0.0")
     monkeypatch.setattr(
         deliberate_break,
         "_ensure_pytest_runtime_deps",
-        lambda: events.append("repair"),
+        lambda: pytest.fail("wrapper-owned environment must not be mutated"),
     )
 
-    result = deliberate_break._run_with_runtime_deps(command, tmp_path)
+    with pytest.raises(deliberate_break.RuntimeDependencyError) as caught:
+        deliberate_break._run_with_runtime_deps(command, tmp_path)
 
-    assert result is completed
-    assert events == ["repair", "run"]
+    assert isinstance(caught.value.error, ImportError)
+    assert "wrapped or custom" in str(caught.value.error)
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -226,8 +226,7 @@ def test_coerce_response_content_survives_failing_string_conversion() -> None:
             raise RuntimeError("broken string conversion")
 
     assert (
-        pr_verifier._coerce_response_content(Unserializable())
-        == "<unserializable Unserializable>"
+        pr_verifier._coerce_response_content(Unserializable()) == "<unserializable Unserializable>"
     )
 
 

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -220,6 +220,17 @@ def test_coerce_response_content_falls_back_to_string_when_json_serialization_fa
     assert pr_verifier._coerce_response_content(payload) == str(payload)
 
 
+def test_coerce_response_content_survives_failing_string_conversion() -> None:
+    class Unserializable:
+        def __str__(self) -> str:
+            raise RuntimeError("broken string conversion")
+
+    assert (
+        pr_verifier._coerce_response_content(Unserializable())
+        == "<unserializable Unserializable>"
+    )
+
+
 def test_text_from_response_content_concatenates_split_text_blocks_without_separator() -> None:
     payload = _valid_payload()
     encoded = json.dumps(payload)


### PR DESCRIPTION
## Summary
- make verifier response fallback safe even when provider payload serialization and string conversion both fail
- repair stale or unusable pinned PyYAML runtimes when a failed command traces into yaml
- centralize dependency-repair error mapping so head and base verification cannot drift
- mirror the deliberate-break source into the consumer template

## Review lineage
Addresses live review findings surfaced on Manager-Database#1527, Travel-Plan-Permission#1378, and trip-planner#1625 during the exact-head review window. This is review-residue work and intentionally has no source-issue closure.

## Verification
- 62 focused pytest tests passed
- Ruff passed
- mypy passed for both changed source modules
- source/template diff is empty
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from missing, outdated, or unusable YAML runtime dependencies.
  * Standardized dependency-repair error reporting across verification flows.
  * Prevented verification failures when response content cannot be serialized or converted to text.
* **Tests**
  * Added coverage for stale YAML dependency retry and recovery.
  * Added coverage for safely handling unconvertible response content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- workflow-source:review_followup -->
