### PR TITLE
fix(gate): distinguish YAML test failures

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -249,9 +249,39 @@ def _run(
     )
 
 
-def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | None:
+UV_RUN_VALUE_OPTIONS = frozenset(
+    {
+        "--directory",
+        "--env-file",
+        "--package",
+        "--project",
+        "--python",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+    }
+)
+
+
+def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return ``uv run`` plus options when its command operand is pytest."""
+    if len(command) < 3 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option == "--":
+            index += 1
+            break
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    if index >= len(command) or Path(command[index]).name != "pytest":
+        return None
+    return command[:index]
+
+
+def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Resolve the Python shebang launcher used by ``uv run pytest``."""
-    located = _run((uv_command, "run", "which", "pytest"), cwd)
+    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
     if located.returncode != 0 or not located.stdout.strip():
         return None
     pytest_path = Path(located.stdout.strip().splitlines()[-1])
@@ -273,7 +303,7 @@ def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | 
             env_args = env_args[1:]
         if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((uv_command, "run", "which", env_args[0]), cwd)
+        resolved = _run((*uv_run_prefix, "which", env_args[0]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
         return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
@@ -286,11 +316,8 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
         return (command[0], "-c", "import yaml")
-    if (
-        len(command) >= 3
-        and Path(command[0]).name == "uv"
-        and command[1:3] == ("run", "pytest")
-        and (launcher := _uv_pytest_python_launcher(command[0], cwd))
+    if (uv_prefix := _uv_run_pytest_prefix(command)) and (
+        launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
         return (*launcher, "-c", "import yaml")
     return None

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -228,6 +228,15 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
+def _pyyaml_probe_command(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return a read-only PyYAML import probe for a recognized pytest runtime."""
+    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
+        return (command[0], "-c", "import yaml")
+    if len(command) >= 3 and Path(command[0]).name == "uv" and command[1:3] == ("run", "pytest"):
+        return (command[0], "run", "python", "-c", "import yaml")
+    return None
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -283,27 +292,14 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
-    yaml_import_exception = bool(
-        re.search(
-            r"^(?:e\s+)?"
-            r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
-            output,
-            re.MULTILINE,
-        )
-    )
-    yaml_import_context = bool(
-        re.search(
-            r"(?:error collecting|while importing test module|"
-            r"importlib|import_module|^\s*(?:from yaml|import yaml)\b)",
-            output,
-            re.MULTILINE,
-        )
-    )
-    yaml_import_failure = yaml_import_exception and yaml_import_context
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = (
-            yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()
-        )
+        if managed_runtime:
+            missing_pyyaml = _pyyaml_runtime_needs_repair()
+        elif probe_command := _pyyaml_probe_command(command):
+            try:
+                missing_pyyaml = _run(probe_command, cwd).returncode != 0
+            except OSError as exc:
+                raise CommandUnavailableError(exc) from exc
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -228,15 +228,6 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
-def _pyyaml_probe_command(command: tuple[str, ...]) -> tuple[str, ...] | None:
-    """Return a read-only PyYAML import probe for a recognized pytest runtime."""
-    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
-        return (command[0], "-c", "import yaml")
-    if len(command) >= 3 and Path(command[0]).name == "uv" and command[1:3] == ("run", "pytest"):
-        return (command[0], "run", "python", "-c", "import yaml")
-    return None
-
-
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -256,6 +247,46 @@ def _run(
         env=env,
         timeout=timeout,
     )
+
+
+def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
+    """Resolve the shebang interpreter used by ``uv run pytest``."""
+    located = _run((uv_command, "run", "which", "pytest"), cwd)
+    if located.returncode != 0 or not located.stdout.strip():
+        return None
+    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+    try:
+        shebang = pytest_path.read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, UnicodeError, IndexError):
+        return None
+    if not shebang.startswith("#!"):
+        return None
+    try:
+        launcher = shlex.split(shebang[2:].strip())
+    except ValueError:
+        return None
+    if not launcher:
+        return None
+    if Path(launcher[0]).name == "env" and len(launcher) > 1:
+        resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            return None
+        return resolved.stdout.strip().splitlines()[-1]
+    return launcher[0]
+
+
+def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
+    """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
+    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
+        return (command[0], "-c", "import yaml")
+    if (
+        len(command) >= 3
+        and Path(command[0]).name == "uv"
+        and command[1:3] == ("run", "pytest")
+        and (interpreter := _uv_pytest_interpreter(command[0], cwd))
+    ):
+        return (interpreter, "-c", "import yaml")
+    return None
 
 
 def _run_with_runtime_deps(
@@ -295,7 +326,7 @@ def _run_with_runtime_deps(
     if yaml_traceback and not missing_pyyaml:
         if managed_runtime:
             missing_pyyaml = _pyyaml_runtime_needs_repair()
-        elif probe_command := _pyyaml_probe_command(command):
+        elif probe_command := _pyyaml_probe_command(command, cwd):
             try:
                 missing_pyyaml = _run(probe_command, cwd).returncode != 0
             except OSError as exc:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -285,7 +285,8 @@ def _run_with_runtime_deps(
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     yaml_import_failure = bool(
         re.search(
-            r"^(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
+            r"^(?:e\s+)?"
+            r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
             output,
             re.MULTILINE,
         )

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -317,6 +317,23 @@ def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
     return command[:index]
 
 
+def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return uv options preceding ``-m pytest`` or ``--module pytest``."""
+    if len(command) < 4 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option in {"-m", "--module"}:
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return command[:index]
+            return None
+        if option == "--":
+            return None
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    return None
+
+
 def _python_shebang_launcher(
     executable: Path,
     resolve_name: Callable[[str], str | None],
@@ -367,9 +384,12 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
 
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
-    for index in range(1, len(command) - 1):
-        if command[index : index + 2] == ("-m", "pytest"):
-            return (*command[:index], "-c", "import yaml")
+    if uv_prefix := _uv_module_pytest_prefix(command):
+        return (*uv_prefix, "python", "-c", "import yaml")
+    if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
+        for index in range(1, len(command) - 1):
+            if command[index : index + 2] == ("-m", "pytest"):
+                return (*command[:index], "-c", "import yaml")
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -268,11 +268,15 @@ def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
     if not launcher:
         return None
     if Path(launcher[0]).name == "env" and len(launcher) > 1:
+        if not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[1]).name):
+            return None
         resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
         return resolved.stdout.strip().splitlines()[-1]
-    return launcher[0]
+    if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
+        return launcher[0]
+    return None
 
 
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from importlib import import_module, metadata
 from io import BytesIO
@@ -251,11 +251,49 @@ def _run(
 
 UV_RUN_VALUE_OPTIONS = frozenset(
     {
+        "-C",
+        "-P",
+        "-f",
+        "-i",
+        "-p",
+        "-w",
+        "--allow-insecure-host",
+        "--cache-dir",
+        "--color",
+        "--config-file",
+        "--config-setting",
+        "--config-settings-package",
+        "--default-index",
         "--directory",
         "--env-file",
+        "--exclude-newer",
+        "--exclude-newer-package",
+        "--extra",
+        "--extra-index-url",
+        "--find-links",
+        "--fork-strategy",
+        "--group",
+        "--index",
+        "--index-strategy",
+        "--index-url",
+        "--keyring-provider",
+        "--link-mode",
+        "--no-binary-package",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-extra",
+        "--no-group",
+        "--no-sources-package",
+        "--only-group",
         "--package",
+        "--prerelease",
         "--project",
         "--python",
+        "--python-platform",
+        "--refresh-package",
+        "--reinstall-package",
+        "--resolution",
+        "--upgrade-package",
         "--with",
         "--with-editable",
         "--with-requirements",
@@ -279,14 +317,13 @@ def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
     return command[:index]
 
 
-def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
-    """Resolve the Python shebang launcher used by ``uv run pytest``."""
-    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
-    if located.returncode != 0 or not located.stdout.strip():
-        return None
-    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+def _python_shebang_launcher(
+    executable: Path,
+    resolve_name: Callable[[str], str | None],
+) -> tuple[str, ...] | None:
+    """Return a verified Python shebang launcher, preserving interpreter flags."""
     try:
-        shebang = pytest_path.read_text(encoding="utf-8").splitlines()[0]
+        shebang = executable.read_text(encoding="utf-8").splitlines()[0]
     except (OSError, UnicodeError, IndexError):
         return None
     if not shebang.startswith("#!"):
@@ -303,23 +340,44 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
             env_args = env_args[1:]
         if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((*uv_run_prefix, "which", env_args[0]), cwd)
-        if resolved.returncode != 0 or not resolved.stdout.strip():
+        resolved = resolve_name(env_args[0])
+        if not resolved:
             return None
-        return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
+        return (resolved, *env_args[1:])
     if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
         return tuple(launcher)
     return None
 
 
+def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
+    """Resolve the Python shebang launcher used by ``uv run pytest``."""
+    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
+    if located.returncode != 0 or not located.stdout.strip():
+        return None
+
+    def resolve_name(name: str) -> str | None:
+        resolved = _run((*uv_run_prefix, "which", name), cwd)
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            return None
+        return resolved.stdout.strip().splitlines()[-1]
+
+    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+    return _python_shebang_launcher(pytest_path, resolve_name)
+
+
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
-    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
-        return (command[0], "-c", "import yaml")
+    for index in range(1, len(command) - 1):
+        if command[index : index + 2] == ("-m", "pytest"):
+            return (*command[:index], "-c", "import yaml")
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
         return (*launcher, "-c", "import yaml")
+    if command and Path(command[0]).name == "pytest":
+        pytest_path = shutil.which(command[0])
+        if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
+            return (*launcher, "-c", "import yaml")
     return None
 
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -334,6 +334,29 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
     return None
 
 
+def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Build a probe for ``uv run [options] python [flags] -m pytest``."""
+    if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option in {"-m", "--module"}:
+            return None
+        if option == "--":
+            index += 1
+            break
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    if index >= len(command) or not re.fullmatch(
+        r"python(?:\d+(?:\.\d+)*)?", Path(command[index]).name
+    ):
+        return None
+    for module_index in range(index + 1, len(command) - 1):
+        if command[module_index : module_index + 2] == ("-m", "pytest"):
+            return (*command[:module_index], "-c", "import yaml")
+    return None
+
+
 def _python_shebang_launcher(
     executable: Path,
     resolve_name: Callable[[str], str | None],
@@ -386,6 +409,8 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if uv_prefix := _uv_module_pytest_prefix(command):
         return (*uv_prefix, "python", "-c", "import yaml")
+    if probe := _uv_python_module_probe(command):
+        return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
         for index in range(1, len(command) - 1):
             if command[index : index + 2] == ("-m", "pytest"):

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -283,7 +283,7 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
-    yaml_import_failure = bool(
+    yaml_import_exception = bool(
         re.search(
             r"^(?:e\s+)?"
             r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
@@ -291,6 +291,15 @@ def _run_with_runtime_deps(
             re.MULTILINE,
         )
     )
+    yaml_import_context = bool(
+        re.search(
+            r"(?:error collecting|while importing test module|"
+            r"importlib|import_module|^\s*(?:from yaml|import yaml)\b)",
+            output,
+            re.MULTILINE,
+        )
+    )
+    yaml_import_failure = yaml_import_exception and yaml_import_context
     if yaml_traceback and not missing_pyyaml:
         missing_pyyaml = (
             yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -249,8 +249,8 @@ def _run(
     )
 
 
-def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
-    """Resolve the shebang interpreter used by ``uv run pytest``."""
+def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | None:
+    """Resolve the Python shebang launcher used by ``uv run pytest``."""
     located = _run((uv_command, "run", "which", "pytest"), cwd)
     if located.returncode != 0 or not located.stdout.strip():
         return None
@@ -267,15 +267,18 @@ def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
         return None
     if not launcher:
         return None
-    if Path(launcher[0]).name == "env" and len(launcher) > 1:
-        if not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[1]).name):
+    if Path(launcher[0]).name == "env":
+        env_args = launcher[1:]
+        if env_args[:1] == ["-S"]:
+            env_args = env_args[1:]
+        if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
+        resolved = _run((uv_command, "run", "which", env_args[0]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
-        return resolved.stdout.strip().splitlines()[-1]
+        return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
     if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
-        return launcher[0]
+        return tuple(launcher)
     return None
 
 
@@ -287,9 +290,9 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
         len(command) >= 3
         and Path(command[0]).name == "uv"
         and command[1:3] == ("run", "pytest")
-        and (interpreter := _uv_pytest_interpreter(command[0], cwd))
+        and (launcher := _uv_pytest_python_launcher(command[0], cwd))
     ):
-        return (interpreter, "-c", "import yaml")
+        return (*launcher, "-c", "import yaml")
     return None
 
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -173,6 +173,8 @@ def _ensure_pytest_runtime_deps() -> None:
         else:
             return
     if installed_version != PYYAML_VERSION or import_error is not None:
+        # Local and custom environments are user-owned; only Actions may mutate
+        # its active interpreter to repair the managed Gate runtime.
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML {PYYAML_VERSION} is required; install "
@@ -281,8 +283,17 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
+    yaml_import_failure = bool(
+        re.search(
+            r"^(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
+            output,
+            re.MULTILINE,
+        )
+    )
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = True if not managed_runtime else _pyyaml_runtime_needs_repair()
+        missing_pyyaml = (
+            yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()
+        )
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -334,6 +334,27 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
     return None
 
 
+PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+
+
+def _python_module_pytest_probe(
+    command: tuple[str, ...],
+    python_index: int,
+) -> tuple[str, ...] | None:
+    """Replace Python's program selector only when it is exactly ``-m pytest``."""
+    index = python_index + 1
+    while index < len(command):
+        option = command[index]
+        if option == "-m":
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return (*command[:index], "-c", "import yaml")
+            return None
+        if option in {"-c", "-"} or not option.startswith("-"):
+            return None
+        index += 2 if option in PYTHON_VALUE_OPTIONS else 1
+    return None
+
+
 def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
     """Build a probe for ``uv run [options] python [flags] -m pytest``."""
     if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
@@ -351,10 +372,7 @@ def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
         r"python(?:\d+(?:\.\d+)*)?", Path(command[index]).name
     ):
         return None
-    for module_index in range(index + 1, len(command) - 1):
-        if command[module_index : module_index + 2] == ("-m", "pytest"):
-            return (*command[:module_index], "-c", "import yaml")
-    return None
+    return _python_module_pytest_probe(command, index)
 
 
 def _python_shebang_launcher(
@@ -412,9 +430,7 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if probe := _uv_python_module_probe(command):
         return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
-        for index in range(1, len(command) - 1):
-            if command[index : index + 2] == ("-m", "pytest"):
-                return (*command[:index], "-c", "import yaml")
+        return _python_module_pytest_probe(command, 0)
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -173,8 +173,8 @@ def _ensure_pytest_runtime_deps() -> None:
         else:
             return
     if installed_version != PYYAML_VERSION or import_error is not None:
-        # Local and custom environments are user-owned; only Actions may mutate
-        # its active interpreter to repair the managed Gate runtime.
+        # Local and custom environments are user-owned; dependency repair may
+        # mutate the active interpreter only in GitHub Actions.
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML {PYYAML_VERSION} is required; install "

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -249,9 +249,39 @@ def _run(
     )
 
 
-def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | None:
+UV_RUN_VALUE_OPTIONS = frozenset(
+    {
+        "--directory",
+        "--env-file",
+        "--package",
+        "--project",
+        "--python",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+    }
+)
+
+
+def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return ``uv run`` plus options when its command operand is pytest."""
+    if len(command) < 3 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option == "--":
+            index += 1
+            break
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    if index >= len(command) or Path(command[index]).name != "pytest":
+        return None
+    return command[:index]
+
+
+def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Resolve the Python shebang launcher used by ``uv run pytest``."""
-    located = _run((uv_command, "run", "which", "pytest"), cwd)
+    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
     if located.returncode != 0 or not located.stdout.strip():
         return None
     pytest_path = Path(located.stdout.strip().splitlines()[-1])
@@ -273,7 +303,7 @@ def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | 
             env_args = env_args[1:]
         if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((uv_command, "run", "which", env_args[0]), cwd)
+        resolved = _run((*uv_run_prefix, "which", env_args[0]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
         return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
@@ -286,11 +316,8 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
         return (command[0], "-c", "import yaml")
-    if (
-        len(command) >= 3
-        and Path(command[0]).name == "uv"
-        and command[1:3] == ("run", "pytest")
-        and (launcher := _uv_pytest_python_launcher(command[0], cwd))
+    if (uv_prefix := _uv_run_pytest_prefix(command)) and (
+        launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
         return (*launcher, "-c", "import yaml")
     return None

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -228,6 +228,15 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
+def _pyyaml_probe_command(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return a read-only PyYAML import probe for a recognized pytest runtime."""
+    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
+        return (command[0], "-c", "import yaml")
+    if len(command) >= 3 and Path(command[0]).name == "uv" and command[1:3] == ("run", "pytest"):
+        return (command[0], "run", "python", "-c", "import yaml")
+    return None
+
+
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -283,27 +292,14 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
-    yaml_import_exception = bool(
-        re.search(
-            r"^(?:e\s+)?"
-            r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
-            output,
-            re.MULTILINE,
-        )
-    )
-    yaml_import_context = bool(
-        re.search(
-            r"(?:error collecting|while importing test module|"
-            r"importlib|import_module|^\s*(?:from yaml|import yaml)\b)",
-            output,
-            re.MULTILINE,
-        )
-    )
-    yaml_import_failure = yaml_import_exception and yaml_import_context
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = (
-            yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()
-        )
+        if managed_runtime:
+            missing_pyyaml = _pyyaml_runtime_needs_repair()
+        elif probe_command := _pyyaml_probe_command(command):
+            try:
+                missing_pyyaml = _run(probe_command, cwd).returncode != 0
+            except OSError as exc:
+                raise CommandUnavailableError(exc) from exc
     if not missing_pyyaml:
         return completed
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -228,15 +228,6 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     return Path(executable).resolve() == Path(sys.executable).resolve()
 
 
-def _pyyaml_probe_command(command: tuple[str, ...]) -> tuple[str, ...] | None:
-    """Return a read-only PyYAML import probe for a recognized pytest runtime."""
-    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
-        return (command[0], "-c", "import yaml")
-    if len(command) >= 3 and Path(command[0]).name == "uv" and command[1:3] == ("run", "pytest"):
-        return (command[0], "run", "python", "-c", "import yaml")
-    return None
-
-
 def _run(
     command: tuple[str, ...],
     cwd: Path,
@@ -256,6 +247,46 @@ def _run(
         env=env,
         timeout=timeout,
     )
+
+
+def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
+    """Resolve the shebang interpreter used by ``uv run pytest``."""
+    located = _run((uv_command, "run", "which", "pytest"), cwd)
+    if located.returncode != 0 or not located.stdout.strip():
+        return None
+    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+    try:
+        shebang = pytest_path.read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, UnicodeError, IndexError):
+        return None
+    if not shebang.startswith("#!"):
+        return None
+    try:
+        launcher = shlex.split(shebang[2:].strip())
+    except ValueError:
+        return None
+    if not launcher:
+        return None
+    if Path(launcher[0]).name == "env" and len(launcher) > 1:
+        resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            return None
+        return resolved.stdout.strip().splitlines()[-1]
+    return launcher[0]
+
+
+def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
+    """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
+    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
+        return (command[0], "-c", "import yaml")
+    if (
+        len(command) >= 3
+        and Path(command[0]).name == "uv"
+        and command[1:3] == ("run", "pytest")
+        and (interpreter := _uv_pytest_interpreter(command[0], cwd))
+    ):
+        return (interpreter, "-c", "import yaml")
+    return None
 
 
 def _run_with_runtime_deps(
@@ -295,7 +326,7 @@ def _run_with_runtime_deps(
     if yaml_traceback and not missing_pyyaml:
         if managed_runtime:
             missing_pyyaml = _pyyaml_runtime_needs_repair()
-        elif probe_command := _pyyaml_probe_command(command):
+        elif probe_command := _pyyaml_probe_command(command, cwd):
             try:
                 missing_pyyaml = _run(probe_command, cwd).returncode != 0
             except OSError as exc:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -285,7 +285,8 @@ def _run_with_runtime_deps(
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
     yaml_import_failure = bool(
         re.search(
-            r"^(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
+            r"^(?:e\s+)?"
+            r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
             output,
             re.MULTILINE,
         )

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -317,6 +317,23 @@ def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
     return command[:index]
 
 
+def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Return uv options preceding ``-m pytest`` or ``--module pytest``."""
+    if len(command) < 4 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option in {"-m", "--module"}:
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return command[:index]
+            return None
+        if option == "--":
+            return None
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    return None
+
+
 def _python_shebang_launcher(
     executable: Path,
     resolve_name: Callable[[str], str | None],
@@ -367,9 +384,12 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
 
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
-    for index in range(1, len(command) - 1):
-        if command[index : index + 2] == ("-m", "pytest"):
-            return (*command[:index], "-c", "import yaml")
+    if uv_prefix := _uv_module_pytest_prefix(command):
+        return (*uv_prefix, "python", "-c", "import yaml")
+    if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
+        for index in range(1, len(command) - 1):
+            if command[index : index + 2] == ("-m", "pytest"):
+                return (*command[:index], "-c", "import yaml")
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -268,11 +268,15 @@ def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
     if not launcher:
         return None
     if Path(launcher[0]).name == "env" and len(launcher) > 1:
+        if not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[1]).name):
+            return None
         resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
         return resolved.stdout.strip().splitlines()[-1]
-    return launcher[0]
+    if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
+        return launcher[0]
+    return None
 
 
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from importlib import import_module, metadata
 from io import BytesIO
@@ -251,11 +251,49 @@ def _run(
 
 UV_RUN_VALUE_OPTIONS = frozenset(
     {
+        "-C",
+        "-P",
+        "-f",
+        "-i",
+        "-p",
+        "-w",
+        "--allow-insecure-host",
+        "--cache-dir",
+        "--color",
+        "--config-file",
+        "--config-setting",
+        "--config-settings-package",
+        "--default-index",
         "--directory",
         "--env-file",
+        "--exclude-newer",
+        "--exclude-newer-package",
+        "--extra",
+        "--extra-index-url",
+        "--find-links",
+        "--fork-strategy",
+        "--group",
+        "--index",
+        "--index-strategy",
+        "--index-url",
+        "--keyring-provider",
+        "--link-mode",
+        "--no-binary-package",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-extra",
+        "--no-group",
+        "--no-sources-package",
+        "--only-group",
         "--package",
+        "--prerelease",
         "--project",
         "--python",
+        "--python-platform",
+        "--refresh-package",
+        "--reinstall-package",
+        "--resolution",
+        "--upgrade-package",
         "--with",
         "--with-editable",
         "--with-requirements",
@@ -279,14 +317,13 @@ def _uv_run_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None:
     return command[:index]
 
 
-def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
-    """Resolve the Python shebang launcher used by ``uv run pytest``."""
-    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
-    if located.returncode != 0 or not located.stdout.strip():
-        return None
-    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+def _python_shebang_launcher(
+    executable: Path,
+    resolve_name: Callable[[str], str | None],
+) -> tuple[str, ...] | None:
+    """Return a verified Python shebang launcher, preserving interpreter flags."""
     try:
-        shebang = pytest_path.read_text(encoding="utf-8").splitlines()[0]
+        shebang = executable.read_text(encoding="utf-8").splitlines()[0]
     except (OSError, UnicodeError, IndexError):
         return None
     if not shebang.startswith("#!"):
@@ -303,23 +340,44 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
             env_args = env_args[1:]
         if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((*uv_run_prefix, "which", env_args[0]), cwd)
-        if resolved.returncode != 0 or not resolved.stdout.strip():
+        resolved = resolve_name(env_args[0])
+        if not resolved:
             return None
-        return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
+        return (resolved, *env_args[1:])
     if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
         return tuple(launcher)
     return None
 
 
+def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
+    """Resolve the Python shebang launcher used by ``uv run pytest``."""
+    located = _run((*uv_run_prefix, "which", "pytest"), cwd)
+    if located.returncode != 0 or not located.stdout.strip():
+        return None
+
+    def resolve_name(name: str) -> str | None:
+        resolved = _run((*uv_run_prefix, "which", name), cwd)
+        if resolved.returncode != 0 or not resolved.stdout.strip():
+            return None
+        return resolved.stdout.strip().splitlines()[-1]
+
+    pytest_path = Path(located.stdout.strip().splitlines()[-1])
+    return _python_shebang_launcher(pytest_path, resolve_name)
+
+
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
-    if len(command) >= 3 and command[1:3] == ("-m", "pytest"):
-        return (command[0], "-c", "import yaml")
+    for index in range(1, len(command) - 1):
+        if command[index : index + 2] == ("-m", "pytest"):
+            return (*command[:index], "-c", "import yaml")
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
         return (*launcher, "-c", "import yaml")
+    if command and Path(command[0]).name == "pytest":
+        pytest_path = shutil.which(command[0])
+        if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
+            return (*launcher, "-c", "import yaml")
     return None
 
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -334,6 +334,29 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
     return None
 
 
+def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    """Build a probe for ``uv run [options] python [flags] -m pytest``."""
+    if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
+        return None
+    index = 2
+    while index < len(command) and command[index].startswith("-"):
+        option = command[index]
+        if option in {"-m", "--module"}:
+            return None
+        if option == "--":
+            index += 1
+            break
+        index += 2 if option in UV_RUN_VALUE_OPTIONS else 1
+    if index >= len(command) or not re.fullmatch(
+        r"python(?:\d+(?:\.\d+)*)?", Path(command[index]).name
+    ):
+        return None
+    for module_index in range(index + 1, len(command) - 1):
+        if command[module_index : module_index + 2] == ("-m", "pytest"):
+            return (*command[:module_index], "-c", "import yaml")
+    return None
+
+
 def _python_shebang_launcher(
     executable: Path,
     resolve_name: Callable[[str], str | None],
@@ -386,6 +409,8 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if uv_prefix := _uv_module_pytest_prefix(command):
         return (*uv_prefix, "python", "-c", "import yaml")
+    if probe := _uv_python_module_probe(command):
+        return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
         for index in range(1, len(command) - 1):
             if command[index : index + 2] == ("-m", "pytest"):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -283,7 +283,7 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
-    yaml_import_failure = bool(
+    yaml_import_exception = bool(
         re.search(
             r"^(?:e\s+)?"
             r"(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
@@ -291,6 +291,15 @@ def _run_with_runtime_deps(
             re.MULTILINE,
         )
     )
+    yaml_import_context = bool(
+        re.search(
+            r"(?:error collecting|while importing test module|"
+            r"importlib|import_module|^\s*(?:from yaml|import yaml)\b)",
+            output,
+            re.MULTILINE,
+        )
+    )
+    yaml_import_failure = yaml_import_exception and yaml_import_context
     if yaml_traceback and not missing_pyyaml:
         missing_pyyaml = (
             yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -249,8 +249,8 @@ def _run(
     )
 
 
-def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
-    """Resolve the shebang interpreter used by ``uv run pytest``."""
+def _uv_pytest_python_launcher(uv_command: str, cwd: Path) -> tuple[str, ...] | None:
+    """Resolve the Python shebang launcher used by ``uv run pytest``."""
     located = _run((uv_command, "run", "which", "pytest"), cwd)
     if located.returncode != 0 or not located.stdout.strip():
         return None
@@ -267,15 +267,18 @@ def _uv_pytest_interpreter(uv_command: str, cwd: Path) -> str | None:
         return None
     if not launcher:
         return None
-    if Path(launcher[0]).name == "env" and len(launcher) > 1:
-        if not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[1]).name):
+    if Path(launcher[0]).name == "env":
+        env_args = launcher[1:]
+        if env_args[:1] == ["-S"]:
+            env_args = env_args[1:]
+        if not env_args or not re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(env_args[0]).name):
             return None
-        resolved = _run((uv_command, "run", "which", launcher[1]), cwd)
+        resolved = _run((uv_command, "run", "which", env_args[0]), cwd)
         if resolved.returncode != 0 or not resolved.stdout.strip():
             return None
-        return resolved.stdout.strip().splitlines()[-1]
+        return (resolved.stdout.strip().splitlines()[-1], *env_args[1:])
     if re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(launcher[0]).name):
-        return launcher[0]
+        return tuple(launcher)
     return None
 
 
@@ -287,9 +290,9 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
         len(command) >= 3
         and Path(command[0]).name == "uv"
         and command[1:3] == ("run", "pytest")
-        and (interpreter := _uv_pytest_interpreter(command[0], cwd))
+        and (launcher := _uv_pytest_python_launcher(command[0], cwd))
     ):
-        return (interpreter, "-c", "import yaml")
+        return (*launcher, "-c", "import yaml")
     return None
 
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -173,6 +173,8 @@ def _ensure_pytest_runtime_deps() -> None:
         else:
             return
     if installed_version != PYYAML_VERSION or import_error is not None:
+        # Local and custom environments are user-owned; only Actions may mutate
+        # its active interpreter to repair the managed Gate runtime.
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML {PYYAML_VERSION} is required; install "
@@ -281,8 +283,17 @@ def _run_with_runtime_deps(
         )
     )
     yaml_traceback = bool(re.search(r"(?:^|[/\\])yaml[/\\][^\n]*", output, re.MULTILINE))
+    yaml_import_failure = bool(
+        re.search(
+            r"^(?:attributeerror|importerror|modulenotfounderror|oserror|syntaxerror):",
+            output,
+            re.MULTILINE,
+        )
+    )
     if yaml_traceback and not missing_pyyaml:
-        missing_pyyaml = True if not managed_runtime else _pyyaml_runtime_needs_repair()
+        missing_pyyaml = (
+            yaml_import_failure if not managed_runtime else _pyyaml_runtime_needs_repair()
+        )
     if not missing_pyyaml:
         return completed
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -334,6 +334,27 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
     return None
 
 
+PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+
+
+def _python_module_pytest_probe(
+    command: tuple[str, ...],
+    python_index: int,
+) -> tuple[str, ...] | None:
+    """Replace Python's program selector only when it is exactly ``-m pytest``."""
+    index = python_index + 1
+    while index < len(command):
+        option = command[index]
+        if option == "-m":
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return (*command[:index], "-c", "import yaml")
+            return None
+        if option in {"-c", "-"} or not option.startswith("-"):
+            return None
+        index += 2 if option in PYTHON_VALUE_OPTIONS else 1
+    return None
+
+
 def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
     """Build a probe for ``uv run [options] python [flags] -m pytest``."""
     if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
@@ -351,10 +372,7 @@ def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
         r"python(?:\d+(?:\.\d+)*)?", Path(command[index]).name
     ):
         return None
-    for module_index in range(index + 1, len(command) - 1):
-        if command[module_index : module_index + 2] == ("-m", "pytest"):
-            return (*command[:module_index], "-c", "import yaml")
-    return None
+    return _python_module_pytest_probe(command, index)
 
 
 def _python_shebang_launcher(
@@ -412,9 +430,7 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if probe := _uv_python_module_probe(command):
         return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
-        for index in range(1, len(command) - 1):
-            if command[index : index + 2] == ("-m", "pytest"):
-                return (*command[:index], "-c", "import yaml")
+        return _python_module_pytest_probe(command, 0)
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -173,8 +173,8 @@ def _ensure_pytest_runtime_deps() -> None:
         else:
             return
     if installed_version != PYYAML_VERSION or import_error is not None:
-        # Local and custom environments are user-owned; only Actions may mutate
-        # its active interpreter to repair the managed Gate runtime.
+        # Local and custom environments are user-owned; dependency repair may
+        # mutate the active interpreter only in GitHub Actions.
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML {PYYAML_VERSION} is required; install "

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -677,8 +677,14 @@ def test_uv_pyyaml_probe_preserves_uv_run_options(tmp_path, monkeypatch) -> None
         "uv",
         "run",
         "--frozen",
-        "--with",
+        "--group",
+        "test",
+        "-w",
         "pytest-xdist",
+        "-p",
+        "3.13",
+        "--config-file",
+        "uv.toml",
         "--isolated",
         "pytest",
         "-q",
@@ -694,8 +700,14 @@ def test_uv_pyyaml_probe_preserves_uv_run_options(tmp_path, monkeypatch) -> None
             "uv",
             "run",
             "--frozen",
-            "--with",
+            "--group",
+            "test",
+            "-w",
             "pytest-xdist",
+            "-p",
+            "3.13",
+            "--config-file",
+            "uv.toml",
             "--isolated",
             "which",
             "pytest",
@@ -762,6 +774,31 @@ def test_uv_pyyaml_probe_rejects_shell_shim_launcher(tmp_path, monkeypatch) -> N
 
     assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) is None
     assert calls == [("uv", "run", "which", "pytest")]
+
+
+def test_bare_pytest_probe_uses_launcher_shebang(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "bin" / "pytest"
+    pytest_launcher.parent.mkdir()
+    pytest_launcher.write_text("#!/usr/bin/env -S python3 -I\n", encoding="utf-8")
+
+    def which(name):
+        return str(pytest_launcher) if name == "pytest" else "/venv/bin/python3"
+
+    monkeypatch.setattr(deliberate_break.shutil, "which", which)
+
+    assert deliberate_break._pyyaml_probe_command(("pytest", "-q"), tmp_path) == (
+        "/venv/bin/python3",
+        "-I",
+        "-c",
+        "import yaml",
+    )
+
+
+def test_python_module_probe_preserves_interpreter_flags(tmp_path) -> None:
+    assert deliberate_break._pyyaml_probe_command(
+        ("/venv/bin/python", "-I", "-m", "pytest", "-q"),
+        tmp_path,
+    ) == ("/venv/bin/python", "-I", "-c", "import yaml")
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -683,6 +683,22 @@ def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypat
     )
 
 
+def test_uv_pyyaml_probe_rejects_shell_shim_launcher(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "bin" / "pytest"
+    pytest_launcher.parent.mkdir()
+    pytest_launcher.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def run(command, _cwd):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, f"{pytest_launcher}\n", "")
+
+    monkeypatch.setattr(deliberate_break, "_run", run)
+
+    assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) is None
+    assert calls == [("uv", "run", "which", "pytest")]
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -548,8 +548,10 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
     "stderr",
     [
         "ModuleNotFoundError: No module named 'yaml'",
+        "ERROR collecting tests/test_manifest.py\n"
         'File "/other/venv/lib/site-packages/yaml/__init__.py", line 1\n'
         "SyntaxError: broken wheel",
+        "ERROR collecting tests/test_manifest.py\n"
         'File "/other/venv/lib/site-packages/yaml/__init__.py", line 1\n'
         "E   SyntaxError: broken wheel",
     ],
@@ -590,6 +592,23 @@ def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
         "",
         'File "/other/venv/lib/site-packages/yaml/parser.py", line 98\n'
         "yaml.parser.ParserError: malformed fixture",
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+
+    result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
+
+    assert result is completed
+
+
+def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
+    tmp_path, monkeypatch
+) -> None:
+    completed = subprocess.CompletedProcess(
+        ["uv", "run", "pytest"],
+        1,
+        "",
+        'File "/other/venv/lib/site-packages/yaml/__init__.py", line 125, in safe_load\n'
+        "E   AttributeError: 'NoneType' object has no attribute 'read'",
     )
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -809,6 +809,34 @@ def test_uv_module_pytest_probe_uses_uv_selected_python(tmp_path, module_option)
     ) == ("uv", "run", "--frozen", "python", "-c", "import yaml")
 
 
+def test_uv_nested_python_module_probe_preserves_uv_and_python_options(tmp_path) -> None:
+    assert deliberate_break._pyyaml_probe_command(
+        (
+            "uv",
+            "run",
+            "--no-project",
+            "--python",
+            "3.13",
+            "python",
+            "-I",
+            "-m",
+            "pytest",
+            "-q",
+        ),
+        tmp_path,
+    ) == (
+        "uv",
+        "run",
+        "--no-project",
+        "--python",
+        "3.13",
+        "python",
+        "-I",
+        "-c",
+        "import yaml",
+    )
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -565,10 +565,13 @@ def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
         "",
         stderr,
     )
+    attempts = [completed]
+    if "No module named" not in stderr:
+        attempts.append(subprocess.CompletedProcess(["probe"], 1, "", "broken import"))
     monkeypatch.setattr(
         deliberate_break,
         "_run",
-        lambda *_args: completed,
+        lambda *_args: attempts.pop(0),
     )
     monkeypatch.setattr(
         deliberate_break,
@@ -581,6 +584,7 @@ def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
 
     assert isinstance(caught.value.error, ImportError)
     assert "wrapped or custom" in str(caught.value.error)
+    assert attempts == []
 
 
 def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
@@ -593,11 +597,13 @@ def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
         'File "/other/venv/lib/site-packages/yaml/parser.py", line 98\n'
         "yaml.parser.ParserError: malformed fixture",
     )
-    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
 
     result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
 
     assert result is completed
+    assert attempts == []
 
 
 def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
@@ -610,11 +616,13 @@ def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
         'File "/other/venv/lib/site-packages/yaml/__init__.py", line 125, in safe_load\n'
         "E   AttributeError: 'NoneType' object has no attribute 'read'",
     )
-    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
 
     result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
 
     assert result is completed
+    assert attempts == []
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -575,6 +575,11 @@ def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
     )
     monkeypatch.setattr(
         deliberate_break,
+        "_pyyaml_probe_command",
+        lambda _command, _cwd: ("probe",),
+    )
+    monkeypatch.setattr(
+        deliberate_break,
         "_ensure_pytest_runtime_deps",
         lambda: pytest.fail("wrapper-owned environment must not be mutated"),
     )
@@ -599,6 +604,11 @@ def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
     )
     attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_pyyaml_probe_command",
+        lambda _command, _cwd: ("probe",),
+    )
 
     result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
 
@@ -618,11 +628,59 @@ def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
     )
     attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_pyyaml_probe_command",
+        lambda _command, _cwd: ("probe",),
+    )
 
     result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
 
     assert result is completed
     assert attempts == []
+
+
+def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "global" / "bin" / "pytest"
+    pytest_launcher.parent.mkdir(parents=True)
+    pytest_launcher.write_text("#!/global/python\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run",
+        lambda *_args: subprocess.CompletedProcess(
+            ["uv", "run", "which", "pytest"],
+            0,
+            f"{pytest_launcher}\n",
+            "",
+        ),
+    )
+
+    assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
+        "/global/python",
+        "-c",
+        "import yaml",
+    )
+
+
+def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "bin" / "pytest"
+    pytest_launcher.parent.mkdir()
+    pytest_launcher.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    results = iter(
+        (
+            subprocess.CompletedProcess(["which", "pytest"], 0, f"{pytest_launcher}\n", ""),
+            subprocess.CompletedProcess(
+                ["which", "python3"], 0, "/project/.venv/bin/python3\n", ""
+            ),
+        )
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: next(results))
+
+    assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
+        "/project/.venv/bin/python3",
+        "-c",
+        "import yaml",
+    )
 
 
 def _sound_spec(repo: Path) -> tuple[str, object]:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -662,6 +662,47 @@ def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monk
     )
 
 
+def test_uv_pyyaml_probe_preserves_uv_run_options(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "bin" / "pytest"
+    pytest_launcher.parent.mkdir()
+    pytest_launcher.write_text("#!/project/.venv/bin/python\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def run(command, _cwd):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, f"{pytest_launcher}\n", "")
+
+    monkeypatch.setattr(deliberate_break, "_run", run)
+    command = (
+        "uv",
+        "run",
+        "--frozen",
+        "--with",
+        "pytest-xdist",
+        "--isolated",
+        "pytest",
+        "-q",
+    )
+
+    assert deliberate_break._pyyaml_probe_command(command, tmp_path) == (
+        "/project/.venv/bin/python",
+        "-c",
+        "import yaml",
+    )
+    assert calls == [
+        (
+            "uv",
+            "run",
+            "--frozen",
+            "--with",
+            "pytest-xdist",
+            "--isolated",
+            "which",
+            "pytest",
+        )
+    ]
+
+
 def test_uv_pyyaml_probe_preserves_python_shebang_flags(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "global" / "bin" / "pytest"
     pytest_launcher.parent.mkdir(parents=True)

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -662,10 +662,33 @@ def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monk
     )
 
 
+def test_uv_pyyaml_probe_preserves_python_shebang_flags(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "global" / "bin" / "pytest"
+    pytest_launcher.parent.mkdir(parents=True)
+    pytest_launcher.write_text("#!/usr/bin/python3 -I\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run",
+        lambda *_args: subprocess.CompletedProcess(
+            ["uv", "run", "which", "pytest"],
+            0,
+            f"{pytest_launcher}\n",
+            "",
+        ),
+    )
+
+    assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
+        "/usr/bin/python3",
+        "-I",
+        "-c",
+        "import yaml",
+    )
+
+
 def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "bin" / "pytest"
     pytest_launcher.parent.mkdir()
-    pytest_launcher.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    pytest_launcher.write_text("#!/usr/bin/env -S python3 -I\n", encoding="utf-8")
     results = iter(
         (
             subprocess.CompletedProcess(["which", "pytest"], 0, f"{pytest_launcher}\n", ""),
@@ -678,6 +701,7 @@ def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypat
 
     assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
         "/project/.venv/bin/python3",
+        "-I",
         "-c",
         "import yaml",
     )

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -801,6 +801,14 @@ def test_python_module_probe_preserves_interpreter_flags(tmp_path) -> None:
     ) == ("/venv/bin/python", "-I", "-c", "import yaml")
 
 
+@pytest.mark.parametrize("module_option", ["-m", "--module"])
+def test_uv_module_pytest_probe_uses_uv_selected_python(tmp_path, module_option) -> None:
+    assert deliberate_break._pyyaml_probe_command(
+        ("uv", "run", "--frozen", module_option, "pytest", "-q"),
+        tmp_path,
+    ) == ("uv", "run", "--frozen", "python", "-c", "import yaml")
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -550,6 +550,8 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
         "ModuleNotFoundError: No module named 'yaml'",
         'File "/other/venv/lib/site-packages/yaml/__init__.py", line 1\n'
         "SyntaxError: broken wheel",
+        'File "/other/venv/lib/site-packages/yaml/__init__.py", line 1\n'
+        "E   SyntaxError: broken wheel",
     ],
 )
 def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -837,6 +837,18 @@ def test_uv_nested_python_module_probe_preserves_uv_and_python_options(tmp_path)
     )
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("uv", "run", "python", "scripts/run_tests.py", "-m", "pytest"),
+        ("uv", "run", "python", "-c", "run_tests()", "-m", "pytest"),
+        ("python", "scripts/run_tests.py", "-m", "pytest"),
+    ],
+)
+def test_python_probe_stops_after_first_program_selector(tmp_path, command) -> None:
+    assert deliberate_break._pyyaml_probe_command(command, tmp_path) is None
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -579,6 +579,23 @@ def test_runtime_dependencies_do_not_repair_unmanaged_command_environment(
     assert "wrapped or custom" in str(caught.value.error)
 
 
+def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
+    tmp_path, monkeypatch
+) -> None:
+    completed = subprocess.CompletedProcess(
+        ["uv", "run", "pytest"],
+        1,
+        "",
+        'File "/other/venv/lib/site-packages/yaml/parser.py", line 98\n'
+        "yaml.parser.ParserError: malformed fixture",
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+
+    result = deliberate_break._run_with_runtime_deps(("uv", "run", "pytest"), tmp_path)
+
+    assert result is completed
+
+
 def _sound_spec(repo: Path) -> tuple[str, object]:
     _write_app(repo, 0)
     base = _commit(repo, "base behavior")


### PR DESCRIPTION
## Summary
- keep wrapper-owned YAML parser/test failures as ordinary deliberate-break results
- reserve unmanaged runtime dependency classification for explicit missing-import or broken-import exception output
- document that only GitHub Actions may mutate the managed runtime

## Evidence
- `.venv/bin/python -m pytest tests/scripts/test_check_deliberate_break.py -q` (36 passed)
- Black check passed
- Ruff passed
- mypy passed
- source/template diff is empty

## Lineage
Follow-up from exact-head consumer reviews on Travel-Plan-Permission#1379 and trip-planner#1626. Those consumers remain held pending this source correction and propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of missing or unusable YAML dependencies by distinguishing import failures from ordinary YAML parsing and attribute errors.
  * Preserved automatic dependency repair for supported managed environments while preventing unintended changes to local interpreter environments.
  * Improved handling of additional traceback formats, including pytest-prefixed errors.

* **Tests**
  * Expanded coverage for YAML import failures and confirmed regular YAML errors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->