### PR TITLE
fix(gate): recognize flagged managed pytest

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -341,7 +341,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRtuvx")
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -362,6 +362,11 @@ def _python_module_pytest_probe(
         ):
             return None
         if option in PYTHON_VALUE_OPTIONS:
+            if option == "--check-hash-based-pycs" and (
+                index + 1 >= len(command)
+                or command[index + 1] not in {"always", "default", "never"}
+            ):
+                return None
             index += 2
             continue
         if option.startswith("--"):

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -395,7 +395,7 @@ def _python_module_pytest_probe(
 
 def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
     """Build a probe for ``uv run [options] python [flags] -m pytest``."""
-    if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
+    if len(command) < 4 or Path(command[0]).name != "uv" or command[1] != "run":
         return None
     index = 2
     while index < len(command) and command[index].startswith("-"):

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -354,6 +354,13 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
+        if (
+            option == "-c"
+            or option in PYTHON_TERMINATING_OPTIONS
+            or option.startswith("--help-")
+            or not option.startswith("-")
+        ):
+            return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
             for position, character in enumerate(compact):
@@ -380,13 +387,6 @@ def _python_module_pytest_probe(
             else:
                 index += 1
             continue
-        if (
-            option == "-c"
-            or option in PYTHON_TERMINATING_OPTIONS
-            or option.startswith("--help-")
-            or not option.startswith("-")
-        ):
-            return None
         index += 2 if option in PYTHON_VALUE_OPTIONS else 1
     return None
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -227,9 +227,11 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     if not command:
         return False
     executable = shutil.which(command[0]) or command[0]
+    probe = _python_module_pytest_probe(command, 0)
     return (
         Path(executable).resolve() == Path(sys.executable).resolve()
-        and _python_module_pytest_probe(command, 0) is not None
+        and probe is not None
+        and not _python_probe_changes_import_context(probe)
     )
 
 
@@ -342,6 +344,22 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
 PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRstuvx")
+PYTHON_IMPORT_CONTEXT_FLAGS = frozenset("EIPsS")
+
+
+def _python_probe_changes_import_context(probe: tuple[str, ...]) -> bool:
+    """Return whether a probe uses flags that can change module visibility."""
+    for option in probe[1:]:
+        if option == "-c":
+            break
+        if not option.startswith("-") or option.startswith("--"):
+            continue
+        for character in option[1:]:
+            if character in PYTHON_IMPORT_CONTEXT_FLAGS:
+                return True
+            if character in {"W", "X"}:
+                break
+    return False
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
@@ -356,16 +374,20 @@ def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
     for option in options:
         if option == "-i":
             continue
-        if (
-            option.startswith("-")
-            and not option.startswith("--")
-            and len(option) > 1
-            and all(character in PYTHON_COMPACT_FLAGS for character in option[1:])
-        ):
-            body = option[1:].replace("i", "")
-            if not body:
+        if option.startswith("-") and not option.startswith("--") and len(option) > 1:
+            body = option[1:]
+            kept: list[str] = []
+            for position, character in enumerate(body):
+                if character == "i":
+                    continue
+                kept.append(character)
+                if character in {"W", "X"}:
+                    kept.append(body[position + 1 :])
+                    break
+            cleaned_body = "".join(kept)
+            if not cleaned_body:
                 continue
-            cleaned.append(f"-{body}")
+            cleaned.append(f"-{cleaned_body}")
             continue
         cleaned.append(option)
     return tuple(cleaned)

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -342,6 +342,33 @@ PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--h
 PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
 
 
+def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
+    """Omit lowercase ``-i`` from probe argv.
+
+    Interactive mode forces a prompt after ``-c`` scripts. An import-time
+    traceback followed by EOF then exits 0, so PyYAML probe return codes
+    become unreliable when ``i`` is preserved from the original launcher.
+    Uppercase ``-I`` (isolated mode) is kept.
+    """
+    cleaned: list[str] = []
+    for option in options:
+        if option == "-i":
+            continue
+        if (
+            option.startswith("-")
+            and not option.startswith("--")
+            and len(option) > 1
+            and all(character in PYTHON_COMPACT_FLAGS for character in option[1:])
+        ):
+            body = option[1:].replace("i", "")
+            if not body:
+                continue
+            cleaned.append(f"-{body}")
+            continue
+        cleaned.append(option)
+    return tuple(cleaned)
+
+
 def _python_module_pytest_probe(
     command: tuple[str, ...],
     python_index: int,
@@ -352,7 +379,12 @@ def _python_module_pytest_probe(
         option = command[index]
         if option == "-m":
             if index + 1 < len(command) and command[index + 1] == "pytest":
-                return (*command[:index], "-c", "import yaml")
+                return (
+                    *command[: python_index + 1],
+                    *_drop_interactive_python_flags(command[python_index + 1 : index]),
+                    "-c",
+                    "import yaml",
+                )
             return None
         if (
             option == "-c"
@@ -391,9 +423,17 @@ def _python_module_pytest_probe(
                             and command[index + 1] == "pytest"
                         )
                     ):
-                        prefix = compact[:position]
+                        prefix = compact[:position].replace("i", "")
                         preserved = (f"-{prefix}",) if prefix else ()
-                        return (*command[:index], *preserved, "-c", "import yaml")
+                        return (
+                            *command[: python_index + 1],
+                            *_drop_interactive_python_flags(
+                                command[python_index + 1 : index]
+                            ),
+                            *preserved,
+                            "-c",
+                            "import yaml",
+                        )
                     return None
                 return None
             else:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -339,7 +339,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_PREFIX_RE = re.compile(r"^-(?:[bBdEIOPqRsSuvx]|O)+m$")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsSuvx")
 
 
 def _python_module_pytest_probe(
@@ -354,12 +354,27 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
-        if option.startswith(("-c", "-m")):
-            return None
-        if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
-            if index + 1 < len(command) and command[index + 1] == "pytest":
-                return (*command[:index], option[:-1], "-c", "import yaml")
-            return None
+        if option.startswith("-") and not option.startswith("--"):
+            compact = option[1:]
+            selector_index = next(
+                (position for position, character in enumerate(compact) if character in {"c", "m"}),
+                None,
+            )
+            if selector_index is not None and all(
+                character in PYTHON_COMPACT_FLAGS for character in compact[:selector_index]
+            ):
+                selector = compact[selector_index]
+                selector_value = compact[selector_index + 1 :]
+                if (
+                    selector == "m"
+                    and not selector_value
+                    and index + 1 < len(command)
+                    and command[index + 1] == "pytest"
+                ):
+                    prefix = compact[:selector_index]
+                    preserved = (f"-{prefix}",) if prefix else ()
+                    return (*command[:index], *preserved, "-c", "import yaml")
+                return None
         if (
             option == "-c"
             or option in PYTHON_TERMINATING_OPTIONS

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -356,25 +356,30 @@ def _python_module_pytest_probe(
             return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
-            selector_index = next(
-                (position for position, character in enumerate(compact) if character in {"c", "m"}),
-                None,
-            )
-            if selector_index is not None and all(
-                character in PYTHON_COMPACT_FLAGS for character in compact[:selector_index]
-            ):
-                selector = compact[selector_index]
-                selector_value = compact[selector_index + 1 :]
-                if (
-                    selector == "m"
-                    and not selector_value
-                    and index + 1 < len(command)
-                    and command[index + 1] == "pytest"
-                ):
-                    prefix = compact[:selector_index]
-                    preserved = (f"-{prefix}",) if prefix else ()
-                    return (*command[:index], *preserved, "-c", "import yaml")
+            for position, character in enumerate(compact):
+                if character in PYTHON_COMPACT_FLAGS:
+                    continue
+                if character in {"V", "h", "?"}:
+                    return None
+                if character in {"W", "X"}:
+                    index += 2 if position + 1 == len(compact) else 1
+                    break
+                if character in {"c", "m"}:
+                    selector_value = compact[position + 1 :]
+                    if (
+                        character == "m"
+                        and not selector_value
+                        and index + 1 < len(command)
+                        and command[index + 1] == "pytest"
+                    ):
+                        prefix = compact[:position]
+                        preserved = (f"-{prefix}",) if prefix else ()
+                        return (*command[:index], *preserved, "-c", "import yaml")
+                    return None
                 return None
+            else:
+                index += 1
+            continue
         if (
             option == "-c"
             or option in PYTHON_TERMINATING_OPTIONS

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -361,6 +361,11 @@ def _python_module_pytest_probe(
             or not option.startswith("-")
         ):
             return None
+        if option in PYTHON_VALUE_OPTIONS:
+            index += 2
+            continue
+        if option.startswith("--"):
+            return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
             for position, character in enumerate(compact):
@@ -389,7 +394,7 @@ def _python_module_pytest_probe(
             else:
                 index += 1
             continue
-        index += 2 if option in PYTHON_VALUE_OPTIONS else 1
+        index += 1
     return None
 
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -36,6 +36,8 @@ DEFAULT_TIMEOUT_SECONDS = 120
 # This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
+PYYAML_PROBE_SENTINEL = "__gate_pyyaml_import_ok__"
+PYYAML_PROBE_CODE = f"import yaml; print({PYYAML_PROBE_SENTINEL!r})"
 
 
 @dataclass(frozen=True)
@@ -383,7 +385,7 @@ def _python_module_pytest_probe(
                     *command[: python_index + 1],
                     *_drop_interactive_python_flags(command[python_index + 1 : index]),
                     "-c",
-                    "import yaml",
+                    PYYAML_PROBE_CODE,
                 )
             return None
         if (
@@ -430,7 +432,7 @@ def _python_module_pytest_probe(
                             *_drop_interactive_python_flags(command[python_index + 1 : index]),
                             *preserved,
                             "-c",
-                            "import yaml",
+                            PYYAML_PROBE_CODE,
                         )
                     return None
                 return None
@@ -512,7 +514,7 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if uv_prefix := _uv_module_pytest_prefix(command):
-        return (*uv_prefix, "python", "-c", "import yaml")
+        return (*uv_prefix, "python", "-c", PYYAML_PROBE_CODE)
     if probe := _uv_python_module_probe(command):
         return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
@@ -520,11 +522,11 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
-        return (*launcher, "-c", "import yaml")
+        return (*launcher, "-c", PYYAML_PROBE_CODE)
     if command and Path(command[0]).name == "pytest":
         pytest_path = shutil.which(command[0])
         if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
-            return (*launcher, "-c", "import yaml")
+            return (*launcher, "-c", PYYAML_PROBE_CODE)
     return None
 
 
@@ -570,18 +572,7 @@ def _run_with_runtime_deps(
                 probe = _run(probe_command, cwd)
             except OSError as exc:
                 raise CommandUnavailableError(exc) from exc
-            probe_output = f"{probe.stdout}\n{probe.stderr}".lower()
-            missing_pyyaml = probe.returncode != 0 or any(
-                marker in probe_output
-                for marker in (
-                    "traceback (most recent call last)",
-                    "attributeerror:",
-                    "importerror:",
-                    "modulenotfounderror:",
-                    "oserror:",
-                    "syntaxerror:",
-                )
-            )
+            missing_pyyaml = probe.returncode != 0 or PYYAML_PROBE_SENTINEL not in probe.stdout
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -222,10 +222,13 @@ def _pyyaml_runtime_needs_repair() -> bool:
 
 def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
-    if len(command) < 3 or command[1:3] != ("-m", "pytest"):
+    if not command:
         return False
     executable = shutil.which(command[0]) or command[0]
-    return Path(executable).resolve() == Path(sys.executable).resolve()
+    return (
+        Path(executable).resolve() == Path(sys.executable).resolve()
+        and _python_module_pytest_probe(command, 0) is not None
+    )
 
 
 def _run(

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -341,7 +341,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRtuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRstuvx")
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -427,9 +427,7 @@ def _python_module_pytest_probe(
                         preserved = (f"-{prefix}",) if prefix else ()
                         return (
                             *command[: python_index + 1],
-                            *_drop_interactive_python_flags(
-                                command[python_index + 1 : index]
-                            ),
+                            *_drop_interactive_python_flags(command[python_index + 1 : index]),
                             *preserved,
                             "-c",
                             "import yaml",

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -373,11 +373,13 @@ def _python_module_pytest_probe(
                     break
                 if character in {"c", "m"}:
                     selector_value = compact[position + 1 :]
-                    if (
-                        character == "m"
-                        and not selector_value
-                        and index + 1 < len(command)
-                        and command[index + 1] == "pytest"
+                    if character == "m" and (
+                        selector_value == "pytest"
+                        or (
+                            not selector_value
+                            and index + 1 < len(command)
+                            and command[index + 1] == "pytest"
+                        )
                     ):
                         prefix = compact[:position]
                         preserved = (f"-{prefix}",) if prefix else ()

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -529,9 +529,21 @@ def _run_with_runtime_deps(
             missing_pyyaml = _pyyaml_runtime_needs_repair()
         elif probe_command := _pyyaml_probe_command(command, cwd):
             try:
-                missing_pyyaml = _run(probe_command, cwd).returncode != 0
+                probe = _run(probe_command, cwd)
             except OSError as exc:
                 raise CommandUnavailableError(exc) from exc
+            probe_output = f"{probe.stdout}\n{probe.stderr}".lower()
+            missing_pyyaml = probe.returncode != 0 or any(
+                marker in probe_output
+                for marker in (
+                    "traceback (most recent call last)",
+                    "attributeerror:",
+                    "importerror:",
+                    "modulenotfounderror:",
+                    "oserror:",
+                    "syntaxerror:",
+                )
+            )
     if not missing_pyyaml:
         return completed
 

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -338,6 +338,8 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
+PYTHON_COMPACT_PREFIX_RE = re.compile(r"^-(?:[bBdEIOPqRsSuvx]|O)+m$")
 
 
 def _python_module_pytest_probe(
@@ -352,7 +354,16 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
-        if option in {"-c", "-"} or not option.startswith("-"):
+        if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return (*command[:index], option[:-1], "-c", "import yaml")
+            return None
+        if (
+            option == "-c"
+            or option in PYTHON_TERMINATING_OPTIONS
+            or option.startswith("--help-")
+            or not option.startswith("-")
+        ):
             return None
         index += 2 if option in PYTHON_VALUE_OPTIONS else 1
     return None

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -339,7 +339,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsSuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
 
 
 def _python_module_pytest_probe(

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -354,6 +354,8 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
+        if option.startswith(("-c", "-m")):
+            return None
         if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], option[:-1], "-c", "import yaml")

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -341,7 +341,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRtuvx")
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -362,6 +362,11 @@ def _python_module_pytest_probe(
         ):
             return None
         if option in PYTHON_VALUE_OPTIONS:
+            if option == "--check-hash-based-pycs" and (
+                index + 1 >= len(command)
+                or command[index + 1] not in {"always", "default", "never"}
+            ):
+                return None
             index += 2
             continue
         if option.startswith("--"):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -395,7 +395,7 @@ def _python_module_pytest_probe(
 
 def _uv_python_module_probe(command: tuple[str, ...]) -> tuple[str, ...] | None:
     """Build a probe for ``uv run [options] python [flags] -m pytest``."""
-    if len(command) < 5 or Path(command[0]).name != "uv" or command[1] != "run":
+    if len(command) < 4 or Path(command[0]).name != "uv" or command[1] != "run":
         return None
     index = 2
     while index < len(command) and command[index].startswith("-"):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -354,6 +354,13 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
+        if (
+            option == "-c"
+            or option in PYTHON_TERMINATING_OPTIONS
+            or option.startswith("--help-")
+            or not option.startswith("-")
+        ):
+            return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
             for position, character in enumerate(compact):
@@ -380,13 +387,6 @@ def _python_module_pytest_probe(
             else:
                 index += 1
             continue
-        if (
-            option == "-c"
-            or option in PYTHON_TERMINATING_OPTIONS
-            or option.startswith("--help-")
-            or not option.startswith("-")
-        ):
-            return None
         index += 2 if option in PYTHON_VALUE_OPTIONS else 1
     return None
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -227,9 +227,11 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     if not command:
         return False
     executable = shutil.which(command[0]) or command[0]
+    probe = _python_module_pytest_probe(command, 0)
     return (
         Path(executable).resolve() == Path(sys.executable).resolve()
-        and _python_module_pytest_probe(command, 0) is not None
+        and probe is not None
+        and not _python_probe_changes_import_context(probe)
     )
 
 
@@ -342,6 +344,22 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
 PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRstuvx")
+PYTHON_IMPORT_CONTEXT_FLAGS = frozenset("EIPsS")
+
+
+def _python_probe_changes_import_context(probe: tuple[str, ...]) -> bool:
+    """Return whether a probe uses flags that can change module visibility."""
+    for option in probe[1:]:
+        if option == "-c":
+            break
+        if not option.startswith("-") or option.startswith("--"):
+            continue
+        for character in option[1:]:
+            if character in PYTHON_IMPORT_CONTEXT_FLAGS:
+                return True
+            if character in {"W", "X"}:
+                break
+    return False
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
@@ -356,16 +374,20 @@ def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
     for option in options:
         if option == "-i":
             continue
-        if (
-            option.startswith("-")
-            and not option.startswith("--")
-            and len(option) > 1
-            and all(character in PYTHON_COMPACT_FLAGS for character in option[1:])
-        ):
-            body = option[1:].replace("i", "")
-            if not body:
+        if option.startswith("-") and not option.startswith("--") and len(option) > 1:
+            body = option[1:]
+            kept: list[str] = []
+            for position, character in enumerate(body):
+                if character == "i":
+                    continue
+                kept.append(character)
+                if character in {"W", "X"}:
+                    kept.append(body[position + 1 :])
+                    break
+            cleaned_body = "".join(kept)
+            if not cleaned_body:
                 continue
-            cleaned.append(f"-{body}")
+            cleaned.append(f"-{cleaned_body}")
             continue
         cleaned.append(option)
     return tuple(cleaned)

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -342,6 +342,33 @@ PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--h
 PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
 
 
+def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:
+    """Omit lowercase ``-i`` from probe argv.
+
+    Interactive mode forces a prompt after ``-c`` scripts. An import-time
+    traceback followed by EOF then exits 0, so PyYAML probe return codes
+    become unreliable when ``i`` is preserved from the original launcher.
+    Uppercase ``-I`` (isolated mode) is kept.
+    """
+    cleaned: list[str] = []
+    for option in options:
+        if option == "-i":
+            continue
+        if (
+            option.startswith("-")
+            and not option.startswith("--")
+            and len(option) > 1
+            and all(character in PYTHON_COMPACT_FLAGS for character in option[1:])
+        ):
+            body = option[1:].replace("i", "")
+            if not body:
+                continue
+            cleaned.append(f"-{body}")
+            continue
+        cleaned.append(option)
+    return tuple(cleaned)
+
+
 def _python_module_pytest_probe(
     command: tuple[str, ...],
     python_index: int,
@@ -352,7 +379,12 @@ def _python_module_pytest_probe(
         option = command[index]
         if option == "-m":
             if index + 1 < len(command) and command[index + 1] == "pytest":
-                return (*command[:index], "-c", "import yaml")
+                return (
+                    *command[: python_index + 1],
+                    *_drop_interactive_python_flags(command[python_index + 1 : index]),
+                    "-c",
+                    "import yaml",
+                )
             return None
         if (
             option == "-c"
@@ -391,9 +423,17 @@ def _python_module_pytest_probe(
                             and command[index + 1] == "pytest"
                         )
                     ):
-                        prefix = compact[:position]
+                        prefix = compact[:position].replace("i", "")
                         preserved = (f"-{prefix}",) if prefix else ()
-                        return (*command[:index], *preserved, "-c", "import yaml")
+                        return (
+                            *command[: python_index + 1],
+                            *_drop_interactive_python_flags(
+                                command[python_index + 1 : index]
+                            ),
+                            *preserved,
+                            "-c",
+                            "import yaml",
+                        )
                     return None
                 return None
             else:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -339,7 +339,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_PREFIX_RE = re.compile(r"^-(?:[bBdEIOPqRsSuvx]|O)+m$")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsSuvx")
 
 
 def _python_module_pytest_probe(
@@ -354,12 +354,27 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
-        if option.startswith(("-c", "-m")):
-            return None
-        if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
-            if index + 1 < len(command) and command[index + 1] == "pytest":
-                return (*command[:index], option[:-1], "-c", "import yaml")
-            return None
+        if option.startswith("-") and not option.startswith("--"):
+            compact = option[1:]
+            selector_index = next(
+                (position for position, character in enumerate(compact) if character in {"c", "m"}),
+                None,
+            )
+            if selector_index is not None and all(
+                character in PYTHON_COMPACT_FLAGS for character in compact[:selector_index]
+            ):
+                selector = compact[selector_index]
+                selector_value = compact[selector_index + 1 :]
+                if (
+                    selector == "m"
+                    and not selector_value
+                    and index + 1 < len(command)
+                    and command[index + 1] == "pytest"
+                ):
+                    prefix = compact[:selector_index]
+                    preserved = (f"-{prefix}",) if prefix else ()
+                    return (*command[:index], *preserved, "-c", "import yaml")
+                return None
         if (
             option == "-c"
             or option in PYTHON_TERMINATING_OPTIONS

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -356,25 +356,30 @@ def _python_module_pytest_probe(
             return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
-            selector_index = next(
-                (position for position, character in enumerate(compact) if character in {"c", "m"}),
-                None,
-            )
-            if selector_index is not None and all(
-                character in PYTHON_COMPACT_FLAGS for character in compact[:selector_index]
-            ):
-                selector = compact[selector_index]
-                selector_value = compact[selector_index + 1 :]
-                if (
-                    selector == "m"
-                    and not selector_value
-                    and index + 1 < len(command)
-                    and command[index + 1] == "pytest"
-                ):
-                    prefix = compact[:selector_index]
-                    preserved = (f"-{prefix}",) if prefix else ()
-                    return (*command[:index], *preserved, "-c", "import yaml")
+            for position, character in enumerate(compact):
+                if character in PYTHON_COMPACT_FLAGS:
+                    continue
+                if character in {"V", "h", "?"}:
+                    return None
+                if character in {"W", "X"}:
+                    index += 2 if position + 1 == len(compact) else 1
+                    break
+                if character in {"c", "m"}:
+                    selector_value = compact[position + 1 :]
+                    if (
+                        character == "m"
+                        and not selector_value
+                        and index + 1 < len(command)
+                        and command[index + 1] == "pytest"
+                    ):
+                        prefix = compact[:position]
+                        preserved = (f"-{prefix}",) if prefix else ()
+                        return (*command[:index], *preserved, "-c", "import yaml")
+                    return None
                 return None
+            else:
+                index += 1
+            continue
         if (
             option == "-c"
             or option in PYTHON_TERMINATING_OPTIONS

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -361,6 +361,11 @@ def _python_module_pytest_probe(
             or not option.startswith("-")
         ):
             return None
+        if option in PYTHON_VALUE_OPTIONS:
+            index += 2
+            continue
+        if option.startswith("--"):
+            return None
         if option.startswith("-") and not option.startswith("--"):
             compact = option[1:]
             for position, character in enumerate(compact):
@@ -389,7 +394,7 @@ def _python_module_pytest_probe(
             else:
                 index += 1
             continue
-        index += 2 if option in PYTHON_VALUE_OPTIONS else 1
+        index += 1
     return None
 
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -36,6 +36,8 @@ DEFAULT_TIMEOUT_SECONDS = 120
 # This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
+PYYAML_PROBE_SENTINEL = "__gate_pyyaml_import_ok__"
+PYYAML_PROBE_CODE = f"import yaml; print({PYYAML_PROBE_SENTINEL!r})"
 
 
 @dataclass(frozen=True)
@@ -383,7 +385,7 @@ def _python_module_pytest_probe(
                     *command[: python_index + 1],
                     *_drop_interactive_python_flags(command[python_index + 1 : index]),
                     "-c",
-                    "import yaml",
+                    PYYAML_PROBE_CODE,
                 )
             return None
         if (
@@ -430,7 +432,7 @@ def _python_module_pytest_probe(
                             *_drop_interactive_python_flags(command[python_index + 1 : index]),
                             *preserved,
                             "-c",
-                            "import yaml",
+                            PYYAML_PROBE_CODE,
                         )
                     return None
                 return None
@@ -512,7 +514,7 @@ def _uv_pytest_python_launcher(uv_run_prefix: tuple[str, ...], cwd: Path) -> tup
 def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...] | None:
     """Return a read-only PyYAML import probe for the pytest launcher's runtime."""
     if uv_prefix := _uv_module_pytest_prefix(command):
-        return (*uv_prefix, "python", "-c", "import yaml")
+        return (*uv_prefix, "python", "-c", PYYAML_PROBE_CODE)
     if probe := _uv_python_module_probe(command):
         return probe
     if command and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", Path(command[0]).name):
@@ -520,11 +522,11 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
-        return (*launcher, "-c", "import yaml")
+        return (*launcher, "-c", PYYAML_PROBE_CODE)
     if command and Path(command[0]).name == "pytest":
         pytest_path = shutil.which(command[0])
         if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
-            return (*launcher, "-c", "import yaml")
+            return (*launcher, "-c", PYYAML_PROBE_CODE)
     return None
 
 
@@ -570,18 +572,7 @@ def _run_with_runtime_deps(
                 probe = _run(probe_command, cwd)
             except OSError as exc:
                 raise CommandUnavailableError(exc) from exc
-            probe_output = f"{probe.stdout}\n{probe.stderr}".lower()
-            missing_pyyaml = probe.returncode != 0 or any(
-                marker in probe_output
-                for marker in (
-                    "traceback (most recent call last)",
-                    "attributeerror:",
-                    "importerror:",
-                    "modulenotfounderror:",
-                    "oserror:",
-                    "syntaxerror:",
-                )
-            )
+            missing_pyyaml = probe.returncode != 0 or PYYAML_PROBE_SENTINEL not in probe.stdout
     if not missing_pyyaml:
         return completed
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -222,10 +222,13 @@ def _pyyaml_runtime_needs_repair() -> bool:
 
 def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
-    if len(command) < 3 or command[1:3] != ("-m", "pytest"):
+    if not command:
         return False
     executable = shutil.which(command[0]) or command[0]
-    return Path(executable).resolve() == Path(sys.executable).resolve()
+    return (
+        Path(executable).resolve() == Path(sys.executable).resolve()
+        and _python_module_pytest_probe(command, 0) is not None
+    )
 
 
 def _run(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -341,7 +341,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRtuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRstuvx")
 
 
 def _drop_interactive_python_flags(options: tuple[str, ...]) -> tuple[str, ...]:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -427,9 +427,7 @@ def _python_module_pytest_probe(
                         preserved = (f"-{prefix}",) if prefix else ()
                         return (
                             *command[: python_index + 1],
-                            *_drop_interactive_python_flags(
-                                command[python_index + 1 : index]
-                            ),
+                            *_drop_interactive_python_flags(command[python_index + 1 : index]),
                             *preserved,
                             "-c",
                             "import yaml",

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -373,11 +373,13 @@ def _python_module_pytest_probe(
                     break
                 if character in {"c", "m"}:
                     selector_value = compact[position + 1 :]
-                    if (
-                        character == "m"
-                        and not selector_value
-                        and index + 1 < len(command)
-                        and command[index + 1] == "pytest"
+                    if character == "m" and (
+                        selector_value == "pytest"
+                        or (
+                            not selector_value
+                            and index + 1 < len(command)
+                            and command[index + 1] == "pytest"
+                        )
                     ):
                         prefix = compact[:position]
                         preserved = (f"-{prefix}",) if prefix else ()

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -529,9 +529,21 @@ def _run_with_runtime_deps(
             missing_pyyaml = _pyyaml_runtime_needs_repair()
         elif probe_command := _pyyaml_probe_command(command, cwd):
             try:
-                missing_pyyaml = _run(probe_command, cwd).returncode != 0
+                probe = _run(probe_command, cwd)
             except OSError as exc:
                 raise CommandUnavailableError(exc) from exc
+            probe_output = f"{probe.stdout}\n{probe.stderr}".lower()
+            missing_pyyaml = probe.returncode != 0 or any(
+                marker in probe_output
+                for marker in (
+                    "traceback (most recent call last)",
+                    "attributeerror:",
+                    "importerror:",
+                    "modulenotfounderror:",
+                    "oserror:",
+                    "syntaxerror:",
+                )
+            )
     if not missing_pyyaml:
         return completed
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -338,6 +338,8 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
+PYTHON_COMPACT_PREFIX_RE = re.compile(r"^-(?:[bBdEIOPqRsSuvx]|O)+m$")
 
 
 def _python_module_pytest_probe(
@@ -352,7 +354,16 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
-        if option in {"-c", "-"} or not option.startswith("-"):
+        if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
+            if index + 1 < len(command) and command[index + 1] == "pytest":
+                return (*command[:index], option[:-1], "-c", "import yaml")
+            return None
+        if (
+            option == "-c"
+            or option in PYTHON_TERMINATING_OPTIONS
+            or option.startswith("--help-")
+            or not option.startswith("-")
+        ):
             return None
         index += 2 if option in PYTHON_VALUE_OPTIONS else 1
     return None

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -339,7 +339,7 @@ def _uv_module_pytest_prefix(command: tuple[str, ...]) -> tuple[str, ...] | None
 
 PYTHON_VALUE_OPTIONS = frozenset({"-W", "-X", "--check-hash-based-pycs"})
 PYTHON_TERMINATING_OPTIONS = frozenset({"-", "--", "-?", "-V", "-VV", "-h", "--help", "--version"})
-PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsSuvx")
+PYTHON_COMPACT_FLAGS = frozenset("bBdEIiOPqRsStuvx")
 
 
 def _python_module_pytest_probe(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -354,6 +354,8 @@ def _python_module_pytest_probe(
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], "-c", "import yaml")
             return None
+        if option.startswith(("-c", "-m")):
+            return None
         if PYTHON_COMPACT_PREFIX_RE.fullmatch(option):
             if index + 1 < len(command) and command[index + 1] == "pytest":
                 return (*command[:index], option[:-1], "-c", "import yaml")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -839,7 +839,7 @@ def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 
 
-@pytest.mark.parametrize("compact_option", ["-Im", "-im", "-OOm"])
+@pytest.mark.parametrize("compact_option", ["-Im", "-im", "-OOm", "-tm"])
 def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_option) -> None:
     command = (sys.executable, compact_option, "pytest", "-q")
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -807,6 +807,10 @@ def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
     )
 
 
+def test_empty_command_is_not_managed_pytest_runtime() -> None:
+    assert not deliberate_break._uses_pytest_runtime(())
+
+
 def test_active_python_with_compact_flags_is_managed_pytest_runtime() -> None:
     command = (sys.executable, "-Im", "pytest", "-q")
 
@@ -819,7 +823,10 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime() -> None:
     )
 
 
-@pytest.mark.parametrize("terminator", ["--", "-V", "-VV", "--version", "-h", "--help"])
+@pytest.mark.parametrize(
+    "terminator",
+    ["--", "-V", "-VV", "--version", "-h", "--help", "-cprint(1)", "-mthis"],
+)
 def test_python_terminator_prevents_managed_pytest_classification(terminator) -> None:
     assert not deliberate_break._uses_pytest_runtime((sys.executable, terminator, "-m", "pytest"))
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -929,6 +929,19 @@ def test_uv_nested_python_module_probe_preserves_uv_and_python_options(tmp_path)
 
 
 @pytest.mark.parametrize(
+    ("compact_option", "preserved"),
+    [("-mpytest", ()), ("-Impytest", ("-I",))],
+)
+def test_minimal_uv_nested_attached_pytest_module_probe(
+    tmp_path, compact_option, preserved
+) -> None:
+    assert deliberate_break._pyyaml_probe_command(
+        ("uv", "run", "python", compact_option),
+        tmp_path,
+    ) == ("uv", "run", "python", *preserved, "-c", "import yaml")
+
+
+@pytest.mark.parametrize(
     "command",
     [
         ("uv", "run", "python", "scripts/run_tests.py", "-m", "pytest"),

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -811,13 +811,14 @@ def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 
 
-def test_active_python_with_compact_flags_is_managed_pytest_runtime() -> None:
-    command = (sys.executable, "-Im", "pytest", "-q")
+@pytest.mark.parametrize("compact_option", ["-Im", "-im", "-OOm"])
+def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_option) -> None:
+    command = (sys.executable, compact_option, "pytest", "-q")
 
     assert deliberate_break._uses_pytest_runtime(command)
     assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
         sys.executable,
-        "-I",
+        compact_option[:-1],
         "-c",
         "import yaml",
     )
@@ -825,7 +826,18 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime() -> None:
 
 @pytest.mark.parametrize(
     "terminator",
-    ["--", "-V", "-VV", "--version", "-h", "--help", "-cprint(1)", "-mthis"],
+    [
+        "--",
+        "-V",
+        "-VV",
+        "--version",
+        "-h",
+        "--help",
+        "-cprint(1)",
+        "-mthis",
+        "-Icprint(1)",
+        "-Imthis",
+    ],
 )
 def test_python_terminator_prevents_managed_pytest_classification(terminator) -> None:
     assert not deliberate_break._uses_pytest_runtime((sys.executable, terminator, "-m", "pytest"))

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -807,6 +807,23 @@ def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
     )
 
 
+def test_active_python_with_compact_flags_is_managed_pytest_runtime() -> None:
+    command = (sys.executable, "-Im", "pytest", "-q")
+
+    assert deliberate_break._uses_pytest_runtime(command)
+    assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
+        sys.executable,
+        "-I",
+        "-c",
+        "import yaml",
+    )
+
+
+@pytest.mark.parametrize("terminator", ["--", "-V", "-VV", "--version", "-h", "--help"])
+def test_python_terminator_prevents_managed_pytest_classification(terminator) -> None:
+    assert not deliberate_break._uses_pytest_runtime((sys.executable, terminator, "-m", "pytest"))
+
+
 def test_active_python_script_with_pytest_arguments_is_not_managed_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(
         (sys.executable, "scripts/run_tests.py", "-m", "pytest")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -942,6 +942,14 @@ def test_import_context_changed_python_is_not_managed_pytest_runtime(context_fla
     assert not deliberate_break._uses_pytest_runtime((sys.executable, context_flag, "-m", "pytest"))
 
 
+@pytest.mark.parametrize(
+    "compact_option",
+    ["-Empytest", "-Impytest", "-Pmpytest", "-smpytest"],
+)
+def test_compact_import_context_changed_python_is_not_managed(compact_option) -> None:
+    assert not deliberate_break._uses_pytest_runtime((sys.executable, compact_option))
+
+
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -640,6 +640,37 @@ def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
     assert attempts == []
 
 
+def test_interactive_probe_traceback_is_dependency_failure_despite_zero_exit(
+    tmp_path, monkeypatch
+) -> None:
+    command = ("uv", "run", "python", "-im", "pytest")
+    attempts = [
+        subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            'File "/venv/lib/site-packages/yaml/__init__.py", line 1\n' "SyntaxError: broken wheel",
+        ),
+        subprocess.CompletedProcess(
+            ["probe"],
+            0,
+            "",
+            "Traceback (most recent call last):\nSyntaxError: broken wheel\n>>> ",
+        ),
+    ]
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_pyyaml_probe_command",
+        lambda _command, _cwd: ("probe",),
+    )
+
+    with pytest.raises(deliberate_break.RuntimeDependencyError):
+        deliberate_break._run_with_runtime_deps(command, tmp_path)
+
+    assert attempts == []
+
+
 def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "global" / "bin" / "pytest"
     pytest_launcher.parent.mkdir(parents=True)

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -801,6 +801,18 @@ def test_python_module_probe_preserves_interpreter_flags(tmp_path) -> None:
     ) == ("/venv/bin/python", "-I", "-c", "import yaml")
 
 
+def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
+    assert deliberate_break._uses_pytest_runtime(
+        (sys.executable, "-X", "dev", "-I", "-m", "pytest", "-q")
+    )
+
+
+def test_active_python_script_with_pytest_arguments_is_not_managed_runtime() -> None:
+    assert not deliberate_break._uses_pytest_runtime(
+        (sys.executable, "scripts/run_tests.py", "-m", "pytest")
+    )
+
+
 @pytest.mark.parametrize("module_option", ["-m", "--module"])
 def test_uv_module_pytest_probe_uses_uv_selected_python(tmp_path, module_option) -> None:
     assert deliberate_break._pyyaml_probe_command(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -819,6 +819,22 @@ def test_active_python_with_hash_policy_is_managed_pytest_runtime() -> None:
     )
 
 
+def test_invalid_hash_policy_is_not_managed_pytest_runtime() -> None:
+    assert not deliberate_break._uses_pytest_runtime(
+        (
+            sys.executable,
+            "--check-hash-based-pycs",
+            "bogus",
+            "-m",
+            "pytest",
+        )
+    )
+
+
+def test_unsupported_lowercase_r_is_not_managed_pytest_runtime() -> None:
+    assert not deliberate_break._uses_pytest_runtime((sys.executable, "-r", "-m", "pytest"))
+
+
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -903,6 +903,18 @@ def test_unsupported_lowercase_r_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime((sys.executable, "-r", "-m", "pytest"))
 
 
+@pytest.mark.parametrize(
+    "options",
+    [
+        ("-S", "-m", "pytest"),
+        ("-OSm", "pytest"),
+        ("-OSmpytest",),
+    ],
+)
+def test_site_disabled_python_is_not_managed_pytest_runtime(options) -> None:
+    assert not deliberate_break._uses_pytest_runtime((sys.executable, *options))
+
+
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -870,14 +870,36 @@ def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 
 
-@pytest.mark.parametrize("compact_option", ["-Im", "-im", "-OOm", "-tm"])
-def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_option) -> None:
+@pytest.mark.parametrize(
+    ("compact_option", "preserved"),
+    [
+        ("-Im", ("-I",)),
+        ("-im", ()),  # lowercase -i must not reach the import probe
+        ("-OOm", ("-OO",)),
+        ("-tm", ("-t",)),
+        ("-Oim", ("-O",)),
+    ],
+)
+def test_active_python_with_compact_flags_is_managed_pytest_runtime(
+    compact_option, preserved
+) -> None:
     command = (sys.executable, compact_option, "pytest", "-q")
 
     assert deliberate_break._uses_pytest_runtime(command)
     assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
         sys.executable,
-        compact_option[:-1],
+        *preserved,
+        "-c",
+        "import yaml",
+    )
+
+
+def test_active_python_separate_interactive_flag_omitted_from_probe() -> None:
+    command = (sys.executable, "-i", "-m", "pytest", "-q")
+
+    assert deliberate_break._uses_pytest_runtime(command)
+    assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
+        sys.executable,
         "-c",
         "import yaml",
     )
@@ -885,7 +907,7 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_opti
 
 @pytest.mark.parametrize(
     ("compact_option", "preserved"),
-    [("-mpytest", ()), ("-Impytest", ("-I",))],
+    [("-mpytest", ()), ("-Impytest", ("-I",)), ("-impytest", ())],
 )
 def test_active_python_with_attached_pytest_module_is_managed_runtime(
     compact_option, preserved

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -825,6 +825,24 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_opti
 
 
 @pytest.mark.parametrize(
+    ("compact_option", "preserved"),
+    [("-mpytest", ()), ("-Impytest", ("-I",))],
+)
+def test_active_python_with_attached_pytest_module_is_managed_runtime(
+    compact_option, preserved
+) -> None:
+    command = (sys.executable, compact_option, "-q")
+
+    assert deliberate_break._uses_pytest_runtime(command)
+    assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
+        sys.executable,
+        *preserved,
+        "-c",
+        "import yaml",
+    )
+
+
+@pytest.mark.parametrize(
     "options",
     [
         ("-IW", "ignore"),

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -537,6 +537,28 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
     assert events == ["repair", "run"]
 
 
+def test_import_context_changed_active_python_is_not_repaired(tmp_path, monkeypatch) -> None:
+    command = (sys.executable, "-s", "-m", "pytest")
+    completed = subprocess.CompletedProcess(
+        command,
+        1,
+        "",
+        "ModuleNotFoundError: No module named 'yaml'",
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_ensure_pytest_runtime_deps",
+        lambda: pytest.fail("flagged import context must not mutate the active environment"),
+    )
+
+    with pytest.raises(deliberate_break.RuntimeDependencyError) as caught:
+        deliberate_break._run_with_runtime_deps(command, tmp_path)
+
+    assert isinstance(caught.value.error, ImportError)
+    assert "wrapped or custom" in str(caught.value.error)
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -871,7 +893,7 @@ def test_python_module_probe_preserves_interpreter_flags(tmp_path) -> None:
 
 def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
     assert deliberate_break._uses_pytest_runtime(
-        (sys.executable, "-X", "dev", "-I", "-m", "pytest", "-q")
+        (sys.executable, "-X", "dev", "-O", "-m", "pytest", "-q")
     )
 
 
@@ -915,8 +937,9 @@ def test_site_disabled_python_is_not_managed_pytest_runtime(options) -> None:
     assert not deliberate_break._uses_pytest_runtime((sys.executable, *options))
 
 
-def test_user_site_disabled_python_is_managed_pytest_runtime() -> None:
-    assert deliberate_break._uses_pytest_runtime((sys.executable, "-s", "-m", "pytest"))
+@pytest.mark.parametrize("context_flag", ["-E", "-I", "-P", "-s"])
+def test_import_context_changed_python_is_not_managed_pytest_runtime(context_flag) -> None:
+    assert not deliberate_break._uses_pytest_runtime((sys.executable, context_flag, "-m", "pytest"))
 
 
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
@@ -926,7 +949,6 @@ def test_empty_command_is_not_managed_pytest_runtime() -> None:
 @pytest.mark.parametrize(
     ("compact_option", "preserved"),
     [
-        ("-Im", ("-I",)),
         ("-im", ()),  # lowercase -i must not reach the import probe
         ("-OOm", ("-OO",)),
         ("-tm", ("-t",)),
@@ -960,7 +982,7 @@ def test_active_python_separate_interactive_flag_omitted_from_probe() -> None:
 
 @pytest.mark.parametrize(
     ("compact_option", "preserved"),
-    [("-mpytest", ()), ("-Impytest", ("-I",)), ("-impytest", ())],
+    [("-mpytest", ()), ("-Ompytest", ("-O",)), ("-impytest", ())],
 )
 def test_active_python_with_attached_pytest_module_is_managed_runtime(
     compact_option, preserved
@@ -979,10 +1001,10 @@ def test_active_python_with_attached_pytest_module_is_managed_runtime(
 @pytest.mark.parametrize(
     "options",
     [
-        ("-IW", "ignore"),
-        ("-IX", "dev"),
-        ("-IWignore",),
-        ("-IXdev",),
+        ("-OW", "ignore"),
+        ("-OX", "dev"),
+        ("-OWignore",),
+        ("-OXdev",),
     ],
 )
 def test_active_python_with_compact_value_option_is_managed_runtime(options) -> None:
@@ -992,6 +1014,29 @@ def test_active_python_with_compact_value_option_is_managed_runtime(options) -> 
     assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
         sys.executable,
         *options,
+        "-c",
+        deliberate_break.PYYAML_PROBE_CODE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("interactive_option", "preserved"),
+    [
+        ("-iWerror", "-Werror"),
+        ("-iXdev", "-Xdev"),
+        ("-OiWerror", "-OWerror"),
+        ("-OiXdev", "-OXdev"),
+    ],
+)
+def test_compact_interactive_value_option_is_removed_from_probe(
+    interactive_option, preserved
+) -> None:
+    command = (sys.executable, interactive_option, "-m", "pytest")
+
+    assert deliberate_break._uses_pytest_runtime(command)
+    assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
+        sys.executable,
+        preserved,
         "-c",
         deliberate_break.PYYAML_PROBE_CODE,
     )

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -602,7 +602,10 @@ def test_unmanaged_yaml_test_failure_is_not_misclassified_as_dependency_error(
         'File "/other/venv/lib/site-packages/yaml/parser.py", line 98\n'
         "yaml.parser.ParserError: malformed fixture",
     )
-    attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
+    attempts = [
+        completed,
+        subprocess.CompletedProcess(["probe"], 0, deliberate_break.PYYAML_PROBE_SENTINEL, ""),
+    ]
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
     monkeypatch.setattr(
         deliberate_break,
@@ -626,7 +629,10 @@ def test_unmanaged_yaml_attribute_error_is_not_misclassified_as_import_failure(
         'File "/other/venv/lib/site-packages/yaml/__init__.py", line 125, in safe_load\n'
         "E   AttributeError: 'NoneType' object has no attribute 'read'",
     )
-    attempts = [completed, subprocess.CompletedProcess(["probe"], 0, "", "")]
+    attempts = [
+        completed,
+        subprocess.CompletedProcess(["probe"], 0, deliberate_break.PYYAML_PROBE_SENTINEL, ""),
+    ]
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
     monkeypatch.setattr(
         deliberate_break,
@@ -671,6 +677,37 @@ def test_interactive_probe_traceback_is_dependency_failure_despite_zero_exit(
     assert attempts == []
 
 
+def test_probe_sentinel_ignores_unrelated_startup_traceback(tmp_path, monkeypatch) -> None:
+    command = ("uv", "run", "python", "-im", "pytest")
+    completed = subprocess.CompletedProcess(
+        command,
+        1,
+        "",
+        'File "/venv/lib/site-packages/yaml/parser.py", line 98\n'
+        "yaml.parser.ParserError: malformed fixture",
+    )
+    attempts = [
+        completed,
+        subprocess.CompletedProcess(
+            ["probe"],
+            0,
+            deliberate_break.PYYAML_PROBE_SENTINEL,
+            "Traceback from unrelated .pth startup error",
+        ),
+    ]
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
+    monkeypatch.setattr(
+        deliberate_break,
+        "_pyyaml_probe_command",
+        lambda _command, _cwd: ("probe",),
+    )
+
+    result = deliberate_break._run_with_runtime_deps(command, tmp_path)
+
+    assert result is completed
+    assert attempts == []
+
+
 def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "global" / "bin" / "pytest"
     pytest_launcher.parent.mkdir(parents=True)
@@ -689,7 +726,7 @@ def test_uv_pyyaml_probe_uses_resolved_pytest_shebang_interpreter(tmp_path, monk
     assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
         "/global/python",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -724,7 +761,7 @@ def test_uv_pyyaml_probe_preserves_uv_run_options(tmp_path, monkeypatch) -> None
     assert deliberate_break._pyyaml_probe_command(command, tmp_path) == (
         "/project/.venv/bin/python",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
     assert calls == [
         (
@@ -765,7 +802,7 @@ def test_uv_pyyaml_probe_preserves_python_shebang_flags(tmp_path, monkeypatch) -
         "/usr/bin/python3",
         "-I",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -787,7 +824,7 @@ def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypat
         "/project/.venv/bin/python3",
         "-I",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -821,7 +858,7 @@ def test_bare_pytest_probe_uses_launcher_shebang(tmp_path, monkeypatch) -> None:
         "/venv/bin/python3",
         "-I",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -829,7 +866,7 @@ def test_python_module_probe_preserves_interpreter_flags(tmp_path) -> None:
     assert deliberate_break._pyyaml_probe_command(
         ("/venv/bin/python", "-I", "-m", "pytest", "-q"),
         tmp_path,
-    ) == ("/venv/bin/python", "-I", "-c", "import yaml")
+    ) == ("/venv/bin/python", "-I", "-c", deliberate_break.PYYAML_PROBE_CODE)
 
 
 def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
@@ -890,7 +927,7 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime(
         sys.executable,
         *preserved,
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -901,7 +938,7 @@ def test_active_python_separate_interactive_flag_omitted_from_probe() -> None:
     assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
         sys.executable,
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -919,7 +956,7 @@ def test_active_python_with_attached_pytest_module_is_managed_runtime(
         sys.executable,
         *preserved,
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -940,7 +977,7 @@ def test_active_python_with_compact_value_option_is_managed_runtime(options) -> 
         sys.executable,
         *options,
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -979,7 +1016,14 @@ def test_uv_module_pytest_probe_uses_uv_selected_python(tmp_path, module_option)
     assert deliberate_break._pyyaml_probe_command(
         ("uv", "run", "--frozen", module_option, "pytest", "-q"),
         tmp_path,
-    ) == ("uv", "run", "--frozen", "python", "-c", "import yaml")
+    ) == (
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "-c",
+        deliberate_break.PYYAML_PROBE_CODE,
+    )
 
 
 def test_uv_nested_python_module_probe_preserves_uv_and_python_options(tmp_path) -> None:
@@ -1006,7 +1050,7 @@ def test_uv_nested_python_module_probe_preserves_uv_and_python_options(tmp_path)
         "python",
         "-I",
         "-c",
-        "import yaml",
+        deliberate_break.PYYAML_PROBE_CODE,
     )
 
 
@@ -1020,7 +1064,14 @@ def test_minimal_uv_nested_attached_pytest_module_probe(
     assert deliberate_break._pyyaml_probe_command(
         ("uv", "run", "python", compact_option),
         tmp_path,
-    ) == ("uv", "run", "python", *preserved, "-c", "import yaml")
+    ) == (
+        "uv",
+        "run",
+        "python",
+        *preserved,
+        "-c",
+        deliberate_break.PYYAML_PROBE_CODE,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -825,6 +825,27 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_opti
 
 
 @pytest.mark.parametrize(
+    "options",
+    [
+        ("-IW", "ignore"),
+        ("-IX", "dev"),
+        ("-IWignore",),
+        ("-IXdev",),
+    ],
+)
+def test_active_python_with_compact_value_option_is_managed_runtime(options) -> None:
+    command = (sys.executable, *options, "-m", "pytest", "-q")
+
+    assert deliberate_break._uses_pytest_runtime(command)
+    assert deliberate_break._pyyaml_probe_command(command, Path.cwd()) == (
+        sys.executable,
+        *options,
+        "-c",
+        "import yaml",
+    )
+
+
+@pytest.mark.parametrize(
     "terminator",
     [
         "--",
@@ -837,6 +858,9 @@ def test_active_python_with_compact_flags_is_managed_pytest_runtime(compact_opti
         "-mthis",
         "-Icprint(1)",
         "-Imthis",
+        "-IV",
+        "-Ih",
+        "-I?",
     ],
 )
 def test_python_terminator_prevents_managed_pytest_classification(terminator) -> None:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -915,6 +915,10 @@ def test_site_disabled_python_is_not_managed_pytest_runtime(options) -> None:
     assert not deliberate_break._uses_pytest_runtime((sys.executable, *options))
 
 
+def test_user_site_disabled_python_is_managed_pytest_runtime() -> None:
+    assert deliberate_break._uses_pytest_runtime((sys.executable, "-s", "-m", "pytest"))
+
+
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -807,6 +807,18 @@ def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
     )
 
 
+def test_active_python_with_hash_policy_is_managed_pytest_runtime() -> None:
+    assert deliberate_break._uses_pytest_runtime(
+        (
+            sys.executable,
+            "--check-hash-based-pycs",
+            "default",
+            "-m",
+            "pytest",
+        )
+    )
+
+
 def test_empty_command_is_not_managed_pytest_runtime() -> None:
     assert not deliberate_break._uses_pytest_runtime(())
 
@@ -880,6 +892,7 @@ def test_active_python_with_compact_value_option_is_managed_runtime(options) -> 
         "-IV",
         "-Ih",
         "-I?",
+        "--bogus",
     ],
 )
 def test_python_terminator_prevents_managed_pytest_classification(terminator) -> None:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -849,6 +849,7 @@ def test_active_python_with_compact_value_option_is_managed_runtime(options) -> 
     "terminator",
     [
         "--",
+        "-",
         "-V",
         "-VV",
         "--version",


### PR DESCRIPTION
## Summary
- classify active-interpreter pytest commands with Python flags as managed runtime
- reuse program-selector parsing so script arguments are not misclassified
- keep source and consumer template identical

## Evidence
- focused suite: 54 passed
- Black, Ruff, mypy, template parity, and diff-check pass

## Lineage
Exact-head consumer review on Travel-Plan-Permission#1380. All generated consumers remain held pending corrected-source propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of pytest commands launched through the active Python interpreter.
  * Supports additional interpreter options, compact flags, and inline or separate pytest module forms.
  * Verifies PyYAML availability more reliably before recognizing a pytest runtime.
  * Prevents scripts, malformed commands, and unsupported execution modes from being misidentified.
  * Improved handling of nested `uv run` Python commands.

* **Tests**
  * Added coverage for interpreter options, command formats, probe failures, and nested invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->