### PR TITLE
fix(verifier): narrow response coercion errors

### DIFF
--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -705,10 +705,14 @@ def _coerce_response_content(content: object) -> str:
         return text
     try:
         return json.dumps(content, default=str)
-    except (TypeError, ValueError, OverflowError, RecursionError, RuntimeError):
+    except MemoryError:
+        raise
+    except Exception:
         try:
             return str(content)
-        except (TypeError, ValueError, OverflowError, RecursionError, RuntimeError):
+        except MemoryError:
+            raise
+        except Exception:
             return f"<unserializable {type(content).__name__}>"
 
 

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -705,10 +705,10 @@ def _coerce_response_content(content: object) -> str:
         return text
     try:
         return json.dumps(content, default=str)
-    except Exception:
+    except (TypeError, ValueError, OverflowError, RecursionError, RuntimeError):
         try:
             return str(content)
-        except Exception:
+        except (TypeError, ValueError, OverflowError, RecursionError, RuntimeError):
             return f"<unserializable {type(content).__name__}>"
 
 

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -230,6 +230,15 @@ def test_coerce_response_content_survives_failing_string_conversion() -> None:
     )
 
 
+def test_coerce_response_content_does_not_swallow_memory_exhaustion() -> None:
+    class Exhausted:
+        def __str__(self) -> str:
+            raise MemoryError("out of memory")
+
+    with pytest.raises(MemoryError, match="out of memory"):
+        pr_verifier._coerce_response_content(Exhausted())
+
+
 def test_text_from_response_content_concatenates_split_text_blocks_without_separator() -> None:
     payload = _valid_payload()
     encoded = json.dumps(payload)

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -230,6 +230,16 @@ def test_coerce_response_content_survives_failing_string_conversion() -> None:
     )
 
 
+def test_coerce_response_content_survives_arbitrary_string_conversion_failure() -> None:
+    class Unserializable:
+        def __str__(self) -> str:
+            raise AttributeError("broken provider object")
+
+    assert (
+        pr_verifier._coerce_response_content(Unserializable()) == "<unserializable Unserializable>"
+    )
+
+
 def test_coerce_response_content_does_not_swallow_memory_exhaustion() -> None:
     class Exhausted:
         def __str__(self) -> str:


### PR DESCRIPTION
## Summary
- narrow response JSON and string fallback handlers to expected coercion failures
- allow process-level failures such as MemoryError to propagate
- add regression coverage for memory exhaustion

## Validation
- 32 focused structured-output tests pass under Python 3.12
- Black, Ruff, mypy, diff check

Source follow-up from review on trip-planner #1630.