### PR TITLE
fix: defer PyYAML repair until needed

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -199,7 +199,7 @@ def _ensure_pytest_runtime_deps() -> None:
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML >= {PYYAML_VERSION} is required; install "
-                f"{PYTEST_RUNTIME_DEPENDENCIES[0]} in the active environment"
+                f"'PyYAML>={PYYAML_VERSION}' in the active environment"
             )
             raise error from import_error
         command = [
@@ -584,33 +584,8 @@ def _run_with_runtime_deps(
     command: tuple[str, ...],
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
-    """Preflight PyYAML in managed pytest runtimes and repair YAML-triggered failures."""
+    """Run the check, repairing PyYAML only after a YAML-triggered failure."""
     managed_runtime = _uses_pytest_runtime(command)
-    managed_runtime_needs_repair = False
-    if managed_runtime:
-        try:
-            managed_runtime_needs_repair = (
-                _pyyaml_runtime_needs_repair() or not _pyyaml_probe_succeeds(command, cwd)
-            )
-        except OSError as exc:
-            raise CommandUnavailableError(exc) from exc
-    if managed_runtime_needs_repair:
-        try:
-            _ensure_pytest_runtime_deps()
-        except (
-            subprocess.TimeoutExpired,
-            subprocess.CalledProcessError,
-            ImportError,
-            OSError,
-        ) as exc:
-            raise RuntimeDependencyError(exc) from exc
-        try:
-            probe_succeeded = _pyyaml_probe_succeeds(command, cwd)
-        except OSError as exc:
-            raise CommandUnavailableError(exc) from exc
-        if not probe_succeeded:
-            error = ImportError("PyYAML is unavailable in the managed pytest command environment")
-            raise RuntimeDependencyError(error) from error
     try:
         completed = _run(command, cwd)
     except OSError as exc:
@@ -676,7 +651,7 @@ def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
     if isinstance(error, subprocess.TimeoutExpired):
         return _json_result(
             VERDICT_BROKEN,
-            reason="command-timeout",
+            reason="dependency-install-timeout",
             command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
             timeout=error.timeout,
         )

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -199,7 +199,7 @@ def _ensure_pytest_runtime_deps() -> None:
         if os.environ.get("GITHUB_ACTIONS") != "true":
             error = ImportError(
                 f"PyYAML >= {PYYAML_VERSION} is required; install "
-                f"{PYTEST_RUNTIME_DEPENDENCIES[0]} in the active environment"
+                f"'PyYAML>={PYYAML_VERSION}' in the active environment"
             )
             raise error from import_error
         command = [
@@ -584,33 +584,8 @@ def _run_with_runtime_deps(
     command: tuple[str, ...],
     cwd: Path,
 ) -> subprocess.CompletedProcess[str]:
-    """Preflight PyYAML in managed pytest runtimes and repair YAML-triggered failures."""
+    """Run the check, repairing PyYAML only after a YAML-triggered failure."""
     managed_runtime = _uses_pytest_runtime(command)
-    managed_runtime_needs_repair = False
-    if managed_runtime:
-        try:
-            managed_runtime_needs_repair = (
-                _pyyaml_runtime_needs_repair() or not _pyyaml_probe_succeeds(command, cwd)
-            )
-        except OSError as exc:
-            raise CommandUnavailableError(exc) from exc
-    if managed_runtime_needs_repair:
-        try:
-            _ensure_pytest_runtime_deps()
-        except (
-            subprocess.TimeoutExpired,
-            subprocess.CalledProcessError,
-            ImportError,
-            OSError,
-        ) as exc:
-            raise RuntimeDependencyError(exc) from exc
-        try:
-            probe_succeeded = _pyyaml_probe_succeeds(command, cwd)
-        except OSError as exc:
-            raise CommandUnavailableError(exc) from exc
-        if not probe_succeeded:
-            error = ImportError("PyYAML is unavailable in the managed pytest command environment")
-            raise RuntimeDependencyError(error) from error
     try:
         completed = _run(command, cwd)
     except OSError as exc:
@@ -676,7 +651,7 @@ def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
     if isinstance(error, subprocess.TimeoutExpired):
         return _json_result(
             VERDICT_BROKEN,
-            reason="command-timeout",
+            reason="dependency-install-timeout",
             command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
             timeout=error.timeout,
         )

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -419,7 +419,7 @@ def test_runtime_dependency_installer_does_not_modify_local_environment(monkeypa
         lambda *_args, **_kwargs: pytest.fail("local dependency install should not run"),
     )
 
-    with pytest.raises(ImportError, match="install pyyaml=="):
+    with pytest.raises(ImportError, match=r"install 'PyYAML>=6\.0\.3'"):
         deliberate_break._ensure_pytest_runtime_deps()
 
 
@@ -509,12 +509,11 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
         subprocess.CompletedProcess(["pytest"], 0, "passed", ""),
     ]
     repairs: list[bool] = []
-    repair_checks = iter((False, True))
     monkeypatch.setattr(deliberate_break, "_run", lambda *_args: attempts.pop(0))
     monkeypatch.setattr(
         deliberate_break,
         "_pyyaml_runtime_needs_repair",
-        lambda: next(repair_checks),
+        lambda: True,
     )
     monkeypatch.setattr(deliberate_break, "_pyyaml_probe_succeeds", lambda *_args: True)
     monkeypatch.setattr(
@@ -535,7 +534,9 @@ def test_runtime_dependencies_retry_broken_pyyaml_traceback(tmp_path, monkeypatc
     assert attempts == []
 
 
-def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, monkeypatch) -> None:
+def test_runtime_dependencies_do_not_preflight_pyyaml_for_successful_pytest(
+    tmp_path, monkeypatch
+) -> None:
     events: list[str] = []
     completed = subprocess.CompletedProcess(["pytest"], 0, "passed", "")
     monkeypatch.setattr(
@@ -554,11 +555,18 @@ def test_runtime_dependencies_normalize_stale_pyyaml_before_pytest(tmp_path, mon
     result = deliberate_break._run_with_runtime_deps((sys.executable, "-m", "pytest"), tmp_path)
 
     assert result is completed
-    assert events == ["repair", "run"]
+    assert events == ["run"]
 
 
 def test_managed_runtime_rejects_unrepairable_command_import_context(tmp_path, monkeypatch) -> None:
     repairs: list[bool] = []
+    completed = subprocess.CompletedProcess(
+        ["pytest"],
+        1,
+        "",
+        "ModuleNotFoundError: No module named 'yaml'",
+    )
+    monkeypatch.setattr(deliberate_break, "_run", lambda *_args: completed)
     monkeypatch.setattr(deliberate_break, "_pyyaml_runtime_needs_repair", lambda: False)
     monkeypatch.setattr(deliberate_break, "_pyyaml_probe_succeeds", lambda *_args: False)
     monkeypatch.setattr(
@@ -1230,7 +1238,7 @@ def test_dependency_install_timeout_is_broken(tmp_path, monkeypatch) -> None:
 
     assert result == {
         "verdict": VERDICT_BROKEN,
-        "reason": "command-timeout",
+        "reason": "dependency-install-timeout",
         "command": command,
         "timeout": 17,
     }


### PR DESCRIPTION
## Summary
- run deliberate-break commands before considering PyYAML repair
- repair only after output shows a missing or unusable YAML runtime
- distinguish dependency-install timeouts from deliberate-break command timeouts
- align local install guidance with the accepted compatible-version floor

## Validation
- `107 passed` in `tests/scripts/test_check_deliberate_break.py`
- `65 passed, 3 skipped` in sync dependency and template-drift tests
- Black, Ruff, mypy, and `git diff --check` pass

## Review lineage
Addresses exact-head review findings propagated to Counter_Risk #921, Inv-Man-Intake #890, and Trend_Model_Project #5783. Consumer PRs remain held pending corrected propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Managed test runs now start without unnecessary dependency checks.
  * PyYAML repair is attempted only when a YAML-related failure is detected.
  * Improved error messages identify the required PyYAML version.
  * Dependency-installation timeouts now receive a more accurate classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->