### PR TITLE
fix: remove checker packaging dependency

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -19,8 +19,6 @@ from importlib import import_module, metadata
 from io import BytesIO
 from pathlib import Path
 
-from packaging.version import InvalidVersion, Version
-
 VERDICT_PASS = "PASS"
 VERDICT_HOLLOW = "FAIL_HOLLOW"
 VERDICT_BROKEN = "FAIL_BROKEN"
@@ -165,10 +163,16 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     """Return whether an installed PyYAML version satisfies the bootstrap floor."""
     if installed_version is None:
         return False
-    try:
-        return Version(installed_version) >= Version(PYYAML_VERSION)
-    except InvalidVersion:
+    installed_match = re.fullmatch(r"(\d+(?:\.\d+)*)(?:\+[\w.-]+)?", installed_version)
+    floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
+    if installed_match is None or floor_match is None:
         return False
+    installed_release = tuple(int(part) for part in installed_match.group(1).split("."))
+    floor_release = tuple(int(part) for part in floor_match.group(1).split("."))
+    width = max(len(installed_release), len(floor_release))
+    return installed_release + (0,) * (width - len(installed_release)) >= floor_release + (0,) * (
+        width - len(floor_release)
+    )
 
 
 def _ensure_pytest_runtime_deps() -> None:

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -163,7 +163,9 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     """Return whether an installed PyYAML version satisfies the bootstrap floor."""
     if installed_version is None:
         return False
-    installed_match = re.fullmatch(r"(\d+(?:\.\d+)*)(?:\+[\w.-]+)?", installed_version)
+    installed_match = re.fullmatch(
+        r"(\d+(?:\.\d+)*)(?:\.post\d+)?(?:\+[\w.-]+)?", installed_version
+    )
     floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
     if installed_match is None or floor_match is None:
         return False

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -19,8 +19,6 @@ from importlib import import_module, metadata
 from io import BytesIO
 from pathlib import Path
 
-from packaging.version import InvalidVersion, Version
-
 VERDICT_PASS = "PASS"
 VERDICT_HOLLOW = "FAIL_HOLLOW"
 VERDICT_BROKEN = "FAIL_BROKEN"
@@ -165,10 +163,16 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     """Return whether an installed PyYAML version satisfies the bootstrap floor."""
     if installed_version is None:
         return False
-    try:
-        return Version(installed_version) >= Version(PYYAML_VERSION)
-    except InvalidVersion:
+    installed_match = re.fullmatch(r"(\d+(?:\.\d+)*)(?:\+[\w.-]+)?", installed_version)
+    floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
+    if installed_match is None or floor_match is None:
         return False
+    installed_release = tuple(int(part) for part in installed_match.group(1).split("."))
+    floor_release = tuple(int(part) for part in floor_match.group(1).split("."))
+    width = max(len(installed_release), len(floor_release))
+    return installed_release + (0,) * (width - len(installed_release)) >= floor_release + (0,) * (
+        width - len(floor_release)
+    )
 
 
 def _ensure_pytest_runtime_deps() -> None:

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -163,7 +163,9 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     """Return whether an installed PyYAML version satisfies the bootstrap floor."""
     if installed_version is None:
         return False
-    installed_match = re.fullmatch(r"(\d+(?:\.\d+)*)(?:\+[\w.-]+)?", installed_version)
+    installed_match = re.fullmatch(
+        r"(\d+(?:\.\d+)*)(?:\.post\d+)?(?:\+[\w.-]+)?", installed_version
+    )
     floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
     if installed_match is None or floor_match is None:
         return False

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import subprocess
@@ -340,6 +341,18 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
 )
 def test_supported_pyyaml_version_uses_stdlib_only(installed_version, supported) -> None:
     assert deliberate_break._supported_pyyaml_version(installed_version) is supported
+
+
+def test_pyyaml_version_check_does_not_import_packaging() -> None:
+    module = ast.parse(Path(deliberate_break.__file__).read_text(encoding="utf-8"))
+    imported_modules: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module.split(".", 1)[0])
+
+    assert "packaging" not in imported_modules
 
 
 def test_runtime_dependency_installer_accepts_newer_compatible_pyyaml(monkeypatch) -> None:

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -329,6 +329,8 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
         ("6.0.2", False),
         ("6.0.3", True),
         ("6.0.3.0", True),
+        ("6.0.3.post1", True),
+        ("6.0.2.post1", False),
         ("6.0.3+local.1", True),
         ("6.0.4", True),
         ("99.0.0", True),

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -322,6 +322,24 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
     assert calls == []
 
 
+@pytest.mark.parametrize(
+    ("installed_version", "supported"),
+    [
+        (None, False),
+        ("6.0.2", False),
+        ("6.0.3", True),
+        ("6.0.3.0", True),
+        ("6.0.3+local.1", True),
+        ("6.0.4", True),
+        ("99.0.0", True),
+        ("6.0.3rc1", False),
+        ("not-a-version", False),
+    ],
+)
+def test_supported_pyyaml_version_uses_stdlib_only(installed_version, supported) -> None:
+    assert deliberate_break._supported_pyyaml_version(installed_version) is supported
+
+
 def test_runtime_dependency_installer_accepts_newer_compatible_pyyaml(monkeypatch) -> None:
     calls: list[object] = []
     monkeypatch.setattr(deliberate_break.metadata, "version", lambda _name: "99.0.0")


### PR DESCRIPTION
## Summary
- remove the module-level `packaging` dependency from the consumer checker
- compare stable numeric PyYAML release versions using the standard library
- mirror the checker into the consumer template and add floor/local/invalid-version regression cases

## Validation
- `181 passed, 3 skipped` across checker, sync dependency, and template-drift coverage
- `116 passed` in the expanded checker suite
- Black, Ruff, mypy, template parity, and `git diff --check` pass

## Review lineage
Addresses the exact-head review finding on trip-planner #1633. The consumer fleet remains held pending corrected propagation.