### PR TITLE
fix(gate): handle tamper OS failures

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -787,6 +787,12 @@ def verify_spec(
             stdout=exc.stdout,
             stderr=exc.stderr,
         )
+    except OSError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="tamper-check-unavailable",
+            detail=str(exc),
+        )
 
     try:
         head_run = _run_with_runtime_deps(spec.command, repo)

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -787,6 +787,12 @@ def verify_spec(
             stdout=exc.stdout,
             stderr=exc.stderr,
         )
+    except OSError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="tamper-check-unavailable",
+            detail=str(exc),
+        )
 
     try:
         head_run = _run_with_runtime_deps(spec.command, repo)

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -181,6 +181,26 @@ def test_tamper_git_failure_is_broken(tmp_path, monkeypatch) -> None:
     }
 
 
+def test_tamper_os_error_is_broken(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    monkeypatch.setattr(
+        deliberate_break,
+        "_changed_assertions",
+        lambda *_args: (_ for _ in ()).throw(FileNotFoundError("git unavailable")),
+    )
+
+    result = verify_spec(spec, base=base, cwd=repo)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "tamper-check-unavailable",
+        "detail": "git unavailable",
+    }
+
+
 def test_new_assertion_in_existing_test_file_is_not_tamper(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- map OS failures from the git tamper check to a structured broken verdict
- mirror the checker change into the consumer template
- add exact regression coverage

## Validation
- `python -m pytest tests/scripts/test_check_deliberate_break.py -q` (108 passed)
- template checker parity and `git diff --check`

## Review lineage
Addresses the exact-head review finding on Trend_Model_Project#5784. Consumer sync PRs remain held pending a corrected source wave.

<!-- workflow-source:review_followup -->