### PR TITLE
fix: distinguish tamper timeouts and pytest launchers

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -251,6 +251,17 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
     if not command:
         return False
+    if Path(command[0]).name == "pytest":
+        pytest_path = shutil.which(command[0])
+        if not pytest_path:
+            return False
+        launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
+        if launcher is None:
+            return False
+        probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        return Path(launcher[0]).resolve() == Path(
+            sys.executable
+        ).resolve() and not _python_probe_changes_import_context(probe)
     executable = shutil.which(command[0]) or command[0]
     probe = _python_module_pytest_probe(command, 0)
     return (
@@ -780,7 +791,7 @@ def verify_spec(
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
-            reason="command-timeout",
+            reason="tamper-check-timeout",
             command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
             timeout=exc.timeout,
         )

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -251,6 +251,17 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
     """Return whether a command runs pytest in the active Python environment."""
     if not command:
         return False
+    if Path(command[0]).name == "pytest":
+        pytest_path = shutil.which(command[0])
+        if not pytest_path:
+            return False
+        launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
+        if launcher is None:
+            return False
+        probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        return Path(launcher[0]).resolve() == Path(
+            sys.executable
+        ).resolve() and not _python_probe_changes_import_context(probe)
     executable = shutil.which(command[0]) or command[0]
     probe = _python_module_pytest_probe(command, 0)
     return (
@@ -780,7 +791,7 @@ def verify_spec(
     except subprocess.TimeoutExpired as exc:
         return _json_result(
             VERDICT_BROKEN,
-            reason="command-timeout",
+            reason="tamper-check-timeout",
             command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
             timeout=exc.timeout,
         )

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -202,6 +202,28 @@ def test_tamper_os_error_is_broken(tmp_path, monkeypatch) -> None:
     }
 
 
+def test_tamper_timeout_has_distinct_reason(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    command = ["git", "diff", f"{base}...HEAD"]
+    monkeypatch.setattr(
+        deliberate_break,
+        "_changed_assertions",
+        lambda *_args: (_ for _ in ()).throw(subprocess.TimeoutExpired(command, 17)),
+    )
+
+    result = verify_spec(spec, base=base, cwd=repo)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "tamper-check-timeout",
+        "command": command,
+        "timeout": 17,
+    }
+
+
 def test_new_assertion_in_existing_test_file_is_not_tamper(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -996,6 +1018,30 @@ def test_active_python_with_flags_is_managed_pytest_runtime() -> None:
     assert deliberate_break._uses_pytest_runtime(
         (sys.executable, "-X", "dev", "-O", "-m", "pytest", "-q")
     )
+
+
+def test_plain_pytest_with_active_python_shebang_is_managed(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "pytest"
+    pytest_launcher.write_text(f"#!{sys.executable}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break.shutil,
+        "which",
+        lambda name: str(pytest_launcher) if name == "pytest" else None,
+    )
+
+    assert deliberate_break._uses_pytest_runtime(("pytest", "-q"))
+
+
+def test_plain_pytest_with_changed_import_context_is_not_managed(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "pytest"
+    pytest_launcher.write_text(f"#!{sys.executable} -I\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break.shutil,
+        "which",
+        lambda name: str(pytest_launcher) if name == "pytest" else None,
+    )
+
+    assert not deliberate_break._uses_pytest_runtime(("pytest", "-q"))
 
 
 def test_active_python_with_hash_policy_is_managed_pytest_runtime() -> None:


### PR DESCRIPTION
## Summary
- report git/tamper inspection timeouts as `tamper-check-timeout` instead of command execution timeouts
- treat a plain `pytest` launcher as safely managed only when its shebang resolves to the active interpreter without import-context flags
- mirror the checker into the consumer template and add exact regression coverage

## Validation
- `188 passed, 3 skipped` across checker, sync dependency, and template-drift coverage
- `123 passed` in the focused checker suite after formatting
- Black, Ruff, mypy, template parity, and `git diff --check` pass

## Review lineage
Addresses exact-head review findings on learning-management-system #513 and trip-planner #1635. Ready #503 was resolved with evidence because `EIPsS` already contains uppercase `P`. The consumer fleet remains held pending corrected propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of standalone pytest commands by verifying their launcher uses the active Python interpreter.
  - Rejects launchers that alter the import context.
  - Tamper-check timeouts now report the clearer `tamper-check-timeout` status.

- **Tests**
  - Added coverage for launcher-based pytest classification and distinct timeout reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->