### PR TITLE
fix: separate launcher probe typing

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -258,10 +258,10 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
         launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
         if launcher is None:
             return False
-        probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        launcher_probe = (*launcher, "-c", PYYAML_PROBE_CODE)
         return Path(launcher[0]).resolve() == Path(
             sys.executable
-        ).resolve() and not _python_probe_changes_import_context(probe)
+        ).resolve() and not _python_probe_changes_import_context(launcher_probe)
     executable = shutil.which(command[0]) or command[0]
     probe = _python_module_pytest_probe(command, 0)
     return (

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -258,10 +258,10 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
         launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
         if launcher is None:
             return False
-        probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        launcher_probe = (*launcher, "-c", PYYAML_PROBE_CODE)
         return Path(launcher[0]).resolve() == Path(
             sys.executable
-        ).resolve() and not _python_probe_changes_import_context(probe)
+        ).resolve() and not _python_probe_changes_import_context(launcher_probe)
     executable = shutil.which(command[0]) or command[0]
     probe = _python_module_pytest_probe(command, 0)
     return (


### PR DESCRIPTION
## Summary
- keep the plain-pytest launcher probe in its own variable
- avoid mypy 2.3 narrowing the later optional module probe to a non-optional tuple
- mirror the source and consumer template exactly

## Validation
- `123 passed` in the focused checker suite
- mypy 2.3.0 passes both canonical and template checker files
- Black, Ruff, template parity, and `git diff --check` pass

## Review lineage
Fixes the consumer-only Python CI failure on trip-planner #1636. The consumer fleet remains held pending corrected propagation.