### PR TITLE
docs: clarify PyYAML compatibility floor

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -33,7 +33,8 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
-# This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
+# Compatible installed versions may exceed this Workflows-owned bootstrap floor;
+# automatic repair remains reproducibly pinned by PYTEST_RUNTIME_DEPENDENCIES.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 PYYAML_PROBE_SENTINEL = "__gate_pyyaml_import_ok__"

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -33,7 +33,8 @@ ASSERTION_DIFF_RE = re.compile(
     r"\b(assert|expect\(|pytest\.raises\(|assert\.)\b",
 )
 DEFAULT_TIMEOUT_SECONDS = 120
-# This bootstrap pin is maintained in Workflows; consumers receive the resolved value.
+# Compatible installed versions may exceed this Workflows-owned bootstrap floor;
+# automatic repair remains reproducibly pinned by PYTEST_RUNTIME_DEPENDENCIES.
 PYYAML_VERSION = "6.0.3"
 PYTEST_RUNTIME_DEPENDENCIES = (f"pyyaml=={PYYAML_VERSION}",)
 PYYAML_PROBE_SENTINEL = "__gate_pyyaml_import_ok__"


### PR DESCRIPTION
## Summary
- clarify that `PYYAML_VERSION` is the minimum compatible installed version
- clarify that automatic repair remains exactly pinned via `PYTEST_RUNTIME_DEPENDENCIES`
- mirror the source and consumer template comments exactly

## Validation
- `123 passed` in the focused checker suite
- Black, Ruff, mypy 2.3.0, template parity, and `git diff --check` pass

## Review lineage
Addresses the exact-head maintainability finding on Manager-Database #1539. The consumer fleet remains held pending corrected propagation.