### PR TITLE
fix: harden probes and verifier content

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -259,7 +259,12 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
         launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
         if launcher is None:
             return False
-        launcher_probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        launcher_probe = (
+            launcher[0],
+            *_drop_interactive_python_flags(launcher[1:]),
+            "-c",
+            PYYAML_PROBE_CODE,
+        )
         return Path(launcher[0]).resolve() == Path(
             sys.executable
         ).resolve() and not _python_probe_changes_import_context(launcher_probe)
@@ -581,11 +586,21 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
-        return (*launcher, "-c", PYYAML_PROBE_CODE)
+        return (
+            launcher[0],
+            *_drop_interactive_python_flags(launcher[1:]),
+            "-c",
+            PYYAML_PROBE_CODE,
+        )
     if command and Path(command[0]).name == "pytest":
         pytest_path = shutil.which(command[0])
         if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
-            return (*launcher, "-c", PYYAML_PROBE_CODE)
+            return (
+                launcher[0],
+                *_drop_interactive_python_flags(launcher[1:]),
+                "-c",
+                PYYAML_PROBE_CODE,
+            )
     return None
 
 

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -679,6 +679,12 @@ def _text_from_response_content(content: object) -> str | None:
     """Return provider text, or None when the payload carries no text blocks."""
     if isinstance(content, str):
         return content
+    if isinstance(content, dict):
+        for key in ("text", "content"):
+            text = content.get(key)
+            if isinstance(text, str):
+                return text
+        return None
     if isinstance(content, list):
         text_blocks: list[str] = []
         for block in content:
@@ -686,8 +692,12 @@ def _text_from_response_content(content: object) -> str | None:
                 text = block
             elif isinstance(block, dict):
                 text = block.get("text")
+                if not isinstance(text, str):
+                    text = block.get("content")
             else:
                 text = getattr(block, "text", None)
+                if not isinstance(text, str):
+                    text = getattr(block, "content", None)
             if isinstance(text, str):
                 text_blocks.append(text)
         if any(block and not block.isspace() for block in text_blocks):

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -679,10 +679,16 @@ def _text_from_response_content(content: object) -> str | None:
     """Return provider text, or None when the payload carries no text blocks."""
     if isinstance(content, str):
         return content
-    if isinstance(content, dict):
+    if isinstance(content, Mapping):
         for key in ("text", "content"):
             text = content.get(key)
             if isinstance(text, str):
+                if key == "content" and content.get("type") not in (
+                    None,
+                    "text",
+                    "output_text",
+                ):
+                    continue
                 return text
         return None
     if isinstance(content, list):
@@ -690,14 +696,18 @@ def _text_from_response_content(content: object) -> str | None:
         for block in content:
             if isinstance(block, str):
                 text = block
-            elif isinstance(block, dict):
+            elif isinstance(block, Mapping):
                 text = block.get("text")
                 if not isinstance(text, str):
                     text = block.get("content")
+                    if block.get("type") not in (None, "text", "output_text"):
+                        text = None
             else:
                 text = getattr(block, "text", None)
                 if not isinstance(text, str):
                     text = getattr(block, "content", None)
+                    if getattr(block, "type", None) not in (None, "text", "output_text"):
+                        text = None
             if isinstance(text, str):
                 text_blocks.append(text)
         if any(block and not block.isspace() for block in text_blocks):

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -259,7 +259,12 @@ def _uses_pytest_runtime(command: tuple[str, ...]) -> bool:
         launcher = _python_shebang_launcher(Path(pytest_path), shutil.which)
         if launcher is None:
             return False
-        launcher_probe = (*launcher, "-c", PYYAML_PROBE_CODE)
+        launcher_probe = (
+            launcher[0],
+            *_drop_interactive_python_flags(launcher[1:]),
+            "-c",
+            PYYAML_PROBE_CODE,
+        )
         return Path(launcher[0]).resolve() == Path(
             sys.executable
         ).resolve() and not _python_probe_changes_import_context(launcher_probe)
@@ -581,11 +586,21 @@ def _pyyaml_probe_command(command: tuple[str, ...], cwd: Path) -> tuple[str, ...
     if (uv_prefix := _uv_run_pytest_prefix(command)) and (
         launcher := _uv_pytest_python_launcher(uv_prefix, cwd)
     ):
-        return (*launcher, "-c", PYYAML_PROBE_CODE)
+        return (
+            launcher[0],
+            *_drop_interactive_python_flags(launcher[1:]),
+            "-c",
+            PYYAML_PROBE_CODE,
+        )
     if command and Path(command[0]).name == "pytest":
         pytest_path = shutil.which(command[0])
         if pytest_path and (launcher := _python_shebang_launcher(Path(pytest_path), shutil.which)):
-            return (*launcher, "-c", PYYAML_PROBE_CODE)
+            return (
+                launcher[0],
+                *_drop_interactive_python_flags(launcher[1:]),
+                "-c",
+                PYYAML_PROBE_CODE,
+            )
     return None
 
 

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -951,6 +951,30 @@ def test_uv_pyyaml_probe_preserves_python_shebang_flags(tmp_path, monkeypatch) -
     )
 
 
+def test_uv_pyyaml_probe_omits_interactive_python_shebang_flag(
+    tmp_path, monkeypatch
+) -> None:
+    pytest_launcher = tmp_path / "global" / "bin" / "pytest"
+    pytest_launcher.parent.mkdir(parents=True)
+    pytest_launcher.write_text("#!/usr/bin/python3 -i\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run",
+        lambda *_args: subprocess.CompletedProcess(
+            ["uv", "run", "which", "pytest"],
+            0,
+            f"{pytest_launcher}\n",
+            "",
+        ),
+    )
+
+    assert deliberate_break._pyyaml_probe_command(("uv", "run", "pytest"), tmp_path) == (
+        "/usr/bin/python3",
+        "-c",
+        deliberate_break.PYYAML_PROBE_CODE,
+    )
+
+
 def test_uv_pyyaml_probe_resolves_env_shebang_inside_uv_path(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "bin" / "pytest"
     pytest_launcher.parent.mkdir()

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -1032,6 +1032,23 @@ def test_plain_pytest_with_active_python_shebang_is_managed(tmp_path, monkeypatc
     assert deliberate_break._uses_pytest_runtime(("pytest", "-q"))
 
 
+def test_plain_pytest_with_interactive_shebang_is_managed(tmp_path, monkeypatch) -> None:
+    pytest_launcher = tmp_path / "pytest"
+    pytest_launcher.write_text(f"#!{sys.executable} -i\n", encoding="utf-8")
+    monkeypatch.setattr(
+        deliberate_break.shutil,
+        "which",
+        lambda name: str(pytest_launcher) if name == "pytest" else None,
+    )
+
+    assert deliberate_break._uses_pytest_runtime(("pytest", "-q"))
+    assert deliberate_break._pyyaml_probe_command(("pytest", "-q"), tmp_path) == (
+        sys.executable,
+        "-c",
+        deliberate_break.PYYAML_PROBE_CODE,
+    )
+
+
 def test_plain_pytest_with_changed_import_context_is_not_managed(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "pytest"
     pytest_launcher.write_text(f"#!{sys.executable} -I\n", encoding="utf-8")

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -951,9 +951,7 @@ def test_uv_pyyaml_probe_preserves_python_shebang_flags(tmp_path, monkeypatch) -
     )
 
 
-def test_uv_pyyaml_probe_omits_interactive_python_shebang_flag(
-    tmp_path, monkeypatch
-) -> None:
+def test_uv_pyyaml_probe_omits_interactive_python_shebang_flag(tmp_path, monkeypatch) -> None:
     pytest_launcher = tmp_path / "global" / "bin" / "pytest"
     pytest_launcher.parent.mkdir(parents=True)
     pytest_launcher.write_text("#!/usr/bin/python3 -i\n", encoding="utf-8")

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -310,6 +310,23 @@ def test_text_from_response_content_accepts_strings_and_object_blocks() -> None:
     assert pr_verifier._text_from_response_content(blocks) == '{"summary":"response"}'
 
 
+@pytest.mark.parametrize("key", ("text", "content"))
+def test_text_from_response_content_supports_mapping_payloads(key: str) -> None:
+    payload = {key: '{"summary":"safe"}'}
+
+    assert pr_verifier._text_from_response_content(payload) == '{"summary":"safe"}'
+    assert pr_verifier._coerce_response_content(payload) == '{"summary":"safe"}'
+
+
+def test_text_from_response_content_supports_content_blocks() -> None:
+    blocks = [
+        {"type": "output_text", "content": '{"summary":"'},
+        SimpleNamespace(content='safe"}'),
+    ]
+
+    assert pr_verifier._text_from_response_content(blocks) == '{"summary":"safe"}'
+
+
 def test_evaluate_pr_valid_output_no_repair(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = _valid_payload()
     good = json.dumps(payload)

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import UserDict
 from types import SimpleNamespace
 from unittest import mock
 
@@ -312,7 +313,7 @@ def test_text_from_response_content_accepts_strings_and_object_blocks() -> None:
 
 @pytest.mark.parametrize("key", ("text", "content"))
 def test_text_from_response_content_supports_mapping_payloads(key: str) -> None:
-    payload = {key: '{"summary":"safe"}'}
+    payload = UserDict({key: '{"summary":"safe"}'})
 
     assert pr_verifier._text_from_response_content(payload) == '{"summary":"safe"}'
     assert pr_verifier._coerce_response_content(payload) == '{"summary":"safe"}'
@@ -322,6 +323,16 @@ def test_text_from_response_content_supports_content_blocks() -> None:
     blocks = [
         {"type": "output_text", "content": '{"summary":"'},
         SimpleNamespace(content='safe"}'),
+    ]
+
+    assert pr_verifier._text_from_response_content(blocks) == '{"summary":"safe"}'
+
+
+def test_text_from_response_content_ignores_non_text_content_blocks() -> None:
+    blocks = [
+        {"type": "thinking", "content": "internal analysis"},
+        {"type": "output_text", "content": '{"summary":"safe"}'},
+        SimpleNamespace(type="metadata", content="request-id"),
     ]
 
     assert pr_verifier._text_from_response_content(blocks) == '{"summary":"safe"}'


### PR DESCRIPTION
## Summary
- strip lowercase interactive Python flags from pytest shebang probes while preserving import-context flags
- accept mapping-shaped verifier content and content-key response blocks
- mirror the deliberate-break checker into the consumer template and add regression coverage

## Validation
- 126 deliberate-break tests
- 36 structured-output verifier tests
- Black, Ruff, mypy 2.3
- source/template parity and git diff check

<!-- workflow-source:review_followup -->

