### PR TITLE
fix: harden dependency version and error output

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -165,7 +165,8 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     if installed_version is None:
         return False
     installed_match = re.fullmatch(
-        r"(\d+(?:\.\d+)*)(?:\.post\d+)?(?:\+[\w.-]+)?", installed_version
+        r"(\d+(?:\.\d+)*)(?P<pre>(?:a|b|rc)\d+)?" r"(?:\.post\d+)?(?P<dev>\.dev\d+)?(?:\+[\w.-]+)?",
+        installed_version,
     )
     floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
     if installed_match is None or floor_match is None:
@@ -173,9 +174,11 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     installed_release = tuple(int(part) for part in installed_match.group(1).split("."))
     floor_release = tuple(int(part) for part in floor_match.group(1).split("."))
     width = max(len(installed_release), len(floor_release))
-    return installed_release + (0,) * (width - len(installed_release)) >= floor_release + (0,) * (
-        width - len(floor_release)
-    )
+    normalized_installed = installed_release + (0,) * (width - len(installed_release))
+    normalized_floor = floor_release + (0,) * (width - len(floor_release))
+    if normalized_installed != normalized_floor:
+        return normalized_installed > normalized_floor
+    return installed_match.group("pre") is None and installed_match.group("dev") is None
 
 
 def _ensure_pytest_runtime_deps() -> None:
@@ -694,8 +697,8 @@ def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
             reason="dependency-install-failed",
             command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
             returncode=error.returncode,
-            stdout=error.stdout,
-            stderr=error.stderr,
+            stdout=_subprocess_output_text(error.stdout),
+            stderr=_subprocess_output_text(error.stderr),
         )
     if isinstance(error, ImportError):
         return _json_result(

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -165,7 +165,8 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     if installed_version is None:
         return False
     installed_match = re.fullmatch(
-        r"(\d+(?:\.\d+)*)(?:\.post\d+)?(?:\+[\w.-]+)?", installed_version
+        r"(\d+(?:\.\d+)*)(?P<pre>(?:a|b|rc)\d+)?" r"(?:\.post\d+)?(?P<dev>\.dev\d+)?(?:\+[\w.-]+)?",
+        installed_version,
     )
     floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
     if installed_match is None or floor_match is None:
@@ -173,9 +174,11 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     installed_release = tuple(int(part) for part in installed_match.group(1).split("."))
     floor_release = tuple(int(part) for part in floor_match.group(1).split("."))
     width = max(len(installed_release), len(floor_release))
-    return installed_release + (0,) * (width - len(installed_release)) >= floor_release + (0,) * (
-        width - len(floor_release)
-    )
+    normalized_installed = installed_release + (0,) * (width - len(installed_release))
+    normalized_floor = floor_release + (0,) * (width - len(floor_release))
+    if normalized_installed != normalized_floor:
+        return normalized_installed > normalized_floor
+    return installed_match.group("pre") is None and installed_match.group("dev") is None
 
 
 def _ensure_pytest_runtime_deps() -> None:
@@ -694,8 +697,8 @@ def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
             reason="dependency-install-failed",
             command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
             returncode=error.returncode,
-            stdout=error.stdout,
-            stderr=error.stderr,
+            stdout=_subprocess_output_text(error.stdout),
+            stderr=_subprocess_output_text(error.stderr),
         )
     if isinstance(error, ImportError):
         return _json_result(

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -376,8 +376,11 @@ def test_runtime_dependency_installer_accepts_exact_locked_pyyaml(monkeypatch) -
         ("6.0.2.post1", False),
         ("6.0.3+local.1", True),
         ("6.0.4", True),
+        ("6.0.4rc1", True),
+        ("6.0.4.dev0", True),
         ("99.0.0", True),
         ("6.0.3rc1", False),
+        ("6.0.3.dev0", False),
         ("not-a-version", False),
     ],
 )
@@ -1410,6 +1413,37 @@ def test_dependency_install_failure_preserves_subprocess_context(tmp_path, monke
         "stdout": "resolver output",
         "stderr": "pip denied",
     }
+
+
+def test_dependency_install_failure_normalizes_byte_output(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    base, spec = _sound_spec(repo)
+    error = subprocess.CalledProcessError(
+        17,
+        ["pip", "install", "pyyaml==6.0.3"],
+        output=b"resolver \xff output",
+        stderr=b"pip denied",
+    )
+
+    monkeypatch.setattr(
+        deliberate_break,
+        "_run_with_runtime_deps",
+        lambda *_args: (_ for _ in ()).throw(deliberate_break.RuntimeDependencyError(error)),
+    )
+
+    result = verify_spec(spec, base=base, cwd=repo, enforce_tamper=False)
+
+    assert result == {
+        "verdict": VERDICT_BROKEN,
+        "reason": "dependency-install-failed",
+        "command": ["pip", "install", "pyyaml==6.0.3"],
+        "returncode": 17,
+        "stdout": "resolver \ufffd output",
+        "stderr": "pip denied",
+    }
+    json.dumps(result)
 
 
 def test_dependency_install_unavailable_is_broken(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- accept prerelease/dev PyYAML versions when their release tuple is above the stable compatibility floor
- keep prerelease/dev builds at the exact floor rejected
- normalize byte-valued dependency installer output before JSON serialization
- mirror the checker into the consumer template and add regression coverage

## Validation
- 129 deliberate-break tests
- Black, Ruff, mypy 2.3
- source/template parity and git diff check

<!-- workflow-source:review_followup -->