### PR TITLE
fix: harden release and verifier automation

### DIFF
--- a/scripts/check_issue_consistency.py
+++ b/scripts/check_issue_consistency.py
@@ -105,6 +105,7 @@ def resolve_head_ref_issue_number(head_ref: str) -> tuple[int | None, bool]:
 
 
 AUTO_FIX_PATTERN = re.compile(r"auto[\s-]?fix", re.IGNORECASE)
+RELEASE_PR_PATTERN = re.compile(r"^chore\([^)]*\):\s*release\b", re.IGNORECASE)
 
 
 def _load_event_payload(event_path: str | None) -> dict:
@@ -154,6 +155,11 @@ def is_autofix_context(pr_title: str, head_ref: str, event_path: str | None = No
     if event_path is None:
         event_path = os.environ.get("GITHUB_EVENT_PATH")
     return _has_autofix_label(event_path)
+
+
+def is_release_context(pr_title: str) -> bool:
+    """Return whether the PR is an automated release without issue lineage."""
+    return RELEASE_PR_PATTERN.search(pr_title or "") is not None
 
 
 def resolve_pr_context(
@@ -492,6 +498,9 @@ def main() -> int:
     base_sha = (args.base_sha or "").strip() or None
     base_remote = _resolve_base_remote(args.base_remote)
     pr_title, head_ref = resolve_pr_context(args.pr_title, args.head_ref)
+    if is_release_context(pr_title):
+        print("Skipping issue consistency check: automated release PR.")
+        return 0
     autofix_context = is_autofix_context(pr_title, head_ref)
     pr_issue = extract_title_issue_number(pr_title)
     title_has_bare_hash = bool(HASH_PATTERN.search(pr_title or "")) and not (

--- a/scripts/check_issue_consistency.py
+++ b/scripts/check_issue_consistency.py
@@ -106,6 +106,7 @@ def resolve_head_ref_issue_number(head_ref: str) -> tuple[int | None, bool]:
 
 AUTO_FIX_PATTERN = re.compile(r"auto[\s-]?fix", re.IGNORECASE)
 RELEASE_PR_PATTERN = re.compile(r"^chore\([^)]*\):\s*release\b", re.IGNORECASE)
+RELEASE_PLEASE_HEAD_PATTERN = re.compile(r"^release-please--branches--", re.IGNORECASE)
 
 
 def _load_event_payload(event_path: str | None) -> dict:
@@ -157,9 +158,11 @@ def is_autofix_context(pr_title: str, head_ref: str, event_path: str | None = No
     return _has_autofix_label(event_path)
 
 
-def is_release_context(pr_title: str) -> bool:
-    """Return whether the PR is an automated release without issue lineage."""
-    return RELEASE_PR_PATTERN.search(pr_title or "") is not None
+def is_release_context(pr_title: str, head_ref: str) -> bool:
+    """Return whether title and head identify an automated release-please PR."""
+    return RELEASE_PR_PATTERN.match(pr_title or "") is not None and bool(
+        RELEASE_PLEASE_HEAD_PATTERN.match(head_ref or "")
+    )
 
 
 def resolve_pr_context(
@@ -498,7 +501,7 @@ def main() -> int:
     base_sha = (args.base_sha or "").strip() or None
     base_remote = _resolve_base_remote(args.base_remote)
     pr_title, head_ref = resolve_pr_context(args.pr_title, args.head_ref)
-    if is_release_context(pr_title):
+    if is_release_context(pr_title, head_ref):
         print("Skipping issue consistency check: automated release PR.")
         return 0
     autofix_context = is_autofix_context(pr_title, head_ref)

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -678,17 +678,17 @@ def _fallback_evaluation(
 def _text_from_response_content(content: object) -> str | None:
     """Return provider text, or None when the payload carries no text blocks."""
     if isinstance(content, str):
-        return content
+        return content if content and not content.isspace() else None
     if isinstance(content, Mapping):
+        block_type = content.get("type")
         for key in ("text", "content"):
             text = content.get(key)
-            if isinstance(text, str):
-                if key == "content" and content.get("type") not in (
-                    None,
-                    "text",
-                    "output_text",
-                ):
-                    continue
+            if (
+                isinstance(text, str)
+                and text
+                and not text.isspace()
+                and block_type in (None, "text", "output_text")
+            ):
                 return text
         return None
     if isinstance(content, list):
@@ -697,17 +697,19 @@ def _text_from_response_content(content: object) -> str | None:
             if isinstance(block, str):
                 text = block
             elif isinstance(block, Mapping):
-                text = block.get("text")
-                if not isinstance(text, str):
-                    text = block.get("content")
-                    if block.get("type") not in (None, "text", "output_text"):
-                        text = None
+                if block.get("type") not in (None, "text", "output_text"):
+                    text = None
+                else:
+                    text = block.get("text")
+                    if not isinstance(text, str):
+                        text = block.get("content")
             else:
-                text = getattr(block, "text", None)
-                if not isinstance(text, str):
-                    text = getattr(block, "content", None)
-                    if getattr(block, "type", None) not in (None, "text", "output_text"):
-                        text = None
+                if getattr(block, "type", None) not in (None, "text", "output_text"):
+                    text = None
+                else:
+                    text = getattr(block, "text", None)
+                    if not isinstance(text, str):
+                        text = getattr(block, "content", None)
             if isinstance(text, str):
                 text_blocks.append(text)
         if any(block and not block.isspace() for block in text_blocks):

--- a/tests/scripts/test_issue_consistency_check.py
+++ b/tests/scripts/test_issue_consistency_check.py
@@ -90,8 +90,12 @@ def test_is_autofix_context_detects_hyphenated_title() -> None:
 
 
 def test_is_release_context_recognizes_release_please_title() -> None:
-    assert check_issue_consistency.is_release_context("chore(main): release 1.19.19") is True
-    assert check_issue_consistency.is_release_context("fix: release parser") is False
+    title = "chore(main): release 1.19.19"
+    head_ref = "release-please--branches--main--components--workflows"
+
+    assert check_issue_consistency.is_release_context(title, head_ref) is True
+    assert check_issue_consistency.is_release_context(title, "manual/release") is False
+    assert check_issue_consistency.is_release_context("fix: release parser", head_ref) is False
 
 
 def test_resolve_pr_context_reads_event_payload(tmp_path: Path) -> None:

--- a/tests/scripts/test_issue_consistency_check.py
+++ b/tests/scripts/test_issue_consistency_check.py
@@ -89,6 +89,11 @@ def test_is_autofix_context_detects_hyphenated_title() -> None:
     assert check_issue_consistency.is_autofix_context("Auto-fix from CI failure", "") is True
 
 
+def test_is_release_context_recognizes_release_please_title() -> None:
+    assert check_issue_consistency.is_release_context("chore(main): release 1.19.19") is True
+    assert check_issue_consistency.is_release_context("fix: release parser") is False
+
+
 def test_resolve_pr_context_reads_event_payload(tmp_path: Path) -> None:
     payload = {
         "pull_request": {
@@ -309,6 +314,34 @@ def test_main_skips_ambiguous_head_ref(monkeypatch, capsys) -> None:
     assert check_issue_consistency.main() == 0
     captured = capsys.readouterr()
     assert "Skipping issue consistency check: no issue references found." in captured.out
+
+
+def test_main_skips_automated_release_before_issue_collection(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("PR_TITLE", "chore(main): release 1.19.19")
+    monkeypatch.setenv("HEAD_REF", "release-please--branches--main--components--workflows")
+    monkeypatch.setenv("BASE_REF", "main")
+    monkeypatch.setenv("BASE_SHA", "deadbeef")
+    monkeypatch.setenv("BASE_REMOTE", "origin")
+    monkeypatch.setattr(sys, "argv", ["check_issue_consistency.py"])
+    monkeypatch.setattr(
+        check_issue_consistency,
+        "collect_commit_messages",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("release PR must skip commit issue collection")
+        ),
+    )
+    monkeypatch.setattr(
+        check_issue_consistency,
+        "collect_changed_files",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("release PR must skip header issue collection")
+        ),
+    )
+
+    assert check_issue_consistency.main() == 0
+    captured = capsys.readouterr()
+    assert "Skipping issue consistency check: automated release PR." in captured.out
 
 
 def test_main_autofix_title_hash_prefers_head_ref(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_pr_verifier_structured_output.py
+++ b/tests/scripts/test_pr_verifier_structured_output.py
@@ -292,6 +292,19 @@ def test_text_from_response_content_ignores_blank_text_blocks() -> None:
     assert pr_verifier._coerce_response_content(blocks) == json.dumps(blocks, default=str)
 
 
+@pytest.mark.parametrize(
+    "content",
+    (
+        "",
+        "  \n",
+        {"type": "text", "text": "  \n"},
+        {"type": "output_text", "content": ""},
+    ),
+)
+def test_text_from_response_content_ignores_blank_root_content(content: object) -> None:
+    assert pr_verifier._text_from_response_content(content) is None
+
+
 def test_text_from_response_content_does_not_copy_blocks_to_check_whitespace() -> None:
     class NoStripText(str):
         def strip(self, *args, **kwargs):
@@ -331,8 +344,9 @@ def test_text_from_response_content_supports_content_blocks() -> None:
 def test_text_from_response_content_ignores_non_text_content_blocks() -> None:
     blocks = [
         {"type": "thinking", "content": "internal analysis"},
+        {"type": "reasoning", "text": "private reasoning"},
         {"type": "output_text", "content": '{"summary":"safe"}'},
-        SimpleNamespace(type="metadata", content="request-id"),
+        SimpleNamespace(type="metadata", text="request-id"),
     ]
 
     assert pr_verifier._text_from_response_content(blocks) == '{"summary":"safe"}'


### PR DESCRIPTION
## Summary
- classify release-please PR titles before issue-number inference
- skip commit and header issue collection for automated release PRs
- reject blank root verifier content and ignore typed non-text blocks for both text and content fields
- add regression coverage for release early exit and structured response filtering

## Validation
- 69 focused tests
- Black, Ruff, mypy 2.3
- git diff check

<!-- workflow-source:review_followup -->