### PR TITLE
fix: restore agent rail startup recovery

### DIFF
--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -50,11 +50,12 @@ jobs:
             github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
+          path: eligibility-source
 
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: ./.github/actions/agent-event-eligibility
+        uses: ./eligibility-source/.github/actions/agent-event-eligibility
         with:
           expected-actions: opened,reopened,edited
           custom-predicate: >-

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -10,6 +10,11 @@
 # divergence no longer change these fingerprints, so this allowlist stops going
 # stale on dependency bumps; only a genuine logic change to a root workflow will.
 #
+# 2026-08-05 re-baseline: auto-label now isolates the preliminary eligibility
+# sparse checkout under eligibility-source/ in both root and consumer workflows.
+# The remaining root/template differences are the already-reviewed consumer
+# action-pin and auth-plumbing contract.
+#
 # 2026-07-24 re-baseline: refreshed fingerprints for 13 entries (belt 71/72/73,
 # auto-label, autofix-dispatcher, capability-check, decompose, dedup, guard,
 # issue-optimizer, keepalive-loop-reporter, verifier, weekly-metrics) that went
@@ -66,9 +71,9 @@ reason = Existing reviewed baseline drift re-baselined 2026-06-19: runtime AC me
 [pair.5]
 main = .github/workflows/agents-auto-label.yml
 template = templates/consumer-repo/.github/workflows/agents-auto-label.yml
-main_sha256 = 6276b24994010fab62c79085cc41d67ca2d0031580df2f5892c5ed2c7d1e7eba
-template_sha256 = c351fecad5ee3bc4231fc33d7e0c3edbcf539f57105d649601bfbf435561b1f3
-reason = Intentional divergence updated 2026-07-31: root and consumer queries now reject non-positive or invalid bounds and share executable guard tests while retaining consumer SHA pins and auth plumbing. Do not align wholesale: that would strip the consumer security contract.
+main_sha256 = 2b69ddf783e49273b966ab87f0caaf65c0a3c2b803bf46eba240d0637eeda00b
+template_sha256 = 60a5f4bff00adcf4ab9fe967f6f0d4b53d8be8d1111c545aa0778c7424ff69b9
+reason = Intentional divergence updated 2026-08-05: root and consumer workflows both isolate the eligibility sparse checkout under eligibility-source/ while retaining consumer SHA pins and auth plumbing. Do not align wholesale: that would strip the consumer security contract.
 
 [pair.6]
 main = .github/workflows/agents-autofix-dispatcher.yml

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -708,6 +708,12 @@ python scripts/workflow_startup_failure_diagnostic.py --repo OWNER/REPO --run-id
 This inspects check-runs for the same head SHA/run ID and prints the parser error
 title/summary text that is not visible in `actions/runs/<id>/jobs`.
 
+The same diagnostic also recognizes `action_required` runs with zero jobs.
+GitHub may hold a public-repository workflow before job creation under its
+unproven-workflow protection. Review the workflow file and use **Approve and
+run** from an authenticated GitHub web session; the REST approval endpoint for
+fork pull-request runs does not approve this class of hold.
+
 
 ### Startup Failure (Caller Workflow Permissions)
 

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -709,10 +709,14 @@ This inspects check-runs for the same head SHA/run ID and prints the parser erro
 title/summary text that is not visible in `actions/runs/<id>/jobs`.
 
 The same diagnostic also recognizes `action_required` runs with zero jobs.
-GitHub may hold a public-repository workflow before job creation under its
-unproven-workflow protection. Review the workflow file and use **Approve and
-run** from an authenticated GitHub web session; the REST approval endpoint for
-fork pull-request runs does not approve this class of hold.
+When the run event is a public-fork `pull_request` and `head_repository.fork`
+is true, classify it as a fork contributor approval hold (REST
+`/actions/runs/{id}/approve` can recover it). Otherwise treat it as GitHub's
+unproven-workflow protection: review the workflow file and use **Approve and
+run** from an authenticated GitHub web session; the fork-PR REST approval
+endpoint does not cover that class of hold. If the event is `pull_request` but
+fork status cannot be determined, report an unspecified approval hold and
+inspect `event` + `head_repository` before choosing remediation.
 
 
 ### Startup Failure (Caller Workflow Permissions)

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -138,6 +138,21 @@ For bugs affecting multiple repos, create a tracking issue with:
 **Example**: `workflow_run` trigger without handler job  
 **Detection**: Search for trigger in `on:` block, verify matching job exists
 
+### Sparse checkout state leaking into a later checkout
+
+**Pattern**: A job checks out one local action with `sparse-checkout`, then runs a
+second `actions/checkout` into the same workspace and expects the complete
+repository to be present.
+
+**Problem**: The later checkout can retain the first checkout's sparse worktree
+configuration. A subsequent local action then fails before useful work begins
+with `Can't find 'action.yml'`, even though the action is present on the
+repository's default branch.
+
+**Fix**: Put the preliminary sparse checkout in a dedicated `path:` and invoke
+the local action from that path. Reserve the workspace root for the later full
+checkout. The auto-label workflows use `eligibility-source/` for this reason.
+
 ### Hardcoded Values
 
 **Pattern**: Repository-specific values in templates  

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -168,8 +168,7 @@ def main(argv: list[str] | None = None) -> int:
     if report["startup_failures"]:
         return 0
     print(
-        "No matching startup_failure check-runs or zero-job approval hold found "
-        "for this run.",
+        "No matching startup_failure check-runs or zero-job approval hold found " "for this run.",
         file=sys.stderr,
     )
     return 2

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Capture startup_failure details for a workflow run via GitHub check-runs."""
+"""Diagnose zero-job workflow startup failures and approval holds."""
 
 from __future__ import annotations
 
@@ -98,6 +98,18 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
 
     jobs = jobs_payload.get("jobs", [])
     jobs_count = len(jobs) if isinstance(jobs, list) else 0
+    approval_hold = None
+    if run_payload.get("conclusion") == "action_required" and jobs_count == 0:
+        approval_hold = {
+            "failure_phase": "pre_job_workflow_approval",
+            "suspected_root_cause": "github_unproven_workflow_protection",
+            "approval_url": f"https://github.com/{repo}/actions/runs/{run_id}",
+            "remediation": (
+                "Review the workflow file, then use Approve and run from an "
+                "authenticated GitHub web session. The workflow-run approval "
+                "REST endpoint does not cover this protection."
+            ),
+        }
     return {
         "repo": repo,
         "run_id": run_id,
@@ -106,6 +118,7 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
         "run_status": run_payload.get("status", ""),
         "head_sha": head_sha,
         "jobs_count": jobs_count,
+        "approval_hold": approval_hold,
         "startup_failures": findings,
     }
 
@@ -148,11 +161,17 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     print(json.dumps(report, indent=2))
+    if report["approval_hold"]:
+        return 0
     if report["jobs_count"] == 0 and report["startup_failures"]:
         return 0
     if report["startup_failures"]:
         return 0
-    print("No matching startup_failure check-runs found for this run.", file=sys.stderr)
+    print(
+        "No matching startup_failure check-runs or zero-job approval hold found "
+        "for this run.",
+        file=sys.stderr,
+    )
     return 2
 
 

--- a/scripts/workflow_startup_failure_diagnostic.py
+++ b/scripts/workflow_startup_failure_diagnostic.py
@@ -100,16 +100,7 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
     jobs_count = len(jobs) if isinstance(jobs, list) else 0
     approval_hold = None
     if run_payload.get("conclusion") == "action_required" and jobs_count == 0:
-        approval_hold = {
-            "failure_phase": "pre_job_workflow_approval",
-            "suspected_root_cause": "github_unproven_workflow_protection",
-            "approval_url": f"https://github.com/{repo}/actions/runs/{run_id}",
-            "remediation": (
-                "Review the workflow file, then use Approve and run from an "
-                "authenticated GitHub web session. The workflow-run approval "
-                "REST endpoint does not cover this protection."
-            ),
-        }
+        approval_hold = _classify_zero_job_approval_hold(repo, run_id, run_payload)
     return {
         "repo": repo,
         "run_id": run_id,
@@ -120,6 +111,64 @@ def diagnose_startup_failure(repo: str, run_id: int) -> dict[str, Any]:
         "jobs_count": jobs_count,
         "approval_hold": approval_hold,
         "startup_failures": findings,
+    }
+
+
+def _head_repository_is_fork(repo: str, run_payload: dict[str, Any]) -> bool | None:
+    """Return True/False when fork status is known; None when it cannot be told."""
+    head_repo = run_payload.get("head_repository")
+    if not isinstance(head_repo, dict):
+        return None
+    if "fork" in head_repo:
+        return bool(head_repo.get("fork"))
+    head_full = str(head_repo.get("full_name") or "").strip()
+    if not head_full:
+        return None
+    return head_full.lower() != repo.lower()
+
+
+def _classify_zero_job_approval_hold(
+    repo: str, run_id: int, run_payload: dict[str, Any]
+) -> dict[str, str]:
+    """Distinguish fork-PR REST-approvable holds from unproven-workflow web holds."""
+    approval_url = f"https://github.com/{repo}/actions/runs/{run_id}"
+    event = str(run_payload.get("event") or "").strip()
+    is_fork = _head_repository_is_fork(repo, run_payload)
+
+    if event == "pull_request" and is_fork is True:
+        return {
+            "failure_phase": "pre_job_workflow_approval",
+            "suspected_root_cause": "fork_contributor_approval_hold",
+            "approval_url": approval_url,
+            "remediation": (
+                "Public-fork pull-request runs awaiting contributor approval can be "
+                "recovered with POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve "
+                "(or Approve and run in the GitHub UI)."
+            ),
+        }
+
+    if event == "pull_request" and is_fork is None:
+        return {
+            "failure_phase": "pre_job_workflow_approval",
+            "suspected_root_cause": "workflow_approval_hold_unspecified",
+            "approval_url": approval_url,
+            "remediation": (
+                "Zero-job action_required on a pull_request run: inspect event and "
+                "head_repository.fork before choosing remediation. Fork contributor "
+                "holds accept the workflow-run approval REST endpoint; unproven-workflow "
+                "holds require Approve and run in an authenticated GitHub web session."
+            ),
+        }
+
+    return {
+        "failure_phase": "pre_job_workflow_approval",
+        "suspected_root_cause": "github_unproven_workflow_protection",
+        "approval_url": approval_url,
+        "remediation": (
+            "Review the workflow file, then use Approve and run from an "
+            "authenticated GitHub web session. The workflow-run approval "
+            "REST endpoint does not cover this protection."
+        ),
     }
 
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-label.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-label.yml
@@ -50,11 +50,12 @@ jobs:
             github.event.workflow_run.repository.default_branch }}
           sparse-checkout: .github/actions/agent-event-eligibility
           sparse-checkout-cone-mode: false
+          path: eligibility-source
 
       # Escape hatch: set mode: warning if false-negative skips appear post-merge.
       - name: Check event eligibility
         id: eligibility
-        uses: ./.github/actions/agent-event-eligibility
+        uses: ./eligibility-source/.github/actions/agent-event-eligibility
         with:
           expected-actions: opened,reopened,edited
           custom-predicate: >-

--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -114,6 +114,7 @@ def test_diagnose_startup_failure_collects_output_fields(monkeypatch) -> None:
     report = diag.diagnose_startup_failure("owner/repo", 555)
 
     assert report["jobs_count"] == 0
+    assert report["approval_hold"] is None
     assert report["head_sha"] == "abc123"
     assert len(report["startup_failures"]) == 1
     finding = report["startup_failures"][0]
@@ -199,7 +200,61 @@ def test_main_returns_2_when_no_startup_failure(monkeypatch, capsys) -> None:
     exit_code = diag.main(["--repo", "owner/repo", "--run-id", "111"])
 
     assert exit_code == 2
-    assert "No matching startup_failure check-runs found" in capsys.readouterr().err
+    assert "No matching startup_failure check-runs or zero-job approval hold" in (
+        capsys.readouterr().err
+    )
+
+
+def test_diagnose_zero_job_action_required_as_web_approval_hold(monkeypatch) -> None:
+    responses = [
+        {
+            "head_sha": "abc123",
+            "name": "Auto-Label Issues",
+            "conclusion": "action_required",
+            "status": "completed",
+        },
+        {"jobs": []},
+        {"check_runs": []},
+    ]
+
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
+    report = diag.diagnose_startup_failure("owner/repo", 555)
+
+    assert report["approval_hold"] == {
+        "failure_phase": "pre_job_workflow_approval",
+        "suspected_root_cause": "github_unproven_workflow_protection",
+        "approval_url": "https://github.com/owner/repo/actions/runs/555",
+        "remediation": (
+            "Review the workflow file, then use Approve and run from an "
+            "authenticated GitHub web session. The workflow-run approval "
+            "REST endpoint does not cover this protection."
+        ),
+    }
+
+
+def test_main_accepts_zero_job_action_required_hold(monkeypatch, capsys) -> None:
+    responses = [
+        {
+            "head_sha": "abc123",
+            "name": "Auto-Label Issues",
+            "conclusion": "action_required",
+            "status": "completed",
+        },
+        {"jobs": []},
+        {"check_runs": []},
+    ]
+
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
+    exit_code = diag.main(["--repo", "owner/repo", "--run-id", "555"])
+
+    assert exit_code == 0
+    assert "pre_job_workflow_approval" in capsys.readouterr().out
 
 
 def test_main_returns_1_when_diagnosis_raises(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_workflow_startup_failure_diagnostic.py
+++ b/tests/scripts/test_workflow_startup_failure_diagnostic.py
@@ -212,6 +212,7 @@ def test_diagnose_zero_job_action_required_as_web_approval_hold(monkeypatch) -> 
             "name": "Auto-Label Issues",
             "conclusion": "action_required",
             "status": "completed",
+            "event": "issues",
         },
         {"jobs": []},
         {"check_runs": []},
@@ -235,6 +236,63 @@ def test_diagnose_zero_job_action_required_as_web_approval_hold(monkeypatch) -> 
     }
 
 
+def test_diagnose_zero_job_fork_pr_as_rest_approvable_hold(monkeypatch) -> None:
+    responses = [
+        {
+            "head_sha": "abc123",
+            "name": "CI",
+            "conclusion": "action_required",
+            "status": "completed",
+            "event": "pull_request",
+            "head_repository": {"full_name": "contributor/repo", "fork": True},
+        },
+        {"jobs": []},
+        {"check_runs": []},
+    ]
+
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
+    report = diag.diagnose_startup_failure("owner/repo", 555)
+
+    assert report["approval_hold"] == {
+        "failure_phase": "pre_job_workflow_approval",
+        "suspected_root_cause": "fork_contributor_approval_hold",
+        "approval_url": "https://github.com/owner/repo/actions/runs/555",
+        "remediation": (
+            "Public-fork pull-request runs awaiting contributor approval can be "
+            "recovered with POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve "
+            "(or Approve and run in the GitHub UI)."
+        ),
+    }
+
+
+def test_diagnose_zero_job_pr_without_head_repo_is_unspecified(monkeypatch) -> None:
+    responses = [
+        {
+            "head_sha": "abc123",
+            "name": "CI",
+            "conclusion": "action_required",
+            "status": "completed",
+            "event": "pull_request",
+        },
+        {"jobs": []},
+        {"check_runs": []},
+    ]
+
+    def fake_gh_api(path: str, token: str | None = None) -> dict[str, Any]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(diag, "_gh_api", fake_gh_api)
+    report = diag.diagnose_startup_failure("owner/repo", 555)
+
+    hold = report["approval_hold"]
+    assert hold is not None
+    assert hold["suspected_root_cause"] == "workflow_approval_hold_unspecified"
+    assert "head_repository.fork" in hold["remediation"]
+
+
 def test_main_accepts_zero_job_action_required_hold(monkeypatch, capsys) -> None:
     responses = [
         {
@@ -242,6 +300,7 @@ def test_main_accepts_zero_job_action_required_hold(monkeypatch, capsys) -> None
             "name": "Auto-Label Issues",
             "conclusion": "action_required",
             "status": "completed",
+            "event": "issues",
         },
         {"jobs": []},
         {"check_runs": []},

--- a/tests/workflows/test_auto_label_checkout_isolation.py
+++ b/tests/workflows/test_auto_label_checkout_isolation.py
@@ -19,25 +19,18 @@ def test_auto_label_isolates_eligibility_sparse_checkout() -> None:
         eligibility_checkout = next(
             step for step in steps if step.get("name") == "Checkout eligibility action"
         )
-        eligibility = next(
-            step for step in steps if step.get("name") == "Check event eligibility"
-        )
+        eligibility = next(step for step in steps if step.get("name") == "Check event eligibility")
 
         assert eligibility_checkout["with"]["path"] == "eligibility-source", path
         assert (
-            eligibility["uses"]
-            == "./eligibility-source/.github/actions/agent-event-eligibility"
+            eligibility["uses"] == "./eligibility-source/.github/actions/agent-event-eligibility"
         ), path
 
 
 def test_auto_label_full_checkout_keeps_workspace_root() -> None:
     for path in WORKFLOWS:
         steps = _steps(path)
-        full_checkout = next(
-            step for step in steps if step.get("name") == "Checkout repository"
-        )
+        full_checkout = next(step for step in steps if step.get("name") == "Checkout repository")
 
         assert "path" not in full_checkout.get("with", {}), path
-        assert any(
-            step.get("uses") == "./.github/actions/setup-api-client" for step in steps
-        ), path
+        assert any(step.get("uses") == "./.github/actions/setup-api-client" for step in steps), path

--- a/tests/workflows/test_auto_label_checkout_isolation.py
+++ b/tests/workflows/test_auto_label_checkout_isolation.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = (
+    Path(".github/workflows/agents-auto-label.yml"),
+    Path("templates/consumer-repo/.github/workflows/agents-auto-label.yml"),
+)
+
+
+def _steps(path: Path) -> list[dict[str, object]]:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return workflow["jobs"]["auto-label"]["steps"]
+
+
+def test_auto_label_isolates_eligibility_sparse_checkout() -> None:
+    for path in WORKFLOWS:
+        steps = _steps(path)
+        eligibility_checkout = next(
+            step for step in steps if step.get("name") == "Checkout eligibility action"
+        )
+        eligibility = next(
+            step for step in steps if step.get("name") == "Check event eligibility"
+        )
+
+        assert eligibility_checkout["with"]["path"] == "eligibility-source", path
+        assert (
+            eligibility["uses"]
+            == "./eligibility-source/.github/actions/agent-event-eligibility"
+        ), path
+
+
+def test_auto_label_full_checkout_keeps_workspace_root() -> None:
+    for path in WORKFLOWS:
+        steps = _steps(path)
+        full_checkout = next(
+            step for step in steps if step.get("name") == "Checkout repository"
+        )
+
+        assert "path" not in full_checkout.get("with", {}), path
+        assert any(
+            step.get("uses") == "./.github/actions/setup-api-client" for step in steps
+        ), path


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:2868 -->
> **Source:** Issue #2868

Closes #2868

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
## Summary

Since **2026-07-31 ~15:40Z**, workflow runs in `stranske/Workflows` — and **only** this repo — are completing with `conclusion: action_required` and **zero jobs created**. The condition started intermittently and is now persistent for the agent rail. The affected set is concentrated in the workflows that **create or label issues and PRs**.

Net effect: this repo's agent automation has produced **no job output for ~13 hours**. Issues are not auto-labeled, not intaken, and not materialized into PRs by auto-pilot; open agent PRs get no keepalive iterations. `agents-verifier.yml` is **healthy**, so post-merge verification is unaffected.

## Affected workflows and onset

| Workflow | Last healthy run | State since |
| --- | --- | --- |
| `agents-auto-label.yml` (Auto-Label Issues) | `2026-07-31T15:40:34Z` success | every run `action_required` |
| `agents-63-issue-intake.yml` (Agents 63 Issue Intake) | `2026-07-31T16:09:43Z` skipped | every run from `2026-08-01T00:12:31Z` `action_required` |
| `agents-auto-pilot.yml` (Agents Auto-Pilot) | `2026-07-31T16:45:50Z` success | every run from `2026-08-01T00:10:56Z` `action_required` |
| `agents-keepalive-loop.yml` (Agents Keepalive Loop) | `2026-07-31T19:37:32Z` success | every run `action_required` |

Also observed `action_required` in the last 100 runs: `Create Issue from Verification (Enhanced)`, `Create New PR from Verification`, `Health 68 Consumer Sync Drift Check`, and one early `health-keepalive-e2e` run at `2026-07-31T15:40:31Z` (which then recovered to success at `16:41:11Z` — the condition was intermittent before it became persistent).

Representative gated runs: `30686081507`-era window, `30683871877` (Agents Auto-Pilot, `issues`), `30682486654` (Agents Keepalive Loop, `workflow_run`), `30682423354` (Agents 63 Issue Intake, `issues`), `30682426030` (Auto-Label Issues, `issues`).

## What has been ruled out

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2795](https://github.com/stranske/Workflows/issues/2795)
- [#2851](https://github.com/stranske/Workflows/issues/2851)
- [#2854](https://github.com/stranske/Workflows/issues/2854)
- [#2860](https://github.com/stranske/Workflows/issues/2860)
- [#2758](https://github.com/stranske/Workflows/issues/2758)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] **Not a fork / outside-contributor approval gate.** `actor` and `triggering_actor` on the gated runs are `stranske` (repo owner), and `head_branch` is `main`. Owner-initiated `workflow_dispatch` runs of `agents-keepalive-loop.yml` are gated too (`2026-08-01T00:59:07Z`, `01:15:38Z`, `02:07:53Z` — all `action_required`).
- [ ] **Not environment protection.** The repo's three environments (`agent-standard`, `agent-high-privilege`, `copilot`) all have **empty** `protection_rules`. `GET /actions/runs/30682486654/pending_deployments` → `[]`; `GET /actions/runs/30683871877/approvals` → `[]`.
- [ ] **Not a disabled workflow.** Every workflow in the repo reports `state: active`; `maint-47-disable-legacy-workflows.yml` has never run.
- [ ] **Not repo Actions settings.** `GET /actions/permissions` → `{"enabled":true,"allowed_actions":"all"}`; `GET /actions/permissions/workflow` → `{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}`.
- [ ] **Not `environment:` usage per se.** `agents-autofix-loop.yml` also declares `environment: agent-standard` (`:69`) and runs **successfully** throughout the window.
- [ ] **Not the event type.** `Agents Autofix Loop`, `Agents 70 Orchestrator`, `Agents Bot Comment Handler`, `Maint 46 Post CI`, and `Agents PR meta manager` all succeed on the **same** `workflow_run` / `issue_comment` / `pull_request` events that the affected workflows fail on.
- [ ] **Not account-wide or fleet-wide.** All 11 consumer repos are healthy on the same account. Spot-checked `stranske/Manager-Database` and `stranske/Inv-Man-Intake` at `2026-08-01T04:29–05:36Z`: `Agents Keepalive Sweep`, `Keepalive Loop Reporter`, `Agents PR Event Hub`, `Agents Gate Followups`, `Autofix`, and `Gate` are all `success`/`skipped`, with **zero** `action_required`.

#### Acceptance criteria
1. [ ] Open **Actions → any gated run** (e.g. run `30683871877`) in the GitHub UI and check for an approval banner or a "this run requires approval" notice that the API does not expose.
2. [ ] Check **Settings → Actions → General** for a "Require approval" selection, and **Settings → Actions → Runners / usage** for any account or repo-level restriction.
3. [ ] If the UI shows nothing, this is likely a GitHub-side condition on the repository and warrants a support ticket referencing the run IDs above.
4. [ ] Once the gate clears, re-dispatch `agents-auto-pilot.yml` for the open backlog (this also unblocks the separate owner gate recorded on #2758) and confirm `agents-keepalive-loop.yml` produces jobs again.

<!-- auto-status-summary:end -->