### PR TITLE
docs: restore the rationale docstring on the fleet issue-format validator

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -1,4 +1,42 @@
-"""Validate a GitHub issue body against the fleet AGENT_ISSUE_FORMAT contract."""
+"""Validate a GitHub issue body against the fleet's AGENT_ISSUE_FORMAT contract.
+
+Synced to every consumer repo by `maint-68-sync-consumer-repos.yml`. This is the
+single definition of "agent-processable" for the whole fleet — do not fork it
+per repo.
+
+Why it exists: every automated lane reaches an issue through a LABEL. An issue
+filed with no label and no Tasks/Acceptance block is invisible to the entire
+pipeline — nothing validates it, nothing optimises it, nothing claims it. Local
+automation that files *findings* rather than *work orders* therefore produces
+issues no agent can ever pick up: good evidence, permanently unactionable.
+(Observed in Fine-Art-Archive #406-409: four well-evidenced audit findings, zero
+labels, no Tasks section between them.)
+
+Used at both ends:
+  * `agents-issue-format-guard.yml` validates every issue on open/edit and, on
+    failure, applies `agents:format` — the label the existing Agents Issue
+    Optimizer already listens for — so a bad issue is ROUTED to the machinery
+    that repairs it rather than merely flagged;
+  * any local script that files issues can pre-flight with
+    `python .github/scripts/issue_format.py <body-file>` and refuse to file junk
+    (non-zero exit means unfit).
+
+Rules mirror docs/AGENT_ISSUE_FORMAT.md rather than inventing a parallel
+standard: Tasks and Acceptance Criteria are REQUIRED; Why / Scope /
+Implementation Notes / Non-Goals are recommended; and at least one acceptance
+criterion must name a real test, runnable command, or observable verification
+gate.
+
+`_headings()` skips fenced code blocks, and that is load-bearing rather than
+cosmetic. Without it a body whose ONLY "Tasks" and "Acceptance Criteria" lines
+sit inside a ```bash fence validates as conforming — a false negative that lets
+an unactionable issue through the guard. Well-written issues quote commands and
+expected output in fences constantly, so this is the common case, not an edge
+one. Any change to heading detection must keep a fenced-heading case in
+tests/scripts/test_issue_format.py.
+
+Pure stdlib on purpose — it must run on a bare runner with no install step.
+"""
 
 from __future__ import annotations
 

--- a/templates/consumer-repo/.github/scripts/issue_format.py
+++ b/templates/consumer-repo/.github/scripts/issue_format.py
@@ -1,4 +1,42 @@
-"""Validate a GitHub issue body against the fleet AGENT_ISSUE_FORMAT contract."""
+"""Validate a GitHub issue body against the fleet's AGENT_ISSUE_FORMAT contract.
+
+Synced to every consumer repo by `maint-68-sync-consumer-repos.yml`. This is the
+single definition of "agent-processable" for the whole fleet — do not fork it
+per repo.
+
+Why it exists: every automated lane reaches an issue through a LABEL. An issue
+filed with no label and no Tasks/Acceptance block is invisible to the entire
+pipeline — nothing validates it, nothing optimises it, nothing claims it. Local
+automation that files *findings* rather than *work orders* therefore produces
+issues no agent can ever pick up: good evidence, permanently unactionable.
+(Observed in Fine-Art-Archive #406-409: four well-evidenced audit findings, zero
+labels, no Tasks section between them.)
+
+Used at both ends:
+  * `agents-issue-format-guard.yml` validates every issue on open/edit and, on
+    failure, applies `agents:format` — the label the existing Agents Issue
+    Optimizer already listens for — so a bad issue is ROUTED to the machinery
+    that repairs it rather than merely flagged;
+  * any local script that files issues can pre-flight with
+    `python .github/scripts/issue_format.py <body-file>` and refuse to file junk
+    (non-zero exit means unfit).
+
+Rules mirror docs/AGENT_ISSUE_FORMAT.md rather than inventing a parallel
+standard: Tasks and Acceptance Criteria are REQUIRED; Why / Scope /
+Implementation Notes / Non-Goals are recommended; and at least one acceptance
+criterion must name a real test, runnable command, or observable verification
+gate.
+
+`_headings()` skips fenced code blocks, and that is load-bearing rather than
+cosmetic. Without it a body whose ONLY "Tasks" and "Acceptance Criteria" lines
+sit inside a ```bash fence validates as conforming — a false negative that lets
+an unactionable issue through the guard. Well-written issues quote commands and
+expected output in fences constantly, so this is the common case, not an edge
+one. Any change to heading detection must keep a fenced-heading case in
+tests/scripts/test_issue_format.py.
+
+Pure stdlib on purpose — it must run on a bare runner with no install step.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
[#2960](https://github.com/stranske/Workflows/pull/2960) improved this validator's logic and, in doing so, replaced a 22-line docstring with a single summary line. **The logic changes were all good and are untouched here** — this is a docstring-only change.

Losing the reasoning is a real cost for a file synced verbatim into 13 consumer repos: the next reader can't tell *why* the contract is what it is, and a well-meaning simplification can silently reintroduce a bug the wording existed to prevent.

## One addition that #2960 itself earned

`_headings()` skipping fenced code blocks is **load-bearing, not cosmetic**. Without it, a body whose only `Tasks` and `Acceptance Criteria` lines sit inside a ```bash fence validates as **conforming** — a false negative that lets an unactionable issue straight through the guard.

That was live in Fine-Art-Archive until the sync landed there today. Demonstrated with a probe body containing zero real sections:

```
old validator (pre-#2960):  exit 0   ← judged CONFORMING
this validator:             exit 1   ← "Missing required sections: Tasks, Acceptance Criteria"
```

Good issues quote commands and expected output in fences constantly, so this is the common case, not an edge one. The docstring now says so and points at `tests/scripts/test_issue_format.py`, which already covers it via `test_fenced_headings_do_not_satisfy_required_sections`.

## Also
Brings the root `.github/scripts` copy back into byte-for-byte lockstep with the consumer template — it had drifted to the pre-#2960 text.

## Verification
- **AST of both files compared before/after with docstrings stripped — identical.** No behaviour change.
- Fenced-heading probe re-run: still correctly non-conforming.
- `tests/scripts/test_issue_format.py`: **10 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded issue-format documentation to clarify required and recommended sections.
  * Documented acceptance criteria, fenced-code heading handling, validation integrations, synchronization guidance, and runtime requirements.
  * No functional behavior or validation rules changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->