### PR TITLE
fix: clarify issue format guard label message

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -87,7 +87,7 @@ jobs:
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
-              echo "Invalid issue body — cleared agents:formatted before rerouting."
+              echo "Invalid issue body — cleared stale agents:formatted."
             else
               echo "::warning::could not remove stale agents:formatted"
             fi

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -87,7 +87,7 @@ jobs:
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
-              echo "Invalid issue body — cleared agents:formatted before rerouting."
+              echo "Invalid issue body — cleared stale agents:formatted."
             else
               echo "::warning::could not remove stale agents:formatted"
             fi


### PR DESCRIPTION
Clarifies that an invalid issue clears the stale `agents:formatted` marker regardless of whether the issue is eligible for optimizer routing. Updates the canonical workflow and synced consumer template together.\n\nValidation: `python -m pytest -q tests/scripts/test_issue_format.py`; `python scripts/sync_tool_versions.py --check`; `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow messages to indicate when the stale `agents:formatted` label is cleared.
  * Removed references to issue rerouting from invalid-issue cleanup messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->