### PR TITLE
fix(gate): surface issue format validator errors

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -62,19 +62,29 @@ jobs:
         if: steps.issue.outputs.exempt != 'true'
         run: |
           set +e
+          report_file="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/issue_format.py body.md > report.md
+          python3 .github/scripts/issue_format.py body.md > "$report_file" 2> "$error_file"
           rc=$?
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          cat report.md || true
+          cat "$report_file" || true
+          if [[ "$rc" -eq 1 && -s "$error_file" ]]; then
+            echo "::error::issue-format validator failed unexpectedly"
+            cat "$error_file" >&2
+            exit 1
+          fi
           if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            cat "$error_file" >&2
             exit "$rc"
           fi
+          cp "$report_file" report.md
 
       - name: Invalidate stale format completion after an invalid issue change
         if: >-

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-07T17:41:02.702305Z",
+  "emitted_at": "2026-08-07T17:43:36.409758Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-07T17:43:36.409758Z",
+  "emitted_at": "2026-08-07T17:46:15.035406Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,0 +1,16 @@
+{
+  "agent": "codex",
+  "cli_version": "0.144.1",
+  "emitted_at": "2026-08-07T17:38:50.622396Z",
+  "execution_profile": "codex-default",
+  "fallback_models": [
+    "gpt-5.5"
+  ],
+  "operation_role": "worker",
+  "pr_number": "2973",
+  "requested_model": "gpt-5.6-terra",
+  "runner": "reusable-codex-run",
+  "schema": "langsmith-fleet/v1",
+  "selected_model": "",
+  "selection_reason": ""
+}

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-07T17:38:50.622396Z",
+  "emitted_at": "2026-08-07T17:41:02.702305Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -62,19 +62,29 @@ jobs:
         if: steps.issue.outputs.exempt != 'true'
         run: |
           set +e
+          report_file="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/issue_format.py body.md > report.md
+          python3 .github/scripts/issue_format.py body.md > "$report_file" 2> "$error_file"
           rc=$?
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          cat report.md || true
+          cat "$report_file" || true
+          if [[ "$rc" -eq 1 && -s "$error_file" ]]; then
+            echo "::error::issue-format validator failed unexpectedly"
+            cat "$error_file" >&2
+            exit 1
+          fi
           if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            cat "$error_file" >&2
             exit "$rc"
           fi
+          cp "$report_file" report.md
 
       - name: Invalidate stale format completion after an invalid issue change
         if: >-


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

Fixes the active source-owned review finding on Manager-Database#1551.

The issue-format guard now captures validator stderr separately. A normal nonconforming body (exit 1 with no stderr) still routes to the optimizer; an unexpected validator error (exit 1 plus stderr) fails the workflow rather than treating a crash as an ordinary format failure.

Updates the canonical workflow and exact-synced consumer template together.

Validation:
- `python -m pytest -q tests/scripts/test_issue_format.py tests/workflows/test_sync_manifest_delivery.py` (26 passed)
- `python scripts/validate_template_sync.py`
- `git diff --check`

Note: `python scripts/validate_workflow_yaml.py .github/workflows/agents-issue-format-guard.yml` reports 12 existing style findings, none in this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue-format validation reliability by separating validation output from generated reports.
  - Validation reports are now consistently saved and displayed after processing.
  - Unexpected validator failures are clearly reported when diagnostic output is present.
  - Other validation errors continue to return their original status and diagnostics.

- **Chores**
  - Temporary validation files are automatically cleaned up after each run.
  - Updated the consumer repository workflow to use the same improved validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->