### PR TITLE
fix(deps): align canonical ruff 0.16.2 pins

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ app = []
 dev = [
     "pre-commit==4.6.1",
     "black==26.5.1",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "isort==8.0.1",
     "docformatter==1.7.8",
     "mypy==2.3.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -298,7 +298,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.1
+ruff==0.16.2
     # via workflows (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/templates/consumer-repo/.github/workflows/autofix-versions.env
+++ b/templates/consumer-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/templates/integration-repo/.github/workflows/autofix-versions.env
+++ b/templates/integration-repo/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0


### PR DESCRIPTION
Updates the shared Ruff pin atomically across the source env file, consumer/integration templates, Workflows development dependencies, and direct lockfile.

Supersedes the pyproject-only Renovate update in stranske/Workflows-Integration-Tests#54.

Validation:
- `python scripts/sync_tool_versions.py --check`
- `python scripts/sync_dev_dependencies.py --check`
- `python -m pytest -q tests/scripts/test_sync_tool_versions.py tests/scripts/test_sync_dev_dependencies.py` (33 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ruff development tool to version 0.16.2 across project and template configurations.
  * Ensured automated workflows use the latest pinned Ruff version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->