### PR TITLE
fix(agents): stop the format guard inverting its own label checks

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -90,6 +90,11 @@ jobs:
           error_file="$(mktemp)"
           trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
+            # Tolerated: a consumer repo mid-sync may not have the validator yet,
+            # and hard-failing would block every issue there. But the job used to
+            # exit GREEN having validated nothing, so a sync that dropped the
+            # file removed the gate with no signal at all. Make it loud.
+            echo "::warning title=Issue format guard inactive::.github/scripts/issue_format.py is missing, so this issue was NOT validated. Re-sync from stranske/Workflows to restore the gate."
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
@@ -143,8 +148,14 @@ jobs:
             cat "$error_file" >&2
             exit 1
           fi
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+          # `gh … | grep -q` inverts under `set -o pipefail`: grep exits at its
+          # first match, gh dies on SIGPIPE, and the failed pipeline makes this
+          # `if` take the FALSE branch even though the label IS present. It only
+          # bites once gh is slow enough to still be writing — i.e. as the issue
+          # grows. Materialise first, then grep a file.
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:formatted' labels.txt; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
               echo "Invalid issue body — cleared stale agents:formatted."
             else
@@ -351,8 +362,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' > held.txt
+          if grep -qx true held.txt; then
             echo "Issue remains held — leaving agents:formatted cleared."
             exit 0
           fi
@@ -367,8 +379,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:format'; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:format' labels.txt; then
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format"
             echo "Conforms now — cleared agents:format."
           fi

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T04:30:12.896403Z",
+  "emitted_at": "2026-08-09T04:31:19.044018Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T03:47:05.930711Z",
+  "emitted_at": "2026-08-09T04:30:12.896403Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T02:53:39.807977Z",
+  "emitted_at": "2026-08-09T03:45:32.570054Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T02:44:57.905584Z",
+  "emitted_at": "2026-08-09T02:48:01.954936Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T02:50:44.539687Z",
+  "emitted_at": "2026-08-09T02:53:39.807977Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T02:48:01.954936Z",
+  "emitted_at": "2026-08-09T02:50:44.539687Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T03:45:32.570054Z",
+  "emitted_at": "2026-08-09T03:47:05.930711Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T02:47:58.915158Z",
+  "emitted_at": "2026-08-09T02:44:57.905584Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "2999",
+  "pr_number": "2994",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -90,6 +90,11 @@ jobs:
           error_file="$(mktemp)"
           trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
+            # Tolerated: a consumer repo mid-sync may not have the validator yet,
+            # and hard-failing would block every issue there. But the job used to
+            # exit GREEN having validated nothing, so a sync that dropped the
+            # file removed the gate with no signal at all. Make it loud.
+            echo "::warning title=Issue format guard inactive::.github/scripts/issue_format.py is missing, so this issue was NOT validated. Re-sync from stranske/Workflows to restore the gate."
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
@@ -143,8 +148,14 @@ jobs:
             cat "$error_file" >&2
             exit 1
           fi
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+          # `gh … | grep -q` inverts under `set -o pipefail`: grep exits at its
+          # first match, gh dies on SIGPIPE, and the failed pipeline makes this
+          # `if` take the FALSE branch even though the label IS present. It only
+          # bites once gh is slow enough to still be writing — i.e. as the issue
+          # grows. Materialise first, then grep a file.
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:formatted' labels.txt; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
               echo "Invalid issue body — cleared stale agents:formatted."
             else
@@ -351,8 +362,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' > held.txt
+          if grep -qx true held.txt; then
             echo "Issue remains held — leaving agents:formatted cleared."
             exit 0
           fi
@@ -367,8 +379,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:format'; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:format' labels.txt; then
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format"
             echo "Conforms now — cleared agents:format."
           fi


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
<!-- Updated scope for this follow-up -->
Address unmet acceptance criteria from PR #463.

Original scope:
- After merging PR #103 (multi-agent routing infrastructure), we need to:
- 1. Validate the CLI agent pipeline works end-to-end with the new task-focused prompts
- 2. Add `GITHUB_STEP_SUMMARY` output so iteration results are visible in the Actions UI
- 3. Streamline the Automated Status Summary to reduce clutter when using CLI agents
- 4. **Clean up comment patterns** to avoid a mix of old UI-agent and new CLI-agent comments

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Workflows#463](https://github.com/stranske/Workflows/issues/463)
- [#463](https://github.com/stranske/Workflows/issues/463)
- [#103](https://github.com/stranske/Workflows/issues/103)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
<!-- Incomplete tasks from original issue -->
- [ ] After PR #103 merges, create a test PR with `agent:codex` label
- [ ] Verify task appendix appears in Codex prompt (check workflow logs)
- [ ] Verify Codex works on actual tasks (not random infrastructure work)
- [ ] Verify keepalive comment updates with iteration progress
- [ ] Add step summary output to `agents-keepalive-loop.yml` after agent run
- [ ] Include: iteration number, tasks completed, files changed, outcome
- [ ] Ensure summary is visible in workflow run UI
- [ ] Modify `buildStatusBlock()` in `agents_pr_meta_update_body.js` to accept `agentType` parameter
- [ ] When `agentType` is set (CLI agent): hide workflow table, hide head SHA/required checks
- [ ] Keep Scope/Tasks/Acceptance checkboxes for all cases
- [ ] Pass agent type from workflow to the update_body job
- [ ] **For CLI agents (`agent:*` label):**
- [ ] Suppress `<!-- gate-summary: -->` comment posting (use step summary instead)
- [ ] Suppress `<!-- keepalive-round: N -->` instruction comments (task appendix replaces this)
- [ ] Update `<!-- keepalive-loop-summary -->` to be the **single source of truth**
- [ ] Ensure state marker is embedded in the summary comment (not separate)
- [ ] **For UI Codex (no `agent:*` label):**
- [ ] Keep existing comment patterns (instruction comments, connector bot reports)
- [ ] Keep `<!-- gate-summary: -->` comment
- [ ] Add `agent_type` output to detect job so downstream workflows know the mode
- [ ] Update `agents-pr-meta.yml` to conditionally skip gate summary for CLI agent PRs

#### Acceptance criteria
<!-- Criteria verified as unmet by verifier -->
- [ ] CLI agent receives explicit tasks in prompt and works on them
- [ ] CLI agent PRs have ≤3 bot comments total (summary, one per iteration update) instead of 10+
- [ ] Requires PR #103 to be merged first

<!-- auto-status-summary:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue-format validation warnings when the validator is unavailable.
  * Made label checks more reliable during stale cleanup, held-state restoration, and format-trigger processing.
* **Chores**
  * Updated recorded workflow execution metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->