### PR TITLE
fix(agents): release failed format leases safely

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -141,7 +141,7 @@ jobs:
           if [[ "$live_rc" -ne 1 || -s "$error_file" ]]; then
             echo "::error::issue-format validator failed unexpectedly during label revalidation"
             cat "$error_file" >&2
-            exit "$live_rc"
+            exit 1
           fi
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -254,10 +254,14 @@ jobs:
           if [[ "$format_guard_attempts" -ge "$max_format_guard_attempts" ]]; then
             echo "Format guard exhausted $format_guard_attempts optimizer attempts; pausing issue."
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --add-label "agents:auto-pilot-pause" --remove-label "agents:format"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-              "<!-- format-guard:attempt-cap -->
-              Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying."
+              --add-label "agents:auto-pilot-pause" \
+              || echo "::warning::could not apply agents:auto-pilot-pause"
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
+              || echo "::warning::could not release agents:format after attempt cap"
+            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
+          <!-- format-guard:attempt-cap -->
+          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
+          EOF
             exit 0
           fi
           has_format_label=false

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -5,8 +5,7 @@ name: Agents Issue Optimizer
 # nothing and reported 0 for an issue it was re-running every minute. Pin the issue
 # number into the run name so both trigger types are correlatable.
 run-name: >-
-  Agents Issue Optimizer #${{
-  github.event.issue.number || inputs.issue_number }}
+  Agents Issue Optimizer #${{ github.event.issue.number || github.event.inputs.issue_number }}
 
 on:
   issues:
@@ -732,10 +731,14 @@ jobs:
           fi
 
       - name: Release failed format lease
-        if: (failure() || cancelled()) && steps.check.outputs.should_run == 'true' && steps.check.outputs.phase == 'format'
+        if: >-
+          (failure() || cancelled()) &&
+          (steps.check.outputs.phase == 'format' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.phase == 'format') ||
+          (github.event_name == 'issues' && github.event.label.name == 'agents:format'))
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
         run: |
           set -euo pipefail
           # A guard retry may proceed only after the failed format run releases its lease.

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -113,9 +113,9 @@ reason = Intentional divergence re-baselined 2026-06-30: root and consumer guard
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
-main_sha256 = ae9a2d80a47ad995f4ce1a0681a7c8b236518b2c1337370d11578e4059ae7489
-template_sha256 = d5469b188c5e757d2f8a289e40c066961047d8a9625ae32413c2959c7a824c21
-reason = Intentional divergence re-baselined 2026-08-08c: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract this round: concurrency includes inputs.issue_number for workflow_dispatch dedupe, cancel-safe (failure()||cancelled()) agents:format lease release, issue_dedup wrapped in set +e/set -e so advisory failures cannot abort under bash -e, and visible non-zero exit warnings. Re-baselined 2026-08-08d: both surfaces now set a `run-name` carrying `#<issue>` so the recursion guard can correlate workflow_dispatch runs, match prior runs with `endswith` instead of `contains`, and pass `--limit 100` to `gh run list` (see #2991). Do not align wholesale — that would strip consumer action pins/token setup.
+main_sha256 = 5b62401785a5b4e3d64f89048c1919dbc46ee2258db94369cc77cd6b9da75d1d
+template_sha256 = 1f6b83202c08225789bf82761b65d79de9c51c2c2ffe50e8a9d1c3b7e36c9d87
+reason = Intentional divergence re-baselined 2026-08-08c: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract: event-safe optimizer run names, cancel-safe agents:format release even if the initial check fails, and nonzero failure for unexpected validator stderr. Do not align wholesale — that would strip consumer action pins/token setup.
 
 [pair.12]
 main = .github/workflows/agents-keepalive-loop-reporter.yml

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -141,7 +141,7 @@ jobs:
           if [[ "$live_rc" -ne 1 || -s "$error_file" ]]; then
             echo "::error::issue-format validator failed unexpectedly during label revalidation"
             cat "$error_file" >&2
-            exit "$live_rc"
+            exit 1
           fi
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -254,10 +254,14 @@ jobs:
           if [[ "$format_guard_attempts" -ge "$max_format_guard_attempts" ]]; then
             echo "Format guard exhausted $format_guard_attempts optimizer attempts; pausing issue."
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --add-label "agents:auto-pilot-pause" --remove-label "agents:format"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-              "<!-- format-guard:attempt-cap -->
-              Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying."
+              --add-label "agents:auto-pilot-pause" \
+              || echo "::warning::could not apply agents:auto-pilot-pause"
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
+              || echo "::warning::could not release agents:format after attempt cap"
+            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
+          <!-- format-guard:attempt-cap -->
+          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
+          EOF
             exit 0
           fi
           has_format_label=false

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -5,8 +5,7 @@ name: Agents Issue Optimizer
 # nothing and reported 0 for an issue it was re-running every minute. Pin the issue
 # number into the run name so both trigger types are correlatable.
 run-name: >-
-  Agents Issue Optimizer #${{
-  github.event.issue.number || inputs.issue_number }}
+  Agents Issue Optimizer #${{ github.event.issue.number || github.event.inputs.issue_number }}
 
 on:
   issues:
@@ -585,10 +584,14 @@ jobs:
           fi
 
       - name: Release failed format lease
-        if: (failure() || cancelled()) && steps.check.outputs.should_run == 'true' && steps.check.outputs.phase == 'format'
+        if: >-
+          (failure() || cancelled()) &&
+          (steps.check.outputs.phase == 'format' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.phase == 'format') ||
+          (github.event_name == 'issues' && github.event.label.name == 'agents:format'))
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
-          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
         run: |
           set -euo pipefail
           # A guard retry may proceed only after the failed format run releases its lease.

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -134,10 +134,10 @@ def test_format_lease_is_required_and_released_after_failure() -> None:
         CONSUMER_WORKFLOW_PATH.read_text(encoding="utf-8"),
     ):
         assert "Release failed format lease" in text
-        assert (
-            "(failure() || cancelled()) && steps.check.outputs.should_run == 'true' "
-            "&& steps.check.outputs.phase == 'format'"
-        ) in text
+        assert "(failure() || cancelled())" in text
+        assert "steps.check.outputs.phase == 'format'" in text
+        assert "github.event.inputs.phase == 'format'" in text
+        assert "github.event.label.name == 'agents:format'" in text
         assert 'gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format"' in text
 
 


### PR DESCRIPTION
## Summary
- make optimizer run names event-safe for issue and dispatch triggers
- release format leases after check-step failures
- fail closed on unexpected revalidation stderr
- keep intentional template divergence baseline current

## Validation
- `python -m pytest -q tests/workflows/test_agents_issue_optimizer_format_trigger.py` (8 passed)
- `python scripts/check_template_drift.py --allowlist config/template-drift-allowlist.txt` (0 unallowlisted drift)
- `python scripts/validate_template_completeness.py`
- `git diff --check`