### PR TITLE
fix(agents): classify conventional local PR branches

### DIFF
--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -640,6 +640,16 @@ test('resolvePrSourceContext infers local_request for conventional work-branch p
   assert.equal(local.requiresIssue, false);
   assert.equal(local.isExplicit, false);
 
+  const automated = resolvePrSourceContext({
+    body: '',
+    head: { ref: 'chore/ledger-base-sync' },
+    title: 'chore: sync ledger base',
+    user: { login: 'github-actions[bot]' },
+  });
+  assert.equal(automated.sourceType, SOURCE_TYPES.AUTOMATION_RUN);
+  assert.equal(automated.isValid, true);
+  assert.equal(automated.requiresIssue, false);
+
   for (const branch of ['codex/no-issue-link', 'closer/foo']) {
     const lane = resolvePrSourceContext({ body: '', head: { ref: branch }, title: 'Change code' });
     assert.equal(lane.sourceType, SOURCE_TYPES.UNKNOWN);

--- a/.github/scripts/__tests__/source-context.test.js
+++ b/.github/scripts/__tests__/source-context.test.js
@@ -628,6 +628,30 @@ test('resolvePrSourceContext infers sync and dependabot sources for maintenance 
   );
 });
 
+test('resolvePrSourceContext infers local_request for conventional work-branch prefixes', () => {
+  const local = resolvePrSourceContext({
+    body: '',
+    head: { ref: 'feat/retire-plan-v3' },
+    title: 'Change code',
+  });
+
+  assert.equal(local.sourceType, SOURCE_TYPES.LOCAL_REQUEST);
+  assert.equal(local.isValid, true);
+  assert.equal(local.requiresIssue, false);
+  assert.equal(local.isExplicit, false);
+
+  for (const branch of ['codex/no-issue-link', 'closer/foo']) {
+    const lane = resolvePrSourceContext({ body: '', head: { ref: branch }, title: 'Change code' });
+    assert.equal(lane.sourceType, SOURCE_TYPES.UNKNOWN);
+    assert.equal(lane.isValid, false);
+  }
+
+  assert.deepEqual(
+    templateResolvePrSourceContext({ body: '', head: { ref: 'feat/retire-plan-v3' }, title: 'Change code' }),
+    local,
+  );
+});
+
 test('resolvePrSourceContext accepts explicit sync source markers from consumer sync PRs', () => {
   const context = resolvePrSourceContext({
     body: [

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -368,15 +368,16 @@ function inferredSourceType(pull = {}) {
   if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
     return SOURCE_TYPES.DEPENDABOT;
   }
+  if (branch.startsWith('sync/') || branch.startsWith('sync-')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (labels.includes('campaign:sync-dependabot')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
   if (author === 'github-actions[bot]' || author === 'github-actions') {
     return SOURCE_TYPES.AUTOMATION_RUN;
   }
-  if (
-    branch.startsWith('sync/') ||
-    branch.startsWith('sync-') ||
-    labels.includes('campaign:sync-dependabot') ||
-    /\bsync\b/.test(title)
-  ) {
+  if (/\bsync\b/.test(title)) {
     return SOURCE_TYPES.SYNC_CAMPAIGN;
   }
   if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -368,6 +368,9 @@ function inferredSourceType(pull = {}) {
   if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
     return SOURCE_TYPES.DEPENDABOT;
   }
+  if (author === 'github-actions[bot]' || author === 'github-actions') {
+    return SOURCE_TYPES.AUTOMATION_RUN;
+  }
   if (
     branch.startsWith('sync/') ||
     branch.startsWith('sync-') ||

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -379,6 +379,11 @@ function inferredSourceType(pull = {}) {
   if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
     return SOURCE_TYPES.REVIEW_FOLLOWUP;
   }
+  if ([
+    'feat/', 'fix/', 'docs/', 'audit/', 'chore/', 'refactor/', 'perf/', 'test/',
+  ].some((prefix) => branch.startsWith(prefix))) {
+    return SOURCE_TYPES.LOCAL_REQUEST;
+  }
   return SOURCE_TYPES.UNKNOWN;
 }
 

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:19:39.620810Z",
+  "emitted_at": "2026-08-09T14:21:17.845320Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:21:17.845320Z",
+  "emitted_at": "2026-08-09T12:39:29.974733Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3008",
+  "pr_number": "3005",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:16:01.893728Z",
+  "emitted_at": "2026-08-09T14:19:39.620810Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:32:19.198847Z",
+  "emitted_at": "2026-08-09T14:34:05.396021Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:13:27.571024Z",
+  "emitted_at": "2026-08-09T14:16:01.893728Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T14:34:05.396021Z",
+  "emitted_at": "2026-08-09T14:40:55.231515Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T12:39:29.974733Z",
+  "emitted_at": "2026-08-09T14:13:27.571024Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3005",
+  "pr_number": "3008",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T12:39:29.974733Z",
+  "emitted_at": "2026-08-09T14:32:19.198847Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3005",
+  "pr_number": "3008",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -175,7 +175,6 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
-    r"|curl\s+\S+"
     r")",
     re.IGNORECASE,
 )
@@ -464,7 +463,7 @@ _DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # being wrapped again.
 _ORIGINAL_ISSUE_INNER_RE = re.compile(
     r"<details\b[^>]*>\s*<summary>Original Issue</summary>\s*"
-    r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
+    r"(?P<fence>`{3,}|~{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -862,7 +861,7 @@ def main() -> None:
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
-            "needs_refinement": result.get("needs_refinement", False),
+            "needs_refinement": result.get("needs_refinement", True),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -368,15 +368,16 @@ function inferredSourceType(pull = {}) {
   if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
     return SOURCE_TYPES.DEPENDABOT;
   }
+  if (branch.startsWith('sync/') || branch.startsWith('sync-')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (labels.includes('campaign:sync-dependabot')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
   if (author === 'github-actions[bot]' || author === 'github-actions') {
     return SOURCE_TYPES.AUTOMATION_RUN;
   }
-  if (
-    branch.startsWith('sync/') ||
-    branch.startsWith('sync-') ||
-    labels.includes('campaign:sync-dependabot') ||
-    /\bsync\b/.test(title)
-  ) {
+  if (/\bsync\b/.test(title)) {
     return SOURCE_TYPES.SYNC_CAMPAIGN;
   }
   if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -368,6 +368,9 @@ function inferredSourceType(pull = {}) {
   if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
     return SOURCE_TYPES.DEPENDABOT;
   }
+  if (author === 'github-actions[bot]' || author === 'github-actions') {
+    return SOURCE_TYPES.AUTOMATION_RUN;
+  }
   if (
     branch.startsWith('sync/') ||
     branch.startsWith('sync-') ||

--- a/templates/consumer-repo/.github/scripts/source_context.js
+++ b/templates/consumer-repo/.github/scripts/source_context.js
@@ -379,6 +379,11 @@ function inferredSourceType(pull = {}) {
   if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
     return SOURCE_TYPES.REVIEW_FOLLOWUP;
   }
+  if ([
+    'feat/', 'fix/', 'docs/', 'audit/', 'chore/', 'refactor/', 'perf/', 'test/',
+  ].some((prefix) => branch.startsWith(prefix))) {
+    return SOURCE_TYPES.LOCAL_REQUEST;
+  }
   return SOURCE_TYPES.UNKNOWN;
 }
 

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -175,7 +175,6 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
-    r"|curl\s+\S+"
     r")",
     re.IGNORECASE,
 )
@@ -464,7 +463,7 @@ _DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # being wrapped again.
 _ORIGINAL_ISSUE_INNER_RE = re.compile(
     r"<details\b[^>]*>\s*<summary>Original Issue</summary>\s*"
-    r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
+    r"(?P<fence>`{3,}|~{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -862,7 +861,7 @@ def main() -> None:
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
-            "needs_refinement": result.get("needs_refinement", False),
+            "needs_refinement": result.get("needs_refinement", True),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -168,6 +168,18 @@ SECTION_TITLES = {
 LIST_ITEM_REGEX = re.compile(r"^(\s*)([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
 VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
+SAFE_VERIFY_COMMAND_RE = re.compile(
+    r"^(?:"
+    r"(?:python(?:3)?\s+-m\s+)?(?:pytest|unittest)\b"
+    r"|node\s+--test\b"
+    r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
+    r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
+    r"|gh\s+(?:workflow\s+run|run)\s+\S+"
+    r"|curl\s+\S+"
+    r")",
+    re.IGNORECASE,
+)
+SHELL_METACHARACTERS_RE = re.compile(r"[;&|`$<>\n\r]")
 
 
 def _context_token_budget() -> int:
@@ -378,16 +390,24 @@ def _format_issue_fallback(issue_body: str) -> str:
         # Consumer checkouts can be mid-sync or missing the canonical validator.
         # Keep the pre-validator fallback usable instead of failing the formatter.
         validator = None
-    if validator is not None and not validator.GATE.search(acceptance_text):
+    gate = getattr(validator, "GATE", None) if validator is not None else None
+    if gate is not None and not gate.search(acceptance_text):
         verify_hint = VERIFY_HINT_REGEX.search(tasks_text)
         if verify_hint:
             command = verify_hint.group(1).strip().strip("`")
             if command.startswith("pytest "):
                 command = f"python3 -m {command}"
-            acceptance_text = (
-                f"{acceptance_text}\n"
-                f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
-            )
+            if (
+                SAFE_VERIFY_COMMAND_RE.match(command)
+                and not SHELL_METACHARACTERS_RE.search(command)
+                and gate.search(command)
+            ):
+                if is_placeholder_checklist_text(acceptance_text) or re.fullmatch(
+                    r"- \[ \] _Not provided\._", acceptance_text.strip()
+                ):
+                    acceptance_text = ""
+                criterion = f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
+                acceptance_text = "\n".join(part for part in (acceptance_text, criterion) if part)
 
     parts = [
         "## Why",
@@ -443,7 +463,7 @@ _DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # already-embedded original can be recovered (and re-embedded once) instead of
 # being wrapped again.
 _ORIGINAL_ISSUE_INNER_RE = re.compile(
-    r"<details>\s*<summary>Original Issue</summary>\s*"
+    r"<details\b[^>]*>\s*<summary>Original Issue</summary>\s*"
     r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
     re.DOTALL | re.IGNORECASE,
 )
@@ -457,10 +477,38 @@ def _strip_original_issue_blocks(text: str) -> str:
         kept.append(text[cursor : match.start()])
         depth = 1
         end = match.end()
+        fence: tuple[str, int] | None = None
         for tag in _DETAILS_TAG_RE.finditer(text, match.end()):
+            # Literal HTML in the verbatim Original-Issue fence is content, not
+            # structural markup.  Only count tags outside Markdown fences.
+            # Include the tag itself while deciding whether this line is a
+            # marker-only closing fence.  A same-line ``</details>`` is
+            # fenced content, so it must keep the fence open rather than be
+            # counted as structural markup.
+            before = text[end : tag.end()]
+            for line in before.splitlines():
+                fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+                if not fence_match:
+                    continue
+                marker = fence_match.group(1)
+                if fence is None:
+                    fence = (marker[0], len(marker))
+                elif (
+                    marker[0] == fence[0]
+                    and len(marker) >= fence[1]
+                    and re.fullmatch(
+                        rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                        line,
+                    )
+                ):
+                    # Closing fences are marker-only; language tags / trailing
+                    # text must not toggle the fence state.
+                    fence = None
+            end = tag.end()
+            if fence is not None:
+                continue
             depth += -1 if tag.group(0).startswith("</") else 1
             if depth == 0:
-                end = tag.end()
                 break
         else:
             # Leave malformed markup intact rather than silently discarding it.
@@ -644,20 +692,24 @@ def _reuse_already_formatted(issue_body: str, workflow: str) -> dict[str, Any] |
     """
     reused = reuse_formatted_body({"body": issue_body}, workflow)
     if reused is not None:
+        body = _with_reuse_marker(reused)
         return {
-            "formatted_body": _with_reuse_marker(reused),
+            "formatted_body": body,
             "provider_used": None,
             "used_llm": False,
             "skipped": "reused_marker",
             "validation_audit": None,
+            "needs_refinement": not _formatted_output_valid(body),
         }
     if already_conformant(issue_body):
+        body = _with_reuse_marker(issue_body)
         return {
-            "formatted_body": _with_reuse_marker(issue_body),
+            "formatted_body": body,
             "provider_used": None,
             "used_llm": False,
             "skipped": "already_conformant",
             "validation_audit": None,
+            "needs_refinement": not _formatted_output_valid(body),
         }
     return None
 
@@ -749,6 +801,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                         "provider_used": provider,
                         "used_llm": True,
                         "validation_audit": audit,
+                        "needs_refinement": not _formatted_output_valid(formatted),
                     }
                     result.update(trace.as_dict())
                     return result
@@ -757,13 +810,13 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                 pass
 
     formatted = _format_issue_fallback(issue_body)
-    needs_refinement = not _formatted_output_valid(formatted)
     # NOTE: Task decomposition is now handled by agents:optimize step
     # which uses LLM for intelligent splitting. Don't do heuristic
     # splitting here - it causes task explosion (issue #805, #1143).
     formatted, audit = _validate_and_refine_tasks(formatted, use_llm=use_llm)
     formatted = _append_raw_issue_section(formatted, issue_body)
     formatted = _with_reuse_marker(formatted)
+    needs_refinement = not _formatted_output_valid(formatted)
     return {
         "formatted_body": formatted,
         "provider_used": None,
@@ -809,6 +862,7 @@ def main() -> None:
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
+            "needs_refinement": result.get("needs_refinement", False),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -815,11 +815,33 @@ def test_reuse_sets_needs_refinement_when_validator_fails() -> None:
     assert result["needs_refinement"] is True
 
 
-def test_bare_curl_is_not_a_safe_verify_command() -> None:
+def test_curl_is_not_a_safe_verify_command() -> None:
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl") is None
-    assert (
-        issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
+    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is None
+
+
+def test_append_raw_issue_recovers_tilde_fenced_original_issue() -> None:
+    original = "TILDE-FENCED ORIGINAL"
+    formatted = "\n".join(
+        [
+            "## Tasks",
+            "",
+            "- [ ] Keep the original body.",
+            "",
+            "<details>",
+            "<summary>Original Issue</summary>",
+            "",
+            "~~~text",
+            original,
+            "~~~",
+            "</details>",
+        ]
     )
+
+    output = issue_formatter._append_raw_issue_section(formatted, formatted)
+
+    assert output.count("<summary>Original Issue</summary>") == 1
+    assert original in output
 
 
 def test_safe_verify_command_accepts_unittest_and_requires_gh_args() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:3006 -->
> **Source:** Issue #3006

Closes #3006

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Classify conventional non-lane work branches as `LOCAL_REQUEST` only in the root and consumer-template source-context modules. Preserve the existing source precedence and keep lane-owned branches unclassified when they have no explicit source.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#3007](https://github.com/stranske/Workflows/issues/3007)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] In `.github/scripts/source_context.js`, add a rule immediately before the final `return SOURCE_TYPES.UNKNOWN` in `inferredSourceType()` mapping only `feat/`, `fix/`, `docs/`, `audit/`, `chore/`, `refactor/`, `perf/`, and `test/` to `SOURCE_TYPES.LOCAL_REQUEST`. Use trailing-slash `startsWith()` checks, not a bare prefix.
- [x] Mirror the root change byte-for-byte in `templates/consumer-repo/.github/scripts/source_context.js`, preserving the consumer/root synchronization contract.
- [x] Extend `.github/scripts/__tests__/source-context.test.js` with `resolvePrSourceContext infers local_request for conventional work-branch prefixes`, covering `feat/retire-plan-v3` and negative lane cases `codex/no-issue-link` and `closer/foo`.
- [ ] Keep `resolvePrSourceContext()` fallback ordering unchanged so explicit marker, block, checkbox, and label sources still outrank inference and `isExplicit` remains false for inferred local requests.

#### Acceptance criteria
- [ ] Named test gate: `node --test .github/scripts/__tests__/source-context.test.js` passes and the new test proves `feat/retire-plan-v3` resolves to `LOCAL_REQUEST`, `isValid === true`, `requiresIssue === false`, and `isExplicit === false`; `codex/no-issue-link` and `closer/foo` remain `UNKNOWN` and invalid. Capture the command output in the PR.
- [ ] The existing named test `resolvePrSourceContext leaves unrelated PRs unknown` continues to pass unchanged for `feature/no-source`, proving the match is `startsWith('feat/')`, not a bare `feat` prefix.
- [ ] Deliberate-break → revert gate: temporarily change the new `feat/` predicate to a bare `startsWith('feat')`; `node --test .github/scripts/__tests__/source-context.test.js` must fail the existing `feature/no-source` assertion, then revert the deliberate break before committing.
- [ ] Deliberate-break → revert gate: temporarily include `codex/` in the conventional-prefix set; the new lane assertion must fail under the same named test command, then revert it before committing.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local request detection now recognizes additional branch naming patterns.
  - Issue formatting reports whether content needs refinement, including in JSON results.
  - Verification commands are checked for approved, safe formats before inclusion.

- **Bug Fixes**
  - Improved handling of embedded HTML and Markdown code fences when parsing issue details.
  - Kept branch detection behavior consistent across repository templates.

- **Tests**
  - Added coverage for branch inference, invalid source context, and template consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->