### PR TITLE
fix(agents): preserve formatter refinement diagnostics

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -807,6 +807,14 @@ jobs:
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:
               f.write(formatted)
+          if result.get('needs_refinement'):
+              audit = result.get('validation_audit')
+              reason = 'formatted output did not satisfy the issue-format contract'
+              if audit:
+                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
+              with open('/tmp/needs_refinement', 'w') as f:
+                  f.write(reason)
+              print(f'NEEDS_REFINEMENT: {reason}')
           def env_value(value):
               return str(value or '').replace('\r', '').replace('\n', '').strip()
 
@@ -894,6 +902,37 @@ jobs:
             })().catch((error) => { console.error(error); process.exit(1); });
           REFINEMENT_NODE
             echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -f /tmp/needs_refinement ]; then
+            echo "⚠️ Formatted output needs refinement. Pausing auto-pilot."
+            node - <<'REFINEMENT_NODE'
+            (async () => {
+              const fs = require('fs');
+              const { Octokit } = require('@octokit/rest');
+              const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+              const core = { info: () => {}, warning: console.warn, debug: () => {} };
+              const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
+              const { withRetry } = await createTokenAwareRetry({
+                github, core, env: process.env, task: 'auto-pilot', capabilities: ['issues:write'],
+              });
+              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+              const issueNumber = Number(process.env.ISSUE_NUMBER);
+              const reason = fs.readFileSync('/tmp/needs_refinement', 'utf8').trim();
+              await withRetry((client) => client.rest.issues.addLabels({
+                owner, repo, issue_number: issueNumber,
+                labels: ['needs-human', 'agents:auto-pilot-pause'],
+              }));
+              await withRetry((client) => client.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: ['⚠️ **Issue formatting needs refinement.**', '', reason].join('\n'),
+              }));
+            })().catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          REFINEMENT_NODE
             exit 0
           fi
 

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -797,6 +797,9 @@ jobs:
               sys.exit(0)
           if result.get('needs_refinement'):
               reason = 'Formatter output does not satisfy the canonical issue-format contract.'
+              audit = result.get('validation_audit')
+              if audit:
+                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
               print(f'NEEDS_REFINEMENT: {reason}')
               with open('/tmp/needs_refinement', 'w') as f:
                   f.write(reason)
@@ -807,14 +810,6 @@ jobs:
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:
               f.write(formatted)
-          if result.get('needs_refinement'):
-              audit = result.get('validation_audit')
-              reason = 'formatted output did not satisfy the issue-format contract'
-              if audit:
-                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
-              with open('/tmp/needs_refinement', 'w') as f:
-                  f.write(reason)
-              print(f'NEEDS_REFINEMENT: {reason}')
           def env_value(value):
               return str(value or '').replace('\r', '').replace('\n', '').strip()
 
@@ -902,37 +897,6 @@ jobs:
             })().catch((error) => { console.error(error); process.exit(1); });
           REFINEMENT_NODE
             echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -f /tmp/needs_refinement ]; then
-            echo "⚠️ Formatted output needs refinement. Pausing auto-pilot."
-            node - <<'REFINEMENT_NODE'
-            (async () => {
-              const fs = require('fs');
-              const { Octokit } = require('@octokit/rest');
-              const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-              const core = { info: () => {}, warning: console.warn, debug: () => {} };
-              const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
-              const { withRetry } = await createTokenAwareRetry({
-                github, core, env: process.env, task: 'auto-pilot', capabilities: ['issues:write'],
-              });
-              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-              const issueNumber = Number(process.env.ISSUE_NUMBER);
-              const reason = fs.readFileSync('/tmp/needs_refinement', 'utf8').trim();
-              await withRetry((client) => client.rest.issues.addLabels({
-                owner, repo, issue_number: issueNumber,
-                labels: ['needs-human', 'agents:auto-pilot-pause'],
-              }));
-              await withRetry((client) => client.rest.issues.createComment({
-                owner, repo, issue_number: issueNumber,
-                body: ['⚠️ **Issue formatting needs refinement.**', '', reason].join('\n'),
-              }));
-            })().catch((error) => {
-              console.error(error);
-              process.exit(1);
-            });
-          REFINEMENT_NODE
             exit 0
           fi
 

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -58,7 +58,13 @@ def _issue_format_validator() -> Any:
         raise RuntimeError(f"Cannot load canonical issue-format validator: {validator_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        # Do not leave a half-initialized validator behind: callers retry this
+        # loader after transient consumer-sync failures.
+        sys.modules.pop(spec.name, None)
+        raise
     return module
 
 

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -868,6 +868,7 @@ def main() -> None:
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
             "needs_refinement": result.get("needs_refinement", True),
+            "validation_audit": result.get("validation_audit"),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -807,6 +807,14 @@ jobs:
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:
               f.write(formatted)
+          if result.get('needs_refinement'):
+              audit = result.get('validation_audit')
+              reason = 'formatted output did not satisfy the issue-format contract'
+              if audit:
+                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
+              with open('/tmp/needs_refinement', 'w') as f:
+                  f.write(reason)
+              print(f'NEEDS_REFINEMENT: {reason}')
           def env_value(value):
               return str(value or '').replace('\r', '').replace('\n', '').strip()
 
@@ -894,6 +902,37 @@ jobs:
             })().catch((error) => { console.error(error); process.exit(1); });
           REFINEMENT_NODE
             echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -f /tmp/needs_refinement ]; then
+            echo "⚠️ Formatted output needs refinement. Pausing auto-pilot."
+            node - <<'REFINEMENT_NODE'
+            (async () => {
+              const fs = require('fs');
+              const { Octokit } = require('@octokit/rest');
+              const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+              const core = { info: () => {}, warning: console.warn, debug: () => {} };
+              const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
+              const { withRetry } = await createTokenAwareRetry({
+                github, core, env: process.env, task: 'auto-pilot', capabilities: ['issues:write'],
+              });
+              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+              const issueNumber = Number(process.env.ISSUE_NUMBER);
+              const reason = fs.readFileSync('/tmp/needs_refinement', 'utf8').trim();
+              await withRetry((client) => client.rest.issues.addLabels({
+                owner, repo, issue_number: issueNumber,
+                labels: ['needs-human', 'agents:auto-pilot-pause'],
+              }));
+              await withRetry((client) => client.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: ['⚠️ **Issue formatting needs refinement.**', '', reason].join('\n'),
+              }));
+            })().catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          REFINEMENT_NODE
             exit 0
           fi
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -797,6 +797,9 @@ jobs:
               sys.exit(0)
           if result.get('needs_refinement'):
               reason = 'Formatter output does not satisfy the canonical issue-format contract.'
+              audit = result.get('validation_audit')
+              if audit:
+                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
               print(f'NEEDS_REFINEMENT: {reason}')
               with open('/tmp/needs_refinement', 'w') as f:
                   f.write(reason)
@@ -807,14 +810,6 @@ jobs:
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:
               f.write(formatted)
-          if result.get('needs_refinement'):
-              audit = result.get('validation_audit')
-              reason = 'formatted output did not satisfy the issue-format contract'
-              if audit:
-                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
-              with open('/tmp/needs_refinement', 'w') as f:
-                  f.write(reason)
-              print(f'NEEDS_REFINEMENT: {reason}')
           def env_value(value):
               return str(value or '').replace('\r', '').replace('\n', '').strip()
 
@@ -902,37 +897,6 @@ jobs:
             })().catch((error) => { console.error(error); process.exit(1); });
           REFINEMENT_NODE
             echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -f /tmp/needs_refinement ]; then
-            echo "⚠️ Formatted output needs refinement. Pausing auto-pilot."
-            node - <<'REFINEMENT_NODE'
-            (async () => {
-              const fs = require('fs');
-              const { Octokit } = require('@octokit/rest');
-              const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
-              const core = { info: () => {}, warning: console.warn, debug: () => {} };
-              const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
-              const { withRetry } = await createTokenAwareRetry({
-                github, core, env: process.env, task: 'auto-pilot', capabilities: ['issues:write'],
-              });
-              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-              const issueNumber = Number(process.env.ISSUE_NUMBER);
-              const reason = fs.readFileSync('/tmp/needs_refinement', 'utf8').trim();
-              await withRetry((client) => client.rest.issues.addLabels({
-                owner, repo, issue_number: issueNumber,
-                labels: ['needs-human', 'agents:auto-pilot-pause'],
-              }));
-              await withRetry((client) => client.rest.issues.createComment({
-                owner, repo, issue_number: issueNumber,
-                body: ['⚠️ **Issue formatting needs refinement.**', '', reason].join('\n'),
-              }));
-            })().catch((error) => {
-              console.error(error);
-              process.exit(1);
-            });
-          REFINEMENT_NODE
             exit 0
           fi
 

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -58,7 +58,13 @@ def _issue_format_validator() -> Any:
         raise RuntimeError(f"Cannot load canonical issue-format validator: {validator_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        # Do not leave a half-initialized validator behind: callers retry this
+        # loader after transient consumer-sync failures.
+        sys.modules.pop(spec.name, None)
+        raise
     return module
 
 

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -868,6 +868,7 @@ def main() -> None:
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
             "needs_refinement": result.get("needs_refinement", True),
+            "validation_audit": result.get("validation_audit"),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import io
 import json
 import sys
@@ -13,6 +15,29 @@ from scripts.langchain.issue_pr_context import reuse_formatted_body
 
 def _canonical_issue_format():
     return issue_formatter._issue_format_validator()
+
+
+def test_issue_format_validator_removes_partially_loaded_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed validator import must not poison a later retry."""
+
+    class FailingLoader:
+        def create_module(self, spec):  # noqa: ANN001
+            return None
+
+        def exec_module(self, module):  # noqa: ANN001
+            raise RuntimeError("transient validator load failure")
+
+    spec = importlib.machinery.ModuleSpec("_fleet_issue_format", FailingLoader())
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *args: spec)
+    issue_formatter._issue_format_validator.cache_clear()
+
+    with pytest.raises(RuntimeError, match="transient validator load failure"):
+        issue_formatter._issue_format_validator()
+
+    assert "_fleet_issue_format" not in sys.modules
+    issue_formatter._issue_format_validator.cache_clear()
 
 
 def _install_fake_langchain(monkeypatch: pytest.MonkeyPatch, mock_chain: mock.MagicMock) -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -464,6 +464,7 @@ def test_main_emits_json_with_labels(monkeypatch, capsys) -> None:
     }
     assert payload["used_llm"] is False
     assert "## Acceptance Criteria" in payload["formatted_body"]
+    assert "validation_audit" in payload
 
 
 def test_main_writes_output_file(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -22,12 +22,20 @@ def test_issue_format_validator_removes_partially_loaded_module(
 ) -> None:
     """A failed validator import must not poison a later retry."""
 
+    attempts = {"count": 0}
+
+    class ValidationResult:
+        ok = True
+
     class FailingLoader:
         def create_module(self, spec):  # noqa: ANN001
             return None
 
         def exec_module(self, module):  # noqa: ANN001
-            raise RuntimeError("transient validator load failure")
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("transient validator load failure")
+            module.__dict__["validate"] = lambda body: ValidationResult()
 
     spec = importlib.machinery.ModuleSpec("_fleet_issue_format", FailingLoader())
     monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *args: spec)
@@ -37,6 +45,14 @@ def test_issue_format_validator_removes_partially_loaded_module(
         issue_formatter._issue_format_validator()
 
     assert "_fleet_issue_format" not in sys.modules
+    issue_formatter._issue_format_validator.cache_clear()
+
+    validator = issue_formatter._issue_format_validator()
+    assert attempts["count"] == 2
+    assert "_fleet_issue_format" in sys.modules
+    assert validator is sys.modules["_fleet_issue_format"]
+
+    sys.modules.pop("_fleet_issue_format", None)
     issue_formatter._issue_format_validator.cache_clear()
 
 
@@ -448,6 +464,19 @@ def test_build_label_transition_matches_expected_labels() -> None:
 
 
 def test_main_emits_json_with_labels(monkeypatch, capsys) -> None:
+    expected_audit = "Task validation: 1 input → 1 output. All clean."
+    real_format_issue_body = issue_formatter.format_issue_body
+    monkeypatch.setattr(
+        issue_formatter,
+        "format_issue_body",
+        lambda raw, use_llm=True: {
+            "formatted_body": real_format_issue_body(raw, use_llm=False)["formatted_body"],
+            "provider_used": None,
+            "used_llm": False,
+            "validation_audit": expected_audit,
+            "needs_refinement": False,
+        },
+    )
     monkeypatch.setattr(
         sys,
         "argv",
@@ -464,7 +493,7 @@ def test_main_emits_json_with_labels(monkeypatch, capsys) -> None:
     }
     assert payload["used_llm"] is False
     assert "## Acceptance Criteria" in payload["formatted_body"]
-    assert "validation_audit" in payload
+    assert payload["validation_audit"] == expected_audit
 
 
 def test_main_writes_output_file(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
Addresses active source-owned sync review debt. Cleans failed canonical validator imports from `sys.modules`, pauses auto-pilot with the formatter validation audit when refinement is required, and keeps the managed consumer template aligned.\n\nValidation: `actionlint .github/workflows/agents-auto-pilot.yml templates/consumer-repo/.github/workflows/agents-auto-pilot.yml`; `scripts/sync_templates.sh --check`; `python3 scripts/validate_template_completeness.py`; `pytest -q tests/scripts/test_issue_formatter.py`; `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling so failed checks can be retried cleanly.
  * Refinement failure messages now include available validation audit details.

* **New Features**
  * CLI JSON output now includes validation audit results, making task checks easier to inspect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->