### PR TITLE
fix(agents): align formatter and deliberate-break parsing

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T16:03:56.734152Z",
+  "emitted_at": "2026-08-09T19:41:48.872004Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3011",
+  "pr_number": "3014",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T19:41:48.872004Z",
+  "emitted_at": "2026-08-09T20:34:22.350896Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -167,8 +167,9 @@ def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | 
                 continue
             if re.search(r"\s", normalized):
                 continue
-            if "/" in normalized or normalized.endswith((".py", ".yml", ".yaml", ".js")):
-                paths.append(normalized.split(":", 1)[0])
+            path_only = normalized.split(":", 1)[0]
+            if "/" in path_only or path_only.endswith((".py", ".yml", ".yaml", ".js")):
+                paths.append(path_only)
         return paths
 
     ordered_paths: list[str] = []

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -160,10 +160,12 @@ def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | 
     def _candidate_paths(text: str) -> list[str]:
         paths: list[str] = []
         for path in re.findall(r"`([^`]+)`", text):
-            normalized = path.strip()
-            if not normalized or normalized.endswith(":"):
+            normalized = path.strip().rstrip(":")
+            if not normalized:
                 continue
             if re.fullmatch(r"[A-Za-z][\w-]*:\s*.+", normalized):
+                continue
+            if re.search(r"\s", normalized):
                 continue
             if "/" in normalized or normalized.endswith((".py", ".yml", ".yaml", ".js")):
                 paths.append(normalized.split(":", 1)[0])

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -181,7 +181,7 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
-    r"|curl\s+\S+"
+    r"|curl\s+https?://\S+\Z"
     r")",
     re.IGNORECASE,
 )

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -181,6 +181,7 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
+    r"|curl\s+\S+"
     r")",
     re.IGNORECASE,
 )

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -163,8 +163,9 @@ def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | 
                 continue
             if re.search(r"\s", normalized):
                 continue
-            if "/" in normalized or normalized.endswith((".py", ".yml", ".yaml", ".js")):
-                paths.append(normalized.split(":", 1)[0])
+            path_only = normalized.split(":", 1)[0]
+            if "/" in path_only or path_only.endswith((".py", ".yml", ".yaml", ".js")):
+                paths.append(path_only)
         return paths
 
     ordered_paths: list[str] = []

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -172,9 +172,7 @@ def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | 
         ordered_paths.extend(_candidate_paths(text))
 
     workflow_paths = [
-        path
-        for path in ordered_paths
-        if path.endswith((".yml", ".yaml")) and "/workflows/" in path
+        path for path in ordered_paths if path.endswith((".yml", ".yaml")) and "/workflows/" in path
     ]
     return (workflow_paths or ordered_paths or [None])[0]
 

--- a/templates/consumer-repo/scripts/check_deliberate_break.py
+++ b/templates/consumer-repo/scripts/check_deliberate_break.py
@@ -123,7 +123,7 @@ def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
     return None
 
 
-def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
+def _fallback_marker(section: str, markdown: str = "") -> DeliberateBreakSpec | None:
     named_line = next(
         (line for line in section.splitlines() if "named test:" in line.lower()),
         "",
@@ -141,19 +141,47 @@ def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
 
     test_file_match = re.search(r"`([^`]*(?:test|tests)[^`]*\.py)`", named_line)
     test_name_match = re.search(r"\bwith\s+`?([A-Za-z_][A-Za-z0-9_]*)`?", named_line)
-    break_file_match = re.search(r"`([^`]+)`", break_line)
-    if not test_file_match or not test_name_match or not break_file_match:
+    break_file = _infer_break_file(break_line, named_line, markdown)
+    if not test_file_match or not test_name_match or not break_file:
         return None
 
     test_file = test_file_match.group(1)
     test_id = f"{test_file}::{test_name_match.group(1)}"
-    break_file = break_file_match.group(1)
     return DeliberateBreakSpec(test_id, test_file, break_file, _pytest_command(test_id))
+
+
+def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | None:
+    """Pick a revert target from acceptance wording, skipping label-like backticks."""
+
+    def _candidate_paths(text: str) -> list[str]:
+        paths: list[str] = []
+        for path in re.findall(r"`([^`]+)`", text):
+            normalized = path.strip().rstrip(":")
+            if not normalized:
+                continue
+            if re.fullmatch(r"[A-Za-z][\w-]*:\s*.+", normalized):
+                continue
+            if re.search(r"\s", normalized):
+                continue
+            if "/" in normalized or normalized.endswith((".py", ".yml", ".yaml", ".js")):
+                paths.append(normalized.split(":", 1)[0])
+        return paths
+
+    ordered_paths: list[str] = []
+    for text in (break_line, named_line, markdown):
+        ordered_paths.extend(_candidate_paths(text))
+
+    workflow_paths = [
+        path
+        for path in ordered_paths
+        if path.endswith((".yml", ".yaml")) and "/workflows/" in path
+    ]
+    return (workflow_paths or ordered_paths or [None])[0]
 
 
 def parse_deliberate_break_spec(markdown: str) -> DeliberateBreakSpec | None:
     section = _acceptance_criteria(markdown)
-    return _explicit_marker(section) or _fallback_marker(section)
+    return _explicit_marker(section) or _fallback_marker(section, markdown)
 
 
 def _pytest_command(test_id: str) -> tuple[str, ...]:

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -181,7 +181,7 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
-    r"|curl\s+\S+"
+    r"|curl\s+https?://\S+\Z"
     r")",
     re.IGNORECASE,
 )

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -181,6 +181,7 @@ SAFE_VERIFY_COMMAND_RE = re.compile(
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|gh\s+(?:workflow\s+run|run)\s+\S+"
+    r"|curl\s+\S+"
     r")",
     re.IGNORECASE,
 )

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -140,6 +140,19 @@ def test_issue_3007_acceptance_wording_is_supported() -> None:
     assert spec.break_file == ".github/workflows/maint-69-sync-labels.yml"
 
 
+def test_fallback_marker_ignores_backticked_curl_command_and_keeps_trailing_colon_path() -> None:
+    spec = parse_deliberate_break_spec(
+        """## Acceptance Criteria
+- [ ] Deliberate break: change `src/example.py:` and prove the named test fails.
+- [ ] Named test: run `tests/test_example.py` with `test_example`.
+- [ ] Verify with `curl https://example.test/health`.
+"""
+    )
+
+    assert spec is not None
+    assert spec.break_file == "src/example.py"
+
+
 def test_assertion_tamper_is_flagged(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -150,6 +150,13 @@ def test_fallback_marker_ignores_backticked_curl_command_and_keeps_trailing_colo
     assert spec is not None
     assert spec.break_file == "src/example.py"
 
+    curl_only = parse_deliberate_break_spec("""## Acceptance Criteria
+- [ ] Deliberate break: change `curl https://example.test/health` and prove the named test fails.
+- [ ] Named test: run `tests/test_example.py` with `test_example`.
+""")
+
+    assert curl_only is None or curl_only.break_file != "curl https://example.test/health"
+
 
 def test_assertion_tamper_is_flagged(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -141,13 +141,11 @@ def test_issue_3007_acceptance_wording_is_supported() -> None:
 
 
 def test_fallback_marker_ignores_backticked_curl_command_and_keeps_trailing_colon_path() -> None:
-    spec = parse_deliberate_break_spec(
-        """## Acceptance Criteria
+    spec = parse_deliberate_break_spec("""## Acceptance Criteria
 - [ ] Deliberate break: change `src/example.py:` and prove the named test fails.
 - [ ] Named test: run `tests/test_example.py` with `test_example`.
 - [ ] Verify with `curl https://example.test/health`.
-"""
-    )
+""")
 
     assert spec is not None
     assert spec.break_file == "src/example.py"

--- a/tests/scripts/test_check_deliberate_break.py
+++ b/tests/scripts/test_check_deliberate_break.py
@@ -158,6 +158,16 @@ def test_fallback_marker_ignores_backticked_curl_command_and_keeps_trailing_colo
     assert curl_only is None or curl_only.break_file != "curl https://example.test/health"
 
 
+def test_fallback_marker_accepts_root_level_line_range_path() -> None:
+    spec = parse_deliberate_break_spec("""## Acceptance Criteria
+- [ ] Deliberate break: change `app.py:24-25` and prove the named test fails.
+- [ ] Named test: run `tests/test_app.py` with `test_app`.
+""")
+
+    assert spec is not None
+    assert spec.break_file == "app.py"
+
+
 def test_assertion_tamper_is_flagged(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -872,7 +872,9 @@ def test_reuse_sets_needs_refinement_when_validator_fails() -> None:
 
 def test_curl_requires_a_target_for_safe_verify_command() -> None:
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl") is None
-    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
+    assert (
+        issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
+    )
 
 
 def test_append_raw_issue_recovers_tilde_fenced_original_issue() -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -883,6 +883,9 @@ def test_curl_requires_a_target_for_safe_verify_command() -> None:
     assert (
         issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
     )
+    assert (
+        issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl http://example.test/health") is not None
+    )
 
 
 def test_append_raw_issue_recovers_tilde_fenced_original_issue() -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -870,9 +870,9 @@ def test_reuse_sets_needs_refinement_when_validator_fails() -> None:
     assert result["needs_refinement"] is True
 
 
-def test_curl_is_not_a_safe_verify_command() -> None:
+def test_curl_requires_a_target_for_safe_verify_command() -> None:
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl") is None
-    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is None
+    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
 
 
 def test_append_raw_issue_recovers_tilde_fenced_original_issue() -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -872,6 +872,14 @@ def test_reuse_sets_needs_refinement_when_validator_fails() -> None:
 
 def test_curl_requires_a_target_for_safe_verify_command() -> None:
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl") is None
+    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl /etc/passwd") is None
+    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl file:///etc/passwd") is None
+    assert (
+        issue_formatter.SAFE_VERIFY_COMMAND_RE.match(
+            "curl https://example.test/health --output /tmp/result"
+        )
+        is None
+    )
     assert (
         issue_formatter.SAFE_VERIFY_COMMAND_RE.match("curl https://example.test/health") is not None
     )


### PR DESCRIPTION
## Summary
- accept targeted curl verification hints when the canonical issue validator accepts them
- preserve paths ending in a trailing colon while rejecting backticked commands as deliberate-break targets
- keep the consumer issue-formatter template synchronized

## Validation
- `python -m pytest tests/scripts/test_issue_formatter.py tests/scripts/test_check_deliberate_break.py -q` (172 passed)
- `python scripts/validate_template_sync.py`
- `git diff --check`

Source fix for the active review debt on the b7440b sync canaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deliberate-break marker parsing by removing trailing punctuation, ignoring unrelated backtick-enclosed commands, and identifying valid paths more reliably across the full document.
  * Updated verification checks to recognize `curl` commands targeting HTTP(S) URLs without output options as safe, while continuing to reject unsafe variants.

* **Tests**
  * Added regression coverage for marker parsing and expanded command-safety expectations for supported and unsupported `curl` patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->