### PR TITLE
fix(agents): surface formatter errors in sync consumers

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -795,6 +795,9 @@ jobs:
               with open('/tmp/guard_blocked', 'w') as f:
                   f.write(reason)
               sys.exit(0)
+          if result.get('error'):
+              print('ERROR: Formatter failed: ' + str(result.get('error')))
+              sys.exit(1)
           if result.get('needs_refinement'):
               reason = 'Formatter output does not satisfy the canonical issue-format contract.'
               audit = result.get('validation_audit')

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -269,10 +269,10 @@ jobs:
               || echo "::warning::could not apply agents:auto-pilot-pause"
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
               || echo "::warning::could not release agents:format after attempt cap"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
-          <!-- format-guard:attempt-cap -->
-          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
-          EOF
+            printf '%s\n' \
+              '<!-- format-guard:attempt-cap -->' \
+              "Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying." \
+              | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
             exit 0
           fi
           has_format_label=false

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -864,13 +864,15 @@ def main() -> None:
 
     if args.json:
         payload = {
-            "formatted_body": result["formatted_body"],
+            "formatted_body": result.get("formatted_body"),
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
-            "needs_refinement": result.get("needs_refinement", True),
+            "needs_refinement": result.get("needs_refinement", False),
             "validation_audit": result.get("validation_audit"),
         }
+        if result.get("error"):
+            payload["error"] = result["error"]
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True
             payload["guard_reason"] = result.get("guard_reason") or ""

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -795,6 +795,9 @@ jobs:
               with open('/tmp/guard_blocked', 'w') as f:
                   f.write(reason)
               sys.exit(0)
+          if result.get('error'):
+              print('ERROR: Formatter failed: ' + str(result.get('error')))
+              sys.exit(1)
           if result.get('needs_refinement'):
               reason = 'Formatter output does not satisfy the canonical issue-format contract.'
               audit = result.get('validation_audit')

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -269,10 +269,10 @@ jobs:
               || echo "::warning::could not apply agents:auto-pilot-pause"
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
               || echo "::warning::could not release agents:format after attempt cap"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
-          <!-- format-guard:attempt-cap -->
-          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
-          EOF
+            printf '%s\n' \
+              '<!-- format-guard:attempt-cap -->' \
+              "Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying." \
+              | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
             exit 0
           fi
           has_format_label=false

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -864,13 +864,15 @@ def main() -> None:
 
     if args.json:
         payload = {
-            "formatted_body": result["formatted_body"],
+            "formatted_body": result.get("formatted_body"),
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
-            "needs_refinement": result.get("needs_refinement", True),
+            "needs_refinement": result.get("needs_refinement", False),
             "validation_audit": result.get("validation_audit"),
         }
+        if result.get("error"):
+            payload["error"] = result["error"]
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True
             payload["guard_reason"] = result.get("guard_reason") or ""

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -496,6 +496,30 @@ def test_main_emits_json_with_labels(monkeypatch, capsys) -> None:
     assert payload["validation_audit"] == expected_audit
 
 
+def test_main_emits_formatter_error_without_refinement(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        issue_formatter,
+        "format_issue_body",
+        lambda raw, use_llm=True: {
+            "error": "Issue body too large",
+            "formatted_body": None,
+            "provider_used": None,
+            "used_llm": False,
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["issue_formatter.py", "--input-text", "Raw issue", "--json", "--no-llm"],
+    )
+
+    issue_formatter.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["error"] == "Issue body too large"
+    assert payload["needs_refinement"] is False
+
+
 def test_main_writes_output_file(monkeypatch, tmp_path, capsys) -> None:
     output_path = tmp_path / "formatted.md"
     monkeypatch.setattr(


### PR DESCRIPTION
Resolves source-owned review debt blocking the current Maint 68 canaries.

- replace the ambiguous attempt-cap heredoc with a `printf` pipeline in root and consumer template guards
- preserve formatter errors in JSON and fail auto-pilot with the explicit error before refinement handling
- add regression coverage for formatter JSON error payloads

Validation:
- `python -m pytest -q tests/scripts/test_issue_formatter.py tests/workflows/test_agents_issue_optimizer_format_trigger.py` (50 passed)
- `python scripts/validate_template_sync.py`
- `scripts/sync_templates.sh --check`
- `python scripts/check_template_drift.py --allowlist config/template-drift-allowlist.txt` (0 unallowlisted drift)
- `actionlint -ignore 'SC1083:' ...`\n- `git diff --check`