### PR TITLE
fix(workflows): isolate free-text workflow inputs

### DIFF
--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -112,9 +112,11 @@ jobs:
 
       - name: Build repo matrix
         id: repos
+        env:
+          INPUT_REPOS: ${{ inputs.repos }}
         run: |
-          if [ -n "${{ inputs.repos }}" ]; then
-            repos="${{ inputs.repos }}"
+          if [ -n "$INPUT_REPOS" ]; then
+            repos="$INPUT_REPOS"
           else
             repos=$(python scripts/list_registered_consumer_repos.py --separator ',')
           fi

--- a/.github/workflows/maint-52-sync-dev-versions.yml
+++ b/.github/workflows/maint-52-sync-dev-versions.yml
@@ -128,6 +128,11 @@ jobs:
               | map(select(. != ""))
               | map(gsub("^\\s+|\\s+$"; ""))
             ')
+          invalid_repos=$(jq -r '.[] | select(test("^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$") | not)' <<<"$json_array")
+          if [ -n "$invalid_repos" ]; then
+            echo "Invalid owner/repository value(s): $invalid_repos" >&2
+            exit 1
+          fi
           echo "matrix={\"repo\":$json_array}" >> "$GITHUB_OUTPUT"
           echo "Repos to sync: $json_array"
 
@@ -153,8 +158,9 @@ jobs:
       - name: Clone consumer repo
         env:
           GH_TOKEN: ${{ env.REPO_TOKEN }}
+          MATRIX_REPO: ${{ matrix.repo }}
         run: |
-          gh repo clone ${{ matrix.repo }} consumer -- --depth=1
+          gh repo clone "$MATRIX_REPO" consumer -- --depth=1
 
       - name: Download sync script
         uses: actions/download-artifact@v8
@@ -271,8 +277,10 @@ jobs:
 
       - name: Skip - no pyproject.toml
         if: steps.check.outputs.has_pyproject != 'true'
+        env:
+          MATRIX_REPO: ${{ matrix.repo }}
         run: |
-          echo "Skipping ${{ matrix.repo }}: no pyproject.toml found"
+          echo "Skipping $MATRIX_REPO: no pyproject.toml found"
 
       - name: Create sync PR
         if: >-

--- a/.github/workflows/maint-69-sync-labels.yml
+++ b/.github/workflows/maint-69-sync-labels.yml
@@ -68,9 +68,11 @@ jobs:
 
       - name: Determine target repos
         id: repos
+        env:
+          INPUT_REPOS: ${{ inputs.repos }}
         run: |
-          if [ "${{ inputs.repos }}" != "all" ] && [ -n "${{ inputs.repos }}" ]; then
-            repos="${{ inputs.repos }}"
+          if [ "$INPUT_REPOS" != "all" ] && [ -n "$INPUT_REPOS" ]; then
+            repos="$INPUT_REPOS"
           else
             repos=$(python scripts/list_registered_consumer_repos.py --separator ',')
           fi

--- a/.github/workflows/maint-70-fix-integration-formatting.yml
+++ b/.github/workflows/maint-70-fix-integration-formatting.yml
@@ -113,6 +113,8 @@ jobs:
 
       - name: Commit and push changes
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          COMMIT_MESSAGE: ${{ inputs.commit_message }}
         run: |
           cd integration-tests
           git config user.name "github-actions[bot]"
@@ -121,7 +123,7 @@ jobs:
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           git add -A
-          git commit -m "${{ inputs.commit_message }}" \
+          git commit -m "$COMMIT_MESSAGE" \
             -m "" \
             -m "Applied by: ${run_url}"
 

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -865,7 +865,7 @@ jobs:
           SANDBOX: ${{ inputs.sandbox }}
           EXTRA_ARGS_RAW: ${{ inputs.codex_args }}
           MAX_RUNTIME_MIN: ${{ inputs.max_runtime_minutes }}
-          TARGET_BRANCH: ${{ inputs.pr_ref }}
+          TARGET_BRANCH: ${{ inputs.pr_ref || github.ref_name }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -860,6 +860,12 @@ jobs:
           CODEX_HOME: ${{ runner.temp }}/.codex
           CODEX_MODEL_CANDIDATES: ${{ steps.codex_model.outputs.candidates }}
           CODEX_MODEL_SELECTION_REASON: ${{ steps.codex_model.outputs.selection_reason }}
+          PROMPT_FILE: ${{ steps.prompt.outputs.file }}
+          PR_NUM: ${{ inputs.pr_number }}
+          SANDBOX: ${{ inputs.sandbox }}
+          EXTRA_ARGS_RAW: ${{ inputs.codex_args }}
+          MAX_RUNTIME_MIN: ${{ inputs.max_runtime_minutes }}
+          TARGET_BRANCH: ${{ inputs.pr_ref }}
         run: |
           set -euo pipefail
 
@@ -869,9 +875,7 @@ jobs:
           chmod 600 "$CODEX_HOME/auth.json"
 
           # Build codex exec command
-          PROMPT_FILE="${{ steps.prompt.outputs.file }}"
           # Use PR-specific output filename to avoid merge conflicts
-          PR_NUM="${{ inputs.pr_number }}"
           if [ -n "${PR_NUM}" ]; then
             OUTPUT_FILE="codex-output-${PR_NUM}.md"
             SESSION_JSONL="codex-session-${PR_NUM}.jsonl"
@@ -879,8 +883,6 @@ jobs:
             OUTPUT_FILE="codex-output.md"
             SESSION_JSONL="codex-session.jsonl"
           fi
-          SANDBOX="${{ inputs.sandbox }}"
-          EXTRA_ARGS_RAW="${{ inputs.codex_args }}"
 
           # Default sandbox if not specified
           if [ -z "$SANDBOX" ]; then
@@ -949,7 +951,6 @@ jobs:
           # When the job approaches the timeout limit, this background process
           # commits and pushes any uncommitted work so it isn't lost to the
           # job cancellation.  It fires once, 5 minutes before max_runtime.
-          MAX_RUNTIME_MIN=${{ inputs.max_runtime_minutes }}
           GRACE_MIN=5
           WATCHDOG_DELAY=$(( (MAX_RUNTIME_MIN - GRACE_MIN) * 60 ))
           echo "watchdog-saved=false" >> "$GITHUB_OUTPUT"
@@ -961,7 +962,6 @@ jobs:
               echo "::warning::Pre-timeout watchdog fired "\
                 "(${GRACE_MIN}m before ${MAX_RUNTIME_MIN}m limit)"
 
-              TARGET_BRANCH="${{ inputs.pr_ref }}"
               TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
               PUSH_TOKEN="${{ steps.run_base.outputs.push_token }}"
               REMOTE_URL="https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T20:34:22.350896Z",
+  "emitted_at": "2026-08-10T00:11:13.921916Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3014",
+  "pr_number": "3020",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-09T20:34:22.350896Z",
+  "emitted_at": "2026-08-10T02:40:15.408109Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3014",
+  "pr_number": "3020",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:45:50.311078Z",
+  "emitted_at": "2026-08-10T01:49:29.306383Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:33:46.421608Z",
+  "emitted_at": "2026-08-10T01:35:44.683576Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T02:29:47.933677Z",
+  "emitted_at": "2026-08-09T20:34:22.350896Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3020",
+  "pr_number": "3014",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T02:10:25.819697Z",
+  "emitted_at": "2026-08-10T01:35:44.683576Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:35:44.683576Z",
+  "emitted_at": "2026-08-10T02:29:47.933677Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:47:00.885623Z",
+  "emitted_at": "2026-08-10T01:33:46.421608Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:11:13.921916Z",
+  "emitted_at": "2026-08-10T00:14:06.392693Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:42:49.160655Z",
+  "emitted_at": "2026-08-10T00:45:39.240186Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:35:44.683576Z",
+  "emitted_at": "2026-08-10T01:42:15.410089Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T02:40:15.408109Z",
+  "emitted_at": "2026-08-09T20:34:22.350896Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "3020",
+  "pr_number": "3014",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:49:29.306383Z",
+  "emitted_at": "2026-08-10T02:08:13.176461Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:45:39.240186Z",
+  "emitted_at": "2026-08-10T00:47:00.885623Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:39:55.964773Z",
+  "emitted_at": "2026-08-10T00:42:49.160655Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:14:06.392693Z",
+  "emitted_at": "2026-08-10T00:16:42.569466Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T00:16:42.569466Z",
+  "emitted_at": "2026-08-10T00:39:55.964773Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T01:42:15.410089Z",
+  "emitted_at": "2026-08-10T01:45:50.311078Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-10T02:08:13.176461Z",
+  "emitted_at": "2026-08-10T02:10:25.819697Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -54,10 +54,7 @@ def _untrusted_references(script: str) -> list[str]:
     return sorted(
         expression
         for expression in UNTRUSTED_EXPRESSIONS
-        if any(
-            re.search(rf"\b{re.escape(expression)}\b", body)
-            for body in expression_bodies
-        )
+        if any(re.search(rf"\b{re.escape(expression)}\b", body) for body in expression_bodies)
     )
 
 

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -23,7 +23,6 @@ WORKFLOW_GLOBS = (".github/workflows/*.yml", ".github/workflows/*.yaml")
 # constrained-value review; expanding this set is not a substitute for that
 # review.
 UNTRUSTED_EXPRESSIONS = frozenset({"inputs.commit_message", "inputs.codex_args", "inputs.repos"})
-ACTIONS_EXPRESSION = re.compile(r"\$\{\{(?P<body>.*?)\}\}", re.DOTALL)
 
 
 def _workflow_paths() -> Iterable[Path]:
@@ -47,14 +46,54 @@ def _script_values(path: Path) -> Iterable[tuple[str, str]]:
                 yield f"{job_name}/step-{index}/with.script", script
 
 
+def _actions_expression_bodies(script: str) -> Iterable[str]:
+    """Yield Actions expression bodies without ending quoted brace literals early."""
+
+    start = 0
+    while (opening := script.find("${{", start)) != -1:
+        index = opening + 3
+        quote: str | None = None
+        escaped = False
+        while index < len(script) - 1:
+            character = script[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+            elif character in {"'", '"'}:
+                quote = character
+            elif script[index : index + 2] == "}}":
+                yield script[opening + 3 : index]
+                start = index + 2
+                break
+            index += 1
+        else:
+            start = opening + 3
+
+
+def _references_untrusted_input(body: str, expression: str) -> bool:
+    """Recognize equivalent property and bracket references in an expression."""
+
+    _, property_name = expression.split(".", maxsplit=1)
+    return bool(
+        re.search(
+            rf"\binputs\s*(?:\.\s*{re.escape(property_name)}\b|\[\s*['\"]{re.escape(property_name)}['\"]\s*\])",
+            body,
+        )
+    )
+
+
 def _untrusted_references(script: str) -> list[str]:
     """Return free-text inputs referenced anywhere in Actions expressions."""
 
-    expression_bodies = [match.group("body") for match in ACTIONS_EXPRESSION.finditer(script)]
+    expression_bodies = list(_actions_expression_bodies(script))
     return sorted(
         expression
         for expression in UNTRUSTED_EXPRESSIONS
-        if any(re.search(rf"\b{re.escape(expression)}\b", body) for body in expression_bodies)
+        if any(_references_untrusted_input(body, expression) for body in expression_bodies)
     )
 
 
@@ -80,5 +119,9 @@ def test_untrusted_expression_guard_has_a_concrete_target(expression: str) -> No
 def test_untrusted_expression_guard_matches_default_and_wrapper_forms() -> None:
     assert _untrusted_references("echo ${{ inputs.repos || 'all' }}") == ["inputs.repos"]
     assert _untrusted_references("const v = '${{ format('{0}', inputs.codex_args) }}';") == [
+        "inputs.codex_args"
+    ]
+    assert _untrusted_references("echo ${{ inputs['repos'] }}") == ["inputs.repos"]
+    assert _untrusted_references("${{ format('{{prefix}} {0}', inputs.codex_args) }}") == [
         "inputs.codex_args"
     ]

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -21,9 +21,7 @@ WORKFLOW_GLOBS = (".github/workflows/*.yml", ".github/workflows/*.yaml")
 # Keep this deliberately small. Other expressions require a file-by-file
 # constrained-value review; expanding this set is not a substitute for that
 # review.
-UNTRUSTED_EXPRESSIONS = frozenset(
-    {"inputs.commit_message", "inputs.codex_args", "inputs.repos"}
-)
+UNTRUSTED_EXPRESSIONS = frozenset({"inputs.commit_message", "inputs.codex_args", "inputs.repos"})
 
 
 def _workflow_paths() -> Iterable[Path]:
@@ -55,9 +53,7 @@ def test_no_untrusted_expressions_in_script_bodies() -> None:
             for expression in UNTRUSTED_EXPRESSIONS:
                 token = "${{ " + expression + " }}"
                 if token in script:
-                    violations.append(
-                        f"{workflow.relative_to(ROOT)}:{location}: {token}"
-                    )
+                    violations.append(f"{workflow.relative_to(ROOT)}:{location}: {token}")
     assert not violations, (
         "Pass untrusted workflow values through step env and consume the env "
         "variable in the script:\n" + "\n".join(violations)

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -1,0 +1,70 @@
+"""Regression guard for free-text Actions values embedded in scripts.
+
+Workflow expressions are evaluated before a shell or github-script body runs.
+The listed values are free-form workflow-dispatch or runner inputs, so placing
+them directly in a ``run:``/``with.script:`` body can turn quotes or shell
+metacharacters into source code. They must cross that boundary through a
+step-level ``env:`` value instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_GLOBS = (".github/workflows/*.yml", ".github/workflows/*.yaml")
+
+# Keep this deliberately small. Other expressions require a file-by-file
+# constrained-value review; expanding this set is not a substitute for that
+# review.
+UNTRUSTED_EXPRESSIONS = frozenset(
+    {"inputs.commit_message", "inputs.codex_args", "inputs.repos"}
+)
+
+
+def _workflow_paths() -> Iterable[Path]:
+    for pattern in WORKFLOW_GLOBS:
+        yield from sorted(ROOT.glob(pattern))
+
+
+def _script_values(path: Path) -> Iterable[tuple[str, str]]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    for job_name, job in (data.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for index, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if isinstance(run, str):
+                yield f"{job_name}/step-{index}/run", run
+            script = (step.get("with") or {}).get("script")
+            if isinstance(script, str):
+                yield f"{job_name}/step-{index}/with.script", script
+
+
+def test_no_untrusted_expressions_in_script_bodies() -> None:
+    """Free-text inputs must not be interpolated into shell or JS source."""
+    violations: list[str] = []
+    for workflow in _workflow_paths():
+        for location, script in _script_values(workflow):
+            for expression in UNTRUSTED_EXPRESSIONS:
+                token = "${{ " + expression + " }}"
+                if token in script:
+                    violations.append(
+                        f"{workflow.relative_to(ROOT)}:{location}: {token}"
+                    )
+    assert not violations, (
+        "Pass untrusted workflow values through step env and consume the env "
+        "variable in the script:\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.parametrize("expression", sorted(UNTRUSTED_EXPRESSIONS))
+def test_untrusted_expression_guard_has_a_concrete_target(expression: str) -> None:
+    """Keep each listed field intentional rather than a broad catch-all."""
+    assert expression.startswith("inputs.")

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -110,10 +110,30 @@ def test_no_untrusted_expressions_in_script_bodies() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("body", "expression", "expected"),
+    [
+        ("inputs.commit_message", "inputs.commit_message", True),
+        ("inputs['commit_message']", "inputs.commit_message", True),
+        ("inputs.repos || 'all'", "inputs.repos", True),
+        ("inputs['repos']", "inputs.repos", True),
+        ("inputs.codex_args", "inputs.codex_args", True),
+        ("inputs.safe_field", "inputs.commit_message", False),
+    ],
+)
+def test_references_untrusted_input(body: str, expression: str, expected: bool) -> None:
+    assert _references_untrusted_input(body, expression) is expected
+
+
 @pytest.mark.parametrize("expression", sorted(UNTRUSTED_EXPRESSIONS))
-def test_untrusted_expression_guard_has_a_concrete_target(expression: str) -> None:
-    """Keep each listed field intentional rather than a broad catch-all."""
-    assert expression.startswith("inputs.")
+def test_untrusted_expression_guard_detects_listed_inputs(expression: str) -> None:
+    """Each listed field must be detectable via _untrusted_references."""
+
+    property_name = expression.split(".", 1)[1]
+    dot_form = f"echo ${{{{ inputs.{property_name} }}}}"
+    bracket_form = f"echo ${{{{ inputs['{property_name}'] }}}}"
+    assert expression in _untrusted_references(dot_form)
+    assert expression in _untrusted_references(bracket_form)
 
 
 def test_untrusted_expression_guard_matches_default_and_wrapper_forms() -> None:

--- a/tests/workflows/test_no_untrusted_interpolation.py
+++ b/tests/workflows/test_no_untrusted_interpolation.py
@@ -9,6 +9,7 @@ step-level ``env:`` value instead.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -22,6 +23,7 @@ WORKFLOW_GLOBS = (".github/workflows/*.yml", ".github/workflows/*.yaml")
 # constrained-value review; expanding this set is not a substitute for that
 # review.
 UNTRUSTED_EXPRESSIONS = frozenset({"inputs.commit_message", "inputs.codex_args", "inputs.repos"})
+ACTIONS_EXPRESSION = re.compile(r"\$\{\{(?P<body>.*?)\}\}", re.DOTALL)
 
 
 def _workflow_paths() -> Iterable[Path]:
@@ -45,15 +47,27 @@ def _script_values(path: Path) -> Iterable[tuple[str, str]]:
                 yield f"{job_name}/step-{index}/with.script", script
 
 
+def _untrusted_references(script: str) -> list[str]:
+    """Return free-text inputs referenced anywhere in Actions expressions."""
+
+    expression_bodies = [match.group("body") for match in ACTIONS_EXPRESSION.finditer(script)]
+    return sorted(
+        expression
+        for expression in UNTRUSTED_EXPRESSIONS
+        if any(
+            re.search(rf"\b{re.escape(expression)}\b", body)
+            for body in expression_bodies
+        )
+    )
+
+
 def test_no_untrusted_expressions_in_script_bodies() -> None:
     """Free-text inputs must not be interpolated into shell or JS source."""
     violations: list[str] = []
     for workflow in _workflow_paths():
         for location, script in _script_values(workflow):
-            for expression in UNTRUSTED_EXPRESSIONS:
-                token = "${{ " + expression + " }}"
-                if token in script:
-                    violations.append(f"{workflow.relative_to(ROOT)}:{location}: {token}")
+            for expression in _untrusted_references(script):
+                violations.append(f"{workflow.relative_to(ROOT)}:{location}: {expression}")
     assert not violations, (
         "Pass untrusted workflow values through step env and consume the env "
         "variable in the script:\n" + "\n".join(violations)
@@ -64,3 +78,10 @@ def test_no_untrusted_expressions_in_script_bodies() -> None:
 def test_untrusted_expression_guard_has_a_concrete_target(expression: str) -> None:
     """Keep each listed field intentional rather than a broad catch-all."""
     assert expression.startswith("inputs.")
+
+
+def test_untrusted_expression_guard_matches_default_and_wrapper_forms() -> None:
+    assert _untrusted_references("echo ${{ inputs.repos || 'all' }}") == ["inputs.repos"]
+    assert _untrusted_references("const v = '${{ format('{0}', inputs.codex_args) }}';") == [
+        "inputs.codex_args"
+    ]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:3016 -->
> **Source:** Issue #3016

Closes #3016

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#3009](https://github.com/stranske/Workflows/issues/3009)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Fix the free-text exemplars first, since these break on ordinary input: `maint-70-fix-integration-formatting.yml:124` (`inputs.commit_message`) and `reusable-codex-run.yml` (`inputs.codex_args`) — move each to a step-level `env:` entry and reference `"$VAR"` in the script.
- [x] Fix `maint-69-sync-labels.yml`'s 3× `${{ inputs.repos }}` in the "Determine target repos" step the same way.
- [ ] Triage remaining `.github/workflows/*.yml` inventory: convert `run:`/`script:` interpolations to `env:` indirection where free-form; document deliberate exceptions inline where provably constrained (e.g. boolean or number).
- [ ] Add a repository guard so the pattern cannot silently return — a test that parses every file in `.github/workflows/` and fails on `${{ inputs.* }}` / `${{ github.event.* }}` inside a `run:`/`script:` block scalar, with an explicit allowlist for reviewed exceptions.

#### Acceptance criteria
- [ ] Named test: `tests/workflows/test_no_untrusted_interpolation.py::test_no_untrusted_expressions_in_script_bodies` — parses each workflow, walks `run:`/`script:` block scalars, and asserts no `inputs.`/`github.event.` expression appears except those in an explicit, commented allowlist.
- [ ] Deliberate-break → revert: re-introduce `git commit -m "${{ inputs.commit_message }}"` in `maint-70-fix-integration-formatting.yml` → confirm the named test FAILS → revert.
- [ ] Behavioural check for the exemplar: dispatch `maint-70` with `commit_message` set to `a"b` and confirm the step succeeds (today it produces a broken `git commit` command). Note this dispatch is currently blocked by #3009.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated repository synchronization, labeling, formatting, and execution workflows.
  * Added validation for manually entered repository values, rejecting invalid entries before processing.
  * Improved handling of workflow settings, prompts, commit messages, and branch selections.
  * Updated recorded worker execution metadata.

* **Tests**
  * Added regression coverage to detect unsafe workflow input handling and verify validated inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->