### PR TITLE
corpus: harvest realized-outcome verifier cases

### DIFF
--- a/config/model_eval_corpus_staging.json
+++ b/config/model_eval_corpus_staging.json
@@ -136,6 +136,24 @@
       "category": "clean-pass",
       "provenance": "harvested",
       "harvested_at": "2026-08-03"
+    },
+    {
+      "case_id": "workflows-2757",
+      "repo": "stranske/Workflows",
+      "pr": 2757,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-10"
+    },
+    {
+      "case_id": "pension-data-711",
+      "repo": "stranske/Pension-Data",
+      "pr": 711,
+      "expected_verdict": "PASS",
+      "category": "clean-pass",
+      "provenance": "harvested",
+      "harvested_at": "2026-08-10"
     }
   ]
 }


### PR DESCRIPTION
Automated corpus growth (stranske/Workflows#2819 move 2).

High-confidence cases derived from realized PR outcomes — see the run
summary for the promoted case list. Ambiguous cases were routed to the
auto-expiring staging file, not here.

Expected verdicts here come from what the world already adjudicated by
merging or reverting each PR. The semantic NON_PASS categories
(stale-verifier-claim, review-thread-debt, missing-acceptance-criterion)
remain owner-sourced and are never machine-added.