### PR TITLE
fix(deps): promote Renovate verifier CLI repair

### DIFF
--- a/.github/actions/verifier-codex-cli/package-lock.json
+++ b/.github/actions/verifier-codex-cli/package-lock.json
@@ -8,13 +8,13 @@
       "name": "workflows-verifier-codex-cli",
       "version": "1.0.0",
       "dependencies": {
-        "@openai/codex": "0.144.1"
+        "@openai/codex": "0.147.0"
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
+      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -23,19 +23,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.147.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
       "cpu": [
         "arm64"
       ],
@@ -50,9 +50,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.147.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
       "cpu": [
         "x64"
       ],
@@ -67,9 +67,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.147.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
       "cpu": [
         "arm64"
       ],
@@ -84,9 +84,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.147.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
       "cpu": [
         "x64"
       ],
@@ -101,9 +101,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.147.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
       "cpu": [
         "arm64"
       ],
@@ -118,9 +118,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.147.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
       "cpu": [
         "x64"
       ],

--- a/.github/actions/verifier-codex-cli/package.json
+++ b/.github/actions/verifier-codex-cli/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "description": "Locked Codex CLI runtime for the reusable verifier.",
   "dependencies": {
-    "@openai/codex": "0.144.1"
+    "@openai/codex": "0.147.0"
   }
 }

--- a/.github/workflows/reusable-agents-verifier.yml
+++ b/.github/workflows/reusable-agents-verifier.yml
@@ -479,7 +479,7 @@ jobs:
         id: codex_cli
         if: steps.context.outputs.should_run == 'true' && inputs.mode != 'evaluate'
         env:
-          CODEX_CLI_PACKAGE: "@openai/codex@0.144.1"
+          CODEX_CLI_PACKAGE: "@openai/codex@0.147.0"
         run: |
           set -euo pipefail
           # Install from the Workflows sparse checkout so consumer callers (whose

--- a/requirements.lock
+++ b/requirements.lock
@@ -60,7 +60,7 @@ docstring-parser==0.18.0
     # via anthropic
 execnet==2.1.2
     # via pytest-xdist
-faiss-cpu==1.14.3
+faiss-cpu==1.15.0
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
@@ -118,7 +118,7 @@ langchain==1.3.14
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)
-langchain-anthropic==1.5.3
+langchain-anthropic==1.5.4
     # via
     #   -r requirements.txt
     #   workflows (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ langchain==1.3.14
 langchain-core==1.5.3
 langchain-community==0.4.2
 langchain-openai==1.4.1
-langchain-anthropic==1.5.3
-faiss-cpu==1.14.3
+langchain-anthropic==1.5.4
+faiss-cpu==1.15.0

--- a/templates/consumer-repo/tools/requirements-llm.txt
+++ b/templates/consumer-repo/tools/requirements-llm.txt
@@ -10,6 +10,6 @@
 langchain==1.3.14
 langchain-community==0.4.2
 langchain-openai==1.4.1
-langchain-anthropic==1.5.3
+langchain-anthropic==1.5.4
 pydantic==2.13.4
 requests==2.34.2

--- a/tests/workflows/test_verifier_terminal_disposition.py
+++ b/tests/workflows/test_verifier_terminal_disposition.py
@@ -66,7 +66,7 @@ def test_reusable_verifier_uploads_terminal_disposition_artifact() -> None:
         resolve_step.get("if")
         == "steps.context.outputs.should_run == 'true' && inputs.mode != 'evaluate'"
     )
-    assert install_step["env"]["CODEX_CLI_PACKAGE"] == "@openai/codex@0.144.1"
+    assert install_step["env"]["CODEX_CLI_PACKAGE"] == "@openai/codex@0.147.0"
     assert (
         'npm ci --prefix "$codex_cli_prefix" --ignore-scripts' in install_step["run"]
         or "npm ci --prefix .workflows-lib/.github/actions/verifier-codex-cli --ignore-scripts"

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -10,6 +10,6 @@
 langchain==1.3.14
 langchain-community==0.4.2
 langchain-openai==1.4.1
-langchain-anthropic==1.5.3
+langchain-anthropic==1.5.4
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
Promotes Renovate #3029 into an agent-owned dependency-coupled repair.

The first commit reproduces only Renovate commit `0ed3b2415ab590583cfe326552bd675ed9d7ca0d`; the second synchronizes `CODEX_CLI_PACKAGE` with its locked verifier CLI package to restore verifier execution and CI.

Validation:
- `python3 -m pytest tests/workflows/test_verifier_terminal_disposition.py -q` (3 passed)
- `actionlint .github/workflows/reusable-agents-verifier.yml`
- `git diff --check`

<!-- dependency-repair-promotion:v1 {"source_pr":3029,"source_base_sha":"77b85155317e4a0a0d41ce77ddd885b749f6b420","source_head_sha":"0ed3b2415ab590583cfe326552bd675ed9d7ca0d","promotion_base_sha":"77b85155317e4a0a0d41ce77ddd885b749f6b420"} -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Codex CLI to version 0.147.0.
  * Added Anthropic language-model support.
  * Updated the Anthropic integration to version 1.5.4.
  * Upgraded FAISS CPU to version 1.15.0.
* **Tests**
  * Updated workflow validation to reflect the new Codex CLI version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->