### PR TITLE
fix(agents): address corrected sync review debt

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -290,12 +290,14 @@ def validate(body: str) -> Report:
     acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
     if acceptance_at is not None:
         acceptance = _section_text(body, acceptance_at)
-        if not GATE.search(acceptance):
+        acceptance_prose = _without_fenced_code(acceptance)
+        if not GATE.search(acceptance_prose):
             report.problems.append(
                 "`Acceptance Criteria` names no test, runnable command or observable "
                 "verification gate — Definition of Ready / Quality Bar §2 requires one."
             )
-        prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", _without_fenced_code(acceptance))
+        prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", acceptance_prose)
+        prose = re.sub(r"(?<!\w)(?:[\w.-]+/)+[\w.-]+", "", prose)
         hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", prose, re.I)]
         if hits:
             report.problems.append(

--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -297,7 +297,14 @@ def validate(body: str) -> Report:
                 "verification gate — Definition of Ready / Quality Bar §2 requires one."
             )
         prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", acceptance_prose)
-        prose = re.sub(r"(?<!\w)(?:[\w.-]+/)+[\w.-]+", "", prose)
+        # Only discard tokens that are demonstrably file paths.  A broad
+        # slash-separated-word pattern would also erase subjective prose such
+        # as "fast/performant" before the adjective check sees it.
+        prose = re.sub(
+            r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+            "",
+            prose,
+        )
         hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", prose, re.I)]
         if hits:
             report.problems.append(

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -581,7 +581,7 @@ jobs:
               result = json.load(f)
           formatted = result.get('formatted_body', '')
           if not formatted:
-              print(f"ERROR: {result.get('error') or 'No formatted body returned'}")
+              print('ERROR: ' + (result.get('error') or 'No formatted body returned'))
               import sys
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -579,9 +579,9 @@ jobs:
           import json
           with open('/tmp/format_result.json') as f:
               result = json.load(f)
-          formatted = result['formatted_body']
+          formatted = result.get('formatted_body', '')
           if not formatted:
-              print('ERROR: No formatted body returned')
+              print(f"ERROR: {result.get('error') or 'No formatted body returned'}")
               import sys
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -113,8 +113,8 @@ reason = Intentional divergence re-baselined 2026-06-30: root and consumer guard
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
-main_sha256 = fc80b3e1f66e07e0981f486e53cf0618dfd471531a795ae4dba7520d1f00d188
-template_sha256 = 5330b14c833b96080542f15a12db8503677f240309718a89eea5a4fe0450b215
+main_sha256 = f0bc17d390f7b9f1c0398903929a5987c8b6a0c944a5ea5ca0291445df854c44
+template_sha256 = ceef0f57e91084daa86cf6876d89f42350a08678d0a424b459d83dacf2437f0c
 reason = Intentional divergence re-baselined 2026-08-10: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract includes safe linear verify-hint validation, event-safe optimizer run names, cancel-safe agents:format release even if the initial check fails, and nonzero failure for unexpected validator stderr. Do not align wholesale — that would strip consumer action pins/token setup.
 
 [pair.12]

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -113,8 +113,8 @@ reason = Intentional divergence re-baselined 2026-06-30: root and consumer guard
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
-main_sha256 = 178a3fa311c8f92a24d8ab5fc7aa24f6f975c906361d2b2040ed9a4208edca93
-template_sha256 = c4f57ffe386c7e261ac3549ceb9058c8e7c4a5699af3666ccdc038723a023fe4
+main_sha256 = fc80b3e1f66e07e0981f486e53cf0618dfd471531a795ae4dba7520d1f00d188
+template_sha256 = 5330b14c833b96080542f15a12db8503677f240309718a89eea5a4fe0450b215
 reason = Intentional divergence re-baselined 2026-08-10: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract includes safe linear verify-hint validation, event-safe optimizer run names, cancel-safe agents:format release even if the initial check fails, and nonzero failure for unexpected validator stderr. Do not align wholesale — that would strip consumer action pins/token setup.
 
 [pair.12]

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -177,7 +177,7 @@ VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
 SAFE_VERIFY_COMMAND_RE = re.compile(
     r"^(?:"
     r"(?:"
-    r"python(?:3)?\s+-m\s+(?:pytest|unittest)\b"
+    r"(?:python(?:3)?\s+-m\s+)?pytest\b|python(?:3)?\s+-m\s+unittest\b"
     r"|node\s+--test\b"
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo)\s+(?:test|check)\b"

--- a/templates/consumer-repo/.github/scripts/issue_format.py
+++ b/templates/consumer-repo/.github/scripts/issue_format.py
@@ -290,12 +290,14 @@ def validate(body: str) -> Report:
     acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
     if acceptance_at is not None:
         acceptance = _section_text(body, acceptance_at)
-        if not GATE.search(acceptance):
+        acceptance_prose = _without_fenced_code(acceptance)
+        if not GATE.search(acceptance_prose):
             report.problems.append(
                 "`Acceptance Criteria` names no test, runnable command or observable "
                 "verification gate — Definition of Ready / Quality Bar §2 requires one."
             )
-        prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", _without_fenced_code(acceptance))
+        prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", acceptance_prose)
+        prose = re.sub(r"(?<!\w)(?:[\w.-]+/)+[\w.-]+", "", prose)
         hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", prose, re.I)]
         if hits:
             report.problems.append(

--- a/templates/consumer-repo/.github/scripts/issue_format.py
+++ b/templates/consumer-repo/.github/scripts/issue_format.py
@@ -297,7 +297,14 @@ def validate(body: str) -> Report:
                 "verification gate — Definition of Ready / Quality Bar §2 requires one."
             )
         prose = re.sub(r"(?<!`)`(?!`)[^`\n]*`", "", acceptance_prose)
-        prose = re.sub(r"(?<!\w)(?:[\w.-]+/)+[\w.-]+", "", prose)
+        # Only discard tokens that are demonstrably file paths.  A broad
+        # slash-separated-word pattern would also erase subjective prose such
+        # as "fast/performant" before the adjective check sees it.
+        prose = re.sub(
+            r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+            "",
+            prose,
+        )
         hits = [word for word in BANNED_ADJECTIVES if re.search(rf"\b{word}\b", prose, re.I)]
         if hits:
             report.problems.append(

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -521,9 +521,9 @@ jobs:
           import json
           with open('/tmp/format_result.json') as f:
               result = json.load(f)
-          formatted = result['formatted_body']
+          formatted = result.get('formatted_body', '')
           if not formatted:
-              print('ERROR: No formatted body returned')
+              print(f"ERROR: {result.get('error') or 'No formatted body returned'}")
               import sys
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -523,7 +523,7 @@ jobs:
               result = json.load(f)
           formatted = result.get('formatted_body', '')
           if not formatted:
-              print(f"ERROR: {result.get('error') or 'No formatted body returned'}")
+              print('ERROR: ' + (result.get('error') or 'No formatted body returned'))
               import sys
               sys.exit(1)
           with open('/tmp/formatted_body.md', 'w') as f:

--- a/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
+++ b/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
@@ -150,7 +150,8 @@ A qualifying criterion names one of:
 
 - a specific test path / test id (e.g.
   `tests/test_verdict_policy.py::test_select_verdict_worst_policy`), **or**
-- a specific runnable command and its expected observable result (e.g.
+- a specific runnable command written in normal Acceptance Criteria prose (not
+  inside a Markdown fenced code block) and its expected observable result (e.g.
   `gh workflow run selftest-ci.yml` → the run log shows a non-zero collected
   count for the named test files), **or**
 - a documented live-verification step tied to behavior a human or agent can

--- a/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
+++ b/templates/consumer-repo/docs/AGENT_ISSUE_FORMAT.md
@@ -166,7 +166,9 @@ intuitive / polished) are rejected — replace with a measurable check.
 > Acceptance Criteria block references **no** test, smoke test, or verification
 > gate at all (a conservative string check for a test path/id, a runner command
 > like `pytest` / `gh workflow run` / `npm test` / `curl`, or a `smoke` /
-> `verif` token). An acceptance section of pure adjectives will not pass.
+> `verif` token). The qualifying gate must appear in normal Acceptance Criteria
+> prose, not inside a Markdown fenced code block. An acceptance section of pure
+> adjectives will not pass.
 
 #### The deliberate-break pattern (recommended worked form)
 

--- a/templates/consumer-repo/scripts/langchain/issue_formatter.py
+++ b/templates/consumer-repo/scripts/langchain/issue_formatter.py
@@ -177,7 +177,7 @@ VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
 SAFE_VERIFY_COMMAND_RE = re.compile(
     r"^(?:"
     r"(?:"
-    r"python(?:3)?\s+-m\s+(?:pytest|unittest)\b"
+    r"(?:python(?:3)?\s+-m\s+)?pytest\b|python(?:3)?\s+-m\s+unittest\b"
     r"|node\s+--test\b"
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo)\s+(?:test|check)\b"

--- a/tests/scripts/test_issue_format.py
+++ b/tests/scripts/test_issue_format.py
@@ -145,13 +145,24 @@ def test_subjective_words_in_inline_code_are_ignored_but_prose_is_rejected(
     assert report.ok is expected_ok
 
 
-def test_acceptance_gate_inside_fence_and_code_path_adjective_are_valid() -> None:
+def test_acceptance_gate_inside_fence_does_not_satisfy_validation() -> None:
     validator = _validator()
     report = validator.validate(
         VALID_CONTEXT
         + "## Tasks\n- [ ] Update `tests/fast/test_api.py`\n\n"
         + "## Acceptance Criteria\nRun the regression suite:\n"
         + "```sh\npython -m pytest tests/fast/test_api.py -q\n```\n"
+    )
+    assert not report.ok
+    assert "names no test" in report.problems[0]
+
+
+def test_acceptance_path_component_is_not_subjective_prose() -> None:
+    validator = _validator()
+    report = validator.validate(
+        VALID_CONTEXT
+        + "## Tasks\n- [ ] Update `tests/fast/test_api.py`\n\n"
+        + "## Acceptance Criteria\n- [ ] Run pytest tests/fast/test_api.py and confirm it passes.\n"
     )
     assert report.ok
 

--- a/tests/scripts/test_issue_format.py
+++ b/tests/scripts/test_issue_format.py
@@ -145,8 +145,17 @@ def test_subjective_words_in_inline_code_are_ignored_but_prose_is_rejected(
     assert report.ok is expected_ok
 
 
-def test_acceptance_gate_inside_fence_does_not_satisfy_validation() -> None:
-    validator = _validator()
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+def test_acceptance_gate_inside_fence_does_not_satisfy_validation(
+    validator_path: Path,
+) -> None:
+    validator = _validator(validator_path)
     report = validator.validate(
         VALID_CONTEXT
         + "## Tasks\n- [ ] Update `tests/fast/test_api.py`\n\n"
@@ -157,14 +166,41 @@ def test_acceptance_gate_inside_fence_does_not_satisfy_validation() -> None:
     assert "names no test" in report.problems[0]
 
 
-def test_acceptance_path_component_is_not_subjective_prose() -> None:
-    validator = _validator()
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+def test_acceptance_path_component_is_not_subjective_prose(validator_path: Path) -> None:
+    validator = _validator(validator_path)
     report = validator.validate(
         VALID_CONTEXT
         + "## Tasks\n- [ ] Update `tests/fast/test_api.py`\n\n"
         + "## Acceptance Criteria\n- [ ] Run pytest tests/fast/test_api.py and confirm it passes.\n"
     )
     assert report.ok
+
+
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+def test_acceptance_slash_separated_subjective_prose_is_rejected(
+    validator_path: Path,
+) -> None:
+    validator = _validator(validator_path)
+    report = validator.validate(
+        VALID_CONTEXT
+        + "## Tasks\n- [ ] Update `tests/fast/test_api.py`\n\n"
+        + "## Acceptance Criteria\n- [ ] Run pytest tests/fast/test_api.py and make the response fast/performant.\n"
+    )
+    assert not report.ok
+    assert "subjective wording" in report.problems[0]
 
 
 def test_runner_and_curl_are_accepted_gates() -> None:

--- a/tests/scripts/test_issue_formatter.py
+++ b/tests/scripts/test_issue_formatter.py
@@ -956,6 +956,7 @@ def test_safe_verify_command_requires_runnable_unittest_and_gh_args() -> None:
         issue_formatter.SAFE_VERIFY_COMMAND_RE.match("python -m unittest tests.test_x") is not None
     )
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("unittest") is None
+    assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("pytest") is not None
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("go check") is None
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("dotnet check") is None
     assert issue_formatter.SAFE_VERIFY_COMMAND_RE.match("dotnet test") is not None


### PR DESCRIPTION
Repairs the active source-owned review findings in the corrected Maint 68 sync wave.

- fenced examples no longer satisfy an acceptance verification gate
- path components are excluded from subjective-language checks
- bare `pytest` verify hints remain valid while bare `unittest` remains rejected
- formatter errors are surfaced safely in both source and consumer optimizer workflows

Validation: `python3.12 -m pytest -q tests/scripts/test_issue_format.py tests/scripts/test_issue_formatter.py tests/workflows/test_agents_issue_optimizer_format_trigger.py` (132 passed); template completeness/sync; template drift (0 unallowlisted); `git diff --check`.

This replaces the held consumer sync wave after the source merge and full Maint 68 reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved acceptance-criteria validation by ignoring fenced code and path-like tokens when checking verification requirements and subjective language.
  - Improved formatting error messages when formatted content is unavailable.
  - Verification checks now recognize direct `pytest` and `python -m pytest` commands.

- **Tests**
  - Added regression coverage for fenced test commands, path names, and standalone `pytest` verification commands.

- **Documentation**
  - Clarified formatting guidance for acceptance-criteria verification commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->