### PR TITLE
fix(issue-format): handle nested fences and format retry

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -129,6 +129,16 @@ def _task_has_concrete_target(item: str) -> bool:
     for match in re.finditer(rf"\b{_TASK_CATEGORY}\s+(`[^`]+`|[^\s]+)", item, re.I):
         token = match.group(1)
         span = token[1:-1] if token.startswith("`") and token.endswith("`") else token.strip("'\"")
+        # A quoted identifier immediately following an explicit target category
+        # is concrete even when its spelling is a normal lowercase word (for
+        # example, ``function `validate` `` or ``key `timeout` ``).
+        if (
+            token.startswith("`")
+            and token.endswith("`")
+            and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", span)
+            and not re.fullmatch(_TASK_CATEGORY, span, re.I)
+        ):
+            return True
         if _concrete_span(span):
             return True
     for match in re.finditer(r"`([^`]+)`", item):
@@ -158,7 +168,7 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
     out: list[tuple[str, int, int]] = []
     fence: tuple[str, int] | None = None
     for i, line in enumerate(body.splitlines()):
-        fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        fence_match = re.match(r"\s*(`{3,}|~{3,})", line)
         if fence_match:
             marker = fence_match.group(1)
             if fence is None:
@@ -167,7 +177,7 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
                 marker[0] == fence[0]
                 and len(marker) >= fence[1]
                 and re.fullmatch(
-                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    rf"\s*(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
                     line,
                 )
             ):
@@ -204,7 +214,7 @@ def _without_fenced_code(text: str) -> str:
     kept: list[str] = []
     fence: tuple[str, int] | None = None
     for line in text.splitlines():
-        match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        match = re.match(r"\s*(`{3,}|~{3,})", line)
         if match:
             marker = match.group(1)
             if fence is None:
@@ -213,7 +223,7 @@ def _without_fenced_code(text: str) -> str:
                 marker[0] == fence[0]
                 and len(marker) >= fence[1]
                 and re.fullmatch(
-                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    rf"\s*(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
                     line,
                 )
             ):

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -32,9 +32,10 @@ jobs:
       github.event_name != 'issues' ||
       github.event.action == 'opened' || github.event.action == 'edited' ||
       github.event.action == 'reopened' ||
+      (github.event.action == 'unlabeled' &&
+      github.event.label.name == 'agents:format') ||
       ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      (github.event.label.name == 'agents:format' ||
-      github.event.label.name == 'agents:auto-pilot-pause' ||
+      (github.event.label.name == 'agents:auto-pilot-pause' ||
       github.event.label.name == 'needs-human' ||
       github.event.label.name == 'tracker:durable' || github.event.label.name == 'wontfix'))
     runs-on: ubuntu-latest

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -33,7 +33,8 @@ jobs:
       github.event.action == 'opened' || github.event.action == 'edited' ||
       github.event.action == 'reopened' ||
       ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      (github.event.label.name == 'agents:auto-pilot-pause' ||
+      (github.event.label.name == 'agents:format' ||
+      github.event.label.name == 'agents:auto-pilot-pause' ||
       github.event.label.name == 'needs-human' ||
       github.event.label.name == 'tracker:durable' || github.event.label.name == 'wontfix'))
     runs-on: ubuntu-latest

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -39,6 +39,7 @@ jobs:
       issues: write
       contents: read
       models: read
+      actions: write
 
     steps:
       - name: Check trigger conditions

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -744,3 +744,7 @@ jobs:
           # A guard retry may proceed only after the failed format run releases its lease.
           gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format" \
             || echo "::warning::could not release failed agents:format lease"
+          # GITHUB_TOKEN label edits do not emit issues:unlabeled workflows; dispatch explicitly.
+          gh workflow run agents-issue-format-guard.yml --repo "$GITHUB_REPOSITORY" \
+            -f issue_number="$ISSUE_NUMBER" \
+            || echo "::warning::could not dispatch format guard retry after lease release"

--- a/config/template-drift-allowlist.txt
+++ b/config/template-drift-allowlist.txt
@@ -113,9 +113,9 @@ reason = Intentional divergence re-baselined 2026-06-30: root and consumer guard
 [pair.11]
 main = .github/workflows/agents-issue-optimizer.yml
 template = templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
-main_sha256 = f0bc17d390f7b9f1c0398903929a5987c8b6a0c944a5ea5ca0291445df854c44
-template_sha256 = ceef0f57e91084daa86cf6876d89f42350a08678d0a424b459d83dacf2437f0c
-reason = Intentional divergence re-baselined 2026-08-10: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract includes safe linear verify-hint validation, event-safe optimizer run names, cancel-safe agents:format release even if the initial check fails, and nonzero failure for unexpected validator stderr. Do not align wholesale — that would strip consumer action pins/token setup.
+main_sha256 = 2038d4955f38a00ff08f43f061dd803eab32d5d081011915dfbd7d16c9a968b4
+template_sha256 = b216065b897768f47a5a90052ead2a1614af69444ce060e4ebd6049df618d4c6
+reason = Intentional divergence re-baselined 2026-08-11: root remains in-tree (scripts/langchain + .github/scripts/issue_format.py); consumer vendors those via Workflows sparse-checkout under workflows-scripts/. Shared behavioral contract includes format-guard unlabeled-only trigger, explicit guard dispatch after failed format lease release (actions:write on optimize_issue), and quoted lowercase identifier acceptance. Do not align wholesale — that would strip consumer action pins/token setup.
 
 [pair.12]
 main = .github/workflows/agents-keepalive-loop-reporter.yml

--- a/templates/consumer-repo/.github/scripts/issue_format.py
+++ b/templates/consumer-repo/.github/scripts/issue_format.py
@@ -129,6 +129,16 @@ def _task_has_concrete_target(item: str) -> bool:
     for match in re.finditer(rf"\b{_TASK_CATEGORY}\s+(`[^`]+`|[^\s]+)", item, re.I):
         token = match.group(1)
         span = token[1:-1] if token.startswith("`") and token.endswith("`") else token.strip("'\"")
+        # A quoted identifier immediately following an explicit target category
+        # is concrete even when its spelling is a normal lowercase word (for
+        # example, ``function `validate` `` or ``key `timeout` ``).
+        if (
+            token.startswith("`")
+            and token.endswith("`")
+            and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", span)
+            and not re.fullmatch(_TASK_CATEGORY, span, re.I)
+        ):
+            return True
         if _concrete_span(span):
             return True
     for match in re.finditer(r"`([^`]+)`", item):
@@ -158,7 +168,7 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
     out: list[tuple[str, int, int]] = []
     fence: tuple[str, int] | None = None
     for i, line in enumerate(body.splitlines()):
-        fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        fence_match = re.match(r"\s*(`{3,}|~{3,})", line)
         if fence_match:
             marker = fence_match.group(1)
             if fence is None:
@@ -167,7 +177,7 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
                 marker[0] == fence[0]
                 and len(marker) >= fence[1]
                 and re.fullmatch(
-                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    rf"\s*(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
                     line,
                 )
             ):
@@ -204,7 +214,7 @@ def _without_fenced_code(text: str) -> str:
     kept: list[str] = []
     fence: tuple[str, int] | None = None
     for line in text.splitlines():
-        match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        match = re.match(r"\s*(`{3,}|~{3,})", line)
         if match:
             marker = match.group(1)
             if fence is None:
@@ -213,7 +223,7 @@ def _without_fenced_code(text: str) -> str:
                 marker[0] == fence[0]
                 and len(marker) >= fence[1]
                 and re.fullmatch(
-                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    rf"\s*(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
                     line,
                 )
             ):

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -32,9 +32,10 @@ jobs:
       github.event_name != 'issues' ||
       github.event.action == 'opened' || github.event.action == 'edited' ||
       github.event.action == 'reopened' ||
+      (github.event.action == 'unlabeled' &&
+      github.event.label.name == 'agents:format') ||
       ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      (github.event.label.name == 'agents:format' ||
-      github.event.label.name == 'agents:auto-pilot-pause' ||
+      (github.event.label.name == 'agents:auto-pilot-pause' ||
       github.event.label.name == 'needs-human' ||
       github.event.label.name == 'tracker:durable' || github.event.label.name == 'wontfix'))
     runs-on: ubuntu-latest

--- a/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-format-guard.yml
@@ -33,7 +33,8 @@ jobs:
       github.event.action == 'opened' || github.event.action == 'edited' ||
       github.event.action == 'reopened' ||
       ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      (github.event.label.name == 'agents:auto-pilot-pause' ||
+      (github.event.label.name == 'agents:format' ||
+      github.event.label.name == 'agents:auto-pilot-pause' ||
       github.event.label.name == 'needs-human' ||
       github.event.label.name == 'tracker:durable' || github.event.label.name == 'wontfix'))
     runs-on: ubuntu-latest

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -39,6 +39,7 @@ jobs:
       issues: write
       contents: read
       models: read
+      actions: write
 
     steps:
       - name: Check trigger conditions

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -597,3 +597,7 @@ jobs:
           # A guard retry may proceed only after the failed format run releases its lease.
           gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format" \
             || echo "::warning::could not release failed agents:format lease"
+          # GITHUB_TOKEN label edits do not emit issues:unlabeled workflows; dispatch explicitly.
+          gh workflow run agents-issue-format-guard.yml --repo "$GITHUB_REPOSITORY" \
+            -f issue_number="$ISSUE_NUMBER" \
+            || echo "::warning::could not dispatch format guard retry after lease release"

--- a/tests/scripts/test_issue_format.py
+++ b/tests/scripts/test_issue_format.py
@@ -47,16 +47,38 @@ def test_fence_with_language_marker_does_not_close_a_code_block() -> None:
         Path("templates/consumer-repo/.github/scripts/issue_format.py"),
     ],
 )
-def test_list_indented_fenced_acceptance_command_is_ignored(validator_path: Path) -> None:
+@pytest.mark.parametrize("fence", ["```", "~~~"])
+def test_list_indented_fenced_acceptance_command_is_ignored(
+    validator_path: Path, fence: str
+) -> None:
     """A four-space list fence is an example, not an observable gate."""
     validator = _validator(validator_path)
     report = validator.validate(
         VALID_CONTEXT
         + "## Tasks\n- [ ] Update `src/client.py`\n\n"
-        + "## Acceptance Criteria\n- Example command:\n\n    ```sh\n    pytest tests/test_x.py\n    ```\n"
+        + f"## Acceptance Criteria\n- Example command:\n\n    {fence}sh\n    pytest tests/test_x.py\n    {fence}\n"
     )
     assert not report.ok
     assert any("names no test" in problem for problem in report.problems)
+
+
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+def test_category_word_backticked_target_is_not_concrete(validator_path: Path) -> None:
+    """A backticked category word after an explicit category is not a concrete target."""
+    validator = _validator(validator_path)
+    report = validator.validate(
+        VALID_CONTEXT
+        + "## Tasks\n- [ ] Update function `file`\n\n"
+        + "## Acceptance Criteria\n- pytest tests/test_x.py passes\n"
+    )
+    assert not report.ok
+    assert "concrete file" in report.as_markdown()
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_issue_format.py
+++ b/tests/scripts/test_issue_format.py
@@ -40,6 +40,46 @@ def test_fence_with_language_marker_does_not_close_a_code_block() -> None:
     assert "Acceptance Criteria" in report.missing_required
 
 
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+def test_list_indented_fenced_acceptance_command_is_ignored(validator_path: Path) -> None:
+    """A four-space list fence is an example, not an observable gate."""
+    validator = _validator(validator_path)
+    report = validator.validate(
+        VALID_CONTEXT
+        + "## Tasks\n- [ ] Update `src/client.py`\n\n"
+        + "## Acceptance Criteria\n- Example command:\n\n    ```sh\n    pytest tests/test_x.py\n    ```\n"
+    )
+    assert not report.ok
+    assert any("names no test" in problem for problem in report.problems)
+
+
+@pytest.mark.parametrize(
+    "validator_path",
+    [
+        Path(".github/scripts/issue_format.py"),
+        Path("templates/consumer-repo/.github/scripts/issue_format.py"),
+    ],
+)
+@pytest.mark.parametrize("target", ["validate", "timeout"])
+def test_explicit_category_accepts_quoted_lowercase_identifier(
+    validator_path: Path, target: str
+) -> None:
+    validator = _validator(validator_path)
+    category = "function" if target == "validate" else "key"
+    report = validator.validate(
+        VALID_CONTEXT
+        + f"## Tasks\n- [ ] Update {category} `{target}`\n\n"
+        + "## Acceptance Criteria\n- pytest tests/test_x.py passes\n"
+    )
+    assert report.ok
+
+
 @pytest.mark.parametrize("marker", ["```", "~~~"])
 def test_fence_close_requires_marker_only_line(marker: str) -> None:
     """Trailing text after fence markers must not end the fenced region."""

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -108,7 +108,9 @@ def test_format_optimizer_dispatches_guard_after_failed_lease_release() -> None:
     ):
         release_idx = text.index("Release failed format lease")
         release_block = text[release_idx : release_idx + 1200]
-        remove_idx = release_block.index('gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format"')
+        remove_idx = release_block.index(
+            'gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format"'
+        )
         dispatch_idx = release_block.index("gh workflow run agents-issue-format-guard.yml")
         assert remove_idx < dispatch_idx
         assert '-f issue_number="$ISSUE_NUMBER"' in release_block

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -93,6 +93,25 @@ def test_format_guard_rechecks_after_format_lease_release() -> None:
         condition = text[text.index("if: >-") : text.index("runs-on: ubuntu-latest")]
         assert "github.event.action == 'unlabeled'" in condition
         assert "github.event.label.name == 'agents:format'" in condition
+        # Applying agents:format already starts the optimizer via issues:labeled;
+        # the guard must react only when the lease is removed.
+        labeled_format = (
+            "github.event.action == 'labeled'" in condition
+            and condition.index("github.event.action == 'labeled'")
+            < condition.index("github.event.label.name == 'agents:format'")
+        )
+        assert not labeled_format
+
+
+def test_format_optimizer_dispatches_guard_after_failed_lease_release() -> None:
+    for text in (
+        WORKFLOW_PATH.read_text(encoding="utf-8"),
+        CONSUMER_WORKFLOW_PATH.read_text(encoding="utf-8"),
+    ):
+        release_idx = text.index("Release failed format lease")
+        release_block = text[release_idx : release_idx + 1200]
+        assert 'gh workflow run agents-issue-format-guard.yml' in release_block
+        assert '-f issue_number="$ISSUE_NUMBER"' in release_block
 
 
 def test_format_guard_attempt_marker_sequence_consumes_retry_budget() -> None:

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -95,11 +95,9 @@ def test_format_guard_rechecks_after_format_lease_release() -> None:
         assert "github.event.label.name == 'agents:format'" in condition
         # Applying agents:format already starts the optimizer via issues:labeled;
         # the guard must react only when the lease is removed.
-        labeled_format = (
-            "github.event.action == 'labeled'" in condition
-            and condition.index("github.event.action == 'labeled'")
-            < condition.index("github.event.label.name == 'agents:format'")
-        )
+        labeled_format = "github.event.action == 'labeled'" in condition and condition.index(
+            "github.event.action == 'labeled'"
+        ) < condition.index("github.event.label.name == 'agents:format'")
         assert not labeled_format
 
 
@@ -110,7 +108,7 @@ def test_format_optimizer_dispatches_guard_after_failed_lease_release() -> None:
     ):
         release_idx = text.index("Release failed format lease")
         release_block = text[release_idx : release_idx + 1200]
-        assert 'gh workflow run agents-issue-format-guard.yml' in release_block
+        assert "gh workflow run agents-issue-format-guard.yml" in release_block
         assert '-f issue_number="$ISSUE_NUMBER"' in release_block
 
 

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -108,8 +108,14 @@ def test_format_optimizer_dispatches_guard_after_failed_lease_release() -> None:
     ):
         release_idx = text.index("Release failed format lease")
         release_block = text[release_idx : release_idx + 1200]
-        assert "gh workflow run agents-issue-format-guard.yml" in release_block
+        remove_idx = release_block.index('gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format"')
+        dispatch_idx = release_block.index("gh workflow run agents-issue-format-guard.yml")
+        assert remove_idx < dispatch_idx
         assert '-f issue_number="$ISSUE_NUMBER"' in release_block
+        assert (
+            '|| echo "::warning::could not dispatch format guard retry after lease release"'
+            in release_block
+        )
 
 
 def test_format_guard_attempt_marker_sequence_consumes_retry_budget() -> None:

--- a/tests/workflows/test_agents_issue_optimizer_format_trigger.py
+++ b/tests/workflows/test_agents_issue_optimizer_format_trigger.py
@@ -87,6 +87,14 @@ def test_format_guard_deduplicates_inflight_optimizer_dispatch() -> None:
         )
 
 
+def test_format_guard_rechecks_after_format_lease_release() -> None:
+    for path in (GUARD_PATH, CONSUMER_GUARD_PATH):
+        text = path.read_text(encoding="utf-8")
+        condition = text[text.index("if: >-") : text.index("runs-on: ubuntu-latest")]
+        assert "github.event.action == 'unlabeled'" in condition
+        assert "github.event.label.name == 'agents:format'" in condition
+
+
 def test_format_guard_attempt_marker_sequence_consumes_retry_budget() -> None:
     """Exercise the marker contract used by the workflow's routing step."""
     fingerprint = "abc123def456"


### PR DESCRIPTION
## Summary
- Ignore fenced commands nested under Markdown list items when validating acceptance criteria.
- Accept explicitly categorized quoted lowercase identifiers as concrete targets.
- Re-run the format guard when the optimizer releases `agents:format` after failure.

## Validation
- `uv run --isolated --with pytest --with pyyaml python -m pytest -q tests/scripts/test_issue_format.py tests/workflows/test_agents_issue_optimizer_format_trigger.py` (98 passed)

Source fix for active review threads on Portable-Alpha-Extension-Model#2217 and Trend_Model_Project#5807; corrected consumer sync must replace those PRs before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task validation for quoted or backticked lowercase identifiers in explicit categories.
  * Improved handling of indented fenced content and stricter closing-fence validation.
  * Format checks now respond correctly when the `agents:format` label is added or removed, including after failed processing.
  * Failed processing now rechecks formatting automatically, with cleanup warnings handled safely.

* **Tests**
  * Added regression coverage for validation, fenced examples, and label-triggered format checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->