### PR TITLE
fix(tasks): preserve slash-separated subjective prose

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -208,6 +208,29 @@ class ValidationResult:
 # ---------------------------------------------------------------------------
 
 
+_PATH_REFERENCE_PATTERNS = (
+    # Absolute paths such as /etc/nginx.conf or /path/to/Dockerfile
+    r"(?<![\w])/[\w./-]+",
+    # Dot-prefixed paths such as .github/workflows/ci.yml
+    r"(?<![\w])\.[\w.-]+(?:/[\w.-]+)+",
+    # Relative paths with a dotted extension
+    r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+    # Multi-segment extensionless paths such as tests/fast/test_api
+    r"(?<![\w/])(?:[\w.-]+/){2,}[\w.-]+\b",
+    # Two-segment extensionless paths with filename-like basenames
+    r"(?<![\w/])(?:[\w.-]+/)[A-Z][\w.-]*\b",
+    r"(?<![\w/])(?:[\w.-]+/)[\w.-]*_[\w.-]+\b",
+)
+
+
+def _strip_path_references(task: str) -> str:
+    """Remove concrete file/directory references before subjective-word checks."""
+    text = task
+    for pattern in _PATH_REFERENCE_PATTERNS:
+        text = re.sub(pattern, " ", text)
+    return text.lower()
+
+
 def _has_subjective_without_measurable(task: str) -> bool:
     """Check if task has subjective language without measurable verification."""
     # Paths are concrete references, not prose. A path such as
@@ -215,11 +238,7 @@ def _has_subjective_without_measurable(task: str) -> bool:
     # Only strip path-shaped text.  A broad slash-separated-word pattern also
     # removes ordinary subjective prose such as "clean/intuitive" before the
     # warning check can see it.
-    lowered = re.sub(
-        r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
-        " ",
-        task.lower(),
-    )
+    lowered = _strip_path_references(task)
     has_subjective = any(word in lowered for word in SUBJECTIVE_WORDS)
     has_measurable = any(word in lowered for word in MEASURABLE_WORDS)
     return has_subjective and not has_measurable

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -212,7 +212,14 @@ def _has_subjective_without_measurable(task: str) -> bool:
     """Check if task has subjective language without measurable verification."""
     # Paths are concrete references, not prose. A path such as
     # ``tests/fast/test_api.py`` must not be rejected for its components.
-    lowered = re.sub(r"(?<!\w)[\w.-]+(?:/[\w.-]+)+(?!\w)", " ", task.lower())
+    # Only strip path-shaped text.  A broad slash-separated-word pattern also
+    # removes ordinary subjective prose such as "clean/intuitive" before the
+    # warning check can see it.
+    lowered = re.sub(
+        r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+        " ",
+        task.lower(),
+    )
     has_subjective = any(word in lowered for word in SUBJECTIVE_WORDS)
     has_measurable = any(word in lowered for word in MEASURABLE_WORDS)
     return has_subjective and not has_measurable

--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -215,6 +215,8 @@ _PATH_REFERENCE_PATTERNS = (
     r"(?<![\w])\.[\w.-]+(?:/[\w.-]+)+",
     # Relative paths with a dotted extension
     r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+    # Standalone dotted filenames such as quality.md
+    r"(?<![\w/])[\w.-]+\.[A-Za-z0-9]{1,10}\b",
     # Multi-segment extensionless paths such as tests/fast/test_api
     r"(?<![\w/])(?:[\w.-]+/){2,}[\w.-]+\b",
     # Two-segment extensionless paths with filename-like basenames

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -206,6 +206,29 @@ class ValidationResult:
 # ---------------------------------------------------------------------------
 
 
+_PATH_REFERENCE_PATTERNS = (
+    # Absolute paths such as /etc/nginx.conf or /path/to/Dockerfile
+    r"(?<![\w])/[\w./-]+",
+    # Dot-prefixed paths such as .github/workflows/ci.yml
+    r"(?<![\w])\.[\w.-]+(?:/[\w.-]+)+",
+    # Relative paths with a dotted extension
+    r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+    # Multi-segment extensionless paths such as tests/fast/test_api
+    r"(?<![\w/])(?:[\w.-]+/){2,}[\w.-]+\b",
+    # Two-segment extensionless paths with filename-like basenames
+    r"(?<![\w/])(?:[\w.-]+/)[A-Z][\w.-]*\b",
+    r"(?<![\w/])(?:[\w.-]+/)[\w.-]*_[\w.-]+\b",
+)
+
+
+def _strip_path_references(task: str) -> str:
+    """Remove concrete file/directory references before subjective-word checks."""
+    text = task
+    for pattern in _PATH_REFERENCE_PATTERNS:
+        text = re.sub(pattern, " ", text)
+    return text.lower()
+
+
 def _has_subjective_without_measurable(task: str) -> bool:
     """Check if task has subjective language without measurable verification."""
     # Paths are concrete references, not prose. A path such as
@@ -213,11 +236,7 @@ def _has_subjective_without_measurable(task: str) -> bool:
     # Only strip path-shaped text.  A broad slash-separated-word pattern also
     # removes ordinary subjective prose such as "clean/intuitive" before the
     # warning check can see it.
-    lowered = re.sub(
-        r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
-        " ",
-        task.lower(),
-    )
+    lowered = _strip_path_references(task)
     has_subjective = any(word in lowered for word in SUBJECTIVE_WORDS)
     has_measurable = any(word in lowered for word in MEASURABLE_WORDS)
     return has_subjective and not has_measurable

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -210,7 +210,14 @@ def _has_subjective_without_measurable(task: str) -> bool:
     """Check if task has subjective language without measurable verification."""
     # Paths are concrete references, not prose. A path such as
     # ``tests/fast/test_api.py`` must not be rejected for its components.
-    lowered = re.sub(r"(?<!\w)[\w.-]+(?:/[\w.-]+)+(?!\w)", " ", task.lower())
+    # Only strip path-shaped text.  A broad slash-separated-word pattern also
+    # removes ordinary subjective prose such as "clean/intuitive" before the
+    # warning check can see it.
+    lowered = re.sub(
+        r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+        " ",
+        task.lower(),
+    )
     has_subjective = any(word in lowered for word in SUBJECTIVE_WORDS)
     has_measurable = any(word in lowered for word in MEASURABLE_WORDS)
     return has_subjective and not has_measurable

--- a/templates/consumer-repo/scripts/langchain/task_validator.py
+++ b/templates/consumer-repo/scripts/langchain/task_validator.py
@@ -213,6 +213,8 @@ _PATH_REFERENCE_PATTERNS = (
     r"(?<![\w])\.[\w.-]+(?:/[\w.-]+)+",
     # Relative paths with a dotted extension
     r"(?<![\w/])(?:[\w.-]+/)+[\w.-]+\.[A-Za-z0-9]{1,10}\b",
+    # Standalone dotted filenames such as quality.md
+    r"(?<![\w/])[\w.-]+\.[A-Za-z0-9]{1,10}\b",
     # Multi-segment extensionless paths such as tests/fast/test_api
     r"(?<![\w/])(?:[\w.-]+/){2,}[\w.-]+\b",
     # Two-segment extensionless paths with filename-like basenames

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -51,15 +51,12 @@ class TestHeuristicDetection:
             )
             is False
         )
-        assert (
-            _has_subjective_without_measurable("Edit /etc/app/config for deployment defaults")
-            is False
-        )
-        assert (
-            _has_subjective_without_measurable("Update .github/workflows/ci.yml permissions")
-            is False
-        )
-        assert _has_subjective_without_measurable("Run tests/fast/test_api before merge") is False
+        assert _has_subjective_without_measurable("/quality/config") is False
+        assert _has_subjective_without_measurable(".github/quality") is False
+        assert _has_subjective_without_measurable("quality/clean.py") is False
+        assert _has_subjective_without_measurable("src/quality/config") is False
+        assert _has_subjective_without_measurable("clean/src_file") is False
+        assert _has_subjective_without_measurable("quality.md") is False
 
     def test_looks_like_human_activity(self) -> None:
         assert _looks_like_human_activity("Train staff on procedures") is True

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -45,6 +45,15 @@ class TestHeuristicDetection:
         assert _has_subjective_without_measurable("Create metrics file") is False
         assert _has_subjective_without_measurable("Run pytest tests/fast/test_api.py") is False
         assert _has_subjective_without_measurable("Make the UI clean/intuitive") is True
+        assert (
+            _has_subjective_without_measurable(
+                "Update configuration in quality/Dockerfile for deployment defaults"
+            )
+            is False
+        )
+        assert _has_subjective_without_measurable("Edit /etc/app/config for deployment defaults") is False
+        assert _has_subjective_without_measurable("Update .github/workflows/ci.yml permissions") is False
+        assert _has_subjective_without_measurable("Run tests/fast/test_api before merge") is False
 
     def test_looks_like_human_activity(self) -> None:
         assert _looks_like_human_activity("Train staff on procedures") is True

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -51,8 +51,14 @@ class TestHeuristicDetection:
             )
             is False
         )
-        assert _has_subjective_without_measurable("Edit /etc/app/config for deployment defaults") is False
-        assert _has_subjective_without_measurable("Update .github/workflows/ci.yml permissions") is False
+        assert (
+            _has_subjective_without_measurable("Edit /etc/app/config for deployment defaults")
+            is False
+        )
+        assert (
+            _has_subjective_without_measurable("Update .github/workflows/ci.yml permissions")
+            is False
+        )
         assert _has_subjective_without_measurable("Run tests/fast/test_api before merge") is False
 
     def test_looks_like_human_activity(self) -> None:

--- a/tests/scripts/test_task_validator.py
+++ b/tests/scripts/test_task_validator.py
@@ -44,6 +44,7 @@ class TestHeuristicDetection:
         assert _has_subjective_without_measurable("Ensure tests pass") is False  # has "tests"
         assert _has_subjective_without_measurable("Create metrics file") is False
         assert _has_subjective_without_measurable("Run pytest tests/fast/test_api.py") is False
+        assert _has_subjective_without_measurable("Make the UI clean/intuitive") is True
 
     def test_looks_like_human_activity(self) -> None:
         assert _looks_like_human_activity("Train staff on procedures") is True


### PR DESCRIPTION
## Summary
- restrict subjective-language path stripping to file-shaped paths
- preserve slash-separated subjective prose for triage
- mirror the consumer template and add regression coverage

## Validation
- pytest -q tests/scripts/test_task_validator.py
- python scripts/validate_template_sync.py

Related to review feedback on stranske/Portable-Alpha-Extension-Model#2218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task validation to avoid incorrectly flagging file paths, directory references, configuration files, workflow files, and test commands as subjective language.
  - Continued detecting subjective wording in ordinary prose, including slash-separated text, while reducing false positives from concrete technical references.

- **Tests**
  - Added coverage for UI wording, deployment configuration, CI permissions, file references, and test execution commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->