### PR TITLE
fix(sync): update behind generated branches before merge

### DIFF
--- a/.github/scripts/__tests__/sync_pr_merge_contract.test.js
+++ b/.github/scripts/__tests__/sync_pr_merge_contract.test.js
@@ -16,6 +16,7 @@ const {
   collectDeletableSyncBranches,
   evaluatePostPushReviewWindow,
   generatedDeliveryLane,
+  isBlockingSyncSystemFailure,
   isTrustedGeneratedDeliveryPr,
   isTrustedSyncPr,
   normalizeSyncHash,
@@ -366,6 +367,16 @@ test('strict required checks update behind branches before a generated merge', (
     requiredContexts: [],
     willMerge: true,
   }), false);
+  assert.equal(requiresStrictGateBranchUpdate({
+    pr: { mergeable_state: 'behind' },
+    requiredContexts: ['Gate / gate'],
+    willMerge: false,
+  }), false);
+});
+
+test('branch-update failures are blocking sync-system failures', () => {
+  assert.equal(isBlockingSyncSystemFailure('branch_update_failed'), true);
+  assert.equal(isBlockingSyncSystemFailure('checks_failed'), false);
 });
 
 test('candidate mutation requires the evidence pass authorization', () => {

--- a/.github/scripts/__tests__/sync_pr_merge_contract.test.js
+++ b/.github/scripts/__tests__/sync_pr_merge_contract.test.js
@@ -20,6 +20,7 @@ const {
   isTrustedSyncPr,
   normalizeSyncHash,
   parseBooleanInput,
+  requiresStrictGateBranchUpdate,
   requiredContextsFromRulesets,
   rulesetRefPatternMatches,
   selectActiveSyncPr,
@@ -347,6 +348,24 @@ test('post-push review window fails closed until seven full minutes elapse', () 
     true,
   );
   assert.equal(evaluatePostPushReviewWindow({}, '2026-08-11T13:09:00Z').ready, false);
+});
+
+test('strict required checks update behind branches before a generated merge', () => {
+  assert.equal(requiresStrictGateBranchUpdate({
+    pr: { mergeable_state: 'behind' },
+    requiredContexts: new Set(['Gate / gate']),
+    willMerge: true,
+  }), true);
+  assert.equal(requiresStrictGateBranchUpdate({
+    pr: { mergeable_state: 'clean' },
+    requiredContexts: ['Gate / gate'],
+    willMerge: true,
+  }), false);
+  assert.equal(requiresStrictGateBranchUpdate({
+    pr: { mergeable_state: 'behind' },
+    requiredContexts: [],
+    willMerge: true,
+  }), false);
 });
 
 test('candidate mutation requires the evidence pass authorization', () => {

--- a/.github/scripts/__tests__/sync_pr_merge_contract.test.js
+++ b/.github/scripts/__tests__/sync_pr_merge_contract.test.js
@@ -375,7 +375,16 @@ test('strict required checks update behind branches before a generated merge', (
 });
 
 test('branch-update failures are blocking sync-system failures', () => {
-  assert.equal(isBlockingSyncSystemFailure('branch_update_failed'), true);
+  for (const status of [
+    'branch_update_failed',
+    'error',
+    'merge_failed',
+    'pr_refresh_failed',
+    'stale_close_failed',
+    'target_missing',
+  ]) {
+    assert.equal(isBlockingSyncSystemFailure(status), true);
+  }
   assert.equal(isBlockingSyncSystemFailure('checks_failed'), false);
 });
 

--- a/.github/scripts/maint71_merge_sync_prs.js
+++ b/.github/scripts/maint71_merge_sync_prs.js
@@ -16,6 +16,7 @@ async function run({ github, context, core }) {
     collectDeletableSyncBranches,
     evaluatePostPushReviewWindow,
     generatedDeliveryLane,
+    isBlockingSyncSystemFailure,
     normalizeSyncHash,
     parseBooleanInput,
     requiresStrictGateBranchUpdate,
@@ -587,7 +588,28 @@ async function run({ github, context, core }) {
       }
   
       // Process the selected active PR
-      const pr = selection.active;
+      let pr = selection.active;
+      try {
+        const { data: fullPr } = await withRetry((client) => client.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pr.number,
+        }));
+        pr = fullPr;
+      } catch (error) {
+        const message = String(error?.message || error);
+        console.log(`Unable to refresh generated PR #${pr.number}: ${message}`);
+        results.push({
+          owner,
+          repo,
+          pr: pr.number,
+          branch: pr.head.ref,
+          head_sha: pr.head.sha,
+          status: 'pr_refresh_failed',
+          error: `PR refresh before branch update: ${message}`,
+        });
+        continue;
+      }
       const metadata = syncMetadata(pr);
       console.log(`\nProcessing active PR #${pr.number}: ${pr.title}`);
       console.log(`Branch: ${pr.head.ref}`);
@@ -798,7 +820,7 @@ async function run({ github, context, core }) {
         } catch (error) {
           const message = String(error?.message || error);
           console.log(`Unable to update behind PR #${pr.number}: ${message}`);
-          results.push({ ...deliveryContext, status: 'error', error: message });
+          results.push({ ...deliveryContext, status: 'branch_update_failed', error: message });
         }
         continue;
       }
@@ -1061,12 +1083,7 @@ async function run({ github, context, core }) {
   // every scheduled flush red and forces re-runs. Only genuine sync-system action
   // failures (merge/cleanup/missing-target) are blocking; consumer CI health is
   // surfaced via the merge report and Health 68 instead.
-  const blockingFailures = results.filter(
-    (r) =>
-      r.status === 'merge_failed' ||
-      r.status === 'stale_close_failed' ||
-      r.status === 'target_missing',
-  );
+  const blockingFailures = results.filter((r) => isBlockingSyncSystemFailure(r.status));
   const branchDeleteFailures = results.filter((r) => r.status === 'branch_delete_failed');
   if (branchDeleteFailures.length > 0) {
     core.notice(

--- a/.github/scripts/maint71_merge_sync_prs.js
+++ b/.github/scripts/maint71_merge_sync_prs.js
@@ -18,6 +18,7 @@ async function run({ github, context, core }) {
     generatedDeliveryLane,
     normalizeSyncHash,
     parseBooleanInput,
+    requiresStrictGateBranchUpdate,
     requiredContextsFromRulesets,
     isTrustedGeneratedDeliveryPr,
     selectLatestMergedCandidatePr,
@@ -773,6 +774,34 @@ async function run({ github, context, core }) {
       // the final exact-head/thread query so no intervening network action sits
       // between the hard review gate and the merge call.
       const willMerge = autoMerge && !dryRun && !recoveredMergedCandidate;
+      // Strict required-status-check rules evaluate the merge result. If the
+      // head is behind main, every merge strategy creates a new result without
+      // the head's Gate context. Update the generated branch and wait for its
+      // fresh Gate and mandatory review window instead of attempting a merge.
+      if (requiresStrictGateBranchUpdate({ pr, requiredContexts, willMerge })) {
+        try {
+          await withRetry((client) => client.rest.pulls.updateBranch({
+            owner,
+            repo,
+            pull_number: pr.number,
+            expected_head_sha: pr.head.sha,
+          }));
+          console.log(`Requested branch update for behind PR #${pr.number}; awaiting fresh Gate`);
+          results.push({
+            ...deliveryContext,
+            delivery_disposition: 'awaiting-review-window',
+            blocker_owner: 'maint-71',
+            next_command: 'rerun-after-updated-branch-gate',
+            status: 'review_window_pending',
+            branch_update_started: true,
+          });
+        } catch (error) {
+          const message = String(error?.message || error);
+          console.log(`Unable to update behind PR #${pr.number}: ${message}`);
+          results.push({ ...deliveryContext, status: 'error', error: message });
+        }
+        continue;
+      }
       if (willMerge) {
         try {
           await assertRuntimeAcMergeAllowed({

--- a/.github/scripts/maint71_merge_sync_prs.js
+++ b/.github/scripts/maint71_merge_sync_prs.js
@@ -595,6 +595,17 @@ async function run({ github, context, core }) {
           repo,
           pull_number: pr.number,
         }));
+        const changedSinceSelection = !fullPr
+          || fullPr.number !== pr.number
+          || fullPr.head?.ref !== pr.head?.ref
+          || fullPr.head?.sha !== pr.head?.sha
+          || fullPr.base?.ref !== pr.base?.ref
+          || fullPr.user?.login !== pr.user?.login
+          || fullPr.body !== pr.body
+          || !isTrustedGeneratedDeliveryPr(fullPr, trustedSyncActors);
+        if (changedSinceSelection) {
+          throw new Error('refreshed PR no longer matches the trusted delivery selection');
+        }
         pr = fullPr;
       } catch (error) {
         const message = String(error?.message || error);
@@ -1116,8 +1127,9 @@ async function run({ github, context, core }) {
   }
   
   if (failed > 0) {
+    const blockingStatuses = [...new Set(blockingFailures.map((result) => result.status))];
     core.setFailed(
-      `${failed} blocking sync-system failure(s): merge_failed, stale_close_failed, or target_missing`,
+      `${failed} blocking sync-system failure(s): ${blockingStatuses.join(', ')}`,
     );
   }
 }

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -154,6 +154,19 @@ function evaluatePostPushReviewWindow(
   };
 }
 
+function requiresStrictGateBranchUpdate({ pr = {}, requiredContexts = [], willMerge = false } = {}) {
+  const requiredCount = requiredContexts instanceof Set
+    ? requiredContexts.size
+    : Array.isArray(requiredContexts)
+      ? requiredContexts.length
+      : 0;
+  return Boolean(
+    willMerge &&
+    requiredCount > 0 &&
+    String(pr.mergeable_state || '').toLowerCase() === 'behind',
+  );
+}
+
 function collectDeletableSyncBranches({
   branches = [],
   openPullRequests = [],
@@ -614,6 +627,7 @@ module.exports = {
   isTrustedGeneratedDeliveryPr,
   isTrustedSyncPr,
   evaluatePostPushReviewWindow,
+  requiresStrictGateBranchUpdate,
   normalizeSyncHash,
   syncBranchForHash,
   parseBooleanInput,

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -170,6 +170,7 @@ function requiresStrictGateBranchUpdate({ pr = {}, requiredContexts = [], willMe
 function isBlockingSyncSystemFailure(status) {
   return [
     'branch_update_failed',
+    'error',
     'merge_failed',
     'pr_refresh_failed',
     'stale_close_failed',

--- a/.github/scripts/sync_pr_merge_contract.js
+++ b/.github/scripts/sync_pr_merge_contract.js
@@ -167,6 +167,16 @@ function requiresStrictGateBranchUpdate({ pr = {}, requiredContexts = [], willMe
   );
 }
 
+function isBlockingSyncSystemFailure(status) {
+  return [
+    'branch_update_failed',
+    'merge_failed',
+    'pr_refresh_failed',
+    'stale_close_failed',
+    'target_missing',
+  ].includes(status);
+}
+
 function collectDeletableSyncBranches({
   branches = [],
   openPullRequests = [],
@@ -626,6 +636,7 @@ module.exports = {
   isSyncBranchName,
   isTrustedGeneratedDeliveryPr,
   isTrustedSyncPr,
+  isBlockingSyncSystemFailure,
   evaluatePostPushReviewWindow,
   requiresStrictGateBranchUpdate,
   normalizeSyncHash,


### PR DESCRIPTION
## Summary

- update a generated PR that is behind `main` before attempting any merge when required checks are configured
- wait for the refreshed Gate and the mandatory post-push review window instead of trying alternate merge strategies
- cover the strict-required-check predicate with a focused regression test

## Validation

- `node --test .github/scripts/__tests__/sync_pr_merge_contract.test.js` (30 passed)
- `git diff --check`

Fixes the strict Gate failure observed on Travel-Plan-Permission#1431 during Maint 71 candidate reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated merge synchronization for pull requests that are behind their target branch.
  * Branch updates now occur before merging when required status checks apply, ensuring fresh checks run against the latest code.
  * Merging is deferred while updated checks and review requirements are pending.
  * Branch refresh and synchronization failures are now recorded and classified more accurately to prevent unsafe merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->